### PR TITLE
fix(ktable): update row listeners to support clicking non td elements

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -201,7 +201,7 @@ export default {
         return {
           ...pluckedListeners,
           click (e) {
-            if (e.target.tagName === 'TD' && pluckedListeners['click']) {
+            if (e.target.tagName !== 'A' && e.target.tagName !== 'BUTTON' && pluckedListeners['click']) {
               pluckedListeners['click'](e, entity, type)
             }
           }


### PR DESCRIPTION
### Summary
Updated row listeners to support clicking all non Anchor / Button elements rather than just TD elements.

#### Changes made:
*Updated row listeners to support clicking all non Anchor / Button elements rather than just TD elements.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
