### PR TITLE
feat(KPop) Adds prop to hide caret

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -201,6 +201,21 @@ You can pass in an optional flag to disable the popover - by default it is set t
 </KPop>
 ```
 
+### Hide Caret
+You can pass in an optional flag to not show the caret on the edge of the popover.
+
+<KPop title="Cool header" hide-caret placement="right">
+  <KButton>button</KButton>
+  <div slot="content">Look ma, no caret!</div>
+</KPop>
+
+```vue
+<KPop title="Cool header" hide-caret placement="right">
+  <KButton>button</KButton>
+  <div slot="content">Look ma, no caret!</div>
+</KPop>
+```
+
 ### isSVG Flag
 To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` prop.
 This will wrap the content of the KPop in a `<foreignObject>` tag, so that normal

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -9,7 +9,7 @@
           v-show="isShow"
           ref="popper"
           :style="popoverStyle"
-          :class="popoverClasses">
+          :class="[popoverClasses, {'hide-caret': hideCaret }]">
           <div
             v-if="title"
             class="k-popover-title">
@@ -28,7 +28,7 @@
         v-show="isShow"
         ref="popper"
         :style="popoverStyle"
-        :class="popoverClasses">
+        :class="[popoverClasses, {'hide-caret': hideCaret }]">
         <div
           v-if="title"
           class="k-popover-title">
@@ -144,6 +144,13 @@ export default {
     * A flag indicating whether or not the element in the slot will be an SVG element
     */
     isSvg: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * A flag to hide the triangle pointing to the trigger element
+     */
+    hideCaret: {
       type: Boolean,
       default: false
     }
@@ -422,6 +429,13 @@ export default {
       border-right-color: var(--KPopBorder, var(--grey-84, color(grey-84)));
       border-width: 11px;
       margin-top: -11px;
+    }
+  }
+
+  &.hide-caret {
+    &:after,
+    &:before {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
### Summary
This adds a prop which removes the caret (arrow) from the popover. Helpful for use when you need a flyout menu but you don't want the little triangle 

#### Changes made:
* Prop added
* Dynamic `.hide-caret` class added
* `.hide-caret:after` & `.hide-caret:before` set to display none 

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
