### PR TITLE
docs(style): add prism theme

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -15,3 +15,5 @@ table {
     background-color: #fff;
   }
 }
+
+@import "../../../../docs/.vuepress/styles/prism-theme.min.css"

--- a/docs/.vuepress/styles/prism-theme.min.css
+++ b/docs/.vuepress/styles/prism-theme.min.css
@@ -1,0 +1,125 @@
+/* Night Owl + Custom */
+
+code[class*='language-'],
+pre[class*='language-'] {
+  color: #d6deeb;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+code[class*='language-'] ::-moz-selection,
+code[class*='language-']::-moz-selection,
+pre[class*='language-'] ::-moz-selection,
+pre[class*='language-']::-moz-selection {
+  text-shadow: none;
+  background: #011627;
+}
+code[class*='language-'] ::selection,
+code[class*='language-']::selection,
+pre[class*='language-'] ::selection,
+pre[class*='language-']::selection {
+  text-shadow: none;
+  background: #011627;
+}
+@media print {
+  code[class*='language-'],
+  pre[class*='language-'] {
+    text-shadow: none;
+  }
+}
+pre {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+}
+:not(pre) > code,
+pre {
+  background: #011627;
+}
+:not(pre) > code {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+.token.cdata,
+.token.comment,
+.token.prolog {
+  color: #637777;
+  font-style: italic;
+}
+.token.punctuation {
+  color: #c792ea;
+}
+.namespace {
+  color: #b2ccd6;
+}
+.token.deleted {
+  color: rgba(239, 83, 80, 0.56);
+  font-style: italic;
+}
+.token.property,
+.token.symbol {
+  color: #80cbc4;
+}
+.token.keyword,
+.token.operator,
+.token.tag {
+  color: var(--blue-light-01);
+}
+.token.boolean {
+  color: #ff5874;
+}
+.token.number {
+  color: #f78c6c;
+}
+.token.builtin,
+.token.char,
+.token.constant,
+.token.function {
+  color: #82aaff;
+}
+.token.doctype,
+.token.selector {
+  color: #c792ea;
+  font-style: italic;
+}
+.token.attr-name,
+.token.inserted {
+  color: #addb67;
+  font-style: italic;
+}
+.language-css .token.string,
+.style .token.string,
+.token.entity,
+.token.string,
+.token.url {
+  color: #addb67;
+}
+.token.atrule,
+.token.attr-value,
+.token.class-name {
+  color: #ffcb8b;
+}
+.token.important,
+.token.regex,
+.token.variable {
+  color: #d6deeb;
+}
+.token.bold,
+.token.important {
+  font-weight: 700;
+}
+.token.italic {
+  font-style: italic;
+}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "yarn build:styles && yarn build:docs && yarn build:cli",
-    "build:docs": "vuepress build docs",
+    "build": "yarn build:styles && yarn docs:build && yarn build:cli",
     "build:postcss": "postcss packages/styles/styles.css --dir packages/styles",
     "build:cli": "lerna exec --ignore @kongponents/styles \"yarn vue-cli-service build --target lib .\/\\$(cat package.json | jq -r .source) --name \\$(cat package.json | jq -r .componentName) --dest dist\"",
     "build:styles": "yarn node-sass packages/styles/styles.scss -o packages/styles && yarn build:postcss",


### PR DESCRIPTION
### Summary
Adds prism theme for better looking code snippets. Pulled from Night Owl theme and only change I made was that the tag color is now our `--blue-light-01`.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
