### PR TITLE
Feat/intf 2482 add table hover

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -95,6 +95,111 @@ Adds `cursor: pointer` and `user-select: none` styling.
   isClickable />
 ```
 
+### Custom Row Attributes
+
+There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row.
+This prop is on by default.
+These colors can be overridden and customized by using theme variables.
+
+Example with `hasSideBorder` set to false:
+
+<template>
+  <KTable
+    :options="tableOptions"
+    :hasSideBorder="false"
+    />
+</template>
+
+```vue
+<template>
+  <KTable
+    :options="tableOptions"
+    :hasSideBorder="false"
+    />
+</template>
+```
+
+Add custom properties to individual rows. The row object is passed as a param.
+
+- `rowAttrs` - is a Function that returns an object comprising the attributes.
+
+Example below:
+
+<template>
+  <KTable
+    :options="tableOptionsRowAttrs"
+    :rowAttrs="rowAttrsFn"
+    />
+</template>
+
+```vue
+<template>
+  <KTable
+    :options="tableOptions"
+    :rowAttrs="rowAttrsFn"
+    />
+</template>
+<script>
+import { defaultSorter } from '@kongponents/KTable'
+export default {
+  data() {
+    return {
+      row: null,
+      eventType: '',
+      tableOptions: {
+        headers: [
+          { label: 'Type', key: 'type' },
+          { label: 'Value', key: 'value' },
+          { label: 'Enabled', key: 'enabled'}
+        ],
+        data: [
+          {
+            type: 'desktop',
+            value: 'Windows 10',
+            enabled: 'true'
+          },
+          {
+            type: 'phone',
+            value: 'LineageOS',
+            enabled: 'false'
+          },
+          {
+            type: 'tablet',
+            value: 'ipadOS',
+            enabled: 'true'
+          }
+        ]
+      }
+    }
+  },
+  methods: {
+    rowAttrsFn (rowItem) {
+      return {
+        class: {
+          'enabled': rowItem.enabled === 'true',
+          'disabled': rowItem.enabled === 'false'
+        },
+        'data-testid': 'row-item'
+      }
+    }
+  }
+}
+</script>
+<style>
+.k-table {
+  tr.enabled {
+    --KTableHover: var(--green-200, #ccffe1);
+    --KTableBorder: var(--green-400, #19a654);
+  }
+
+  tr.disabled {
+    --KTableHover: var(--yellow-100, #fff9e6);
+    --KTableBorder: var(--yellow-200, #ffdc73);
+  }
+}
+</style>
+```
+
 ## Events
 Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to
 various parts of the table.
@@ -262,111 +367,6 @@ export default {
   }
 }
 </script>
-```
-
-## Custom Row Attributes
-
-There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row, using the color `steal-300` by default.
-This prop is on by default.
-These colors can be overridden by themes or by using custom row attributes.
-Example with `hasSideBorder` set to false:
-
-<template>
-  <KTable
-    :options="tableOptions"
-    :hasSideBorder="false"
-    />
-</template>
-
-```vue
-<template>
-  <KTable
-    :options="tableOptions"
-    :hasSideBorder="false"
-    />
-</template>
-```
-
-We can also add custom row attributes via a prop called `rowAttrs` - this prop is a Function that returns an object comprising the conditional custom attributes
-that you want the rows to have.
-In the following example, the rows have a custom green color if enabled is true, and yellow if enabled is false.
-We can also add a custom data-testid onto each row using these attributes (you can inspect it to see there is a custom data-testid attribute with `rowItem` on each row).
-
-<template>
-  <KTable
-    :options="tableOptionsRowAttrs"
-    hasSideBorder
-    :rowAttrs="rowAttrsFn"
-    />
-</template>
-
-```vue
-<template>
-  <KTable
-    :options="tableOptions"
-    :rowAttrs="rowAttrsFn"
-    hasSideBorder
-    />
-</template>
-<script>
-import { defaultSorter } from '@kongponents/KTable'
-export default {
-  data() {
-    return {
-      row: null,
-      eventType: '',
-      tableOptions: {
-        headers: [
-          { label: 'Type', key: 'type' },
-          { label: 'Value', key: 'value' },
-          { label: 'Enabled', key: 'enabled'}
-        ],
-        data: [
-          {
-            type: 'desktop',
-            value: 'Windows 10',
-            enabled: 'true'
-          },
-          {
-            type: 'phone',
-            value: 'LineageOS',
-            enabled: 'false'
-          },
-          {
-            type: 'tablet',
-            value: 'ipadOS',
-            enabled: 'true'
-          }
-        ]
-      }
-    }
-  },
-  methods: {
-    rowAttrsFn (rowItem) {
-      return {
-        class: {
-          'enabled': rowItem.enabled === 'true',
-          'disabled': rowItem.enabled === 'false'
-        },
-        'data-testid': 'row-item'
-      }
-    }
-  }
-}
-</script>
-<style>
-.k-table {
-  tr.enabled {
-    --KTableHover: var(--green-200, #ccffe1);
-    --KTableBorder: var(--green-400, #19a654);
-  }
-
-  tr.disabled {
-    --KTableHover: var(--yellow-100, #fff9e6);
-    --KTableBorder: var(--yellow-200, #ffdc73);
-  }
-}
-</style>
 ```
 
 ## Slots

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -115,8 +115,10 @@ The below example demonstrates the disabled state:
 </template>
 ```
 
-## rowAttrs
+## Custom Row Attributes
 Add custom properties to individual rows. The row object is passed as a param.
+
+## rowAttrs - Function that returns an object comprising the attributes.
 
 Example below:
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -21,7 +21,7 @@ tableOptions:
       id: 405383051040955
       enabled: true
 ---
-# Table
+# Table 
 Pass an object of headers & data to build a slot-able table.
 
 <KTable :options="$frontmatter.tableOptions" />

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -110,7 +110,20 @@ various parts of the table.
 
 - `@cell:<event>` - returns the `Event`, the cell value, and the type: `cell`
 
-<KTable :options="$frontmatter.tableOptions" @cell:mouseout="actionRow" @cell:mousedown="actionRow" />
+<template>
+  <div>
+    <div v-if="eventType">
+      {{eventType}} on: {{row}}
+    </div>
+    <div v-else>Waiting</div>
+    <KTable
+      :options="tableOptions"
+      is-clickable
+      @row:click="actionRow"
+      @cell:mouseover="actionRow"
+    />
+  </div>
+</template>
 
 #### Example
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -118,7 +118,8 @@ The below example demonstrates the disabled state:
 ## Custom Row Attributes
 Add custom properties to individual rows. The row object is passed as a param.
 
-## rowAttrs - Function that returns an object comprising the attributes.
+## rowAttrs
+Function that returns an object comprising the attributes.
 
 Example below:
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -66,13 +66,13 @@ export default {
 ```
 ## Props
 ### Hover
-Highlight the table row on hover
+Highlight the table row on hover. By default this is set to true. In the example we can set it to false as well.
 
-<KTable :options="$frontmatter.tableOptions" hasHover />
+<KTable :options="$frontmatter.tableOptions" :hasHover="false" />
 ```vue
 <KTable
   :options="tableOptions"
-  hasHover />
+  :hasHover="false" />
 ```
 
 ### Small
@@ -110,9 +110,7 @@ various parts of the table.
 
 - `@cell:<event>` - returns the `Event`, the cell value, and the type: `cell`
 
-```vue
-<KTable @cell:mouseout="cellHandler" @cell:mousedown="cellHandler">
-```
+<KTable :options="$frontmatter.tableOptions" @cell:mouseout="actionRow" @cell:mousedown="actionRow" />
 
 #### Example
 
@@ -123,11 +121,10 @@ various parts of the table.
       {{eventType}} on: {{row}}
     </div>
     <div v-else>Waiting</div>
-
-    <KTable 
+    <KTable
       :options="tableOptions"
       is-clickable
-      @row:click="actionRow" 
+      @row:click="actionRow"
       @cell:mouseover="actionRow"
     />
   </div>
@@ -256,15 +253,15 @@ export default {
 
 ### Custom Row Attributes
 
-There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row, using the color `steal-200` by default.
-It also adds a default hover color on the row that uses the color `steal-100` by default. These colors can be overridden by themes or by using
-custom row attributes. This prop also causes the row borders to be separate and enables spacing between rows.
-Example using `hasSideBorder` prop:
+There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row, using the color `steal-300` by default.
+This prop is on by default.
+These colors can be overridden by themes or by using custom row attributes.
+Example with `hasSideBorder` set to false:
 
 <template>
   <KTable
     :options="tableOptions"
-    hasSideBorder
+    :hasSideBorder="false"
     />
 </template>
 
@@ -272,7 +269,7 @@ Example using `hasSideBorder` prop:
 <template>
   <KTable
     :options="tableOptions"
-    hasSideBorder
+    :hasSideBorder="false"
     />
 </template>
 ```
@@ -314,20 +311,17 @@ export default {
           {
             name: 'Basic Auth',
             id: '517526354743085',
-            enabled: 'true',
-            themeColors: []
+            enabled: 'true'
           },
           {
             name: 'Website Desktop',
             id: '328027447731198',
-            enabled: 'false',
-            themeColors: ['blue','violet']
+            enabled: 'false'
           },
           {
             name: 'Android App',
             id: '405383051040955',
-            enabled: 'true',
-            themeColors: ['green', 'yellow']
+            enabled: 'true'
           }
         ]
       }
@@ -347,7 +341,7 @@ export default {
 }
 </script>
 <style>
-table.k-table.side-border {
+.k-table {
   tr.enabled {
     --KTableHover: var(--green-200, #ccffe1);
     --KTableBorder: var(--green-400, #19a654);
@@ -581,7 +575,7 @@ export default {
   --KTableHover: lavender;
   }
 
-  table.k-table.side-border {
+  .k-table {
     tr.enabled {
       --KTableHover: var(--green-200, #ccffe1);
       --KTableBorder: var(--green-400, #19a654);

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -95,11 +95,9 @@ Adds `cursor: pointer` and `user-select: none` styling.
   isClickable />
 ```
 
-### Custom Row Attributes
-
-## hasSidebar
+### hasSidebar
 Adds left border to each table row. By default set to true. The colors can be overridden by themes.
-The below example demostrates the disabled state:
+The below example demonstrates the disabled state:
 
 <template>
   <KTable
@@ -115,8 +113,6 @@ The below example demostrates the disabled state:
     :hasSideBorder="false"
     />
 </template>
-```
-
 ## rowAttrs
 Add custom properties to individual rows. The row object is passed as a param.
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -279,8 +279,9 @@ Example using `hasSideBorder` prop:
 ```
 
 We can also add custom row attributes via a prop called `rowAttrs` - this prop is a Function that returns an object comprising the conditional custom attributes
-that you want the rows to have. In the following example, the rows have a custom green color if enabled is true, and yellow if enabled is false, coming from the
-custom `rowAttrs` function. Also make sure that `hasSideBorder` prop is passed in to enable custom row attributes.
+that you want the rows to have. `hasSideBorder` prop must be passed in to enable custom row attributes.
+In the following example, the rows have a custom green color if enabled is true, and yellow if enabled is false, coming from the
+custom `rowAttrs` function. We can also add a custom data-testid onto each row using these attributes (you can inspect it to see there is a custom data-testid attribute with `rowItem` on each row).
 
 <template>
   <KTable
@@ -339,7 +340,8 @@ export default {
         class: {
           'enabled': rowItem.enabled === 'true',
           'disabled': rowItem.enabled === 'false'
-        }
+        },
+        'data-testid': 'row-item'
       }
     }
   }
@@ -571,7 +573,8 @@ export default {
         class: {
           'enabled': rowItem.enabled === 'true',
           'disabled': rowItem.enabled === 'false'
-        }
+        },
+        'data-testid': 'row-item'
       }
     },
     defaultSorter

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -113,6 +113,8 @@ The below example demonstrates the disabled state:
     :hasSideBorder="false"
     />
 </template>
