### PR TITLE
feat(kpop): add opened/closed events

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -38,7 +38,7 @@ module.exports = {
           {
             title: 'Components',
             collapsable: false,
-            sidebarDepth: 1,
+            sidebarDepth: 2,
             children: [
               '/components/alert',
               '/components/badge',

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -125,6 +125,15 @@ Fixes KAlert to the top of the container.
 - `alertIcon` - Slot specifically meant for adding an icon
 - `alertMessage` - Default message slot
 
+<KAlert appearance="info">
+  <template slot="alertIcon">
+    <KIcon icon="portal" />
+  </template>
+  <template slot="alertMessage">
+    I have an icon and a <a href="">Link</a>!
+  </template>
+</KAlert>
+
 ```vue
 <KAlert appearance="info">
   <template slot="alertIcon">

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -1,5 +1,7 @@
 # Popover
 
+[[toc]]
+
 **KPop** is a popover component that is used when you need something with more detailed content then fits inside a tooltip.
 KPop has three slots; only two is necessary is to be filled to populate the component with content.
 The title prop must be passed in and the main slot and the content slot must be populated in for the popover to display anything. 
@@ -146,10 +148,16 @@ Custom transitions that you want the popover to have - by default it uses a `fad
 ```
 
 ### Popover Timeout
-Custom timeout setting that you want the popover to have - by default it is set to 300 milliseconds.
+Custom timeout setting that you want the popover to have - by default it is set 
+to 300 milliseconds.
+
+<KPop title="Cool header" :popover-timeout="1000" trigger="hover">
+  <KButton>button</KButton>
+  <div slot="content">I have a 1 second timeout!</div>
+</KPop>
 
 ```vue
-<KPop title="Cool header" popoverTimeout="1000">
+<KPop title="Cool header" :popover-timeout="1000">
   <KButton>button</KButton>
   <div slot="content">I have a 1 second timeout!</div>
 </KPop>
@@ -176,15 +184,28 @@ You can pass in an optional flag to disable the popover - by default it is set t
 ```
 
 ### isSVG Flag
-For SVGs, the popover needs a special `foreignObject` wrapper in order to function, so you can pass in a flag to tell the popover it is taking in an SVG element - by default it is set to `false`
+To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` prop.
+This will wrap the content of the KPop in a `<foreignObject>` tag, so that normal
+HTML content can be injected into the popover.
+
+<svg style="cursor: pointer; height: 20px; width: 20px; margin-right: 1rem;" v-for="light in ['red', 'yellow', 'green']">
+  <KPop trigger="hover" :title="light" :is-svg="true" tag="g" :popover-timeout="10">
+    <template slot="content">
+      <p>{{ light }} means {{ light == 'green' ? 'GO!' : (light == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
+    </template>
+    <rect :fill="`var(--${light}-base)`" width="20" height="20" rx="20" ry="20"></rect>
+  </KPop>
+</svg>
 
 ```vue
-<KPop title="Cool header" isSVG="true">
-  <g>
-    <text>SVG Element</text>
-  </g>
-  <div slot="content">I am an SVG element so I need to set my flag to true!</div>
-</KPop>
+<svg v-for="light in ['red', 'yellow', 'green']">
+  <KPop trigger="hover" title="Light" :is-svg="true" tag="g" :popover-timeout="10">
+    <template slot="content">
+      <p>{{ light }} means {{ light == 'green' ? 'GO!' : (light == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
+    </template>
+    <rect :fill="`var(--${light}-base)`" width="20" height="20" rx="20" ry="20"></rect>
+  </KPop>
+</svg>
 ```
 
 ## Slots
@@ -192,7 +213,7 @@ For SVGs, the popover needs a special `foreignObject` wrapper in order to functi
 - `Default` There is a main slot that takes in the element you want the popover to be triggered over.
 
 ```vue
-<KPop title="Cool header" isSVG="true">
+<KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
 </KPop>
@@ -202,7 +223,7 @@ For SVGs, the popover needs a special `foreignObject` wrapper in order to functi
 There is an optional title slot that can take in an element for the title. The title could alternatively be populated via the prop.
 
 ```vue
-<KPop title="Cool header" isSVG="true">
+<KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your title goes here -->
@@ -216,7 +237,7 @@ There is an optional title slot that can take in an element for the title. The t
 This is the slot that takes in the content of the popover.
 
 ```vue
-<KPop title="Cool header" isSVG="true">
+<KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your content goes here -->
@@ -225,6 +246,130 @@ This is the slot that takes in the content of the popover.
   </div>
 </KPop>
 ```
+
+## Usage
+
+### Events / Loading Content
+
+- `opened` - emitted once the popover has been opened
+- `closed` - emitted when the popover has been triggered closed (emits on all
+triggers)
+
+<KPop @opened="loadSomething" @closed="onClose">
+  <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
+  <div slot="content" style="display: flex; justify-content: center;">
+    <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--tblack90)"/>
+    <div>{{ message }}</div>
+  </div>
+</KPop>
+
+<script>
+  export default {
+    data () {
+      return {
+        currentState: 'idle',
+        states: {
+          'idle': 'pending',
+          'pending': 'idle'
+        },
+        count: 0,
+        timeout: null
+      }
+    },
+    computed: {
+      buttonText () {
+        return {
+          'pending': 'Loading something...',
+          'idle': 'Load something'
+        }[this.currentState]
+      },
+      
+      message () {
+        return {
+          'pending': `Loading ${this.count}...`,
+          'idle': 'Loaded!'
+        }[this.currentState]
+      }
+    },
+    methods: {
+      loadSomething () {
+        this.transition()
+        this.timeout = setTimeout(() => {
+          this.count+=1
+          this.transition()
+        }, 2000)
+      },
+      
+      onClose () {
+        clearTimeout(this.timeout)
+      },
+      
+      transition() {
+        this.currentState = this.states[this.currentState]
+      }
+    }
+  }
+</script>
+
+
+```vue
+<KPop @opened="loadSomething" @closed="onClose">
+  <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
+  <div slot="content" style="display: flex; justify-content: center;">
+    <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--tblack90)"/>
+    <div>{{ message }}</div>
+  </div>
+</KPop>
+
+<script>
+  export default {
+    data () {
+      return {
+        currentState: 'idle',
+        states: {
+          'idle': 'pending',
+          'pending': 'idle'
+        },
+        count: 0,
+        timeout: null
+      }
+    },
+    computed: {
+      buttonText () {
+        return {
+          'pending': 'Loading something...',
+          'idle': 'Load something'
+        }[this.currentState]
+      },
+      
+      message () {
+        return {
+          'pending': `Loading ${this.count}...`,
+          'idle': 'Loaded!'
+        }[this.currentState]
+      }
+    },
+    methods: {
+      loadSomething () {
+        this.transition()
+        this.timeout = setTimeout(() => {
+          this.count+=1
+          this.transition()
+        }, 2000)
+      },
+      
+      onClose () {
+        clearTimeout(this.timeout)
+      },
+      
+      transition() {
+        this.currentState = this.states[this.currentState]
+      }
+    }
+  }
+</script>
+```
+
 
 ## Theming
 | Variable | Purpose

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -1,10 +1,11 @@
 # Popover
 
-[[toc]]
+**KPop** is a popover component that is used when you need something with more 
+detailed content then fits inside a tooltip. KPop has three slots; only two is 
+necessary is to be filled to populate the component with content. The title prop
+must be passed in and the main slot and the content slot must be populated in 
+for the popover to display anything.
 
-**KPop** is a popover component that is used when you need something with more detailed content then fits inside a tooltip.
-KPop has three slots; only two is necessary is to be filled to populate the component with content.
-The title prop must be passed in and the main slot and the content slot must be populated in for the popover to display anything. 
 For example a button:
 
 <KPop title="Cool header">
@@ -22,12 +23,24 @@ For example a button:
 ## Props
 
 ### Target
-This is the target element that the popover is appended to. By default its the body tag.
+This is the target `element` that the <code>popover</code> is appended to. By default its the body tag.
+
+
+<KPop title="Cool header" target=".theme-default-content">
+  <KButton>button</KButton>
+  <div slot="content">
+    I am a popover, inside the <code>.theme-default-content</code> selector so 
+    I can get some of the stylings inside the theme!
+  </div>
+</KPop>
 
 ```vue
-<KPop title="Cool header" target=".custom-class">
+<KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
-  <div slot="content">I am appended to the element with class custom-class!</div>
+  <div slot="content">
+  I am a popover, inside the <code>.theme-default-content</code> selector so 
+  I can get some of the stylings inside the theme!
+  </div>
 </KPop>
 ```
 
@@ -35,11 +48,16 @@ This is the target element that the popover is appended to. By default its the b
 This is the tag that the popover is wrapped around. By default its the div tag.
 
 ```vue
-<KPop title="Cool header" tag="main">
+<KPop title="Cool header" tag="details">
   <KButton>button</KButton>
-  <div slot="content">I am appended to the main element!</div>
+  <div slot="content">I am inside a &lt;details/&gt; block!</div>
 </KPop>
 ```
+
+<KPop title="Cool header" tag="details">
+  <KButton>button</KButton>
+  <div slot="content">I am inside a &lt;details/&gt; block!</div>
+</KPop>
 
 ### Title
 This is the Title of the popover. Either this or the title slot needs to be filled.
@@ -302,6 +320,9 @@ triggers)
       
       onClose () {
         clearTimeout(this.timeout)
+        if (this.currentState == 'pending') {
+          this.transition()
+        }
       },
       
       transition() {
@@ -360,6 +381,7 @@ triggers)
       
       onClose () {
         clearTimeout(this.timeout)
+        this.transition()
       },
       
       transition() {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -208,6 +208,7 @@ export default {
 
       this.timer = setTimeout(() => {
         this.isShow = false
+        this.$emit('close')
         this.destroy()
       }, this.popoverTimeout)
     },
@@ -216,6 +217,7 @@ export default {
       this.isShow = true
       if (this.timer) clearTimeout(this.timer)
       if (this.popperTimer) clearTimeout(this.popperTimer)
+      this.$emit('open')
     },
 
     async createInstance () {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -208,7 +208,7 @@ export default {
 
       this.timer = setTimeout(() => {
         this.isShow = false
-        this.$emit('close')
+        this.$emit('closed')
         this.destroy()
       }, this.popoverTimeout)
     },
@@ -217,7 +217,7 @@ export default {
       this.isShow = true
       if (this.timer) clearTimeout(this.timer)
       if (this.popperTimer) clearTimeout(this.popperTimer)
-      this.$emit('open')
+      this.$emit('opened')
     },
 
     async createInstance () {


### PR DESCRIPTION
### Summary
Adds `opened` and `closed` events so kpop users can load kpop content on-demand. I also corrected some of the KPop docs and improved the isSVG docs to show a good example.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
