### PR TITLE
fix(ktable): beef up defaultSorter to handle null, undefined and array values

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -210,29 +210,36 @@ import { defaultSorter } from '@kongponents/KTable'
 export default {
   data() {
     return {
+      row: null,
+      eventType: '',
       sortOrder: 'ascending',
       sortKey: 'name',
       tableOptions: {
         headers: [
           { label: 'Name', key: 'name', sortable: true },
           { label: 'ID', key: 'id', sortable: true },
-          { label: 'Enabled', key: 'enabled', sortable: true }
+          { label: 'Enabled', key: 'enabled', sortable: true },
+          { label: 'Theme Colors', key: 'themeColors', sortable: true },
+          { key: 'actions', hideLabel: true }
         ],
         data: [
           {
             name: 'Basic Auth',
-            id: 517526354743085,
-            enabled: true
+            id: '517526354743085',
+            enabled: 'true',
+            themeColors: []
           },
           {
             name: 'Website Desktop',
-            id: 328027447731198,
-            enabled: false
+            id: '328027447731198',
+            enabled: 'false',
+            themeColors: ['blue','violet']
           },
           {
             name: 'Android App',
-            id: 405383051040955,
-            enabled: true
+            id: '405383051040955',
+            enabled: 'true',
+            themeColors: ['green', 'yellow']
           }
         ]
       }
@@ -409,23 +416,27 @@ export default {
           { label: 'Name', key: 'name', sortable: true },
           { label: 'ID', key: 'id', sortable: true },
           { label: 'Enabled', key: 'enabled', sortable: true },
+          { label: 'Theme Colors', key: 'themeColors', sortable: true },
           { key: 'actions', hideLabel: true }
         ],
         data: [
           {
             name: 'Basic Auth',
             id: '517526354743085',
-            enabled: 'true'
+            enabled: 'true',
+            themeColors: []
           },
           {
             name: 'Website Desktop',
             id: '328027447731198',
-            enabled: 'false'
+            enabled: 'false',
+            themeColors: ['blue','violet']
           },
           {
             name: 'Android App',
             id: '405383051040955',
-            enabled: 'true'
+            enabled: 'true',
+            themeColors: ['green', 'yellow']
           }
         ]
       }

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -134,9 +134,6 @@ describe('KTable', () => {
         }
       ]
 
-      expect(items[0].username).toEqual('henry')
-      expect(items[0].custom_id).toEqual(1234)
-
       let { previousKey: sortKey1, sortOrder: sortOrder1 } = defaultSorter('custom_id', '', 'ascending', items)
 
       expect(items[0].username).toEqual('bobby')
@@ -210,9 +207,6 @@ describe('KTable', () => {
         }
       ]
 
-      expect(items[0].usernames[0]).toEqual('henry')
-      expect(items[0].custom_id).toEqual(1234)
-
       let { previousKey: sortKey1, sortOrder: sortOrder1 } = defaultSorter('usernames', '', 'ascending', items)
 
       expect(items[0].usernames[0]).toEqual('bobby')
@@ -225,6 +219,43 @@ describe('KTable', () => {
       expect(items[0].usernames[0]).toEqual('zach')
       expect(items[0].custom_id).toEqual(13445)
       expect(sortKey2).toEqual('usernames')
+      expect(sortOrder2).toEqual('descending')
+    })
+
+    it('defaultSorter(): sorts the items by first item in the array - number', () => {
+      const items = [
+        {
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
+          favoriteNumbers: [1234, 2]
+        }, {
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
+          favoriteNumbers: [145]
+        }, {
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
+          favoriteNumbers: [-1]
+        }
+      ]
+
+      let { previousKey: sortKey1, sortOrder: sortOrder1 } =
+        defaultSorter('favoriteNumbers', '', 'ascending', items)
+
+      expect(items.map(i => ({favoriteNumbers: i.favoriteNumbers}))).toEqual([
+        { favoriteNumbers: [-1] },
+        { favoriteNumbers: [145] },
+        { favoriteNumbers: [1234, 2] }
+      ])
+      expect(sortKey1).toEqual('favoriteNumbers')
+      expect(sortOrder1).toEqual('ascending')
+
+      let { previousKey: sortKey2, sortOrder: sortOrder2 } =
+        defaultSorter('favoriteNumbers', 'favoriteNumbers', sortOrder1, items)
+
+      expect(items.map(i => ({favoriteNumbers: i.favoriteNumbers}))).toEqual([
+        { favoriteNumbers: [1234, 2] },
+        { favoriteNumbers: [145] },
+        { favoriteNumbers: [-1] }
+      ])
+      expect(sortKey2).toEqual('favoriteNumbers')
       expect(sortOrder2).toEqual('descending')
     })
   })

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -151,6 +151,82 @@ describe('KTable', () => {
       expect(sortKey2).toEqual('custom_id')
       expect(sortOrder2).toEqual('descending')
     })
