### PR TITLE
fix(styles) import variables with ~

### DIFF
--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -87,7 +87,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@import 'node_modules/@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/_variables.scss';
 
 .button {
   display: inline-flex;

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -266,7 +266,7 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-@import 'node_modules/@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/_variables.scss';
 
 .k-popover {
   z-index: 1000;


### PR DESCRIPTION
Sass imports require `~` when importing from node_modules.