### PR TITLE
feat(KInlineedit) Adds props for overriding styles & ignore value

### DIFF
--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -17,7 +17,49 @@
 ```
 
 ## Props
-- `@changed` - Emitted blurred away from the editing input or when enter is pressed.
+### ignoreValue
+If true, will not set the value of the input when enabled/clicked. This is useful to control placeholder style text
+
+<Komponent :data="{ inlineText: '' }" v-slot="{ data }">
+  <KInlineEdit :ignore-value="data.inlineText.length === 0" @changed="newVal => data.inlineText = newVal"><p>{{ data.inlineText || 'cool placeholder' }}</p></KInlineEdit>
+</Komponent>
+
+> The `Komponent` component is used in this example to create state.
+
+```vue
+<Komponent :data="{ inlineText: '' }" v-slot="{ data }">
+  <KInlineEdit
+    :ignore-value="data.inlineText.length === 0"
+    @changed="newVal => data.inlineText = newVal">
+    <p>{{ data.inlineText || 'cool placeholder' }}</p>
+  </KInlineEdit>
+</Komponent>
+```
+
+### styleOverrides
+Styles to set when the input is active. Useful when styling the default state differently.
+
+<Komponent :data="{ inlineText: '' }" v-slot="{ data }">
+  <KInlineEdit :ignore-value="data.inlineText.length === 0" :style-overrides="{color: 'var(--black-85)'}" @changed="newVal => data.inlineText = newVal"><p :class="data.inlineText.length > 0 ? 'color-black-85' :'color-black-45 text-italic'">{{ data.inlineText || 'cool placeholder' }}</p></KInlineEdit>
+</Komponent>
+
+> The `Komponent` component is used in this example to create state.
+
+```vue
+<Komponent :data="{ inlineText: '' }" v-slot="{ data }">
+  <KInlineEdit
+    :ignore-value="data.inlineText.length === 0"
+    :style-overrides="{ color: 'var(--black-85)' }"
+    @changed="newVal => data.inlineText = newVal">
+    <p :class="data.inlineText.length > 0 ? 'color-black-85' :'color-black-45 text-italic'">
+      {{ data.inlineText || 'cool placeholder' }}
+    </p>
+  </KInlineEdit>
+</Komponent>
+```
+
+### `@changed`
+Emitted blurred away from the editing input or when enter is pressed.
 
 When clicking out of the input `@changed` will fire and emit the value. Can be used to reset the outside data.
 
@@ -94,3 +136,7 @@ export default {
   }
 }
 </script>
+
+<style>
+.text-italic { font-style: italic; }
+</style>

--- a/packages/KInlineEdit/KInlineEdit.spec.js
+++ b/packages/KInlineEdit/KInlineEdit.spec.js
@@ -21,6 +21,34 @@ describe('KInlineEdit', () => {
     expect(console.warn).toBeTruthy()
   })
 
+  it('applies style overrides when prop passed', () => {
+    const wrapper = mount(KInlineEdit, {
+      propsData: {
+        styleOverrides: { color: 'red' }
+      },
+      slots: { default: '<p style="color: black">text</p>' }
+    })
+
+    wrapper.find('p').trigger('click')
+
+    expect(wrapper.find('.k-input').attributes().style).toBe('color: red;')
+  })
+
+  it('does not pass in initial value when prop passed', async () => {
+    const wrapper = mount(KInlineEdit, {
+      propsData: {
+        ignoreValue: true
+      },
+      slots: { default: '<p>text</p>' }
+    })
+
+    wrapper.find('p').trigger('click')
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.inputText).toBe('')
+  })
+
   it('emits updated text on blur', async () => {
     const inputText = 'test'
     const wrapper = mount(KInlineEdit, {

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -82,7 +82,7 @@ Example usage:
 
       // Get current STYLES off of the element
       this.styles = { ...this.getStyles(e.target), ...this.styleOverrides }
-      this.inputText = this.ignoreValue ? '' : e.target.textContent
+      this.inputText = this.ignoreValue ? '' : e.target.textContent.trim()
       this.isEditing = true
 
       // Wait for vue to update styles & text

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -32,6 +32,27 @@ const STYLES = {
 
 export default {
   name: 'KInlineEdit',
+  props: {
+    /**
+     * Sets whether the initial value passed in should be ignored.
+     * Useful for times when you have placeholder text and don't want it passed
+     * in as a value
+     */
+    ignoreValue: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * An object of css styles to override those plucked from the slot element.
+     * Useful if you are styling the default content differently than how the
+     * input should display
+     */
+    styleOverrides: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+
   data () {
     return {
       isEditing: false,
@@ -60,8 +81,8 @@ Example usage:
       if (e.target.id === 'element-content-wrapper') return
 
       // Get current STYLES off of the element
-      this.styles = this.getStyles(e.target)
-      this.inputText = e.target.innerText
+      this.styles = { ...this.getStyles(e.target), ...this.styleOverrides }
+      this.inputText = this.ignoreValue ? '' : e.target.textContent
       this.isEditing = true
 
       // Wait for vue to update styles & text


### PR DESCRIPTION
### Summary
Blocks https://konghq.atlassian.net/browse/KHCP-331

- Adds prop for ignoring initial value when clicking to edit
- Adds prop for adding custom styles to the input which will override those inherited from the element when clicking to edit.

In Konnect we implemented this component to display slightly differently when there was no value. This became a problem when you would click to edit for the first time, the styling from the initial element would transfer in. We also want to display text when empty but NOT pass that text in on click (similar to input placeholder).   

#### Changes made:
* Adds props
* Adds tests
* Updates snapshots
* Adds doc

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
