### PR TITLE
feat(KToaster): change to white style, move to bottom

### DIFF
--- a/packages/KToaster/KToaster.vue
+++ b/packages/KToaster/KToaster.vue
@@ -10,9 +10,11 @@
       <KAlert
         :appearance="toaster.appearance"
         is-dismissible
-        is-bordered
+        has-left-border
         @closed="$emit('close', toaster.key)">
-        <template v-slot:alertMessage>{{ toaster.message }}</template>
+        <template v-slot:alertMessage>
+          <span class="message">{{ toaster.message }}</span>
+        </template>
       </KAlert>
     </div>
   </transition-group>
@@ -51,7 +53,7 @@ export default {
     order: 1;
     right: 0;
     padding: 0 0 0 1rem;
-    margin-left: auto;
+    margin-left: 2rem;
     &:focus,
     &:active {
       outline: none;
@@ -66,9 +68,9 @@ $transition: all .3s;
 
 .toaster-container-outer {
   position: fixed;
-  top: 10px;
-  right: 10px;
   width: auto;
+  bottom: 1rem;
+  right: 1rem;
   max-width: 300px;
   z-index: 10000;
   transition: $transition;
@@ -78,27 +80,37 @@ $transition: all .3s;
   display: flex;
   width: 100%;
   margin-bottom: 1rem;
-  border-radius: 3px;
   transition: $transition;
   overflow: hidden;
+  box-shadow: 0 0 12px rgba(0,0,0,.12);
 
   .k-alert {
+    --KAlertInfoBorder: var(--blue-500, color(blue-500));
+    --KAlertSuccessBorder: var(--green-400, color(green-400));
+    --KAlertWarningBorder: var(--yellow-200, color(yellow-200));
+    --KAlertDangerBorder: var(--red-500, color(red-500));
     display: flex;
     justify-content: space-between;
     flex: 1;
     padding: 1rem;
     text-align: left;
+    background-color: #fff;
+    color: var(--black-70);
   }
 
   .message {
-    flex: 1;
-    padding: 1rem;
-    text-align: left;
-    transition: $transition;
-  }
+-webkit-hyphens: auto;
+   -moz-hyphens: auto;
+        hyphens: auto;
+    max-width: 150ch;
+}
 }
 
 /* Vue Animations */
 .toaster-enter { transform: translateX(300px); }
 .toaster-leave-to { transform: translateX(100%); }
+</style>
+
+<style lang="scss">
+
 </style>

--- a/packages/KToaster/KToaster.vue
+++ b/packages/KToaster/KToaster.vue
@@ -13,7 +13,7 @@
         has-left-border
         @closed="$emit('close', toaster.key)">
         <template v-slot:alertMessage>
-          <span class="message">{{ toaster.message }}</span>
+          <div class="message">{{ toaster.message }}</div>
         </template>
       </KAlert>
     </div>
@@ -109,8 +109,4 @@ $transition: all .3s;
 /* Vue Animations */
 .toaster-enter { transform: translateX(300px); }
 .toaster-leave-to { transform: translateX(100%); }
-</style>
-
-<style lang="scss">
-
 </style>

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,34 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info isBordered"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close"><title>close</title> <g><path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path></g></svg></button> <!----> <span>hey toasty</span></div>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close"><title>close</title> <g><path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path></g></svg></button> <!----> <span><div class="message">hey toasty</div></span></div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert success isBordered"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
+  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
         <title>close</title>
         <g>
           <path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path>
         </g>
       </svg></button>
-    <!----> <span>hey toasty</span></div>
+    <!----> <span><div class="message">hey toasty</div></span></div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger isBordered"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
         <title>close</title>
         <g>
           <path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path>
         </g>
       </svg></button>
-    <!----> <span>hey toasty</span></div>
+    <!----> <span><div class="message">hey toasty</div></span></div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger isBordered"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
         <title>close</title>
         <g>
           <path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path>
         </g>
       </svg></button>
-    <!----> <span>hey toasty</span></div>
+    <!----> <span><div class="message">hey toasty</div></span></div>
 </div>
 </span>
 `;


### PR DESCRIPTION
### Summary
Updates toaster design to more closely match new Kongponent styles. Moves toasters to bottom right to no longer overlap action buttons as well as moves to only theming the left border instead of the entire alert.

Latest designs: 
- https://share.goabstract.com/2084d396-6741-4406-8283-3a20e378e0c1?mode=design&sha=fd108e0f965f983894ceebc3a485f7a17a8f091f
- https://share.goabstract.com/23a7b7d7-3dec-4a3b-bb99-cfa70f4d4c18?mode=design&sha=9ce13587f0d55a0ccf757a887893f34df8aad96d 

![image](https://user-images.githubusercontent.com/5941111/88309767-a066c480-ccc3-11ea-97f2-81e939e2d0e3.png)

#### Changes made:
* Updates KToaster styles

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
