### PR TITLE
chore(*) publish new UMD modules

### DIFF
--- a/packages/KAlert/package.json
+++ b/packages/KAlert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kalert",
-  "version": "0.1.10",
+  "version": "0.1.10-1",
   "description": "Alert component",
   "main": "dist/KAlert.umd.min.js",
   "componentName": "KAlert",

--- a/packages/KAlert/package.json
+++ b/packages/KAlert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kalert",
-  "version": "0.1.10-1",
+  "version": "0.1.11",
   "description": "Alert component",
   "main": "dist/KAlert.umd.min.js",
   "componentName": "KAlert",

--- a/packages/KBadge/package.json
+++ b/packages/KBadge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbadge",
-  "version": "0.1.6-1",
+  "version": "0.1.7",
   "description": "Badges, pills, or whatever you wanna call them.",
   "main": "dist/KBadge.umd.min.js",
   "componentName": "KBadge",

--- a/packages/KBadge/package.json
+++ b/packages/KBadge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbadge",
-  "version": "0.1.6",
+  "version": "0.1.6-1",
   "description": "Badges, pills, or whatever you wanna call them.",
   "main": "dist/KBadge.umd.min.js",
   "componentName": "KBadge",

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbutton",
-  "version": "0.1.10-7",
+  "version": "0.1.11",
   "description": "Button component",
   "main": "dist/KButton.umd.min.js",
   "componentName": "KButton",

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbutton",
-  "version": "0.1.10-7-beta.1",
+  "version": "0.1.10-7",
   "description": "Button component",
   "main": "dist/KButton.umd.min.js",
   "componentName": "KButton",

--- a/packages/KCard/package.json
+++ b/packages/KCard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcard",
-  "version": "0.1.3-7",
+  "version": "0.1.3-8",
   "description": "Card component",
   "main": "dist/KCard.umd.min.js",
   "componentName": "KCard",

--- a/packages/KCard/package.json
+++ b/packages/KCard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcard",
-  "version": "0.1.3-8",
+  "version": "0.1.4",
   "description": "Card component",
   "main": "dist/KCard.umd.min.js",
   "componentName": "KCard",

--- a/packages/KCheckbox/package.json
+++ b/packages/KCheckbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcheckbox",
-  "version": "0.2.0",
+  "version": "0.2.0-1",
   "description": "Checkbox input component",
   "main": "dist/KCheckbox.umd.min.js",
   "componentName": "KCheckbox",

--- a/packages/KCheckbox/package.json
+++ b/packages/KCheckbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcheckbox",
-  "version": "0.2.0-1",
+  "version": "0.2.1",
   "description": "Checkbox input component",
   "main": "dist/KCheckbox.umd.min.js",
   "componentName": "KCheckbox",

--- a/packages/KEmptyState/package.json
+++ b/packages/KEmptyState/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kemptystate",
-  "version": "0.1.9-9",
+  "version": "0.1.9-10",
   "description": "Empty State component",
   "main": "dist/KEmptyState.umd.min.js",
   "componentName": "KEmptyState",

--- a/packages/KEmptyState/package.json
+++ b/packages/KEmptyState/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kemptystate",
-  "version": "0.1.9-10",
+  "version": "0.1.10",
   "description": "Empty State component",
   "main": "dist/KEmptyState.umd.min.js",
   "componentName": "KEmptyState",

--- a/packages/KIcon/package.json
+++ b/packages/KIcon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kicon",
-  "version": "0.3.6",
+  "version": "0.3.6-1",
   "description": "Icon component",
   "main": "dist/KIcon.umd.min.js",
   "componentName": "KIcon",

--- a/packages/KIcon/package.json
+++ b/packages/KIcon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kicon",
-  "version": "0.3.6-1",
+  "version": "0.3.7",
   "description": "Icon component",
   "main": "dist/KIcon.umd.min.js",
   "componentName": "KIcon",

--- a/packages/KInput/package.json
+++ b/packages/KInput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinput",
-  "version": "0.2.0-0",
+  "version": "0.2.0-1",
   "description": "Input component",
   "main": "dist/KInput.umd.min.js",
   "componentName": "KInput",

--- a/packages/KInput/package.json
+++ b/packages/KInput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinput",
-  "version": "0.2.0-1",
+  "version": "0.2.1",
   "description": "Input component",
   "main": "dist/KInput.umd.min.js",
   "componentName": "KInput",

--- a/packages/KInputSwitch/package.json
+++ b/packages/KInputSwitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinputswitch",
-  "version": "0.2.0-0",
+  "version": "0.2.0-1",
   "description": "KInputSwitch description here.",
   "main": "dist/KInputSwitch.umd.min.js",
   "componentName": "KInputSwitch",

--- a/packages/KInputSwitch/package.json
+++ b/packages/KInputSwitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinputswitch",
-  "version": "0.2.0-1",
+  "version": "0.2.1",
   "description": "KInputSwitch description here.",
   "main": "dist/KInputSwitch.umd.min.js",
   "componentName": "KInputSwitch",

--- a/packages/KLabel/package.json
+++ b/packages/KLabel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/klabel",
-  "version": "0.3.0",
+  "version": "0.3.0-1",
   "description": "Form input label",
   "main": "dist/KLabel.umd.min.js",
   "componentName": "KLabel",

