### PR TITLE
feat(KModal) Adds title & content props, Adds more theme options

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -34,21 +34,26 @@ export default {
 ```
 
 ## Props
+**Functional**
 -  `isVisible` - Tells the component whether or not to render the open modal
+- `@canceled` - Emitted when cancel/close button is clicked
+
+**Content**
+- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the close/cancel
+- `title` - Text to display in header if not using slot
+- `content` - Text to display in content if not using slot
+
+**Buttons & Appearance**
 - `actionButtonText` - Change the text content of the submit/proceed button
 - `actionButtonAppearance` - Change the [appearance](/components/button.html#props) of the submit/proceed
 - `cancelButtonText` - Change the text content of the close/cancel button
-- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the close/cancel
-- `@canceled` - Emitted when cancel/close button is clicked
 
 ## Slots
-Although the default is fairly straight forward to use, its not very helpful with the default
-content! There are 5 designated slots you can use to display content in the modal.
+There are 3 designated slots you can use to display content in the modal.
 
-`header-content` - Used to update the title  
-`body-content` - Used for the main content section of the modal  
-`footer-content` - The slot which contains the action buttons by default. Use this
-to replace the buttons
+`header-content`
+`body-content`  
+`footer-content` - Contains action buttons by default.
 
 ---
 ### Usage
@@ -85,8 +90,12 @@ Using both the provided props and slot options we will now demonstrate how to cu
 ## Theming
 | Variable | Purpose
 |:-------- |:-------
-| `--KModalBackdrop `| Backgdrop color
-| `--KModalHeaderColor `| Header text color
+| `--KModalBackdrop` | Backgdrop color
+| `--KModalMaxWidth` | Modal max width
+| `--KModalBorder` | Modal border 
+| `--KModalHeaderColor` | Header text color
+| `--KModalHeaderSize` | Header font size
+| `--KModalHeaderWeight` | Header font weight
 | `--KModalColor `| Main content text color
 | `--KModalFontSize `| Main content text size
 

--- a/packages/KModal/KModal.spec.js
+++ b/packages/KModal/KModal.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import KModal from '@/KModal/KModal'
 
 describe('KModal', () => {
-  it('renders header slots are passed', () => {
+  it('renders proper content when using slots', () => {
     const headerText = 'This is some header text'
     const bodyText = 'This is some body text'
     const footerText = 'This is some footer text'
@@ -20,6 +20,22 @@ describe('KModal', () => {
     expect(wrapper.find('.modal-header').html()).toEqual(expect.stringContaining(headerText))
     expect(wrapper.find('.modal-body').html()).toEqual(expect.stringContaining(bodyText))
     expect(wrapper.find('.modal-footer').html()).toEqual(expect.stringContaining(footerText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders proper content when using props', () => {
+    const title = 'Sweet prop title'
+    const content = 'Sweet prop content'
+    const wrapper = mount(KModal, {
+      propsData: {
+        isVisible: true,
+        title,
+        content
+      }
+    })
+
+    expect(wrapper.find('.modal-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.modal-body').html()).toEqual(expect.stringContaining(content))
     expect(wrapper.html()).toMatchSnapshot()
   })
 

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -13,10 +13,10 @@
         @click.stop>
         <div class="modal-content">
           <div class="modal-header">
-            <slot name="header-content">Modal Title</slot>
+            <slot name="header-content">{{ title }}</slot>
           </div>
           <div class="modal-body">
-            <slot name="body-content">Modal Body</slot>
+            <slot name="body-content">{{ content }}</slot>
           </div>
           <div class="modal-footer">
             <slot name="footer-content">
@@ -47,6 +47,20 @@ export default {
   components: { KButton },
 
   props: {
+    title: {
+      /**
+       * Set the text of the title
+       */
+      type: String,
+      default: 'Modal Title'
+    },
+    /**
+     * Set the text of the body content
+     */
+    content: {
+      type: String,
+      default: 'Modal Content'
+    },
     /**
       *  Pass whether or not the modal should be visible
       */
@@ -124,10 +138,11 @@ export default {
 .modal-dialog {
   position: relative;
   width: auto;
-  max-width: 500px;
+  max-width: var(--KModalMaxWidth, 500px);
   margin: 50px auto;
   padding: var(--spacing-xl, spacing(xl));
   border-radius: 3px;
+  border: var(--KModalBorder);
   box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));
   background: #fff;
   z-index: 9999;
@@ -144,14 +159,14 @@ export default {
     justify-content: space-between;
     margin-bottom: var(--spacing-lg, spacing(lg));
     color: var(--KModalHeaderColor, var(--black-85, color(black-85)));
-    font-size: var(--type-lg, type(lg));
-    font-weight: 500;
+    font-size: var(--KModalHeaderSize, var(--type-lg, type(lg)));
+    font-weight: var(--KModalHeaderWeight, 500);
   }
 
   .modal-body {
     position: relative;
     flex: 1 1 auto;
-    margin-bottom: var(--spacing-xl, spacing(xl));
+    margin-bottom: var(--KModalBottomMargin, var(--spacing-xl, spacing(xl)));
     color: var(--KModalColor, var(--black-70, color(black-70)));
     font-size: var(--KModalFontSize, var(--type-md, type(md)));
   }

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -8,7 +8,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">Modal Title</div>
-        <div class="modal-body">Modal Body</div>
+        <div class="modal-body">Modal Content</div>
         <div class="modal-footer"><button type="button" class="k-button outline-primary">
             click to continue
           </button> <button type="button" class="k-button outline-danger">
@@ -20,7 +20,25 @@ exports[`KModal renders custom button text & appearance 1`] = `
 </div>
 `;
 
-exports[`KModal renders header slots are passed 1`] = `
+exports[`KModal renders proper content when using props 1`] = `
+<div aria-hidden="false" role="dialog" class="k-modal">
+  <div class="modal-backdrop">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">Sweet prop title</div>
+        <div class="modal-body">Sweet prop content</div>
+        <div class="modal-footer"><button type="button" class="k-button primary">
+            Proceed
+          </button> <button type="button" class="k-button secondary">
+            Cancel
+          </button></div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KModal renders proper content when using slots 1`] = `
 <div aria-hidden="false" role="dialog" class="k-modal">
   <div class="modal-backdrop">
     <div class="modal-dialog">


### PR DESCRIPTION
### Summary
Added a few more theming options to the modal as well as added title and content props used as default slot content. Previously you had to slot even just to set a custom title.

#### Changes made:
* Props added
* Theme options added
* Prop test added
* Snapshot updated

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