+```
+
 ## rowAttrs
 Add custom properties to individual rows. The row object is passed as a param.
 
@@ -200,50 +202,17 @@ various parts of the table.
 ### Rows
 - `@row:<event>` - returns the `Event`, the row item, and the type: `row`
 
-<template>
-  <div v-if="eventType">
-    {{eventType}} on: {{row.name}}
-  </div>
-  <div v-else>Waiting</div>
-  <KTable
-      :options="tableOptions"
-      @row:click="actionRow"
-      @row:dblclick="actionRow"
-      />
-</template>
-
 ```vue
-<template>
-  <div v-if="eventType">
-    {{eventType}} on: {{row.name}}
-  </div>
-  <div v-else>Waiting</div>
-  <KTable
-      :options="tableOptions"
-      @row:click="actionRow"
-      @row:dblclick="actionRow"
-      />
-</template>
+<KTable @row:click="rowHandler" @row:dblclick="rowHandler">
 ```
 
 ### Cells
 
 - `@cell:<event>` - returns the `Event`, the cell value, and the type: `cell`
 
-<template>
-  <div>
-    <div v-if="eventType">
-      {{eventType}} on: {{row}}
-    </div>
-    <div v-else>Waiting</div>
-    <KTable
-      :options="tableOptions"
-      is-clickable
-      @row:click="actionRow"
-      @cell:mouseover="actionRow"
-    />
-  </div>
-</template>
+```vue
+<KTable @cell:mouseout="cellHandler" @cell:mousedown="cellHandler">
+```
 
 #### Example
 
@@ -296,6 +265,21 @@ export default {
 }
 </script>
 ```
