### PR TITLE
Fix(kpop) - fix spacing + border issues in kpop - intf-1505

### DIFF
--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -267,7 +267,7 @@ export default {
   white-space: normal;
   color: var(--KPopColor, var(--tblack-70, color(tblack-70)));
   background-color: var(--KPopBackground, var(--twhite-1, color(twhite-1)));
-  border: 1px solid var(--KPopBorder, var(--grey-98, color(grey-98)));
+  border: 1px solid var(--KPopBorder, var(--grey-84, color(grey-84)));
   border-radius: 3px;
   -webkit-box-shadow: 0 0 12px rgba(0,0,0,.12);
   box-shadow: 0 0 12px rgba(0,0,0,.12);
@@ -305,7 +305,7 @@ export default {
     
     &:before {
       border-color: rgba(250, 250, 250, 0);
-      border-bottom-color: var(--KPopBorder, var(--grey-98, color(grey-98)));
+      border-bottom-color: var(--KPopBorder, var(--grey-84, color(grey-84)));
       border-width: 11px;
       margin-left: -11px;
     }
@@ -334,7 +334,7 @@ export default {
 
     &:before {
       border-color: rgba(250, 250, 250, 0);
-      border-top-color: var(--KPopBorder, var(--grey-98, color(grey-98)));
+      border-top-color: var(--KPopBorder, var(--grey-84, color(grey-84)));
       border-width: 11px;
       margin-left: -11px;
     }
@@ -363,7 +363,7 @@ export default {
 
     &:before {
       border-color: rgba(250, 250, 250, 0);
-      border-left-color: var(--KPopBorder, var(--grey-98, color(grey-98)));
+      border-left-color: var(--KPopBorder, var(--grey-84, color(grey-84)));
       border-width: 11px;
       margin-top: -11px;
     }
@@ -392,7 +392,7 @@ export default {
 
     &:before {
       border-color: rgba(250, 250, 250, 0);
-      border-right-color: var(--KPopBorder, var(--grey-98, color(grey-98)));
+      border-right-color: var(--KPopBorder, var(--grey-84, color(grey-84)));
       border-width: 11px;
       margin-top: -11px;
     }

--- a/packages/styles/_variables.scss
+++ b/packages/styles/_variables.scss
@@ -23,6 +23,7 @@ $colors: (
   grey-98: hsla(0, 0%, 98%, 1),
   grey-92: hsla(0, 0%, 92%, 1),
   grey-88: hsla(0, 0%, 88%, 1),
+  grey-84: hsla(0, 0%, 84%, 1),
 
   twhite-75: hsla(100, 100%, 100%, .75),
   twhite-50: hsla(100, 100%, 100%, .5),


### PR DESCRIPTION
### Summary
the border and spacing were not correctly positioned before. This fixes that. See screenshots:
![image](https://user-images.githubusercontent.com/48491545/60056611-582b3c00-9696-11e9-8c6f-777776048c4f.png)
![image](https://user-images.githubusercontent.com/48491545/60056617-5c575980-9696-11e9-9358-692a4526d7c1.png)
![image](https://user-images.githubusercontent.com/48491545/60056621-5f524a00-9696-11e9-8901-24d96f4867c5.png)
![image](https://user-images.githubusercontent.com/48491545/60056627-6416fe00-9696-11e9-8994-5727ddea5d7f.png)


#### Changes made:
*Fixed spacing and border styling which was incorrect before 

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
