### PR TITLE
feat(ktable): add row and cell events

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -85,12 +85,91 @@ Lessen the table cell padding
   isSmall />
 ```
 
+## Events
+Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to
+various parts of the table.
+
+### Rows
+- `@row:<event>` - returns the `Event`, the row item, and the type: `row`
+
+```vue
+<KTable @row:click="rowHandler" @row:dblclick="rowHandler">
+```
+
+### Cells
+
+- `@cell:<event>` - returns the `Event`, the cell value, and the type: `cell`
+
+```vue
+<KTable @cell:mouseout="cellHandler" @cell:mousedown="cellHandler">
+```
+
+#### Example
+
+```vue
+<template>
+  <div>
+    <div v-if="eventType">
+      {{eventType}} on: {{row}}
+    </div>
+    <div v-else>Waiting</div>
+
+    <KTable :options="tableOptions"
+      @row:click="actionRow" 
+      @cell:mouseover="actionRow"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      row: null,
+      eventType: ''
+    }
+  },
+  methods: {
+    actionRow (e, row, type) {
+      this.eventType = e.type
+      this.row = row
+    }
+  }
+}
+</script>
+```
+
+<KCard>
+  <div slot="body">
+  <div v-if="eventType">
+    {{eventType}} on: {{row}}
+  </div>
+  <div v-else>Waiting</div>
+
+  <KTable :options="$frontmatter.tableOptions" 
+    @row:click="actionRow" 
+    @cell:mouseover="actionRow"
+  />
+  </div>
+</KCard>
+
+
 ### Sorting
-There are two props used to make the table sortable; ```sortOrder```, which is either 'ascending' or 'descending' and ```sortKey```, which tells the table which column is currently being sorted. If a sortKey exists, then clicking the
-table header will emit an Event called ```sort``` which must be handled by the parent component to implement the
-actual sorting logic. A basic implementation of ```sort``` called ```defaultSorter``` is included in KTable and can be imported separately and used with a helper function in the parent.
-Once a table column with ```sortable``` is read, that column header will become clickable. An arrow then appears beside the table header, the state of the arrow depending on the sortOrder.
-In the following example, the ```defaultSorter``` from KTable is being imported, and the table is able to be sorted by any of the three columns by clicking on the headers.
+
+- `@sort` - returns header key that was clicked and current `sortOrder`.
+
+There are two props used to make the table sortable; `sortOrder`, which is
+either 'ascending' or 'descending' and `sortKey`, which tells the table which
+column is currently being sorted. If a sortKey exists, then clicking the table
+header will emit an Event called `sort` which must be handled by the parent
+component to implement the actual sorting logic. A basic implementation of
+`sort` called `defaultSorter` is included in KTable and can be imported
+separately and used with a helper function in the parent. Once a table column
+with `sortable` is read, that column header will become clickable. An arrow then
+appears beside the table header, the state of the arrow depending on the
+sortOrder. In the following example, the `defaultSorter` from KTable is being
+imported, and the table is able to be sorted by any of the three columns by
+clicking on the headers.
 
 <template>
   <KTable
@@ -305,6 +384,8 @@ import { defaultSorter } from '../../packages/KTable/KTable'
 export default {
   data() {
     return {
+      row: null,
+      eventType: '',
       sortOrder: 'ascending',
       sortKey: 'name',
       tableOptions: {
@@ -335,6 +416,10 @@ export default {
     }
   },
   methods: {
+    actionRow (e, row, type) {
+      this.eventType = e.type
+      this.row = row
+    },
     sortFieldHelper (key) {
       const {previousKey, sortOrder } = this.defaultSorter(key, this.sortKey, this.sortOrder, this.tableOptions.data)
       this.sortKey = previousKey

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -114,7 +114,9 @@ various parts of the table.
     </div>
     <div v-else>Waiting</div>
 
-    <KTable :options="tableOptions"
+    <KTable 
+      class="clickable-rows"
+      :options="tableOptions"
       @row:click="actionRow" 
       @cell:mouseover="actionRow"
     />
@@ -137,6 +139,11 @@ export default {
   }
 }
 </script>
+<style>
+.clickable-rows tr {
+  cursor: pointer;
+}
+</style>
 ```
 
 <KCard>