+
+<template>
+  <div>
+    <div v-if="eventType">
+      {{eventType}} on: {{row}}
+    </div>
+    <div v-else>Waiting</div>
+    <KTable
+      :options="tableOptions"
+      is-clickable
+      @row:click="actionRow"
+      @cell:mouseover="actionRow"
+    />
+  </div>
+</template>
 
 ### Sorting
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -97,11 +97,9 @@ Adds `cursor: pointer` and `user-select: none` styling.
 
 ### Custom Row Attributes
 
-There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row.
-This prop is on by default.
-These colors can be overridden and customized by using theme variables.
-
-Example with `hasSideBorder` set to false:
+## hasSidebar
+Adds left border to each table row. By default set to true. The colors can be overridden by themes.
+The below example demostrates the disabled state:
 
 <template>
   <KTable
@@ -119,9 +117,8 @@ Example with `hasSideBorder` set to false:
 </template>
 ```
 
+## rowAttrs
 Add custom properties to individual rows. The row object is passed as a param.
-
-- `rowAttrs` - is a Function that returns an object comprising the attributes.
 
 Example below:
 
@@ -207,8 +204,30 @@ various parts of the table.
 ### Rows
 - `@row:<event>` - returns the `Event`, the row item, and the type: `row`
 
+<template>
+  <div v-if="eventType">
+    {{eventType}} on: {{row.name}}
+  </div>
+  <div v-else>Waiting</div>
+  <KTable
+      :options="tableOptions"
+      @row:click="actionRow"
+      @row:dblclick="actionRow"
+      />
+</template>
+
 ```vue
