### PR TITLE
fix(kskeleton): inline bigger gifs

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -17,5 +17,11 @@ module.exports = {
       .use('raw')
       .loader('raw-loader')
       .end().end()
+
+    config.module
+      .rule('images')
+      .use('url-loader')
+      .loader('url-loader')
+      .tap(options => Object.assign(options, { limit: 14000 }))
   }
 }


### PR DESCRIPTION
* the relative path for the .gif was not working, but we might as well
allow for the gif to be inlined into the javascript. Bumping inline gif
sizes to 14kb.

Moral of the testing story is that when running `yarn link` you should also verify that the bundles are working. Shortcut to only build certain packages: `yarn build:cli --scope="@kongponents/kskeleton"`