### PR TITLE
fix(kbutton): change height of kbutton icons to be auto - intf-2282

### DIFF
--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -132,7 +132,7 @@ export default {
 
   &.icon-btn {
     width: 38px;
-    height: 38px;
+    height: auto;
     padding: 0;
     justify-content: center;
     > svg {

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -66,7 +66,7 @@ export default {
 
 .kong-card {
   padding: var(--KCardPaddingY, 1rem) var(--KCardPaddingX, 1rem);
-  margin-bottom: 1rvar(--KCardMarginY, 1rem) var(--KCardMarginX, 1rem);
+  margin-bottom: var(--KCardMarginY, 1rem) var(--KCardMarginX, 1rem);
 
   &.noBoard {
     border: none;


### PR DESCRIPTION
### Summary
Changing height of kbutton icons to be auto, as having a hardcoded size does not work in all scenarios where kbutton is used. Tested with other kbutton icons and changing height to auto does not introduce any regressions
Also fixes margin of KCard

#### Changes made:
*changed height of kbutton icons to be auto
*fixes margin bottom of kcard

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
- [x] **Version:** package.json and the release tag both reflect the same, accurate version