-<KTable @row:click="rowHandler" @row:dblclick="rowHandler">
+<template>
+  <div v-if="eventType">
+    {{eventType}} on: {{row.name}}
+  </div>
+  <div v-else>Waiting</div>
+  <KTable
+      :options="tableOptions"
+      @row:click="actionRow"
+      @row:dblclick="actionRow"
+      />
+</template>
 ```
 
 ### Cells

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -581,27 +581,15 @@ export default {
   --KTableHover: lavender;
   }
 
-table.k-table {
-  &.side-border {
+  table.k-table.side-border {
     tr.enabled {
-      &:hover {
-        background-color: var(--green-200, #ccffe1);
-      }
-
-      td:first-child {
-        border-left: 3px solid var(--green-400, #19a654);
-      }
+      --KTableHover: var(--green-200, #ccffe1);
+      --KTableBorder: var(--green-400, #19a654);
     }
 
     tr.disabled {
-      &:hover {
-        background-color: var(--yellow-100, #fff9e6);
-      }
-
-      td:first-child {
-        border-left: 3px solid var(--yellow-200, #ffdc73);
-      }
+      --KTableHover: var(--yellow-100, #fff9e6);
+      --KTableBorder: var(--yellow-200, #ffdc73);
     }
   }
-}
 </style>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -255,6 +255,123 @@ export default {
 </script>
 ```
 
