### PR TITLE
Style(KButton) Adds isOpen prop for dropdown caret 

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -121,6 +121,24 @@ KButton supports using an icon either before the text or without text.
 ```
 
 ## Theming
+KButton includes a utility class `.has-caret` which displays a dropdown caret to the right hand side. this is useful for buttons that control dropdowns and popovers. You can rotate the caret (active state) by applying `.is-active` as an additional class.
+
+<Komponent :data="{ isActive: false}" v-slot="{ data }">
+  <KButton appearance="primary" class="has-caret" :class="{'is-active': data.isActive}" @click="data.isActive = !data.isActive">I'm a button</KButton> 
+</Komponent>
+
+> The `Komponent` component is used in this example to create state.
+```vue
+<Komponent:data="{ isActive: false}" v-slot="{ data }">
+  <KButton
+    appearance="primary"
+    class="has-caret"
+    :class="{'is-active': data.isActive}"
+    @click="data.isActive = !data.isActive">I'm a button</KButton> 
+</Komponent>
+
+```  
+
 | Variable | Purpose
 |:-------- |:-------
 | `--KButtonPrimaryBase `| Primary background

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -53,6 +53,26 @@ Currently we only support small however, larger sizes may be supported later.
   size="small">Small</KButton>
 ```
 
+### Caret
+- `isOpen`
+
+KButton includes a utility class `.has-caret` which displays a dropdown caret to the right hand side. This is useful for buttons that control dropdowns and popovers. By adding the prop `isOpen` false the caret will display. You can rotate the caret (active state) by setting `isOpen` to true.
+
+<Komponent :data="{ isActive: false}" v-slot="{ data }">
+  <KButton appearance="primary" :isOpen="data.isActive" @click="data.isActive = !data.isActive">I'm a button</KButton> 
+</Komponent>
+
+> The `Komponent` component is used in this example to create state.
+```vue
+<Komponent:data="{ isActive: false}" v-slot="{ data }">
+  <KButton
+    appearance="primary"
+    class="has-caret"
+    :class="{'is-active': data.isActive}"
+    @click="data.isActive = !data.isActive">I'm a button</KButton> 
+</Komponent>
+
+
 ### Anchor Tag
 KButton can render either a `<a>` or `<router-link>` by simply passing the `to` prop. If it receives an object it will render a router link. If it receives a string it will render an HTML anchor tag
 
@@ -121,23 +141,6 @@ KButton supports using an icon either before the text or without text.
 ```
 
 ## Theming
-KButton includes a utility class `.has-caret` which displays a dropdown caret to the right hand side. this is useful for buttons that control dropdowns and popovers. You can rotate the caret (active state) by applying `.is-active` as an additional class.
-
-<Komponent :data="{ isActive: false}" v-slot="{ data }">
-  <KButton appearance="primary" class="has-caret" :class="{'is-active': data.isActive}" @click="data.isActive = !data.isActive">I'm a button</KButton> 
-</Komponent>
-
-> The `Komponent` component is used in this example to create state.
-```vue
-<Komponent:data="{ isActive: false}" v-slot="{ data }">
-  <KButton
-    appearance="primary"
-    class="has-caret"
-    :class="{'is-active': data.isActive}"
-    @click="data.isActive = !data.isActive">I'm a button</KButton> 
-</Komponent>
-
-```  
 
 | Variable | Purpose
 |:-------- |:-------

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -107,6 +107,7 @@ export default {
 }
 
 .k-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   padding: var(--KButtonPaddingY, var(--spacing-xs, spacing(xs))) var(--KButtonPaddingX, var(--spacing-sm, spacing(sm)));
