### PR TITLE
styles(*) Fix broken & missing styles

### DIFF
--- a/docs/.vuepress/components/swatch.vue
+++ b/docs/.vuepress/components/swatch.vue
@@ -5,7 +5,8 @@
       class="swatch" />
     <div class="description">
       <span>{{ colorName(color) }}</span>
-      <span>{{ colorValue(color) }}</span>
+      <span class="mb-2">{{ colorValue(color) }}</span>
+      <code>.color-{{ colorName(color) }}</code>
     </div>
   </div>
 </template>
@@ -47,7 +48,6 @@ export default {
 <style scoped lang="scss">
 .swatch-container {
   display: flex;
-  align-items: center;
   padding: 1.5rem 0;
   border-bottom: 1px solid #efefef;
   .swatch {

--- a/docs/.vuepress/components/text-block.vue
+++ b/docs/.vuepress/components/text-block.vue
@@ -10,7 +10,7 @@
       <strong>Class:</strong> <code>.type-{{variableName}}</code>
     </div>
     <div class="example">
-      <p :class="[variableName, fontType === 'mono' && 'mono']">
+      <p :class="[`type-${variableName}`, fontType === 'mono' && 'mono']">
         Kong is a Lua application running in Nginx
       </p>
     </div>

--- a/docs/.vuepress/components/text-block.vue
+++ b/docs/.vuepress/components/text-block.vue
@@ -6,6 +6,9 @@
     <div class="label">
       <strong>Font Size:</strong> <span>{{ fontSize }}</span>
     </div>
+    <div class="label">
+      <strong>Class:</strong> <code>.type-{{variableName}}</code>
+    </div>
     <div class="example">
       <p :class="[variableName, fontType === 'mono' && 'mono']">
         Kong is a Lua application running in Nginx

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -81,6 +81,17 @@ KButton can render either a `<a>` or `<router-link>` by simply passing the `to` 
 ### Icon
 KButton supports using an icon either before the text or without text.  
 
+<KButton appearance="secondary">
+  <KIcon
+    slot="icon"
+    icon="gear" />With Text
+</KButton>
+<KButton appearance="secondary">
+  <KIcon
+    slot="icon"
+    icon="gear" />
+</KButton>
+
 ```vue
 <KButton appearance="secondary">
   <KIcon

--- a/docs/style-guide/forms.md
+++ b/docs/style-guide/forms.md
@@ -15,7 +15,11 @@ Here is an example of html elements being styled using the including css.
 <input class="k-input mb-2" readonly value="readonly"/>
 <input class="k-input mb-2" type="search" value="search"/>
 <input class="k-input mb-2" type="email" value="error"/>
-
+<select class="k-input">
+  <option value="option1">Option 1</option>
+  <option value="option2">Option 2</option>
+  <option value="option3">Option 3</option>
+</select>
 
 ```html
 <input class="k-input" placeholder="placeholder" />
@@ -26,6 +30,11 @@ Here is an example of html elements being styled using the including css.
 <input class="k-input" readonly value="readonly"/>
 <input class="k-input" type="search" value="search"/>
 <input class="k-input" type="email" value="error"/>
+<select class="k-input">
+  <option value="option1">Option 1</option>
+  <option value="option2">Option 2</option>
+  <option value="option3">Option 3</option>
+</select>
 ```
 
 ## Checkboxes & Radios

--- a/docs/style-guide/utilities.md
+++ b/docs/style-guide/utilities.md
@@ -105,6 +105,21 @@ Example: .pt-2 would add 8px of padding to the top of the element and.mx-0 would
 | .align-self-baseline |  align-self: baseline;
 | .align-self-stretch |  align-self: stretch;
 
+## Colors
+For each color in our [color palette](/style-guide/colors.html) we include a utility class that is prefixed with `color-`.
+
+| Class       | Properties      | Example
+| :---------- |:-------------- |:-----------
+| .type-{color} | color: var(--{color}) | `class="color-blue-base"`
+
+## Type Sizes
+For each size in our [type definitions](/style-guide/type.html) we include a utility class that is prefixed with `type-`. You can also add the class of `.mono` to style as mono
+
+| Class       | Properties      | Example
+| :---------- |:-------------- |:-----------
+| .type-{type-size} | font-size: var(--type-{size}) | `class="type-xl"`
+| .mono | font-size: calc(var(--type-{size}) * .95) | `class="mono type-xl"`
+
 ## General Helpers
 | Class       |Properties
 | :---------- |:-------------- |:-----------

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -81,11 +81,11 @@ export default {
     },
 
     hasIcon () {
-      return this.$slots.icon
+      return !!this.$slots.icon
     },
 
     hasText () {
-      return this.$slots.default
+      return !!this.$slots.default
     },
 
     buttonType () {
@@ -131,9 +131,7 @@ export default {
   }
 
   &.icon-btn {
-    width: 38px;
-    height: auto;
-    padding: 0;
+    height: 38px;
     justify-content: center;
     > svg {
       padding-right: 0;

--- a/packages/styles/_typography.scss
+++ b/packages/styles/_typography.scss
@@ -3,9 +3,9 @@
 /* Regular (Sans) Font Sizes
 ========================================================================== */
 // For each size in the $type-sizes variable
-// Create class (.xxl)
+// Create class (.type-xxl)
 @each $name, $size in $type-sizes {
-  .#{$name} {
+  .type-#{$name} {
     font-size: var(--type-#{$name});
     font-weight: normal;
   }
@@ -19,9 +19,17 @@
 // For each size in the $type-sizes variable
 // Create class (.mono.xxl)
 @each $name, $size in $type-sizes {
-  .mono.#{$name} {
+  .mono.type-#{$name} {
     font-size: calc(var(--type-#{$name}) * .95);
   }
 }
 
-
+/*  Colors
+========================================================================== */
+// For each color in $colors variable
+// Create class (.color-blue-base)
+@each $name, $color in $colors {
+  .color-#{$name} {
+    color: var(--#{$name})
+  }
+}

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -1,7 +1,7 @@
 @import "labels";
 
 .k-input,
-.form-control{
+.form-control {
   $borderColor: var(--KInputBorder, var(--grey-88, color(grey-88)));
 
   &:not([type="checkbox"]),

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -1,7 +1,7 @@
 @import "labels";
 
 .k-input,
-.form-control {
+.form-control{
   $borderColor: var(--KInputBorder, var(--grey-88, color(grey-88)));
 
   &:not([type="checkbox"]),
@@ -65,5 +65,15 @@
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23000' fill-opacity='.45' fill-rule='evenodd' d='M6 12c-3.3137085 0-6-2.6862915-6-6s2.6862915-6 6-6 6 2.6862915 6 6c0 1.29583043-.410791 2.49571549-1.1092521 3.47653436l1.2305724 1.23057244 2.8232632 2.8338633c.3897175.3911808.3947266 1.0192147.005164 1.4087774-.3868655.3868655-1.014825.3873148-1.4087774-.005164l-2.8338633-2.8232632-1.23057244-1.2305724C8.49571549 11.589209 7.29583043 12 6 12zm4-6c0-2.209139-1.790861-4-4-4S2 3.790861 2 6s1.790861 4 4 4 4-1.790861 4-4z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: 12px 50%;
+  }
+}
+
+select.k-input {
+  &:not([type="checkbox"]),
+  &:not([type="checkbox"]):read-only,
+  &:not([type="radio"]),
+  &:not([type="radio"]):read-only {
+    height: 38px;
+    background-color: var(--KInputSelectBackground, var(--twhite-1, color(twhite-1)));
   }
 }


### PR DESCRIPTION
### Summary
- Updates type sizing classes (`.xl`-> `.type-xl`)
- Adds color classes to utils (`.color-blue-base`)
- Adds missing styles for `<select />`
- Fixes svg sizing/spacing in KButton as well as the slot checks

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
