### PR TITLE
fix(KTable) Swap vars for negative margin

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -110,7 +110,8 @@ table.k-table {
       }
       button,
       .k-button {
-        margin: calc(-1 * var(--KButtonPaddingY, var(--spacing-xs))) 0;
+        margin-top: calc(-1 * var(--KButtonPaddingY, var(--spacing-xs)));
+        margin-bottom: calc(-1 * var(--KButtonPaddingY, var(--spacing-xs)));
       }
     }
   }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -110,8 +110,7 @@ table.k-table {
       }
       button,
       .k-button {
-        --KButtonPaddingY: 0;
-        --KButtonPaddingX: 0;
+        margin: calc(-1 * var(--KButtonPaddingY, var(--spacing-xs))) 0;
       }
     }
   }


### PR DESCRIPTION
Swap out css var overrides for negative margin so buttons look normal but row is short