@@ -146,12 +153,21 @@ export default {
   </div>
   <div v-else>Waiting</div>
 
-  <KTable :options="$frontmatter.tableOptions" 
+  <KTable 
+    class="clickable-rows"
+    :options="$frontmatter.tableOptions"
+    has-hover
     @row:click="actionRow" 
     @cell:mouseover="actionRow"
   />
   </div>
 </KCard>
+
+<style>
+  .clickable-rows tr {
+    cursor: pointer;
+  }
+</style>
 
 
 ### Sorting

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import KTable, {defaultSorter} from '@/KTable/KTable'
+import KTable, { defaultSorter } from '@/KTable/KTable'
 
 const options = {
   headers: [
@@ -28,124 +28,174 @@ const options = {
 }
 
 describe('KTable', () => {
-  it('renders link in action slot', () => {
-    const wrapper = mount(KTable, {
-      propsData: {
-        options
-      },
-      scopedSlots: {
-        actions: '<a href="#" slot-scope="actions">Link</a>'
-      }
+  describe('default', () => {
+    it('renders link in action slot', () => {
+      const wrapper = mount(KTable, {
+        propsData: {
+          options
+        },
+        scopedSlots: {
+          actions: '<a href="#" slot-scope="actions">Link</a>'
+        }
+      })
+
+      const actions = wrapper.findAll('.k-table td:last-of-type > *')
+
+      expect(actions.at(0).is('a')).toBe(true)
+      expect(actions.at(1).is('a')).toBe(true)
+      expect(wrapper.html()).toMatchSnapshot()
     })
 
-    const actions = wrapper.findAll('.k-table td:last-of-type > *')
+    it('has hover class when passed', () => {
+      const wrapper = mount(KTable, {
+        propsData: {
+          options,
+          hasHover: true
+        }
+      })
 
-    expect(actions.at(0).is('a')).toBe(true)
-    expect(actions.at(1).is('a')).toBe(true)
-    expect(wrapper.html()).toMatchSnapshot()
-  })
-
-  it('has hover class when passed', () => {
-    const wrapper = mount(KTable, {
-      propsData: {
-        options,
-        hasHover: true
-      }
+      expect(wrapper.classes()).toContain('has-hover')
+      expect(wrapper.html()).toMatchSnapshot()
     })
 
-    expect(wrapper.classes()).toContain('has-hover')
-    expect(wrapper.html()).toMatchSnapshot()
+    it('has small class when passed', () => {
+      const wrapper = mount(KTable, {
+        propsData: {
+          options,
+          isSmall: true
+        }
+      })
+
+      expect(wrapper.classes()).toContain('is-small')
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
 
-  it('has small class when passed', () => {
-    const wrapper = mount(KTable, {
-      propsData: {
-        options,
-        isSmall: true
-      }
+  describe('sorting', () => {
+    it('should have sortable class when passed', () => {
+      const wrapper = mount(KTable, {
+        propsData: {
+          options
+        }
+      })
+
+      const actions = wrapper.findAll('.k-table th')
+
+      expect(actions.at(0).classes()).toContain('sortable')
+      expect(wrapper.html()).toMatchSnapshot()
     })
 
-    expect(wrapper.classes()).toContain('is-small')
-    expect(wrapper.html()).toMatchSnapshot()
-  })
+    it('defaultSorter(): sorts the items by string', () => {
+      const items = [
+        {
+          custom_id: '1234',
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
+          username: 'henry'
+        }, {
+          custom_id: '1345',
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
+          username: 'bobby'
+        }, {
+          custom_id: '13445',
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
+          username: 'zach'
+        }
+      ]
 
-  it('should have sortable class when passed', () => {
-    const wrapper = mount(KTable, {
-      propsData: {
-        options
-      }
+      expect(items[0].username).toEqual('henry')
+
+      let { previousKey: sortKey1, sortOrder: sortOrder1 } = defaultSorter('username', '', 'ascending', items)
+
+      expect(items[0].username).toEqual('bobby')
+      expect(sortKey1).toEqual('username')
+      expect(sortOrder1).toEqual('ascending')
+
+      let { previousKey: sortKey2, sortOrder: sortOrder2 } = defaultSorter('username', 'username', sortOrder1, items)
+
+      expect(items[0].username).toEqual('zach')
+      expect(sortKey2).toEqual('username')
+      expect(sortOrder2).toEqual('descending')
     })
 
-    const actions = wrapper.findAll('.k-table th')
+    it('defaultSorter(): sorts the items by number', () => {
+      const items = [
+        {
+          custom_id: 1234,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
+          username: 'henry'
+        }, {
+          custom_id: 145,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
+          username: 'bobby'
+        }, {
+          custom_id: 13445,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
+          username: 'zach'
+        }
+      ]
 
-    expect(actions.at(0).classes()).toContain('sortable')
-    expect(wrapper.html()).toMatchSnapshot()
+      expect(items[0].username).toEqual('henry')
+      expect(items[0].custom_id).toEqual(1234)
+
+      let { previousKey: sortKey1, sortOrder: sortOrder1 } = defaultSorter('custom_id', '', 'ascending', items)
+
+      expect(items[0].username).toEqual('bobby')
+      expect(items[0].custom_id).toEqual(145)
+      expect(sortKey1).toEqual('custom_id')
+      expect(sortOrder1).toEqual('ascending')
+
+      let { previousKey: sortKey2, sortOrder: sortOrder2 } = defaultSorter('custom_id', 'custom_id', sortOrder1, items)
+
+      expect(items[0].username).toEqual('zach')
+      expect(items[0].custom_id).toEqual(13445)
+      expect(sortKey2).toEqual('custom_id')
+      expect(sortOrder2).toEqual('descending')
+    })
   })
 
-  it('defaultSorter(): sorts the items by string', () => {
-    const items = [
-      {
-        custom_id: '1234',
-        id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
-        username: 'henry'
-      }, {
-        custom_id: '1345',
-        id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
-        username: 'bobby'
-      }, {
-        custom_id: '13445',
-        id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
-        username: 'zach'
-      }
-    ]
+  describe('events', () => {
+    it('@row:event', () => {
+      const evtTrigger = jest.fn()
+      const wrapper = mount(KTable, {
+        attachToDocument: true,
+        propsData: {
+          options
+        },
+        listeners: {
+          [`row:click`]: evtTrigger,
+          [`row:mouseover`]: evtTrigger
+        }
+      })
 
-    expect(items[0].username).toEqual('henry')
+      const bodyRow = wrapper.find('.k-table tbody tr')
 
-    let {previousKey: sortKey1, sortOrder: sortOrder1} = defaultSorter('username', '', 'ascending', items)
+      bodyRow.trigger('click')
+      bodyRow.trigger('mouseover')
+      expect(evtTrigger).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: 'click' }), options.data[0], 'row')
+      expect(evtTrigger).toHaveBeenNthCalledWith(2, expect.objectContaining({ type: 'mouseover' }), options.data[0], 'row')
+    })
 
-    expect(items[0].username).toEqual('bobby')
-    expect(sortKey1).toEqual('username')
-    expect(sortOrder1).toEqual('ascending')
+    it('@cell:event', () => {
+      const evtTrigger = jest.fn()
+      const wrapper = mount(KTable, {
+        attachToDocument: true,
+        propsData: { options },
+        listeners: {
+          [`cell:click`]: evtTrigger,
+          [`cell:mouseover`]: evtTrigger,
+          [`cell:mouseout`]: evtTrigger
+        }
+      })
 
-    let {previousKey: sortKey2, sortOrder: sortOrder2} = defaultSorter('username', 'username', sortOrder1, items)
+      const bodyCell1 = wrapper.find('.k-table tbody td')
+      const bodyCell2 = wrapper.find('.k-table tbody td:nth-child(2)')
 
-    expect(items[0].username).toEqual('zach')
-    expect(sortKey2).toEqual('username')
-    expect(sortOrder2).toEqual('descending')
-  })
-
-  it('defaultSorter(): sorts the items by number', () => {
-    const items = [
-      {
-        custom_id: 1234,
-        id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
-        username: 'henry'
-      }, {
-        custom_id: 145,
-        id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
-        username: 'bobby'
-      }, {
-        custom_id: 13445,
-        id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
-        username: 'zach'
-      }
-    ]
-
-    expect(items[0].username).toEqual('henry')
-    expect(items[0].custom_id).toEqual(1234)
-
-    let {previousKey: sortKey1, sortOrder: sortOrder1} = defaultSorter('custom_id', '', 'ascending', items)
-
-    expect(items[0].username).toEqual('bobby')
-    expect(items[0].custom_id).toEqual(145)
-    expect(sortKey1).toEqual('custom_id')
-    expect(sortOrder1).toEqual('ascending')
-
-    let {previousKey: sortKey2, sortOrder: sortOrder2} = defaultSorter('custom_id', 'custom_id', sortOrder1, items)
-
-    expect(items[0].username).toEqual('zach')
-    expect(items[0].custom_id).toEqual(13445)
-    expect(sortKey2).toEqual('custom_id')
-    expect(sortOrder2).toEqual('descending')
+      bodyCell1.trigger('click')
+      bodyCell1.trigger('mouseover')
+      bodyCell2.trigger('mouseout')
+      expect(evtTrigger).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: 'click' }), 'Basic Auth', 'cell')
+      expect(evtTrigger).toHaveBeenNthCalledWith(2, expect.objectContaining({ type: 'mouseover' }), 'Basic Auth', 'cell')
+      expect(evtTrigger).toHaveBeenNthCalledWith(3, expect.objectContaining({ type: 'mouseout' }), '517526354743085', 'cell')
+    })
   })
 })

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -151,11 +151,11 @@ export default {
   },
 
   computed: {
-    tdlisteners (row) {
+    tdlisteners () {
       return pluckListeners('cell:', this.$listeners)
     },
 
-    trlisteners (entity) {
+    trlisteners () {
       return pluckListeners('row:', this.$listeners)
     }
   }

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KTable has hover class when passed 1`] = `
+exports[`KTable default has hover class when passed 1`] = `
 <table class="k-table has-hover">
   <thead>
     <tr>
@@ -41,7 +41,7 @@ exports[`KTable has hover class when passed 1`] = `
 </table>
 `;
 
-exports[`KTable has small class when passed 1`] = `
+exports[`KTable default has small class when passed 1`] = `
 <table class="k-table is-small">
   <thead>
     <tr>
@@ -82,7 +82,7 @@ exports[`KTable has small class when passed 1`] = `
 </table>
 `;
 
-exports[`KTable renders link in action slot 1`] = `
+exports[`KTable default renders link in action slot 1`] = `
 <table class="k-table">
   <thead>
     <tr>
@@ -123,7 +123,7 @@ exports[`KTable renders link in action slot 1`] = `
 </table>
 `;
 
-exports[`KTable should have sortable class when passed 1`] = `
+exports[`KTable sorting should have sortable class when passed 1`] = `
 <table class="k-table">
   <thead>
     <tr>


### PR DESCRIPTION
### Summary
Adds KTable events to rows and cells e.g.
```vue
<KTable @row:click="rowHandler" @cell:mouseover="cellHandler" ... />
```

See docs for more usage.

#### Changes made:
* feat(ktable): add dynamic row and cell events
* fix(ktable/sort): use header `.sortable` to detect if we should $emit
* test(ktable): split tests into describe sections

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