@@ -159,6 +160,26 @@ export default {
   &.small {
     padding: var(--spacing-xxs, spacing(xxs)) var(--spacing-xs, spacing(xs));
     font-size: var(--type-sm, type(sm));
+  }
+
+  /* class to add for dropdown caret */
+  &.has-caret {
+    &:after {
+      display: inline-block;
+      width: 0;
+      height: 0;
+      margin-left: var(--spacing-xs,8px);
+      vertical-align: middle;
+      content: "";
+      border-top: .325em solid;
+      border-right: .325em solid transparent;
+      border-left: .325em solid transparent;
+      transition: 250ms ease;
+    }
+    &.is-active:after {
+      transform: rotate(-180deg);
+      transition: 250ms ease;
+    }
   }
 
   /* Apperance Variations */

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -13,7 +13,7 @@
     :type="type"
     :is="buttonType"
     :to="to"
-    :class="[size === 'default' ? '' : size, {'icon-btn': !hasText && hasIcon}, appearance]"
+    :class="[size === 'default' ? '' : size, {'icon-btn': !hasText && hasIcon}, appearance, caretClasses]"
     class="k-button"
     v-on="listeners">
     <slot name="icon" /><slot/>
@@ -70,6 +70,10 @@ export default {
     type: {
       type: String,
       default: 'button'
+    },
+    isOpen: {
+      type: Boolean,
+      default: undefined
     }
   },
 
@@ -78,6 +82,12 @@ export default {
       return {
         ...this.$listeners
       }
+    },
+
+    caretClasses () {
+      if (this.isOpen === undefined) return
+
+      return this.isOpen ? 'has-caret is-active' : 'has-caret'
     },
 
     hasIcon () {

--- a/packages/KMultiselect/KMultiselect.vue
+++ b/packages/KMultiselect/KMultiselect.vue
@@ -11,7 +11,7 @@
     <KButton
       v-bind="buttonAttributes"
       :appearance="buttonAttributes.appearance || 'secondary'"
-      :class="{'is-active': isOpen}"
+      :is-open="isOpen"
       class="k-multiselect-trigger has-caret">
       {{ buttonText }}
     </KButton>

--- a/packages/KMultiselect/KMultiselect.vue
+++ b/packages/KMultiselect/KMultiselect.vue
@@ -11,7 +11,8 @@
     <KButton
       v-bind="buttonAttributes"
       :appearance="buttonAttributes.appearance || 'secondary'"
-      class="k-multiselect-trigger">
+      :class="{'is-active': isOpen}"
+      class="k-multiselect-trigger has-caret">
       {{ buttonText }}
     </KButton>
     <template
@@ -108,6 +109,7 @@ export default {
     return {
       filter: '',
       hidePopover: false,
+      isOpen: false,
       internalItems: this.copyItems(this.items)
     }
   },
@@ -140,10 +142,12 @@ export default {
 
     handleApply () {
       this.hidePopover = true
+      this.isOpen = false
       this.$emit('changes', this.copyItems(this.internalItems))
     },
 
     async handleOpen () {
+      this.isOpen = true
       if (!this.hasFilter) return
 
       // Wait for popper to open & position itself
@@ -154,6 +158,7 @@ export default {
 
     async handleClose () {
       await this.$nextTick()
+      this.isOpen = false
       this.hidePopover = false
     },
 
@@ -170,19 +175,7 @@ export default {
 
 .k-multiselect {
   &-trigger {
-    position: relative;
     display: inline-block;
-    &:after {
-      display: inline-block;
-      width: 0;
-      height: 0;
-      margin-left: var(--spacing-xs, spacing(xs));
-      vertical-align: middle;
-      content: "";
-      border-top: 0.325em solid;
-      border-right: 0.325em solid transparent;
-      border-left: 0.325em solid transparent;
-    }
     &:disabled { pointer-events: none; }
   }
   &-filter .k-input {

--- a/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
+++ b/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KMultiselect matches snapshot 1`] = `
-<div><button type="button" class="k-button k-multiselect-trigger has-caret secondary">
+<div><button type="button" class="k-button k-multiselect-trigger has-caret secondary has-caret">
 
   </button>
   <div class="k-popover k-multiselect mt-0 mb-0 hide-caret" style="width: auto; display: none;" name="fade">

--- a/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
+++ b/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KMultiselect matches snapshot 1`] = `
-<div><button type="button" class="k-button k-multiselect-trigger secondary">
+<div><button type="button" class="k-button k-multiselect-trigger has-caret secondary">
 
   </button>
   <div class="k-popover k-multiselect mt-0 mb-0 hide-caret" style="width: auto; display: none;" name="fade">


### PR DESCRIPTION
### Summary
More and more designs are including a button with a dropdown caret similar. Instead of adding one off instances I added a utility class to KButton. I also updated KMultiselect to use the caret 💄

#### Changes made:
* Add KButton classes
* Use class in KMultiselect
* Add example of class to button docs

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
