### PR TITLE
style(KTable) Remove button padding

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -120,6 +120,8 @@ KButton supports using an icon either before the text or without text.
 | `--KButtonOutlineDangerActive`| Danger outline active state
 | `--KButtonLink`| Button link variant
 | `--KButtonLinkDanger`| Button Danger link variant
+| `--KButtonPaddingY`| Button vertical (top and bottom) padding
+| `--KButtonPaddingX`| Button horizontal (left and right) padding
 
 \
 An Example of changing the primary KButton variant to purple instead of blue might

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -150,7 +150,7 @@ export default {
     <span v-if="rowValue" style="color: green">&#10003;</span>
     <span v-else style="color: red">&#10007;</span>
   </template>
-  <template v-slot:actions><a href="">Edit</a></template>
+  <template v-slot:actions><KButton appearance="btn-link">Edit</KButton></template>
 </KTable>
 
 ```vue

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -105,7 +105,7 @@ export default {
 .k-button {
   display: inline-flex;
   align-items: center;
-  padding: var(--spacing-xs, spacing(xs)) var(--spacing-sm, spacing(sm));
+  padding: var(--KButtonPaddingY, var(--spacing-xs, spacing(xs))) var(--KButtonPaddingX, var(--spacing-sm, spacing(sm)));
   font-family: var(--font-family-sans, font(sans));
   font-size: 1rem;
   font-weight: 400;

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -110,8 +110,8 @@ table.k-table {
       }
       button,
       .k-button {
-        padding-top: 0;
-        padding-bottom: 0;
+        --KButtonPaddingY: 0;
+        --KButtonPaddingX: 0;
       }
     }
   }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -108,6 +108,11 @@ table.k-table {
           text-decoration: underline;
         }
       }
+      button,
+      .k-button {
+        padding-top: 0;
+        padding-bottom: 0;
+      }
     }
   }
 


### PR DESCRIPTION
### Summary
It was realized that when using a `KButton` in `KTable` the padding of the button dramatically increased the table row height. This is undesired so this fix will remove any padding. If a design/user calls for it they can override in their project

#### Before
![image](https://user-images.githubusercontent.com/5941111/70831799-4fdfce00-1da8-11ea-8e95-f3e2c4544e81.png)

### After
![image](https://user-images.githubusercontent.com/5941111/70831815-579f7280-1da8-11ea-8a8c-0248ae256028.png)

#### Changes made:
* Remove button top and bottom padding

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
