### PR TITLE
fix(version) update to latest

### DIFF
--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbutton",
-  "version": "0.0.1-beta.4",
+  "version": "0.0.1-beta.6",
   "description": "Button component",
   "main": "KButton.vue",
   "scripts": {


### PR DESCRIPTION
Corrects the `package.json` in the KButton repo to reflect what is actually installed. Note that `package.json` was not updated 4 months ago along with the rest of the repo. When users install the "latest", the version in `node_modules/@kongponents/kbutton/package.json` is already accurate:

<img width="1306" alt="screen shot 2019-01-14 at 4 39 09 pm" src="https://user-images.githubusercontent.com/21048592/51150517-79e8e300-181b-11e9-871b-2202bff5f9f2.png">

Note: when publishing new kongponents in the future, updating package.json will be a necessary step.