### PR TITLE
style(kslideout) adds hardcoded color fallback

### DIFF
--- a/packages/KSlideout/KSlideout.vue
+++ b/packages/KSlideout/KSlideout.vue
@@ -87,7 +87,7 @@ export default {
     right: 0;
     bottom: 0;
     left: 0;
-    background: var(--tblack-45, color(tback-45));
+    background: var(--tblack-45, hsla(0, 0%, 0%, .45));
     z-index: 9999;
   }
   .panel {
@@ -97,7 +97,7 @@ export default {
     height: 100vh;
     width: 100%;
     max-width: 500px;
-    background-color: var(--twhite-1, color(twhite-1));
+    background-color: var(--twhite-1, hsla(100, 100%, 100%, 1));
     z-index: 9999;
     .close-btn {
       position: absolute;

--- a/packages/KSlideout/KSlideout.vue
+++ b/packages/KSlideout/KSlideout.vue
@@ -87,7 +87,7 @@ export default {
     right: 0;
     bottom: 0;
     left: 0;
-    background: var(--tblack-45, hsla(0, 0%, 0%, .45));
+    background: var(--tblack-45, color(tback-45));
     z-index: 9999;
   }
   .panel {
@@ -97,7 +97,7 @@ export default {
     height: 100vh;
     width: 100%;
     max-width: 500px;
-    background-color: var(--twhite-1, hsla(100, 100%, 100%, 1));
+    background-color: var(--twhite-1, color(twhite-1));
     z-index: 9999;
     .close-btn {
       position: absolute;

--- a/packages/KSlideout/KSlideout.vue
+++ b/packages/KSlideout/KSlideout.vue
@@ -87,7 +87,7 @@ export default {
     right: 0;
     bottom: 0;
     left: 0;
-    background: var(--tblack-45);
+    background: var(--tblack-45, hsla(0, 0%, 0%, .45));
     z-index: 9999;
   }
   .panel {
@@ -97,7 +97,7 @@ export default {
     height: 100vh;
     width: 100%;
     max-width: 500px;
-    background-color: var(--twhite-1, color(twhite-1));
+    background-color: var(--twhite-1, hsla(100, 100%, 100%, 1));
     z-index: 9999;
     .close-btn {
       position: absolute;


### PR DESCRIPTION
### Summary
We need to add a hardcoded color fallback to a css-var, then the UMD module can be use in IE11.

![image](https://user-images.githubusercontent.com/52717686/72571368-40a2e300-3874-11ea-9302-4fe2319a3fc2.png)


#### Changes made:

* adds color fallback

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