+### Custom Row Attributes
+
+There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row, using the color `steal-200` by default.
+It also adds a default hover color on the row that uses the color `steal-100` by default. These colors can be overridden by themes or by using
+custom row attributes. This prop also causes the row borders to be separate and enables spacing between rows.
+Example using `hasSideBorder` prop:
+
+<template>
+  <KTable
+    :options="tableOptions"
+    hasSideBorder
+    />
+</template>
+
+```vue
+<template>
+  <KTable
+    :options="tableOptions"
+    hasSideBorder
+    />
+</template>
+```
+
+We can also add custom row attributes via a prop called `rowAttrs` - this prop is a Function that returns an object comprising the conditional custom attributes
+that you want the rows to have. In the following example, the rows have a custom green color if enabled is true, and yellow if enabled is false, coming from the
+custom `rowAttrs` function. Also make sure that `hasSideBorder` prop is passed in to enable custom row attributes.
+
+<template>
+  <KTable
+    :options="tableOptions"
+    hasSideBorder
+    :rowAttrs="rowAttrsFn"
+    />
+</template>
+
+```vue
+<template>
+  <KTable
+    :options="tableOptions"
+    :rowAttrs="rowAttrsFn"
+    hasSideBorder
+    />
+</template>
+<script>
+import { defaultSorter } from '@kongponents/KTable'
+export default {
+  data() {
+    return {
+      row: null,
+      eventType: '',
+      tableOptions: {
+        headers: [
+          { label: 'Type', key: 'type' },
+          { label: 'Value', key: 'value' }
+        ],
+        data: [
+          {
+            name: 'Basic Auth',
+            id: '517526354743085',
+            enabled: 'true',
+            themeColors: []
+          },
+          {
+            name: 'Website Desktop',
+            id: '328027447731198',
+            enabled: 'false',
+            themeColors: ['blue','violet']
+          },
+          {
+            name: 'Android App',
+            id: '405383051040955',
+            enabled: 'true',
+            themeColors: ['green', 'yellow']
+          }
+        ]
+      }
+    }
+  },
+  methods: {
+    rowAttrsFn (rowItem) {
+      return {
+        class: {
+          'enabled': rowItem.enabled === 'true',
+          'disabled': rowItem.enabled === 'false'
+        }
+      }
+    }
+  }
+}
+</script>
+<style>
+table.k-table {
+  &.side-border {
+    tr.enabled {
+      &:hover {
+        background-color: var(--green-200, #ccffe1);
+      }
+
+      td:first-child {
+        border-left: 3px solid var(--green-400, #19a654);
+      }
+    }
+
+    tr.disabled {
+      &:hover {
+        background-color: var(--yellow-100, #fff9e6);
+      }
+
+      td:first-child {
+        border-left: 3px solid var(--yellow-200, #ffdc73);
+      }
+    }
+  }
+}
+</style>
+```
+
 ## Slots
 Both column cells & header cells are slottable in KTable. Use slots to gain
 access to the row data.
@@ -378,7 +495,6 @@ export default {
 | `--KTableHover`| Hover variant background color
 | `--KTableHeaderSize`| Font size of header th
 
-
 \
 An Example of changing the hover background might look like.  
 
@@ -450,6 +566,14 @@ export default {
       this.sortKey = previousKey
       this.sortOrder = sortOrder
     },
+    rowAttrsFn (rowItem) {
+      return {
+        class: {
+          'enabled': rowItem.enabled === 'true',
+          'disabled': rowItem.enabled === 'false'
+        }
+      }
+    },
     defaultSorter
   }
 }
