### PR TITLE
fix(KPop) fix pop-over not showing in IE - intf-1636

### DIFF
--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -145,10 +145,6 @@ export default {
       return {
         width: this.width + 'px'
       }
-    },
-
-    isIE () {
-      return !!window.MSInputMethodContext && !!document.documentMode
     }
   },
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/52717686/62579602-0bbc4a00-b859-11e9-8e2a-0c31c9756b2e.png)

### Summary

* fix pop-over not showing in IE
* background transparency was fixed in the ServiceMap, by over-riding  `background-color`
