### PR TITLE
feat(KPop) Adds positions & theme

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -113,21 +113,67 @@ Here are the different options:
 The position of where the popover appears - by default it appears on top.
 Here are the different options:
 
-- `top`
-- `bottom`
-- `left`
-- `right`
+<ul>
+  <li
+    v-for="p in positions"
+    :key="p">
+    <code>{{ p }}</code>
+  </li>
+</ul>
 
-<KPop title="Cool header" placement="bottom">
+<select
+  class="k-input"
+  v-model="selectedPosition">
+  <option
+    v-for="p in positions"
+    :key="p"
+    :value="p">{{ p }}</option> 
+</select>
+
+<KPop title="Cool header" trigger="hover" :placement="selectedPosition">
   <KButton>button</KButton>
-  <div slot="content">I am placed on the bottom!</div>
+  <div slot="content">I am placed on the {{ selectedPosition }}!</div>
 </KPop>
 
 ```vue
-<KPop title="Cool header" placement="bottom">
+<template>
+<select v-model="selectedPosition">
+  <option
+    v-for="p in positions"
+    :key="p"
+    :value="p">{{ p }}</option> 
+</select>
+
+<KPop title="Cool header" trigger="hover" :placement="selectedPosition">
   <KButton>button</KButton>
-  <div slot="content">I am placed on the bottom!</div>
+  <div slot="content">I am placed on the {{ selectedPosition }}!</div>
 </KPop>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      selectedPosition: 'auto',
+      positions: [
+        'auto',
+        'top',
+        'topStart',
+        'topEnd',
+        'left',
+        'leftStart',
+        'leftEnd',
+        'right',
+        'rightStart',
+        'rightEnd',
+        'bottom',
+        'bottomStart',
+        'bottomEnd'
+      ]
+    }
+  }
+}
+</script>
 ```
 
 ### Width