@@ -466,4 +590,28 @@ export default {
   .table-wrapper {
   --KTableHover: lavender;
   }
+
+table.k-table {
+  &.side-border {
+    tr.enabled {
+      &:hover {
+        background-color: var(--green-200, #ccffe1);
+      }
+
+      td:first-child {
+        border-left: 3px solid var(--green-400, #19a654);
+      }
+    }
+
+    tr.disabled {
+      &:hover {
+        background-color: var(--yellow-100, #fff9e6);
+      }
+
+      td:first-child {
+        border-left: 3px solid var(--yellow-200, #ffdc73);
+      }
+    }
+  }
+}
 </style>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -132,7 +132,23 @@ various parts of the table.
     />
   </div>
 </template>
-
+<template>
+  <KCard>
+    <div slot="body">
+      <div v-if="eventType">
+        {{eventType}} on: {{row}}
+      </div>
+      <div v-else>Waiting</div>
+      <KTable
+        :options="$frontmatter.tableOptions"
+        is-clickable
+        has-hover
+        @row:click="actionRow"
+        @cell:mouseover="actionRow"
+      />
+    </div>
+  </KCard>
+</template>
 <script>
 export default {
   data() {
@@ -150,23 +166,6 @@ export default {
 }
 </script>
 ```
-
-<KCard>
-  <div slot="body">
-    <div v-if="eventType">
-      {{eventType}} on: {{row}}
-    </div>
-    <div v-else>Waiting</div>
-    
-    <KTable 
-      :options="$frontmatter.tableOptions"
-      is-clickable
-      has-hover
-      @row:click="actionRow"
-      @cell:mouseover="actionRow"
-    />
-  </div>
-</KCard>
 
 ### Sorting
 
@@ -348,27 +347,15 @@ export default {
 }
 </script>
 <style>
-table.k-table {
-  &.side-border {
-    tr.enabled {
-      &:hover {
-        background-color: var(--green-200, #ccffe1);
-      }
+table.k-table.side-border {
+  tr.enabled {
+    --KTableHover: var(--green-200, #ccffe1);
+    --KTableBorder: var(--green-400, #19a654);
+  }
 
-      td:first-child {
-        border-left: 3px solid var(--green-400, #19a654);
-      }
-    }
-
-    tr.disabled {
-      &:hover {
-        background-color: var(--yellow-100, #fff9e6);
-      }
-
-      td:first-child {
-        border-left: 3px solid var(--yellow-200, #ffdc73);
-      }
-    }
+  tr.disabled {
+    --KTableHover: var(--yellow-100, #fff9e6);
+    --KTableBorder: var(--yellow-200, #ffdc73);
   }
 }
 </style>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -66,7 +66,7 @@ export default {
 ```
 ## Props
 ### Hover
-highlight the table row on hover
+Highlight the table row on hover
 
 <KTable :options="$frontmatter.tableOptions" hasHover />
 ```vue
@@ -83,6 +83,16 @@ Lessen the table cell padding
 <KTable
   :options="tableOptions"
   isSmall />
+```
+
+### Clickable
+Adds `cursor: pointer` and `user-select: none` styling. 
+
+<KTable :options="$frontmatter.tableOptions" isClickable />
+```vue
+<KTable
+  :options="tableOptions"
+  isClickable />
 ```
 
 ## Events
@@ -115,8 +125,8 @@ various parts of the table.
     <div v-else>Waiting</div>
 
     <KTable 
-      class="clickable-rows"
       :options="tableOptions"
+      is-clickable
       @row:click="actionRow" 
       @cell:mouseover="actionRow"
     />
@@ -139,36 +149,24 @@ export default {
   }
 }
 </script>
-<style>
-.clickable-rows tr {
-  cursor: pointer;
-}
-</style>
 ```
 
 <KCard>
   <div slot="body">
-  <div v-if="eventType">
-    {{eventType}} on: {{row}}
-  </div>
-  <div v-else>Waiting</div>
-
-  <KTable 
-    class="clickable-rows"
-    :options="$frontmatter.tableOptions"
-    has-hover
-    @row:click="actionRow" 
-    @cell:mouseover="actionRow"
-  />
+    <div v-if="eventType">
+      {{eventType}} on: {{row}}
+    </div>
+    <div v-else>Waiting</div>
+    
+    <KTable 
+      :options="$frontmatter.tableOptions"
+      is-clickable
+      has-hover
+      @row:click="actionRow"
+      @cell:mouseover="actionRow"
+    />
   </div>
 </KCard>
-
-<style>
-  .clickable-rows tr {
-    cursor: pointer;
-  }
-</style>
-
 
 ### Sorting
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -251,7 +251,7 @@ export default {
 </script>
 ```
 
-### Custom Row Attributes
+## Custom Row Attributes
 
 There is a prop called `hasSideBorder` that when passed in, enables a default side border on each row, using the color `steal-300` by default.
 This prop is on by default.
@@ -275,13 +275,13 @@ Example with `hasSideBorder` set to false:
 ```
 
 We can also add custom row attributes via a prop called `rowAttrs` - this prop is a Function that returns an object comprising the conditional custom attributes
-that you want the rows to have. `hasSideBorder` prop must be passed in to enable custom row attributes.
-In the following example, the rows have a custom green color if enabled is true, and yellow if enabled is false, coming from the
-custom `rowAttrs` function. We can also add a custom data-testid onto each row using these attributes (you can inspect it to see there is a custom data-testid attribute with `rowItem` on each row).
+that you want the rows to have.
+In the following example, the rows have a custom green color if enabled is true, and yellow if enabled is false.
+We can also add a custom data-testid onto each row using these attributes (you can inspect it to see there is a custom data-testid attribute with `rowItem` on each row).
 
 <template>
   <KTable
-    :options="tableOptions"
+    :options="tableOptionsRowAttrs"
     hasSideBorder
     :rowAttrs="rowAttrsFn"
     />
@@ -305,22 +305,23 @@ export default {
       tableOptions: {
         headers: [
           { label: 'Type', key: 'type' },
-          { label: 'Value', key: 'value' }
+          { label: 'Value', key: 'value' },
+          { label: 'Enabled', key: 'enabled'}
         ],
         data: [
           {
-            name: 'Basic Auth',
-            id: '517526354743085',
+            type: 'desktop',
+            value: 'Windows 10',
             enabled: 'true'
           },
           {
-            name: 'Website Desktop',
-            id: '328027447731198',
+            type: 'phone',
+            value: 'LineageOS',
             enabled: 'false'
           },
           {
-            name: 'Android App',
-            id: '405383051040955',
+            type: 'tablet',
+            value: 'ipadOS',
             enabled: 'true'
           }
         ]
@@ -534,6 +535,30 @@ export default {
             id: '405383051040955',
             enabled: 'true',
             themeColors: ['green', 'yellow']
+          }
+        ]
+      },
+      tableOptionsRowAttrs: {
+        headers: [
+          { label: 'Type', key: 'type' },
+          { label: 'Value', key: 'value' },
+          { label: 'Enabled', key: 'enabled'}
+        ],
+        data: [
+          {
+            type: 'desktop',
+            value: 'Windows 10',
+            enabled: 'true'
+          },
+          {
+            type: 'phone',
+            value: 'LineageOS',
+            enabled: 'false'
+          },
+          {
+            type: 'tablet',
+            value: 'ipadOS',
+            enabled: 'true'
           }
         ]
       }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -140,7 +140,7 @@ export default {
      */
     hasHover: {
       type: Boolean,
-      default: false
+      default: true
     },
     /**
      * Lowers overall table padding
@@ -214,27 +214,20 @@ export default {
 
 <style scoped lang="scss">
 @import '~@kongponents/styles/_variables.scss';
-
-table.k-table {
+.k-table {
+  width: 100%;
+  max-width: 100%;
   border-collapse: collapse;
 
   &.side-border {
     border-collapse: separate;
-    border-spacing: 0 5px;
+    border-spacing: 0 4px;
 
-    tr:hover {
-      background-color: var(--KTableHover, var(--steal-100, color(steal-100)));
-    }
-
-    td:first-child {
-      border-left: 3px solid var(--KTableBorder, var(--steal-200, color(steal-200)));
+    tbody tr {
+      border: none;
+      box-shadow: -2px 0 0 var(--KTableBorder, var(--steal-300, color(steal-300)));
     }
   }
-}
-
-.k-table {
-  width: 100%;
-  max-width: 100%;
 
   th,
   td {
@@ -312,7 +305,7 @@ table.k-table {
     }
   }
   &.has-hover tbody tr:hover {
-    background-color: var(--KTableHover, var(--blue-100, color(blue-100)));
+    background-color: var(--KTableHover, var(--steal-100, color(steal-100)));
   }
   &.is-clickable {
     cursor: pointer;

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -219,15 +219,17 @@ export default {
   max-width: 100%;
   border-collapse: collapse;
 
-  &.side-border.has-hover {
+  &.side-border {
     border-collapse: separate;
     border-spacing: 0 4px;
 
     tbody tr {
       border: none;
       box-shadow: -2px 0 0 var(--KTableBorder, var(--steal-200, color(steal-200)));
+    }
 
-      &:hover {
+    &.has-hover {
+      tbody tr:hover {
         box-shadow: -2px 0 0 var(--KTableBorder, var(--steal-300, color(steal-300)));
       }
     }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -1,6 +1,6 @@
 <template>
   <table
-    :class="{'has-hover': hasHover, 'is-small': isSmall}"
+    :class="{'has-hover': hasHover, 'is-small': isSmall, 'is-clickable': isClickable}"
     class="k-table">
     <thead>
       <tr>
@@ -149,6 +149,12 @@ export default {
       default: false
     },
     /**
+     */
+    isClickable: {
+      type: Boolean,
+      default: false
+    },
+    /**
      * the sort order for the table.
      */
     sortOrder: {
@@ -173,7 +179,18 @@ export default {
     },
 
     trlisteners () {
-      return pluckListeners('row:', this.$listeners)
+      return (entity, type) => {
+        const pluckedListeners = pluckListeners('row:', this.$listeners)(entity, type)
+
+        return {
+          ...pluckedListeners,
+          mouseup (e) {
+            if (e.target.tagName === 'TD' && pluckedListeners['mouseup']) {
+              pluckedListeners['mouseup'](e, entity, type)
+            }
+          }
+        }
+      }
     }
   }
 }
@@ -267,6 +284,13 @@ table.k-table {
   }
   &.has-hover tbody tr:hover {
     background-color: var(--KTableHover, var(--blue-lightest, color(blue-lightest)));
+  }
+  &.is-clickable {
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
   }
 }
 </style>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -150,6 +150,7 @@ export default {
       default: false
     },
     /**
+     * Adds hover and non selectable styling
      */
     isClickable: {
       type: Boolean,
@@ -184,7 +185,7 @@ export default {
      */
     hasSideBorder: {
       type: Boolean,
-      default: false
+      default: true
     }
   },
 

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -219,13 +219,17 @@ export default {
   max-width: 100%;
   border-collapse: collapse;
 
-  &.side-border {
+  &.side-border.has-hover {
     border-collapse: separate;
     border-spacing: 0 4px;
 
     tbody tr {
       border: none;
-      box-shadow: -2px 0 0 var(--KTableBorder, var(--steal-300, color(steal-300)));
+      box-shadow: -2px 0 0 var(--KTableBorder, var(--steal-200, color(steal-200)));
+
+      &:hover {
+        box-shadow: -2px 0 0 var(--KTableBorder, var(--steal-300, color(steal-300)));
+      }
     }
   }
 

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -1,6 +1,6 @@
 <template>
   <table
-    :class="{'has-hover': hasHover, 'is-small': isSmall, 'is-clickable': isClickable}"
+    :class="{'has-hover': hasHover, 'is-small': isSmall, 'is-clickable': isClickable, 'side-border': hasSideBorder}"
     class="k-table">
     <thead>
       <tr>
@@ -25,7 +25,7 @@
       <tr
         v-for="(row, rowIndex) in options.data"
         :key="rowIndex"
-        :class="rowClasses(row)"
+        v-bind="rowAttrs(row)"
         v-on="trlisteners(row, 'row')">
         <template>
           <td
@@ -173,11 +173,18 @@ export default {
       default: ''
     },
     /**
-     * A function that conditionally specifies the row classes on the rows
+     * A function that conditionally specifies row attributes on each row
      */
-    rowClasses: {
+    rowAttrs: {
       type: Function,
-      default: null
+      default: () => ({})
+    },
+    /**
+     * A prop that enables a side border with a themable color to it.
+     */
+    hasSideBorder: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -209,6 +216,19 @@ export default {
 
 table.k-table {
   border-collapse: collapse;
+
+  &.side-border {
+    border-collapse: separate;
+    border-spacing: 0 5px;
+
+    tr:hover {
+      background-color: var(--KTableHover, var(--steal-100, color(steal-100)));
+    }
+
+    td:first-child {
+      border-left: 3px solid var(--KTableBorder, var(--steal-200, color(steal-200)));
+    }
+  }
 }
 
 .k-table {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -25,6 +25,7 @@
       <tr
         v-for="(row, rowIndex) in options.data"
         :key="rowIndex"
+        :class="rowClasses(row)"
         v-on="trlisteners(row, 'row')">
         <template>
           <td
@@ -170,6 +171,13 @@ export default {
     sortKey: {
       type: String,
       default: ''
+    },
+    /**
+     * A function that conditionally specifies the row classes on the rows
+     */
+    rowClasses: {
+      type: Function,
+      default: null
     }
   },
 

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KTable default has hover class when passed 1`] = `
-<table class="k-table has-hover">
+<table class="k-table has-hover side-border">
   <thead>
     <tr>
       <th class="sortable">
@@ -42,7 +42,7 @@ exports[`KTable default has hover class when passed 1`] = `
 `;
 
 exports[`KTable default has small class when passed 1`] = `
-<table class="k-table is-small">
+<table class="k-table has-hover is-small side-border">
   <thead>
     <tr>
       <th class="sortable">
@@ -83,7 +83,7 @@ exports[`KTable default has small class when passed 1`] = `
 `;
 
 exports[`KTable default renders link in action slot 1`] = `
-<table class="k-table">
+<table class="k-table has-hover side-border">
   <thead>
     <tr>
       <th class="sortable">
@@ -124,7 +124,7 @@ exports[`KTable default renders link in action slot 1`] = `
 `;
 
 exports[`KTable sorting should have sortable class when passed 1`] = `
-<table class="k-table">
+<table class="k-table has-hover side-border">
   <thead>
     <tr>
       <th class="sortable">


### PR DESCRIPTION
### Summary
Add ability to add custom row bindings via a passed in function

#### Changes made:
*Added rowAttrs, a custom function that adds row bindings onto KTable
*Added hasSideBorder, a prop that adds a default side border onto KTable

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