--- a/packages/KLabel/package.json
+++ b/packages/KLabel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/klabel",
-  "version": "0.3.0-1",
+  "version": "0.3.1",
   "description": "Form input label",
   "main": "dist/KLabel.umd.min.js",
   "componentName": "KLabel",

--- a/packages/KModal/package.json
+++ b/packages/KModal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmodal",
-  "version": "0.1.4-11",
+  "version": "0.1.5",
   "description": "Modal component",
   "main": "dist/KModal.umd.min.js",
   "componentName": "KModal",

--- a/packages/KModal/package.json
+++ b/packages/KModal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmodal",
-  "version": "0.1.4-10",
+  "version": "0.1.4-11",
   "description": "Modal component",
   "main": "dist/KModal.umd.min.js",
   "componentName": "KModal",

--- a/packages/KPop/package.json
+++ b/packages/KPop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kpop",
-  "version": "0.3.0-1",
+  "version": "0.3.1",
   "description": "A Popover component",
   "main": "dist/KPop.umd.min.js",
   "componentName": "KPop",

--- a/packages/KPop/package.json
+++ b/packages/KPop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kpop",
-  "version": "0.3.0",
+  "version": "0.3.0-1",
   "description": "A Popover component",
   "main": "dist/KPop.umd.min.js",
   "componentName": "KPop",

--- a/packages/KRadio/package.json
+++ b/packages/KRadio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kradio",
-  "version": "0.2.0-1",
+  "version": "0.2.1",
   "description": "Radio input component",
   "main": "dist/KButton.umd.min.js",
   "componentName": "KRadio",

--- a/packages/KRadio/package.json
+++ b/packages/KRadio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kradio",
-  "version": "0.2.0",
+  "version": "0.2.0-1",
   "description": "Radio input component",
   "main": "dist/KButton.umd.min.js",
   "componentName": "KRadio",

--- a/packages/KSlideout/package.json
+++ b/packages/KSlideout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kslideout",
-  "version": "0.1.7",
+  "version": "0.1.7-1",
   "description": "KSlideout description here.",
   "main": "dist/KSlideout.umd.min.js",
   "componentName": "KSlideout",

--- a/packages/KSlideout/package.json
+++ b/packages/KSlideout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kslideout",
-  "version": "0.1.7-1",
+  "version": "0.1.8",
   "description": "KSlideout description here.",
   "main": "dist/KSlideout.umd.min.js",
   "componentName": "KSlideout",

--- a/packages/KTable/package.json
+++ b/packages/KTable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktable",
-  "version": "0.1.4-7",
+  "version": "0.1.4-8",
   "description": "Table component",
   "main": "dist/KTable.umd.min.js",
   "componentName": "KTable",

--- a/packages/KTable/package.json
+++ b/packages/KTable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktable",
-  "version": "0.1.4-8",
+  "version": "0.1.5",
   "description": "Table component",
   "main": "dist/KTable.umd.min.js",
   "componentName": "KTable",

--- a/packages/KTest/package.json
+++ b/packages/KTest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktest",
-  "version": "1.0.1",
+  "version": "1.0.1-1",
   "description": "Testing 1, 2, 3...",
   "main": "dist/KTest.umd.min.js",
   "componentName": "KTest",

--- a/packages/KTest/package.json
+++ b/packages/KTest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktest",
-  "version": "1.0.1-1",
+  "version": "1.0.2",
   "description": "Testing 1, 2, 3...",
   "main": "dist/KTest.umd.min.js",
   "componentName": "KTest",

--- a/packages/KToaster/package.json
+++ b/packages/KToaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktoaster",
-  "version": "1.0.4",
+  "version": "1.0.4-1",
   "description": "Toaster component.",
   "main": "dist/KToaster.umd.min.js",
   "componentName": "KToaster",

--- a/packages/KToaster/package.json
+++ b/packages/KToaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktoaster",
-  "version": "1.0.4-1",
+  "version": "1.0.5",
   "description": "Toaster component.",
   "main": "dist/KToaster.umd.min.js",
   "componentName": "KToaster",

--- a/packages/KoolTip/package.json
+++ b/packages/KoolTip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kooltip",
-  "version": "0.2.5-1",
+  "version": "0.2.6",
   "description": "A tooltip component",
   "main": "dist/KoolTip.umd.min.js",
   "componentName": "KoolTip",

--- a/packages/KoolTip/package.json
+++ b/packages/KoolTip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kooltip",
-  "version": "0.2.5",
+  "version": "0.2.5-1",
   "description": "A tooltip component",
   "main": "dist/KoolTip.umd.min.js",
   "componentName": "KoolTip",

--- a/packages/Krumbs/package.json
+++ b/packages/Krumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/krumbs",
-  "version": "0.1.6",
+  "version": "0.1.6-1",
   "description": "Breadcrumbs component",
   "main": "dist/Krumbs.umd.min.js",
   "componentName": "Krumbs",

--- a/packages/Krumbs/package.json
+++ b/packages/Krumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/krumbs",
-  "version": "0.1.6-1",
+  "version": "0.1.7",
   "description": "Breadcrumbs component",
   "main": "dist/Krumbs.umd.min.js",
   "componentName": "Krumbs",


### PR DESCRIPTION
### Summary
The PR(#181 ) builds new UMD modules with `Postcss` enable. But new modules haven't publish, since `lerna` did not mark the component as `changed`

In this PR, we pump up package version to trigger the `lerna` publish process.

#### Changes made:

* pumps up version in package.json

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
