### PR TITLE
feat(styles) add grey-84, fix red-dark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Table of Contents
 
-- [KButton-0.1.10](#KButton-0.1.10)
+- [@kongponents/kbutton@0.1.10](#kongponents-kbutton-0.1.10)
+- [@kongponents/styles@0.0.4](#kongponents-styles-0.0.4)
 
-## [KButton-0.1.10]
+## [@kongponents/styles@0.0.4](kongponents-styles-0.0.4)
+
+- Updated `--red-dark` to 100% saturation.
+- Add `--grey-84`
+
+## [@kongponents/kbutton@0.1.10](kongponents-kbutton-0.1.10)
 > Released on 2019/07/29
 
 💥️**Breaking Change**  
- - This release updates KButton's general `.button` class to a more unique prefixed `k-button`. 
+ - This release updates KButton's general `.button` class to a more unique prefixed `k-button`.
 
 
 [Back to TOC](#table-of-contents)

--- a/packages/styles/_variables.scss
+++ b/packages/styles/_variables.scss
@@ -13,7 +13,7 @@ $colors: (
   red-light: hsla(0, 85%, 70%, 1),
   red-base: hsla(0, 80%, 50%, 1),
   red-link: hsla(0, 80%, 45%, 1),
-  red-dark: hsla(0, 80%, 35%, 1),
+  red-dark: hsla(0, 100%, 35%, 1),
 
   green-lighter: hsla(145, 45%, 94%, 1),
   green-light-01: hsla(145, 45%, 82%, 1),

--- a/packages/styles/styles.css
+++ b/packages/styles/styles.css
@@ -457,7 +457,7 @@
   --red-light: #f47171;
   --red-base: #e61a1a;
   --red-link: #cf1717;
-  --red-dark: #a11212;
+  --red-dark: #b30000;
   --green-lighter: #e9f7ef;
   --green-light-01: #bce6ce;
   --green-light: #90d5ad;
@@ -475,6 +475,7 @@
   --grey-98: #fafafa;
   --grey-92: #ebebeb;
   --grey-88: #e0e0e0;
+  --grey-84: #d6d6d6;
   --twhite-75: rgba(255, 255, 255, 0.75);
   --twhite-50: rgba(255, 255, 255, 0.5);
   --twhite-1: white;


### PR DESCRIPTION
### Summary
`--grey-84` wasn't in the build output, and `--red-dark` wasn't saturated according to the DPL

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
