### PR TITLE
chore(version) bump

### DIFF
--- a/packages/KEmptyState/package.json
+++ b/packages/KEmptyState/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kongponents/kemptystate",
   "version": "0.2.2",
-  "description": "Empty State component",
+  "description": "Empty state component",
   "main": "dist/KEmptyState.umd.min.js",
   "componentName": "KEmptyState",
   "source": "KEmptyState.vue",

--- a/packages/KSkeleton/package.json
+++ b/packages/KSkeleton/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kongponents/kskeleton",
   "version": "0.1.1",
-  "description": "A loading state component",
+  "description": "Loading state component",
   "main": "dist/KSkeleton.umd.min.js",
   "componentName": "KSkeleton",
   "source": "KSkeleton.vue",


### PR DESCRIPTION
`YARN_TOKEN` did not have publish privileges. Making trivial changes to bump versions.