+
+    it('defaultSorter(): sorts undefined and null values', () => {
+      const items = [
+        {
+          custom_id: 2145,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
+          username: 'bobby'
+        }, {
+          custom_id: 13445,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
+          username: 'zach'
+        },
+        {
+          custom_id: 3145,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb5',
+          username: undefined
+        },
+        {
+          custom_id: 1234,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
+          username: null
+        }
+      ]
+
+      expect(items[0].username).toEqual('bobby')
+      expect(items[0].custom_id).toEqual(2145)
+
+      let { previousKey: sortKey1, sortOrder: sortOrder1 } = defaultSorter('username', '', 'ascending', items)
+
+      expect(items[0].username).toBeUndefined()
+      expect(items[0].custom_id).toEqual(3145)
+      expect(sortKey1).toEqual('username')
+      expect(sortOrder1).toEqual('ascending')
+
+      let { previousKey: sortKey2, sortOrder: sortOrder2 } = defaultSorter('username', 'username', sortOrder1, items)
+
+      expect(items[0].username).toEqual('zach')
+      expect(items[0].custom_id).toEqual(13445)
+      expect(sortKey2).toEqual('username')
+      expect(sortOrder2).toEqual('descending')
+    })
+
+    it('defaultSorter(): sorts the items by first item in the array', () => {
+      const items = [
+        {
+          custom_id: 1234,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
+          usernames: ['henry', 'jacob']
+        }, {
+          custom_id: 145,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
+          usernames: ['bobby', 'jones']
+        }, {
+          custom_id: 13445,
+          id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb4',
+          usernames: ['zach', 'hondo']
+        }
+      ]
+
+      expect(items[0].usernames[0]).toEqual('henry')
+      expect(items[0].custom_id).toEqual(1234)
+
+      let { previousKey: sortKey1, sortOrder: sortOrder1 } = defaultSorter('usernames', '', 'ascending', items)
+
+      expect(items[0].usernames[0]).toEqual('bobby')
+      expect(items[0].custom_id).toEqual(145)
+      expect(sortKey1).toEqual('usernames')
+      expect(sortOrder1).toEqual('ascending')
+
+      let { previousKey: sortKey2, sortOrder: sortOrder2 } = defaultSorter('usernames', 'usernames', sortOrder1, items)
+
+      expect(items[0].usernames[0]).toEqual('zach')
+      expect(items[0].custom_id).toEqual(13445)
+      expect(sortKey2).toEqual('usernames')
+      expect(sortOrder2).toEqual('descending')
+    })
   })
 
   describe('events', () => {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -53,26 +53,35 @@
  */
 export const defaultSorter = (key, previousKey, sortOrder, items) => {
   let comparator = null
-  const type = typeof items[0][key]
+  const numberComparator = (a, b) => a && b && a - b
+  const stringComparator = (a, b) => a.localeCompare(b)
 
   if (key !== previousKey) {
-    if (type === 'number') {
-      comparator = (a, b) => a[key] && b[key] && a[key] - b[key]
-    } else {
-      comparator = (a, b) => {
-        const transformer = (val) => {
-          if (val === undefined || val === null) {
-            return ''
-          }
-
-          if (Array.isArray(val)) {
-            return String(val[0])
-          }
-
-          return String(val)
+    comparator = (a, b) => {
+      const transformer = (val) => {
+        if (val === undefined || val === null) {
+          return ''
         }
 
-        return transformer(a[key]).localeCompare(transformer(b[key]))
+        if (typeof val === 'number') {
+          return val
+        }
+
+        if (Array.isArray(val) && val.length && typeof val[0] === 'number') {
+          return val[0]
+        }
+
+        return String(val)
+      }
+
+      const newValA = transformer(a[key])
+      const newValB = transformer(b[key])
+
+      switch (typeof newValA) {
+        case 'number':
+          return numberComparator(newValA, newValB)
+        default:
+          return stringComparator(newValA, newValB)
       }
     }
 
@@ -260,5 +269,4 @@ table.k-table {
     background-color: var(--KTableHover, var(--blue-lightest, color(blue-lightest)));
   }
 }
-
 </style>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -53,19 +53,27 @@
  */
 export const defaultSorter = (key, previousKey, sortOrder, items) => {
   let comparator = null
-
   const type = typeof items[0][key]
 
   if (key !== previousKey) {
-    if (type === 'string') {
-      comparator = (a, b) => {
-        if (a[key] < b[key]) return -1
-        if (a[key] > b[key]) return 1
-
-        return 0
-      }
+    if (type === 'number') {
+      comparator = (a, b) => a[key] && b[key] && a[key] - b[key]
     } else {
-      comparator = (a, b) => a[key] - b[key]
+      comparator = (a, b) => {
+        const transformer = (val) => {
+          if (val === undefined || val === null) {
+            return ''
+          }
+
+          if (Array.isArray(val)) {
+            return String(val[0])
+          }
+
+          return String(val)
+        }
+
+        return transformer(a[key]).localeCompare(transformer(b[key]))
+      }
     }
 
     items.sort(comparator)


### PR DESCRIPTION
### Summary
Added additional functionality to KTable's defaultSorter to handle null, undefined and array values

#### Changes made:
*Add type checking for ktable to properly sort null, defined and array values
*added associated unit tests
*Updated docs to have array example

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
