### PR TITLE
feat(kcard): add permanent shadow property

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -125,21 +125,34 @@ Sets top border or no border. If neither set default will have border
   borderVariant="borderTop"/>
 ```
 
-### Hover
-Sets if card has hover state (shadow)
+### Shadow
+Sets if card has shadow state (shadow)
 
-- `hasHover` 
+- `hasHover` only set shadow on hover
+- `hasShadow` always setShadow
 
 <KCard
-  title="Card Title"
-  body="Body Content"
+  title="hasHover"
+  class="mb-2"
+  body="This card only has a shadow on hover"
   hasHover/>
+
+<KCard
+  title="hasShadow"
+  body="This card always has a shadow"
+  hasShadow/>
 
 ```vue
 <KCard
-  title="Card Title"
-  body="Body Content"
+  title="hasHover"
+  class="mb-2"
+  body="This card only has a shadow on hover"
   hasHover/>
+
+<KCard
+  title="hasShadow"
+  body="This card always has a shadow"
+  hasShadow/>
 ```
 
 ## Slots

--- a/packages/KCard/KCard.spec.js
+++ b/packages/KCard/KCard.spec.js
@@ -38,6 +38,17 @@ describe('KCard', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('has shadow class when passed', () => {
+    const wrapper = mount(KCard, {
+      propsData: {
+        hasShadow: true
+      }
+    })
+
+    expect(wrapper.classes()).toContain('kcard-shadow')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('matches snapshot', () => {
     const wrapper = mount(KCard)
 

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="[borderVariant, {'hover': hasHover }]"
+    :class="[borderVariant, {'hover': hasHover, 'kcard-shadow': hasShadow }]"
     class="kong-card">
     <div
       v-if="title || $scopedSlots.title || $scopedSlots.actions || $slots.title"
@@ -56,6 +56,11 @@ export default {
     hasHover: {
       type: Boolean,
       default: false
+    },
+
+    hasShadow: {
+      type: Boolean,
+      default: false
     }
   }
 }
@@ -66,7 +71,6 @@ export default {
 
 .kong-card {
   padding: var(--KCardPaddingY, 1rem) var(--KCardPaddingX, 1rem);
-  margin-bottom: var(--KCardMarginY, 1rem) var(--KCardMarginX, 1rem);
 
   &.noBoard {
     border: none;
@@ -82,7 +86,7 @@ export default {
     border-top: 1px solid rgba(0, 0, 0, 0.08);
   }
 
-  &.hover:hover {
+  &.hover:hover, &.kcard-shadow {
     box-shadow: 0 4px 8px var(--tblack-10, color(tblack-10));
   }
 

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -7,6 +7,13 @@ exports[`KCard has hover class when passed 1`] = `
 </div>
 `;
 
+exports[`KCard has shadow class when passed 1`] = `
+<div class="kong-card border kcard-shadow">
+  <!---->
+  <div class="k-card-body"></div>
+</div>
+`;
+
 exports[`KCard matches snapshot 1`] = `
 <div class="kong-card border">
   <!---->


### PR DESCRIPTION
### Summary
adds permanent shadow property to card even when not hovering.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
