### PR TITLE
fix(KModal) Fix event listener & button spacing

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -85,14 +85,19 @@ export default {
   },
 
   mounted () {
-    document.addEventListener('keydown', (e) => {
-      if (this.isVisible && e.keyCode === 27) {
-        this.close()
-      }
-    })
+    document.addEventListener('keydown', this.handleKeydown)
+  },
+
+  beforeDestroy () {
+    document.removeEventListener('keydown', this.handleKeydown)
   },
 
   methods: {
+    handleKeydown (e) {
+      if (this.isVisible && e.keyCode === 27) {
+        this.close()
+      }
+    },
     close () {
       this.$emit('canceled')
     },
@@ -153,8 +158,8 @@ export default {
     font-size: var(--KModalFontSize, var(--type-md, type(md)));
   }
 
-  .modal-footer button:last-of-type {
-    margin-left: spacing(sm);
+  .modal-footer button {
+    margin-right: spacing(sm);
   }
 }
 </style>


### PR DESCRIPTION
### Summary
- Fixes #135 where Keydown listener was not removed when the component is destroyed. https://github.com/Kong/kongponents/issues/135 
- Updates button margin to properly space more than one

#### Changes made:
* Add EventListener method
* Remove EventListener on destroy
* Fix modal-footer button margin

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
