### PR TITLE
feat(KInlineEdit): Adds KInlineEdit component

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,6 +46,7 @@ module.exports = {
               '/components/button',
               '/components/card',
               '/components/empty-state',
+              '/components/inline-edit',
               '/components/input-checkbox',
               '/components/input',
               '/components/icon',

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -11,6 +11,7 @@ import KClipboardProvider from '../../packages/KClipboardProvider/KClipboardProv
 import KMultiselect from '../../packages/KMultiselect/KMultiselect.vue'
 import KEmptyState from '../../packages/KEmptyState/KEmptyState.vue'
 import KIcon from '../../packages/KIcon/KIcon.vue'
+import KInlineEdit from '../../packages/KInlineEdit/KInlineEdit.vue'
 import KInput from '../../packages/KInput/KInput.vue'
 import KInputSwitch from '../../packages/KInputSwitch/KInputSwitch.vue'
 import KCheckbox from '../../packages/KCheckbox/KCheckbox.vue'
@@ -43,6 +44,7 @@ export default ({
   Vue.component('KMultiselect', KMultiselect)
   Vue.component('KEmptyState', KEmptyState)
   Vue.component('KIcon', KIcon)
+  Vue.component('KInlineEdit', KInlineEdit)
   Vue.component('KInput', KInput)
   Vue.component('KInputSwitch', KInputSwitch)
   Vue.component('KCheckbox', KCheckbox)

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -39,15 +39,13 @@ export default {
 </script>
 ```
 
-<Komponent :data="{ inlineText: 'Cool Text', emitedVal: '' }" v-slot="{ data }">
 <KCard>
   <template slot="body">
-    <div class="mb-4">Emit Value: {{ data.emitedVal }}</div>
+    <div class="mb-4">Emit Value: {{ emittedVal }}</div>
     <label class="k-input-label">Click to edit</label>
-    <KInlineEdit @changed="val => data.emitedVal = val"><p class="mt-0 mb-0">{{ data.emitedVal || data.inlineText }}</p></KInlineEdit>
+    <KInlineEdit @changed="handleEmitChange"><p class="mt-0 mb-0">{{ emittedDefault }}</p></KInlineEdit>
   </template>
 </KCard>
-</Komponent>
 
 ## Slots
 - `default` - Content to be edited
@@ -69,4 +67,33 @@ An HTML element must be passed in the slot. An error will be thrown if not passe
 :::
 
 ## Theming
-:lipstick: To theme, reference [KInput](/components/input.html#theming).
+:lipstick: To theme, reference [KInput](/components/input.html#theming). The input takes up 100% of its parent container. To change, add a class or width styling to the wrapping component.
+
+<Komponent :data="{ inlineText: 'Im 50%!' }" v-slot="{ data }">
+  <KInlineEdit class="w-50" @changed="newVal => data.inlineText = newVal"><h3>{{ data.inlineText }}</h3></KInlineEdit>
+</Komponent>
+
+```vue
+<KInlineEdit
+  class="w-50"
+  @changed="newVal => text = newVal">
+  <h3>{{ text }}</h3>
+</KInlineEdit>
+```
+
+<script>
+export default {
+  data() {
+    return {
+      emittedVal: '',
+      emittedDefault: 'Cool Text'
+    }
+  },
+  methods: {
+    handleEmitChange(val) {
+      this.emittedVal = val
+      this.emittedDefault = val
+    }
+  }
+}
+</script>

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -17,35 +17,39 @@
 ```
 
 ## Props
-- `@changed` - Emitted blurred away from the editing input
+- `@changed` - Emitted blurred away from the editing input or when enter is pressed.
 
-When clicking out of the input `@changed` will fire and emit the value. Can be used to reset the outside data
+When clicking out of the input `@changed` will fire and emit the value. Can be used to reset the outside data.
 
-```vue
-<template>
-  <label>Click this text</label>
-  <EditableInput @changed="newValue => editableText = newValue ">
-    <h4>{{ editableText }}</h4>
-  </EditableInput>
-</template>
-<script>
-export default {
-  data() {
-    return {
-      editableText: 'Cool Text'
-    }
-  }
-}
-</script>
-```
+:::tip
+While the component itself does not protect against returning empty an empty value, it is advised to do a check at the implementation layer to ensure empty & validation are accounted for.
+:::
 
 <KCard>
   <template slot="body">
-    <div class="mb-4">Emit Value: {{ emittedVal }}</div>
-    <label class="k-input-label">Click to edit</label>
-    <KInlineEdit @changed="handleEmitChange"><p class="mt-0 mb-0">{{ emittedDefault }}</p></KInlineEdit>
+    <Komponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
+      <div>
+        Updated: {{ data.inlineText }}
+        <KInlineEdit @changed="newVal => { if(newVal.length) { data.inlineText = newVal } else { alert('cannot be empty') } }">
+          <h3>{{ data.inlineText }}</h3>
+        </KInlineEdit>
+      </div>
+    </Komponent>
   </template>
 </KCard>
+
+> The `Komponent` component is used in this example to create state.
+
+```vue
+<Komponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
+  <div>
+    Updated: {{ data.inlineText }}
+    <KInlineEdit @changed="newVal => { if(newVal.length) { data.inlineText = newVal } else { alert('cannot be empty') } }">
+      <h3>{{ data.inlineText }}</h3>
+    </KInlineEdit>
+  </div>
+</Komponent>
+```
 
 ## Slots
 - `default` - Content to be edited
@@ -83,16 +87,9 @@ An HTML element must be passed in the slot. An error will be thrown if not passe
 
 <script>
 export default {
-  data() {
-    return {
-      emittedVal: '',
-      emittedDefault: 'Cool Text'
-    }
-  },
   methods: {
-    handleEmitChange(val) {
-      this.emittedVal = val
-      this.emittedDefault = val
+    alert(msg) {
+      window.alert(msg)
     }
   }
 }

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -1,0 +1,72 @@
+# Inline Edit
+
+**KInlineEdit** - A wrapper which adds inline edit capability. Currently only supports single text input.
+
+<Komponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
+  <KInlineEdit @changed="newVal => data.inlineText = newVal"><h3>{{ data.inlineText }}</h3></KInlineEdit>
+</Komponent>
+
+> The `Komponent` component is used in this example to create state.
+
+```vue
+<Komponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
+  <KInlineEdit>
+    <h3>{{ data.inlineText }}</h3>
+  </KInlineEdit>
+</Komponent>
+```
+
+## Props
+- `@changed` - Emitted blurred away from the editing input
+
+When clicking out of the input `@changed` will fire and emit the value. Can be used to reset the outside data
+
+```vue
+<template>
+  <label>Click this text</label>
+  <EditableInput @changed="newValue => editableText = newValue ">
+    <h4>{{ editableText }}</h4>
+  </EditableInput>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      editableText: 'Cool Text'
+    }
+  }
+}
+</script>
+```
+
+<Komponent :data="{ inlineText: 'Cool Text', emitedVal: '' }" v-slot="{ data }">
+<KCard>
+  <template slot="body">
+    <div class="mb-4">Emit Value: {{ data.emitedVal }}</div>
+    <label class="k-input-label">Click to edit</label>
+    <KInlineEdit @changed="val => data.emitedVal = val"><p class="mt-0 mb-0">{{ data.emitedVal || data.inlineText }}</p></KInlineEdit>
+  </template>
+</KCard>
+</Komponent>
+
+## Slots
+- `default` - Content to be edited
+
+:::warning
+An HTML element must be passed in the slot. An error will be thrown if not passed.
+
+```vue
+<!-- good -->
+<KInlineEdit>
+  <p>Some text</p>
+</KInlineEdit>
+
+<!-- bad -->
+<KInlineEdit>
+  Some text
+</KInlineEdit>
+```
+:::
+
+## Theming
+:lipstick: To theme, reference [KInput](/components/input.html#theming).

--- a/packages/KInlineEdit/KInlineEdit.spec.js
+++ b/packages/KInlineEdit/KInlineEdit.spec.js
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils'
+import KInlineEdit from '@/KInlineEdit/KInlineEdit'
+
+describe('KInlineEdit', () => {
+  it('copies element css to input on click', () => {
+    const wrapper = mount(KInlineEdit, {
+      slots: { default: '<p style="padding:10px">text</p>' }
+    })
+
+    wrapper.find('p').trigger('click')
+
+    expect(wrapper.find('.k-input').attributes().style).toBe('padding: 10px;')
+  })
+
+  it('console warns when html tag not passed in slot', () => {
+    console.warn = jest.fn()
+    mount(KInlineEdit, {
+      slots: { default: 'text' }
+    })
+
+    expect(console.warn).toBeTruthy()
+  })
+
+  it('emits updated text on blur', async () => {
+    const inputText = 'test'
+    const wrapper = mount(KInlineEdit, {
+      slots: { default: '<p>text</p>' }
+    })
+
+    wrapper.find('p').trigger('click')
+
+    await wrapper.vm.$nextTick()
+
+    const input = wrapper.find('.k-input')
+
+    input.setValue(inputText)
+    input.trigger('blur')
+    expect(wrapper.emitted().changed).toBeTruthy()
+    expect(wrapper.emitted().changed[0][0]).toEqual(inputText)
+  })
+
+  it('matches snapshot', () => {
+    const wrapper = mount(KInlineEdit, {
+      slots: { default: '<p>text</p>' }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -38,16 +38,6 @@ export default {
       styles: {}
     }
   },
-  computed: {
-    listeners () {
-      return {
-        ...this.$listeners,
-        blur: e => {
-          this.handleSave(e)
-        }
-      }
-    }
-  },
 
   mounted () {
     if (this.$slots.default[0].tag === undefined) {

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -1,0 +1,131 @@
+<template>
+  <div
+    id="editable-wrapper"
+    class="k-inline-edit">
+    <input
+      v-if="isEditing"
+      ref="input"
+      :style="styles"
+      v-model="inputText"
+      class="k-input"
+      @blur="handleSave"
+      @keyup.enter="handleSave">
+    <div
+      id="element-content-wrapper"
+      @click="handleClick">
+      <slot v-if="!isEditing" />
+    </div>
+  </div>
+</template>
+
+<script>
+// Styles we want copied from the element
+const STYLES = {
+  fontSize: 'font-size',
+  fontWeight: 'font-weight',
+  fontFamily: 'font-family',
+  color: 'color',
+  margin: 'margin',
+  padding: 'padding'
+}
+
+export default {
+  name: 'KInlineEdit',
+  data () {
+    return {
+      isEditing: false,
+      inputText: '',
+      styles: {}
+    }
+  },
+  computed: {
+    listeners () {
+      return {
+        ...this.$listeners,
+        blur: e => {
+          this.handleSave(e)
+        }
+      }
+    }
+  },
+
+  mounted () {
+    if (this.$slots.default[0].tag === undefined) {
+      console.warn(`KInlineEdit expects slotted HTML tag.
+
+Example usage:
+
+<KInlineEdit>
+  <p>Some text</p>
+</KInlineEdit>
+      `)
+    }
+  },
+
+  methods: {
+    async handleClick (e) {
+      // If clicking the slot wrapper lets exit out as to not
+      // copy its styles to the input
+      if (e.target.id === 'element-content-wrapper') return
+
+      // Get current STYLES off of the element
+      this.styles = this.getStyles(e.target)
+      this.inputText = e.target.innerText
+      this.isEditing = true
+
+      // Wait for vue to update styles & text
+      await this.$nextTick()
+      this.$refs.input.focus()
+    },
+
+    handleSave (e) {
+      this.isEditing = false
+      this.$emit('changed', this.inputText)
+    },
+
+    getStyles (element) {
+      const elementStyles = getComputedStyle(element)
+
+      return Object.keys(STYLES).reduce((acc, cur) => {
+        acc[cur] = elementStyles.getPropertyValue(STYLES[cur])
+
+        return acc
+      }, {})
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/forms/_inputs.scss';
+
+.k-inline-edit {
+  --padding: var(--spacing-xxs) var(--spacing-xs);
+  box-sizing: border-box;
+  > div {
+    display: inline-flex;
+    cursor: text;
+    > * {
+      border: 1px solid transparent;
+      border-radius: 3px;
+      padding: var(--padding);
+      margin-left: calc(-1 * var(--spacing-xs)); // align the left side of content
+      line-height: 1.20;
+      overflow: hidden;
+      transition: background-color 200ms ease;
+    }
+    &:hover > * {
+      background-color: var(--grey-92);
+    }
+  }
+  .k-input {
+    display: inline-flex;
+    padding: var(--padding);
+    &:focus,
+    &:hover {
+      background-color: var(--twhite-1);
+    }
+  }
+}
+</style>

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -11,6 +11,7 @@
       @blur="handleSave"
       @keyup.enter="handleSave">
     <div
+      v-if="!isEditing"
       id="element-content-wrapper"
       @click="handleClick">
       <slot v-if="!isEditing" />
@@ -103,7 +104,7 @@ Example usage:
       border-radius: 3px;
       padding: var(--padding);
       margin-left: calc(-1 * var(--spacing-xs)); // align the left side of content
-      line-height: 1.20;
+      line-height: 1.25;
       overflow: hidden;
       transition: background-color 200ms ease;
     }

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -121,6 +121,7 @@ Example usage:
   }
   .k-input {
     display: inline-flex;
+    width: 100%;
     padding: var(--padding);
     &:focus,
     &:hover {

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -9,7 +9,7 @@
       v-model="inputText"
       class="k-input"
       @blur="handleSave"
-      @keyup.enter="handleSave">
+      @keyup.enter="$event.target.blur()">
     <div
       v-if="!isEditing"
       id="element-content-wrapper"

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -95,8 +95,10 @@ Example usage:
   box-sizing: border-box;
   > div {
     display: inline-flex;
+    width: 100%;
     cursor: text;
     > * {
+      width: 100%;
       border: 1px solid transparent;
       border-radius: 3px;
       padding: var(--padding);
@@ -106,7 +108,7 @@ Example usage:
       transition: background-color 200ms ease;
     }
     &:hover > * {
-      background-color: var(--grey-92);
+      background-color: var(--blue-lightest);
     }
   }
   .k-input {

--- a/packages/KInlineEdit/README.md
+++ b/packages/KInlineEdit/README.md
@@ -1,0 +1,23 @@
+# @kongponents/kinlineedit
+
+[![](https://img.shields.io/npm/v/@kongponents/kinlineedit.svg?style=flat-square)](https://www.npmjs.com/package/@kongponents/kinlineedit)
+
+```vue
+<template>
+  <EditableInput @changed="val => textVal = val">
+    <h1>{{ textVal }}</h1>
+  </EditableInput>
+</template>
+<script>
+import EditableInput from "@/components/EditableInput";
+export default {
+  name: "App",
+  components: { EditableInput },
+  data() {
+    return {
+      textVal: "Inline Text"
+    };
+  }
+};
+</script>
+```

--- a/packages/KInlineEdit/__snapshots__/KInlineEdit.spec.js.snap
+++ b/packages/KInlineEdit/__snapshots__/KInlineEdit.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KInlineEdit matches snapshot 1`] = `
+<div id="editable-wrapper" class="k-inline-edit">
+  <!---->
+  <div id="element-content-wrapper">
+    <p>text</p>
+  </div>
+</div>
+`;

--- a/packages/KInlineEdit/package.json
+++ b/packages/KInlineEdit/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@kongponents/kinlineedit",
+  "version": "0.1.0",
+  "description": "Inline editable field.",
+  "main": "dist/KInlineEdit.umd.min.js",
+  "componentName": "KInlineEdit",
+  "source": "KInlineEdit.vue",
+  "files": [
+    "dist",
+    "KInlineEdit.vue"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kong/kongponents.git"
+  },
+  "author": "Kong Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Kong/kongponents/issues"
+  },
+  "homepage": "https://github.com/Kong/kongponents#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
### Summary
Adds inline edit. Currently only supports text input editing per feature request. More input types to come.

![Screen Recording 2020-06-12 at 4 30 20 PM](https://user-images.githubusercontent.com/5941111/84553864-33c2d800-acca-11ea-9c76-077790f6e16c.gif)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
