### PR TITLE
feat(kinput): add v-model

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -32,6 +32,54 @@ You can pass any input attribute and it will get properly bound to the element.
 <KInput type="email" value="error" class="input-error"/>
 ```
 
+### v-model
+
+KInput works as regular inputs do using v-model for data binding:
+
+<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+  <div>
+    {{ data.myInput }}
+    <KInput 
+      v-model="data.myInput"
+      @blur="e => (data.myInput = 'blurred')" />
+  </div>
+</Komponent>
+
+```vue
+<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+  {{ myInput }}
+  <KInput v-model="data.myInput" />
+</Komponent>
+```
+
+### Events
+
+KInput transparently binds to events:
+
+<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+  <div>
+    <KInput
+      v-model="data.myInput"
+      @blur="e => (data.myInput = 'blurred')"
+      @focus="e => (data.myInput = 'focused')"
+    />
+  </div>
+</Komponent>
+
+```vue
+<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+  <div>
+    <KInput
+      v-model="data.myInput"
+      @blur="e => (data.myInput = 'blurred')"
+      @focus="e => (data.myInput = 'focused')"
+    />
+  </div>
+</Komponent>
+```
+
+## Labels
+
 Additionally you you can use in conjunction with **KLabel** and or a paragraph with the utility class of `.help`. These are meant to be used before and after KInput and will be styled appropriately. 
 
 <KLabel for="my-input">Label</KLabel>

--- a/packages/KInput/KInput.spec.js
+++ b/packages/KInput/KInput.spec.js
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import KInput from '@/KInput/KInput'
+
+describe('KInput', () => {
+  it('renders text when value is passed', () => {
+    const wrapper = mount(KInput, {
+      propsData: {
+        value: 'Hello' // e.g. v-model
+      }
+    })
+
+    expect(wrapper.find('input').element.value).toBe('Hello')
+  })
+
+  it('reacts to text changes', () => {
+    const wrapper = mount(KInput, {
+      propsData: {
+        value: 'hey'
+      }
+    })
+    const input = wrapper.find('input')
+
+    expect(input.element.value).toBe('hey')
+    input.setValue('hey, dude')
+
+    expect(wrapper.emitted().input).toHaveLength(1)
+    expect(wrapper.emitted().input[0]).toEqual(['hey, dude'])
+    expect(input.element.value).toBe('hey, dude')
+  })
+
+  it('matches snapshot', () => {
+    const wrapper = mount(KInput, {
+      propsData: {
+        value: 'Full Name',
+        placeholder: 'I am a placeholder',
+        name: 'custom-input-name',
+        id: 'custom-input-id',
+        'data-testid': 'custom-input'
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -1,17 +1,28 @@
 <template>
   <input
+    :value="value"
     class="form-control k-input"
+    @input="e => $emit('input', e.target.value)"
     v-on="listeners">
 </template>
 
 <script>
 export default {
   name: 'KInput',
+  props: {
+    value: {
+      type: String,
+      default: ''
+    }
+  },
   computed: {
     listeners () {
-      return {
-        ...this.$listeners
-      }
+      const listeners = { ...this.$listeners }
+
+      // use @input in template for v-model support
+      delete listeners['input']
+
+      return listeners
     }
   }
 }

--- a/packages/KInput/__snapshots__/KInput.spec.js.snap
+++ b/packages/KInput/__snapshots__/KInput.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KInput matches snapshot 1`] = `<input class="form-control k-input" placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input">`;


### PR DESCRIPTION
### Summary
Add v-model support to `KInput`

#### Changes made:
Fixes #186 

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
