### PR TITLE
chore(KIcon) add folder to package.json - intf-2259

### DIFF
--- a/packages/KIcon/package.json
+++ b/packages/KIcon/package.json
@@ -7,6 +7,7 @@
   "source": "KIcon.vue",
   "files": [
     "dist",
+    "icons",
     "KIcon.vue"
   ],
   "repository": {


### PR DESCRIPTION
### Summary

Adds './icons' folder to the KIcon's npm package, then we can imports KIcon or KIcon related Kongponents by the vue files.

#### Changes made:

* includes './icons' to the package.json of `KIcon`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