@@ -300,6 +346,22 @@ triggers)
   export default {
     data () {
       return {
+        selectedPosition: 'auto',
+        positions: [
+          'auto',
+          'top',
+          'topStart',
+          'topEnd',
+          'left',
+          'leftStart',
+          'leftEnd',
+          'right',
+          'rightStart',
+          'rightEnd',
+          'bottom',
+          'bottomStart',
+          'bottomEnd'
+        ],
         currentState: 'idle',
         states: {
           'idle': 'pending',
@@ -416,6 +478,8 @@ triggers)
 | `--KPopBodySize`| Font size of the body content
 | `--KPopColor`| Text color of the content
 | `--KPopHeaderSize`| Font size of the header content
+| `--KPopPaddingY`| Vertical top/bottom spacing
+| `--KPopPaddingX`| Horizontal left/right padding
 
 ## Browser Compatibility
 
@@ -423,3 +487,11 @@ triggers)
 For Internet Explorer 11 and below, the Popover component will not work due to `Node.contains` not being supported by the browser. 
 You will have to manually polyfill this functionality if you choose to support IE11 or below.
 :::
+
+<style scoped>
+  select {
+    height: calc(2.25rem + 2px);
+    background-color: #fff !important;
+    width: 250px;
+  }
+</style>

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -9,7 +9,8 @@
           v-show="isShow"
           ref="popper"
           :style="popoverStyle"
-          :class="[popoverClasses, {'hide-caret': hideCaret }]">
+          :class="[popoverClasses, {'hide-caret': hideCaret }]"
+          class="k-popover">
           <div
             v-if="title"
             class="k-popover-title">
@@ -28,7 +29,8 @@
         v-show="isShow"
         ref="popper"
         :style="popoverStyle"
-        :class="[popoverClasses, {'hide-caret': hideCaret }]">
+        :class="[popoverClasses, {'hide-caret': hideCaret }]"
+        class="k-popover">
         <div
           v-if="title"
           class="k-popover-title">
@@ -43,6 +45,21 @@
 </template>
 <script>
 import Popper from 'popper.js'
+
+const positions = {
+  top: 'top',
+  topStart: 'top-start',
+  topEnd: 'top-end',
+  left: 'left',
+  leftStart: 'left-start',
+  leftEnd: 'left-end',
+  right: 'right',
+  rightStart: 'right-start',
+  rightEnd: 'right-end',
+  bottom: 'bottom',
+  bottomStart: 'bottom-start',
+  bottomEnd: 'bottom-end'
+}
 
 export default {
   name: 'KPop',
@@ -75,12 +92,7 @@ export default {
     placement: {
       type: String,
       validator: function (value) {
-        return [
-          'top',
-          'bottom',
-          'left',
-          'right'
-        ].indexOf(value) !== -1
+        return Object.keys(positions).indexOf(value) !== -1
       },
       default: 'top'
     },
@@ -110,7 +122,7 @@ export default {
      */
     popoverClasses: {
       type: String,
-      default: 'k-popover'
+      default: ''
     },
     /**
      * Custom transition names that will be applied to the popover
@@ -231,18 +243,22 @@ export default {
       this.showPopper()
       // destroy any previous poppers before creating new one
       this.destroy()
-      const placementMapper = {
-        top: 'top',
-        left: 'left',
-        right: 'right',
-        bottom: 'bottom'
-      }
-      const placement = placementMapper[this.placement] ? placementMapper[this.placement] : 'bottom'
+      const placement = positions[this.placement] ? positions[this.placement] : 'bottom'
       const popperEl = this.$refs.popper
 
       document.querySelector(this.target).appendChild(popperEl)
       await this.$nextTick()
-      this.popper = new Popper(this.reference, popperEl, { placement, removeOnDestroy: true })
+      this.popper = new Popper(this.reference, popperEl, {
+        placement,
+        removeOnDestroy: true,
+        modifiers: {
+          // Ensures element does not ovflow outside of boundary
+          preventOverflow: {
+            enabled: true,
+            boundariesElement: 'viewport'
+          }
+        }
+      })
 
       await this.$nextTick()
       this.popper.update()
@@ -305,7 +321,7 @@ export default {
   border-radius: 3px;
   -webkit-box-shadow: 0 0 12px rgba(0,0,0,.12);
   box-shadow: 0 0 12px rgba(0,0,0,.12);
-  padding: 1rem;
+  padding: var(--KPopPaddingY, var(--spacing-md, spacing(md))) var(--KPopPaddingX, var(--spacing-md, spacing(md)));
 
   .k-popover-title {
     padding-bottom: 1rem;

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -46,7 +46,8 @@
 <script>
 import Popper from 'popper.js'
 
-const positions = {
+const placements = {
+  auto: 'auto',
   top: 'top',
   topStart: 'top-start',
   topEnd: 'top-end',
@@ -92,9 +93,9 @@ export default {
     placement: {
       type: String,
       validator: function (value) {
-        return Object.keys(positions).indexOf(value) !== -1
+        return Object.keys(placements).indexOf(value) !== -1
       },
-      default: 'top'
+      default: 'auto'
     },
     /**
      * How the Popover will trigger
@@ -243,7 +244,7 @@ export default {
       this.showPopper()
       // destroy any previous poppers before creating new one
       this.destroy()
-      const placement = positions[this.placement] ? positions[this.placement] : 'bottom'
+      const placement = placements[this.placement] ? placements[this.placement] : 'auto'
       const popperEl = this.$refs.popper
 
       document.querySelector(this.target).appendChild(popperEl)
@@ -446,6 +447,26 @@ export default {
       border-width: 11px;
       margin-top: -11px;
     }
+  }
+
+  &[x-placement^="top-start"],
+  &[x-placement^="bottom-start"] {
+    &:after, &:before { left: 11px; }
+  }
+
+  &[x-placement^="top-end"],
+  &[x-placement^="bottom-end"] {
+    &:after, &:before { left: calc(100% - 11px); }
+  }
+
+  &[x-placement^="right-start"],
+  &[x-placement^="left-start"] {
+    &:after, &:before { top: 11px; }
+  }
+
+  &[x-placement^="right-end"],
+  &[x-placement^="left-end"] {
+    &:after, &:before { top: calc(100% - 11px); }
   }
 
   &.hide-caret {


### PR DESCRIPTION
### Summary
This PR adds all popper.js supported positions (-start, -end) to supported positions. It also updates the class prop to not remove `.k-popover` when passed. This also adds css padding theming. Additionally I added a [setting](https://github.com/Kong/kongponents/compare/feat/kpop-add-more-positions?expand=1#diff-198bd74514b5965edfd8dd6f5317205fR256) to ensure the pop over does not flow outside of the viewport ever.

#### Changes made:
* Updated placement prop
* Updated class logic
* Adds `KPopPaddingX` & `KPopPaddingY`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
