### PR TITLE
fix(kcard) title might be in $slots in vue <2.6

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -15,6 +15,20 @@ String to be used in the title slot.
 
 - `title`
 
+<KCard title="Title">
+  <template slot="body">
+    I am the body.
+  </template>
+</KCard>
+
+```vue
+<KCard title="Title">
+  <template slot="body">
+    I am the body.
+  </template>
+</KCard>
+```
+
 If the title is ommitted, then KCard acts as a generic Box element.
 
 <KCard>
@@ -22,6 +36,14 @@ If the title is ommitted, then KCard acts as a generic Box element.
     I am a box. I have padding and a border. Useful for composing other components
   </template>
 </KCard>
+
+```vue
+<KCard>
+  <template slot="body">
+    I am a box. I have padding and a border. Useful for composing other components
+  </template>
+</KCard>
+```
 
 Example composing `KCard` with other Kongponents to make another component:
 
@@ -42,10 +64,36 @@ Example composing `KCard` with other Kongponents to make another component:
   </template>
 </KCard>
 
+
+```vue
+<KCard :hasHover="true">
+  <template slot="body">
+    <KAlert alert-message="Welcome to Kong!" />
+    <div class="mx-4">
+      <div>
+        <h2>Kong Enterprise Edition</h2>
+        <KButton to="https://docs.konghq.com/enterprise" target="_blank">
+          Docs
+        </KButton>
+      </div>
+      <div class="mt-2">
+        <p>Kong Enterprise adds features, functionality, and performance to Kong. This documentation doesn’t cover the general practices that are common to both Kong and Kong Enterprise—learn the basics in Kong documentation.</p>
+      </div>
+    </div>
+  </template>
+</KCard>
+```
+
 ### Body
 String to be used in the body slot.
 
 - `body`
+
+<KCard body="I am the body."/>
+
+```vue
+<KCard body="I am the body."/>
+```
 
 ### Border Variants
 Sets top border or no border. If neither set default will have border
@@ -103,18 +151,16 @@ Sets if card has hover state (shadow)
 <KCard>
   <template slot="title">Look Mah!</template>
   <template slot="actions"><a href="#">View All</a></template>
-  <template slot="body">
-    <h3>We're slotted!</h3>
-  </template>
+  <span slot="body">Body slot content here</span>
 </KCard>
 
 ```vue
 <KCard>
   <template slot="title">Look Mah!</template>
-  <template slot="actions"><a href="#">View All</a></template>
-  <template slot="body">
-    <h3>We're slotted!</h3>
+  <template slot="actions">
+    <a href="#">View All</a>
   </template>
+  <span slot="body">Body slot content here</span>
 </KCard>
 ```
 

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -3,7 +3,7 @@
     :class="[borderVariant, {'hover': hasHover }]"
     class="kong-card">
     <div
-      v-if="title || $scopedSlots.title || $scopedSlots.actions"
+      v-if="title || $scopedSlots.title || $scopedSlots.actions || $slots.title"
       class="k-card-header">
       <div class="k-card-title">
         <h4>


### PR DESCRIPTION
### Summary
Didn't catch it, but in Vue <2.6, you have both `$slots` and `$scopedSlots`, so we have to check both to be backwards compatible. Adding some more docs as well.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
