### PR TITLE
chore(kpop) rename kpop prop to be more vue friendly

### DIFF
--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -2,7 +2,7 @@
   <component :is="tag">
     <slot/>
     <div
-      v-if="isSVG"
+      v-if="isSvg"
       :name="popoverTransitions">
       <foreignObject>
         <div
@@ -133,7 +133,7 @@ export default {
     /**
     * A flag indicating whether or not the element in the slot will be an SVG element
     */
-    isSVG: {
+    isSvg: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
### Summary
the prop I named `isSVG` is very Vue unfriendly due to the multiple capital case letters. This means, in order to pass lint in components using KPop, the prop name must be `is-s-v-g` which is very inconvenient

#### Changes made:
*renamed isSVG prop 

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
