### PR TITLE
feat(skeleton): add box primitive

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -26,6 +26,7 @@ import KToggle from '../../packages/KToggle/KToggle.js'
 import Komponent from '../../packages/Komponent/Komponent.js'
 import KSlideout from '../../packages/KSlideout/KSlideout.vue'
 import KSkeleton from '../../packages/KSkeleton/KSkeleton.vue'
+import KSkeletonBox from '../../packages/KSkeleton/KSkeletonBox.vue'
 
 export default ({
   Vue,
@@ -56,6 +57,7 @@ export default ({
   Vue.component('KToggle', KToggle)
   Vue.component('KSlideout', KSlideout)
   Vue.component('KSkeleton', KSkeleton)
+  Vue.component('KSkeletonBox', KSkeletonBox)
 
   Vue.prototype.$icons = Object.keys(icons)
 }

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -6,7 +6,9 @@
 ### type
 - `type`
 
-There are 5 different types of loading states that KSkeleton supports: Card, Table, Form, Spinner and a generic loading state. Defaults to a generic loading state. The following example shows a Form type KSKeleton.
+There are 5 different types of loading states that KSkeleton supports: Card, 
+Table, Form, Spinner and a generic loading state. Defaults to a generic loading 
+state. The following example shows a Form type KSKeleton.
 
 <template>
   <KSkeleton type="form" />
@@ -165,12 +167,137 @@ to perform any expensive querying on first load.
 </template>
 ```
 
+## KSkeletonBox
+
+KSkeleton package uses a component to render the placeholder content 
+`<KSkeletonBox>`. It can be used as a component primitive to create your own
+custom placeholder components.
+
+<KSkeletonBox />
+<KSkeletonBox width="2" height="2"/>
+<KSkeletonBox width="5" height="2"/>
+<KSkeletonBox width="50" height="1"/>
+<KSkeletonBox width="100" height="2"/>
+
+```vue
+<KSkeletonBox />
+<KSkeletonBox width="2" height="2"/>
+<KSkeletonBox width="5" height="2"/>
+<KSkeletonBox width="50" height="1"/>
+<KSkeletonBox width="100" height="2"/>
+```
+
+
+For example, here is a card skeleton with different arrangement of placeholders:
+
+<template>
+  <KSkeleton class="k-skeleton-modified" type="card" :card-count="3">
+    <template slot="card-header">
+      <div>
+        <div class="d-flex justify-content-center pb-3">
+          <KSkeletonBox width="5" />
+        </div>
+        <hr>
+      </div>
+    </template>
+    <template slot="card-content">
+      <KSkeletonBox width="100"/>
+    </template>
+    <template slot="card-footer">
+      <div class="w-100">
+        <div class="d-flex justify-content-center">
+          <KSkeletonBox width="5" />
+        </div>
+      </div>
+    </template>
+  </KSkeleton>
+</template>
+
+```vue
+<KSkeleton type="card" :card-count="3">
+  <template slot="card-header">
+    <div>
+      <div class="d-flex justify-content-center pb-2">
+        <KSkeletonBox width="5" />
+      </div>
+      <hr>
+    </div>
+  </template>
+  <template slot="card-footer">
+    <div class="w-100">
+      <div class="d-flex justify-content-center pb-2">
+        <KSkeletonBox width="5" />
+      </div>
+    </div>
+  </template>
+</KSkeleton>
+```
+
+And another example:
+
+<template>
+  <KSkeleton type="card">
+    <template slot="card-header">
+      <div>
+        <div class="d-flex justify-content-center pb-2">
+          <KSkeletonBox width="5" />
+        </div>
+        <hr>
+      </div>
+    </template>
+    <template slot="card-content">
+      <div class="d-block">
+        <template v-for="i in 8">
+          <KSkeletonBox width="5" />
+          <KSkeletonBox width="5" />
+          <KSkeletonBox width="1" />
+          <KSkeletonBox width="2" />
+        </template>
+      </div>
+    </template>
+    <template slot="card-footer">
+      <KSkeletonBox width="100" />
+    </template>
+  </KSkeleton>
+</template>
+
+
+```vue
+<KSkeleton type="card">
+  <template slot="card-header">
+    <div>
+      <div class="d-flex justify-content-center pb-2">
+        <KSkeletonBox width="5" />
+      </div>
+      <hr>
+    </div>
+  </template>
+  <template slot="card-content">
+    <div class="d-block">
+      <template v-for="i in 8">
+        <KSkeletonBox width="5" />
+        <KSkeletonBox width="5" />
+        <KSkeletonBox width="1" />
+        <KSkeletonBox width="2" />
+      </template>
+    </div>
+  </template>
+  <template slot="card-footer">
+    <KSkeletonBox width="100" />
+  </template>
+</KSkeleton>
+```
+
+
+
+
 ## Theming
 
 | Variable                             | Purpose                                                                                                                                                                    |
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--KSkeletonFullScreenMargin`        | Margin around full screen variant. Useful for when you want to show full screen loader under header or next to sidebar since the full screen component has fixed position. |
 | `--KSkeletonFullScreenProgressColor` | Progress bar fill color.                                                                                                                                                   |
+| `--KSkeletonCardWidth`               | Width of the card. Default is 33%                                                                                                                                          |
 
 ### Examples
 
@@ -225,5 +352,8 @@ export default {
 .k-skeleton-full-screen-margin {
   --KSkeletonFullScreenMargin: 58px 0 0;
   --KSkeletonFullScreenProgressColor: var(--tblack-70);
+}
+.k-skeleton-modified {
+  --KSkeletonCardWidth: 30%;
 }
 </style>

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -173,6 +173,15 @@ KSkeleton package uses a component to render the placeholder content
 `<KSkeletonBox>`. It can be used as a component primitive to create your own
 custom placeholder components.
 
+### Props
+
+
+| Prop   | Allowed Values                                              | Description                                  |
+| :----- | :---------------------------------------------------------- | -------------------------------------------- |
+| width  | '1' (default), '2', '5', '6', '10', '50', '75', '100'       | Width of the skeleton box in relative units. Values 10, 50, 75, 100 are percentage based. |
+| height | '1' (default), '2'                                          | Height of the skeleton box in relative units |
+
+
 <KSkeletonBox />
 <KSkeletonBox width="2" height="2"/>
 <KSkeletonBox width="5" height="2"/>
@@ -193,8 +202,8 @@ For example, here is a card skeleton with different arrangement of placeholders:
 <template>
   <KSkeleton class="k-skeleton-modified" type="card" :card-count="3">
     <template slot="card-header">
-      <div>
-        <div class="d-flex justify-content-center pb-3">
+      <div class="w-100">
+        <div class="justify-content-center pb-3">
           <KSkeletonBox width="5" />
         </div>
         <hr>
@@ -216,7 +225,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 ```vue
 <KSkeleton type="card" :card-count="3">
   <template slot="card-header">
-    <div>
+    <div class="w-100">
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
       </div>

--- a/packages/KSkeleton/CardSkeleton.vue
+++ b/packages/KSkeleton/CardSkeleton.vue
@@ -9,18 +9,17 @@
           <slot name="card-header">
             <KSkeletonBox
               height="2"
-              width="2" />
+              width="25" />
             <KSkeletonBox
               class="ml-2"
-              width="10"
+              width="75"
               height="2" />
             <hr class="mb-0">
           </slot>
         </div>
         <div class="skeleton-card-content">
           <slot name="card-content">
-            <KSkeletonBox
-              width="10" />
+            <KSkeletonBox width="10" />
           </slot>
         </div>
         <div class="skeleton-card-footer">
@@ -70,9 +69,11 @@ $borderColor: #e6e6e6;
   padding: 1rem;
   border-radius: 3px;
   border: 1px solid $borderColor;
+  overflow: hidden;
   .skeleton-card-header {
     width: 100%;
     margin-bottom: 1rem;
+    display: flex;
   }
   .skeleton-card-content {
     display: flex;

--- a/packages/KSkeleton/CardSkeleton.vue
+++ b/packages/KSkeleton/CardSkeleton.vue
@@ -1,22 +1,33 @@
-<template functional>
+<template>
   <div class="skeleton-card-wrapper">
     <div
-      v-for="c in props.cardCount"
+      v-for="c in cardCount"
       :key="c"
       class="skeleton-card-column">
       <div class="skeleton-card">
         <div class="skeleton-card-header">
-          <div class="box width-2 height-2" />
-          <div class="box width-10 height-2" />
+          <slot name="card-header">
+            <KSkeletonBox
+              height="2"
+              width="2" />
+            <KSkeletonBox
+              class="ml-2"
+              width="10"
+              height="2" />
+            <hr class="mb-0">
+          </slot>
         </div>
-        <div class="skeleton-card-subheader">
-          <div class="box width-6 height-1" />
-          <div class="box width-6 height-1" />
+        <div class="skeleton-card-content">
+          <slot name="card-content">
+            <KSkeletonBox
+              width="10" />
+          </slot>
         </div>
         <div class="skeleton-card-footer">
-          <div class="box width-5 height-1" />
-          <div class="box width-5 height-1" />
-          <div class="box width-5 height-1" />
+          <slot name="card-footer">
+            <KSkeletonBox width="5" />
+            <KSkeletonBox width="5" />
+          </slot>
         </div>
       </div>
     </div>
@@ -24,8 +35,11 @@
 </template>
 
 <script>
+import KSkeletonBox from './KSkeletonBox'
+
 export default {
   name: 'CardSkeleton',
+  components: { KSkeletonBox },
   props: {
     cardCount: {
       type: Number,
@@ -44,9 +58,9 @@ $borderColor: #e6e6e6;
 }
 
 .skeleton-card-column {
-  width: 33.33%;
   padding: 0 1rem 0 0;
   margin-bottom: 1rem;
+  width: var(--KSkeletonCardWidth, 33%);
 }
 
 .skeleton-card {
@@ -58,14 +72,9 @@ $borderColor: #e6e6e6;
   border: 1px solid $borderColor;
   .skeleton-card-header {
     width: 100%;
-    padding-bottom: 1rem;
     margin-bottom: 1rem;
-    border-bottom: 1px dotted $borderColor;
-    > div:nth-of-type(2) {
-      margin-left: 1rem;
-    }
   }
-  .skeleton-card-subheader {
+  .skeleton-card-content {
     display: flex;
     justify-content: space-between;
   }
@@ -76,7 +85,6 @@ $borderColor: #e6e6e6;
     width: 100%;
     margin-top: auto;
     padding-top: 1rem;
-    border-top: 1px solid $borderColor;
   }
 }
 </style>

--- a/packages/KSkeleton/FormSkeleton.vue
+++ b/packages/KSkeleton/FormSkeleton.vue
@@ -1,27 +1,46 @@
-<template functional>
+<template>
   <div class="skeleton-form-wrapper">
     <div class="skeleton-form-row">
-      <div class="box width-10 height-1" />
-      <div class="box width-100 height-2" />
+      <KSkeletonBox
+        width="10"
+        height="1" />
+      <KSkeletonBox
+        width="100"
+        height="2" />
     </div>
     <div class="skeleton-form-row">
-      <div class="box width-10 height-1" />
-      <div class="box width-100 height-2" />
+      <KSkeletonBox
+        width="10"
+        height="1" />
+      <KSkeletonBox
+        width="100"
+        height="2" />
     </div>
     <div class="skeleton-form-row">
-      <div class="box width-10 height-1" />
-      <div class="box width-100 height-2" />
+      <KSkeletonBox
+        width="10"
+        height="1" />
+      <KSkeletonBox
+        width="100"
+        height="2" />
     </div>
     <div class="skeleton-form-row">
-      <div class="box width-10 height-1" />
-      <div class="box width-100 height-2" />
+      <KSkeletonBox
+        width="10"
+        height="1" />
+      <KSkeletonBox
+        width="100"
+        height="2" />
     </div>
   </div>
 </template>
 
 <script>
+import KSkeletonBox from './KSkeletonBox'
+
 export default {
-  name: 'FormSkeleton'
+  name: 'FormSkeleton',
+  components: { KSkeletonBox }
 }
 </script>
 

--- a/packages/KSkeleton/KSkeleton.spec.js
+++ b/packages/KSkeleton/KSkeleton.spec.js
@@ -1,98 +1,115 @@
 import { mount } from '@vue/test-utils'
 import KSkeleton from '@/KSkeleton/KSkeleton'
+import KSkeletonBox from '@/KSkeleton/KSkeletonBox'
 
 describe('KSkeleton', () => {
-  it('renders generic skeleton state by default', () => {
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        delayMilliseconds: 0
-      }
+  describe('variants', () => {
+    it('renders generic skeleton state by default', () => {
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.find('.skeleton-loader').exists()).toBe(true)
     })
 
-    expect(wrapper.find('.skeleton-loader').exists()).toBe(true)
+    it('renders form skeleton state with 4 rows by default', () => {
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          type: 'form',
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.find('.skeleton-form-wrapper').exists()).toBe(true)
+      expect(wrapper.findAll('.skeleton-form-row')).toHaveLength(4)
+    })
+
+    it('renders card skeleton state with 2 cards', () => {
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          type: 'card',
+          cardCount: 2,
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.find('.skeleton-card-wrapper').exists()).toBe(true)
+      expect(wrapper.findAll('.skeleton-card')).toHaveLength(2)
+    })
+
+    it('renders table skeleton state with 6 rows by default', () => {
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          type: 'table',
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.find('.skeleton-table-wrapper').exists()).toBe(true)
+      expect(wrapper.findAll('.skeleton-table-row')).toHaveLength(6)
+    })
+
+    it('renders spinner skeleton state', () => {
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          type: 'spinner',
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.find('.kong-icon').exists()).toBe(true)
+    })
+
+    it('renders full screen loader with progress bar', () => {
+      jest.useFakeTimers()
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          type: 'fullscreen-kong',
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.find('[data-testid="full-screen-loader"]').exists()).toBe(true)
+
+      const progressBar = wrapper.find('[role="progressbar"]')
+
+      expect(progressBar.exists()).toBe(true)
+      const getProgressValue = () => parseInt(progressBar.element.style.width.split('%')[0])
+
+      expect(getProgressValue()).toEqual(0)
+
+      jest.advanceTimersByTime(300)
+      expect(getProgressValue()).toBeGreaterThan(0)
+      expect(getProgressValue()).toBeLessThan(100)
+
+      jest.advanceTimersByTime(3000)
+      expect(getProgressValue()).toEqual(100)
+    })
+
+    it('matches snapshot', () => {
+      const wrapper = mount(KSkeleton, {
+        propsData: {
+          delayMilliseconds: 0
+        }
+      })
+
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
+  describe('KSkeletonBox', () => {
+    it('renders width and height', () => {
+      const wrapper1 = mount(KSkeletonBox)
+      const wrapper2 = mount(KSkeletonBox, {
+        propsData: {
+          height: '2',
+          width: '100'
+        }
+      })
 
-  it('renders form skeleton state with 4 rows by default', () => {
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        type: 'form',
-        delayMilliseconds: 0
-      }
+      expect(wrapper1.html()).toMatchSnapshot()
+      expect(wrapper2.html()).toMatchSnapshot()
     })
-
-    expect(wrapper.find('.skeleton-form-wrapper').exists()).toBe(true)
-    expect(wrapper.findAll('.skeleton-form-row')).toHaveLength(4)
-  })
-
-  it('renders card skeleton state with 2 cards', () => {
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        type: 'card',
-        cardCount: 2,
-        delayMilliseconds: 0
-      }
-    })
-
-    expect(wrapper.find('.skeleton-card-wrapper').exists()).toBe(true)
-    expect(wrapper.findAll('.skeleton-card')).toHaveLength(2)
-  })
-
-  it('renders table skeleton state with 6 rows by default', () => {
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        type: 'table',
-        delayMilliseconds: 0
-      }
-    })
-
-    expect(wrapper.find('.skeleton-table-wrapper').exists()).toBe(true)
-    expect(wrapper.findAll('.skeleton-table-row')).toHaveLength(6)
-  })
-
-  it('renders spinner skeleton state', () => {
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        type: 'spinner',
-        delayMilliseconds: 0
-      }
-    })
-
-    expect(wrapper.find('.kong-icon').exists()).toBe(true)
-  })
-
-  it('renders full screen loader with progress bar', () => {
-    jest.useFakeTimers()
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        type: 'fullscreen-kong',
-        delayMilliseconds: 0
-      }
-    })
-
-    expect(wrapper.find('[data-testid="full-screen-loader"]').exists()).toBe(true)
-
-    const progressBar = wrapper.find('[role="progressbar"]')
-
-    expect(progressBar.exists()).toBe(true)
-    const getProgressValue = () => parseInt(progressBar.element.style.width.split('%')[0])
-
-    expect(getProgressValue()).toEqual(0)
-
-    jest.advanceTimersByTime(300)
-    expect(getProgressValue()).toBeGreaterThan(0)
-    expect(getProgressValue()).toBeLessThan(100)
-
-    jest.advanceTimersByTime(3000)
-    expect(getProgressValue()).toEqual(100)
-  })
-
-  it('matches snapshot', () => {
-    const wrapper = mount(KSkeleton, {
-      propsData: {
-        delayMilliseconds: 0
-      }
-    })
-
-    expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/packages/KSkeleton/KSkeleton.vue
+++ b/packages/KSkeleton/KSkeleton.vue
@@ -2,14 +2,26 @@
   <div
     v-if="isVisible || delayMilliseconds === 0"
     :class="{ 'w-100': type !== 'spinner' }"
-    class="k-loading-state">
+    class="d-flex flex-wrap">
     <CardSkeleton
       v-if="type === 'card'"
-      :card-count="cardCount "/>
+      :card-count="cardCount ">
+      <template slot="card-header">
+        <slot name="card-header" />
+      </template>
+      <template slot="card-content">
+        <slot name="card-content" />
+      </template>
+      <template slot="card-footer">
+        <slot name="card-footer" />
+      </template>
+    </CardSkeleton>
     <TableSkeleton
       v-else-if="type === 'table'"
       :columns="tableColumns"
-      :rows="tableRows"/>
+      :rows="tableRows">
+      <slot />
+    </TableSkeleton>
     <FormSkeleton v-else-if="type === 'form'"/>
     <FullScreenKongSkeleton
       v-else-if="type === 'fullscreen-kong'"
@@ -18,7 +30,7 @@
       v-else-if="type === 'spinner'"
       icon="spinner"
       view-box="0 0 16 16"
-      color="#000" />
+      color="#000"/>
     <Skeleton v-else />
   </div>
 </template>
@@ -92,74 +104,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss">
-.k-loading-state {
-  display: flex;
-  flex-wrap: wrap;
-  .box {
-    display: inline-flex;
-    border-radius: 3px;
-    background: linear-gradient(
-        -70deg,
-        #f2f2f2 0%,
-        #f2f2f2 40%,
-        #f7f7f7 50%,
-        #f2f2f2 60%,
-        #f2f2f2 100%
-      )
-      repeat;
-    background-size: 400% 100%;
-    animation: gradient 1s ease infinite;
-
-    // Provided box widths
-    &.width {
-      &-1 {
-        width: 1rem;
-      }
-      &-2 {
-        width: 2rem;
-      }
-      &-5 {
-        width: 5rem;
-      }
-      &-6 {
-        width: 6rem;
-      }
-      &-10 {
-        width: 10rem;
-      }
-      &-12 {
-        width: 12rem;
-      }
-      &-50 {
-        width: 50%;
-      }
-      &-80 {
-        width: 80%;
-      }
-      &-100 {
-        width: 100%;
-      }
-    }
-    // Provided box heights
-    &.height {
-      &-1 {
-        height: 1rem;
-      }
-      &-2 {
-        height: 2rem;
-      }
-    }
-  }
-}
-
-@keyframes gradient {
-  0% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-</style>

--- a/packages/KSkeleton/KSkeletonBox.vue
+++ b/packages/KSkeleton/KSkeletonBox.vue
@@ -13,7 +13,7 @@ export default {
       type: String,
       default: '1',
       validator: function (val) {
-        return ['1', '2', '5', '6', '10', '12', '25', '50', '75', '100'].includes(val)
+        return ['1', '2', '5', '6', '10', '25', '50', '75', '100'].includes(val)
       }
     },
     height: {

--- a/packages/KSkeleton/KSkeletonBox.vue
+++ b/packages/KSkeleton/KSkeletonBox.vue
@@ -1,0 +1,98 @@
+<template>
+  <div
+    :class="{[`width-${width}`]: true, [`height-${height}`]: true }"
+    class="box"
+  />
+</template>
+
+<script>
+export default {
+  name: 'KSkeletonBox',
+  props: {
+    width: {
+      type: String,
+      default: '1',
+      validator: function (val) {
+        return ['1', '2', '5', '6', '10', '12', '50', '80', '100'].includes(val)
+      }
+    },
+    height: {
+      type: String,
+      default: '1',
+      validator: function (val) {
+        return ['1', '2', '100'].includes(val)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.box {
+  display: inline-flex;
+  border-radius: 3px;
+  background: linear-gradient(
+      -70deg,
+      #f2f2f2 0%,
+      #f2f2f2 40%,
+      #f7f7f7 50%,
+      #f2f2f2 60%,
+      #f2f2f2 100%
+    )
+    repeat;
+  background-size: 400% 100%;
+  animation: gradient 1s ease infinite;
+
+  // Provided box widths
+  &.width {
+    &-1 {
+      width: 1rem;
+    }
+    &-2 {
+      width: 2rem;
+    }
+    &-5 {
+      width: 5rem;
+    }
+    &-6 {
+      width: 6rem;
+    }
+    &-10 {
+      width: 10rem;
+    }
+    &-12 {
+      width: 12rem;
+    }
+    &-50 {
+      width: 50%;
+    }
+    &-80 {
+      width: 80%;
+    }
+    &-100 {
+      width: 100%;
+    }
+  }
+  // Provided box heights
+  &.height {
+    &-1 {
+      height: 1rem;
+    }
+    &-2 {
+      height: 2rem;
+    }
+    &-100 {
+      height: 100%;
+    }
+  }
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+</style>

--- a/packages/KSkeleton/KSkeletonBox.vue
+++ b/packages/KSkeleton/KSkeletonBox.vue
@@ -13,14 +13,14 @@ export default {
       type: String,
       default: '1',
       validator: function (val) {
-        return ['1', '2', '5', '6', '10', '12', '50', '80', '100'].includes(val)
+        return ['1', '2', '5', '6', '10', '12', '25', '50', '75', '100'].includes(val)
       }
     },
     height: {
       type: String,
       default: '1',
       validator: function (val) {
-        return ['1', '2', '100'].includes(val)
+        return ['1', '2'].includes(val)
       }
     }
   }
@@ -58,15 +58,15 @@ export default {
       width: 6rem;
     }
     &-10 {
-      width: 10rem;
+      width: 25%;
     }
-    &-12 {
-      width: 12rem;
+    &-25 {
+      width: 25%;
     }
     &-50 {
       width: 50%;
     }
-    &-80 {
+    &-75 {
       width: 80%;
     }
     &-100 {
@@ -80,9 +80,6 @@ export default {
     }
     &-2 {
       height: 2rem;
-    }
-    &-100 {
-      height: 100%;
     }
   }
 }

--- a/packages/KSkeleton/Skeleton.vue
+++ b/packages/KSkeleton/Skeleton.vue
@@ -8,7 +8,7 @@
         width="100"
         height="1"/>
       <KSkeletonBox
-        width="80"
+        width="75"
         height="1"/>
     </slot>
   </div>

--- a/packages/KSkeleton/Skeleton.vue
+++ b/packages/KSkeleton/Skeleton.vue
@@ -1,14 +1,25 @@
-<template functional>
+<template>
   <div class="skeleton-loader">
-    <div class="box width-100 height-1"/>
-    <div class="box width-100 height-1"/>
-    <div class="box width-80 height-1"/>
+    <slot>
+      <KSkeletonBox
+        width="100"
+        height="1"/>
+      <KSkeletonBox
+        width="100"
+        height="1"/>
+      <KSkeletonBox
+        width="80"
+        height="1"/>
+    </slot>
   </div>
 </template>
 
 <script>
+import KSkeletonBox from './KSkeletonBox.vue'
+
 export default {
-  name: 'Skeleton'
+  name: 'Skeleton',
+  components: { KSkeletonBox }
 }
 </script>
 

--- a/packages/KSkeleton/TableSkeleton.vue
+++ b/packages/KSkeleton/TableSkeleton.vue
@@ -1,26 +1,33 @@
-<template functional>
+<template>
   <div class="skeleton-table-wrapper">
     <div
-      v-for="row in props.rows"
+      v-for="row in rows"
       :key="row"
       class="skeleton-table-row">
-      <div
-        v-for="cell in props.columns"
-        :key="cell"
-        :class="{
-          'mr-6': cell !== props.columns,
-          'ml-auto': cell === props.columns,
-          'width-10': [3,4].indexOf(cell) === -1 && cell !== props.columns,
-          'width-6': [3,4].indexOf(cell) > -1 || cell === props.columns
-        }"
-        class="box height-1 skeleton-cell"/>
+      <slot>
+        <KSkeletonBox
+          v-for="cell in columns"
+          :key="cell"
+          :width="calcWidth(cell, columns)"
+          :class="{
+            'mr-6': cell !== columns,
+            'ml-auto': cell === columns,
+            'skeleton-cell': true
+          }"
+        />
+      </slot>
     </div>
   </div>
 </template>
 
 <script>
+import KSkeletonBox from './KSkeletonBox'
+
 export default {
   name: 'TableSkeleton',
+  components: {
+    KSkeletonBox
+  },
   props: {
     rows: {
       type: Number,
@@ -29,6 +36,13 @@ export default {
     columns: {
       type: Number,
       default: 6
+    }
+  },
+
+  methods: {
+    calcWidth (cell, columns) {
+      if ([3, 4].indexOf(cell) === -1 && cell !== columns) return '10'
+      if ([3, 4].indexOf(cell) > -1 || cell === columns) return '6'
     }
   }
 }

--- a/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
+++ b/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KSkeleton matches snapshot 1`] = `
-<div class="k-loading-state w-100">
+exports[`KSkeleton KSkeletonBox renders width and height 1`] = `<div class="box width-1 height-1"></div>`;
+
+exports[`KSkeleton KSkeletonBox renders width and height 2`] = `<div class="box width-100 height-2"></div>`;
+
+exports[`KSkeleton variants matches snapshot 1`] = `
+<div class="d-flex flex-wrap w-100">
   <div class="skeleton-loader">
     <div class="box width-100 height-1"></div>
     <div class="box width-100 height-1"></div>

--- a/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
+++ b/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
@@ -9,7 +9,7 @@ exports[`KSkeleton variants matches snapshot 1`] = `
   <div class="skeleton-loader">
     <div class="box width-100 height-1"></div>
     <div class="box width-100 height-1"></div>
-    <div class="box width-80 height-1"></div>
+    <div class="box width-75 height-1"></div>
   </div>
 </div>
 `;

--- a/packages/KSkeleton/index.js
+++ b/packages/KSkeleton/index.js
@@ -1,0 +1,16 @@
+import KSkeleton from './KSkeleton'
+import KSkeletonBox from './KSkeletonBox'
+
+const Plugin = {
+  install (Vue) {
+    Vue.component('KSkeleton', KSkeleton)
+    Vue.component('KSkeletonBox', KSkeletonBox)
+  }
+}
+
+export default Plugin
+export { KSkeleton, KSkeletonBox }
+
+if (typeof window !== 'undefined' && window.Vue) {
+  window.Vue.use(Plugin)
+}

--- a/packages/KSkeleton/package.json
+++ b/packages/KSkeleton/package.json
@@ -4,10 +4,11 @@
   "description": "Loading/Skeleton state component",
   "main": "dist/KSkeleton.umd.min.js",
   "componentName": "KSkeleton",
-  "source": "KSkeleton.vue",
+  "source": "index.js",
   "files": [
     "dist",
-    "KSkeleton.vue"
+    "*.vue",
+    "index.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary
Introduce a new skeleton component `<KSkeletonBox />` which allows users to compose skeletons to form their own placeholder content. This was born from needing to create a custom placeholder that looks more like the content it is place-holding. For example, Kong Manager there are multiple cards with different layouts, so instead of making the cards look generic everywhere, allow them to be composable and specialized to the content. e.g. plugin select cards, workspace dashboard cards. Check new docs in this PR for more information on usage.

#### Changes made:
* export kskeleton as a plugin, auto-importing components
* use KSkeletonBox in all the skeleton variants
* slot content in skeleton card
* allow KSkeletonBox to be used as a primitive outside of KSkeleton

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
