### PR TITLE
feat(kpop): kpop adds an optional callback function when popover is already opened

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -264,12 +264,35 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 
 ### onPopoverClick
 You can pass in an optional callback function to trigger when the popup is already open and the trigger method is click.
+The callback function can optionally return a boolean, which will show or hide the popup depending on the value of the boolean.
+
+<KPop title="Cool header" :on-popover-click="toggle">
+  <KButton>button</KButton>
+  <div slot="content">
+  The first time you click the button, I will close when you click here once.
+  The second time you click the button, I will close when you click here twice.</div>
+</KPop>
 
 ```vue
-<KPop title="Cool header" on-already-open="onPopoverClick()">
+<KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
   <div slot="content">Click me and you will get an alert if I am already opened!</div>
 </KPop>
+<script>
+  export default {
+    data () {
+      return {
+        isToggled: true
+      }
+    },
+    methods: {
+      toggle () {
+        this.isToggled = !this.isToggled
+        return this.isToggled
+      }
+    }
+  }
+</script>
 ```
 
 ### isSVG Flag
@@ -377,6 +400,7 @@ This is the slot that takes in the content of the popover.
           'pending': 'idle'
         },
         count: 0,
+        isToggled: true,
         timeout: null
       }
     },
@@ -387,7 +411,6 @@ This is the slot that takes in the content of the popover.
           'idle': 'Load something'
         }[this.currentState]
       },
-      
       message () {
         return {
           'pending': `Loading ${this.count}...`,
@@ -403,14 +426,16 @@ This is the slot that takes in the content of the popover.
           this.transition()
         }, 2000)
       },
-      
+      toggle () {
+        this.isToggled = !this.isToggled
+        return this.isToggled
+      },
       onClose () {
         clearTimeout(this.timeout)
         if (this.currentState == 'pending') {
           this.transition()
         }
       },
-      
       transition() {
         this.currentState = this.states[this.currentState]
       }
@@ -448,7 +473,6 @@ This is the slot that takes in the content of the popover.
           'idle': 'Load something'
         }[this.currentState]
       },
-      
       message () {
         return {
           'pending': `Loading ${this.count}...`,
@@ -464,17 +488,12 @@ This is the slot that takes in the content of the popover.
           this.transition()
         }, 2000)
       },
-      
       onClose () {
         clearTimeout(this.timeout)
         this.transition()
       },
-      
       transition() {
         this.currentState = this.states[this.currentState]
-      },
-      onPopoverClick() {
-        alert('This triggered while the popover is already opened!')
       }
     }
   }

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -341,7 +341,7 @@ This is the slot that takes in the content of the popover.
 
 ### Events / Loading Content
 
-- `opened` - emitted once the popover has been opened, also passes in whether or not the popover is currently being displayed
+- `opened` - emitted once the popover has been opened
 - `closed` - emitted when the popover has been triggered closed (emits on all triggers)
 
 <KPop @opened="loadSomething" @closed="onClose">

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -262,14 +262,13 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 </KPop>
 ```
 
-### onAlreadyOpen
-You can pass in an optional callback function to trigger when the popup is already open (usually when the trigger method is by clicking).
-This can be useful in situations where for example, you need to close the popup.
+### onPopoverClick
+You can pass in an optional callback function to trigger when the popup is already open and the trigger method is click.
 
 ```vue
-<KPop title="Cool header" on-already-open="closePopup()">
+<KPop title="Cool header" on-already-open="onPopoverClick()">
   <KButton>button</KButton>
-  <div slot="content">I will close when I am clicked while already opened!</div>
+  <div slot="content">Click me and you will get an alert if I am already opened!</div>
 </KPop>
 ```
 
@@ -473,6 +472,9 @@ This is the slot that takes in the content of the popover.
       
       transition() {
         this.currentState = this.states[this.currentState]
+      },
+      onPopoverClick() {
+        alert('This triggered while the popover is already opened!')
       }
     }
   }

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -330,11 +330,10 @@ This is the slot that takes in the content of the popover.
 
 ### Events / Loading Content
 
-- `opened` - emitted once the popover has been opened
-- `closed` - emitted when the popover has been triggered closed (emits on all
-triggers)
+- `opened` - emitted once the popover has been opened, also passes in whether or not the popover is currently being displayed
+- `closed` - emitted when the popover has been triggered closed (emits on all triggers)
 
-<KPop @opened="loadSomething" @closed="onClose">
+<KPop @opened="(isShow) => loadSomething(isShow)" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <div slot="content" style="display: flex; justify-content: center;">
     <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
@@ -387,8 +386,9 @@ triggers)
       }
     },
     methods: {
-      loadSomething () {
+      loadSomething (isShow) {
         this.transition()
+        if (isShow) { alert('this popover is already showing!') }
         this.timeout = setTimeout(() => {
           this.count+=1
           this.transition()
@@ -411,7 +411,7 @@ triggers)
 
 
 ```vue
-<KPop @opened="loadSomething" @closed="onClose">
+<KPop @opened="(isShow) => loadSomething(isShow)" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <div slot="content" style="display: flex; justify-content: center;">
     <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
@@ -448,8 +448,9 @@ triggers)
       }
     },
     methods: {
-      loadSomething () {
+      loadSomething (isShow) {
         this.transition()
+        if (isShow) { alert('this popover is already showing!') }
         this.timeout = setTimeout(() => {
           this.count+=1
           this.transition()

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -262,6 +262,17 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 </KPop>
 ```
 
+### onAlreadyOpen
+You can pass in an optional callback function to trigger when the popup is already open (usually when the trigger method is by clicking).
+This can be useful in situations where for example, you need to close the popup.
+
+```vue
+<KPop title="Cool header" on-already-open="closePopup()">
+  <KButton>button</KButton>
+  <div slot="content">I will close when I am clicked while already opened!</div>
+</KPop>
+```
+
 ### isSVG Flag
 To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` prop.
 This will wrap the content of the KPop in a `<foreignObject>` tag, so that normal
@@ -333,7 +344,7 @@ This is the slot that takes in the content of the popover.
 - `opened` - emitted once the popover has been opened, also passes in whether or not the popover is currently being displayed
 - `closed` - emitted when the popover has been triggered closed (emits on all triggers)
 
-<KPop @opened="(isOpen) => loadSomething(isOpen)" @closed="onClose">
+<KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <div slot="content" style="display: flex; justify-content: center;">
     <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
@@ -386,9 +397,8 @@ This is the slot that takes in the content of the popover.
       }
     },
     methods: {
-      loadSomething (isOpen) {
+      loadSomething () {
         this.transition()
-        if (isOpen) { alert('this popover is already showing!') }
         this.timeout = setTimeout(() => {
           this.count+=1
           this.transition()
@@ -411,7 +421,7 @@ This is the slot that takes in the content of the popover.
 
 
 ```vue
-<KPop @opened="(isOpen) => loadSomething(isOpen)" @closed="onClose">
+<KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <div slot="content" style="display: flex; justify-content: center;">
     <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
@@ -448,9 +458,8 @@ This is the slot that takes in the content of the popover.
       }
     },
     methods: {
-      loadSomething (isOpen) {
+      loadSomething () {
         this.transition()
-        if (isOpen) { alert('this popover is already showing!') }
         this.timeout = setTimeout(() => {
           this.count+=1
           this.transition()

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -276,7 +276,9 @@ The callback function can optionally return a boolean, which will show or hide t
 ```vue
 <KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
-  <div slot="content">Click me and you will get an alert if I am already opened!</div>
+  <div slot="content">
+  The first time you click the button, I will close when you click here once.
+  The second time you click the button, I will close when you click here twice.</div>
 </KPop>
 <script>
   export default {

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -333,7 +333,7 @@ This is the slot that takes in the content of the popover.
 - `opened` - emitted once the popover has been opened, also passes in whether or not the popover is currently being displayed
 - `closed` - emitted when the popover has been triggered closed (emits on all triggers)
 
-<KPop @opened="(isShow) => loadSomething(isShow)" @closed="onClose">
+<KPop @opened="(isOpen) => loadSomething(isOpen)" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <div slot="content" style="display: flex; justify-content: center;">
     <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
@@ -386,9 +386,9 @@ This is the slot that takes in the content of the popover.
       }
     },
     methods: {
-      loadSomething (isShow) {
+      loadSomething (isOpen) {
         this.transition()
-        if (isShow) { alert('this popover is already showing!') }
+        if (isOpen) { alert('this popover is already showing!') }
         this.timeout = setTimeout(() => {
           this.count+=1
           this.transition()
@@ -411,7 +411,7 @@ This is the slot that takes in the content of the popover.
 
 
 ```vue
-<KPop @opened="(isShow) => loadSomething(isShow)" @closed="onClose">
+<KPop @opened="(isOpen) => loadSomething(isOpen)" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <div slot="content" style="display: flex; justify-content: center;">
     <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
@@ -448,9 +448,9 @@ This is the slot that takes in the content of the popover.
       }
     },
     methods: {
-      loadSomething (isShow) {
+      loadSomething (isOpen) {
         this.transition()
-        if (isShow) { alert('this popover is already showing!') }
+        if (isOpen) { alert('this popover is already showing!') }
         this.timeout = setTimeout(() => {
           this.count+=1
           this.transition()

--- a/packages/KPop/KPop.spec.js
+++ b/packages/KPop/KPop.spec.js
@@ -65,9 +65,9 @@ describe('KPop', () => {
 
     const slottedEl = wrapper.find('.slottedEl')
 
-    expect(wrapper.vm.isShow).toBe(false)
+    expect(wrapper.vm.isOpen).toBe(false)
     slottedEl.trigger('click')
-    expect(wrapper.vm.isShow).toBe(true)
+    expect(wrapper.vm.isOpen).toBe(true)
   })
 
   it('shows element on hover', () => {
@@ -83,9 +83,9 @@ describe('KPop', () => {
 
     const slottedEl = wrapper.find('.slottedEl')
 
-    expect(wrapper.vm.isShow).toBe(false)
+    expect(wrapper.vm.isOpen).toBe(false)
     slottedEl.trigger('mouseenter')
-    expect(wrapper.vm.isShow).toBe(true)
+    expect(wrapper.vm.isOpen).toBe(true)
 
     wrapper.destroy()
   })

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -166,6 +166,13 @@ export default {
     hideCaret: {
       type: Boolean,
       default: false
+    },
+    /**
+     * A custom callback function to call when the popover is already opened
+     */
+    onAlreadyOpen: {
+      type: Function,
+      default: null
     }
   },
 
@@ -234,10 +241,10 @@ export default {
     },
 
     showPopper () {
+      this.isOpen = true
       if (this.timer) clearTimeout(this.timer)
       if (this.popperTimer) clearTimeout(this.popperTimer)
-      this.$emit('opened', this.isOpen)
-      this.isOpen = true
+      this.$emit('opened')
     },
 
     async createInstance () {
@@ -273,6 +280,8 @@ export default {
         } else {
           this.createInstance()
         }
+      } else if (this.$refs.popper && this.$refs.popper.contains(e.target) && this.onAlreadyOpen) {
+        this.onAlreadyOpen()
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target)) {
         this.showPopper()
       } else {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -6,7 +6,7 @@
       :name="popoverTransitions">
       <foreignObject>
         <div
-          v-show="isShow"
+          v-show="isOpen"
           ref="popper"
           :style="popoverStyle"
           :class="[popoverClasses, {'hide-caret': hideCaret }]"
@@ -26,7 +26,7 @@
       v-else
       name="fade">
       <div
-        v-show="isShow"
+        v-show="isOpen"
         ref="popper"
         :style="popoverStyle"
         :class="[popoverClasses, {'hide-caret': hideCaret }]"
@@ -173,7 +173,7 @@ export default {
     return {
       popper: null,
       reference: null,
-      isShow: false
+      isOpen: false
     }
   },
 
@@ -188,7 +188,7 @@ export default {
   watch: {
     hidePopover: function () {
       // whenever this prop gets updated, hide the popper
-      if (this.isShow) {
+      if (this.isOpen) {
         this.hidePopper()
       }
     }
@@ -223,11 +223,11 @@ export default {
   methods: {
     hidePopper () {
       if (this.trigger !== 'hover') {
-        this.isShow = false
+        this.isOpen = false
       }
 
       this.timer = setTimeout(() => {
-        this.isShow = false
+        this.isOpen = false
         this.$emit('closed')
         this.destroy()
       }, this.popoverTimeout)
@@ -236,8 +236,8 @@ export default {
     showPopper () {
       if (this.timer) clearTimeout(this.timer)
       if (this.popperTimer) clearTimeout(this.popperTimer)
-      this.$emit('opened', this.isShow)
-      this.isShow = true
+      this.$emit('opened', this.isOpen)
+      this.isOpen = true
     },
 
     async createInstance () {
@@ -268,7 +268,7 @@ export default {
     handleClick (e) {
       e.stopPropagation()
       if (this.reference && this.reference.contains(e.target)) {
-        if (this.isShow) {
+        if (this.isOpen) {
           this.hidePopper()
         } else {
           this.createInstance()
@@ -276,7 +276,7 @@ export default {
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target)) {
         this.showPopper()
       } else {
-        if (this.isShow) this.hidePopper()
+        if (this.isOpen) this.hidePopper()
       }
     },
 
@@ -298,7 +298,7 @@ export default {
 
     destroy () {
       if (this.popper) {
-        this.isShow = false
+        this.isOpen = false
         this.popper.destroy()
         this.popper = null
       }

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -168,9 +168,9 @@ export default {
       default: false
     },
     /**
-     * A custom callback function to call when the popover is already opened
+     * A custom callback function to call when the popover is already opened and an element inside has been clicked
      */
-    onAlreadyOpen: {
+    onPopoverClick: {
       type: Function,
       default: null
     }
@@ -280,13 +280,11 @@ export default {
         } else {
           this.createInstance()
         }
-      } else if (this.$refs.popper && this.$refs.popper.contains(e.target) && this.onAlreadyOpen) {
-        this.onAlreadyOpen()
+      } else if (this.$refs.popper && this.$refs.popper.contains(e.target) && this.onPopoverClick) {
+        this.onPopoverClick()
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target)) {
         this.showPopper()
-      } else {
-        if (this.isOpen) this.hidePopper()
-      }
+      } else if (this.isOpen) { this.hidePopper() }
     },
 
     bindEvents () {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -234,10 +234,10 @@ export default {
     },
 
     showPopper () {
-      this.isShow = true
       if (this.timer) clearTimeout(this.timer)
       if (this.popperTimer) clearTimeout(this.popperTimer)
-      this.$emit('opened')
+      this.$emit('opened', this.isShow)
+      this.isShow = true
     },
 
     async createInstance () {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -281,7 +281,10 @@ export default {
           this.createInstance()
         }
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target) && this.onPopoverClick) {
-        this.onPopoverClick()
+        const isOpen = this.onPopoverClick()
+        if (isOpen !== undefined) {
+          isOpen ? this.showPopper() : this.hidePopper()
+        }
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target)) {
         this.showPopper()
       } else if (this.isOpen) { this.hidePopper() }


### PR DESCRIPTION
### Summary
Adding a callback function prop that triggers when the popover has already been opened

#### Changes made:
*Adding a callback function prop that triggers when the popover has already been opened
*Rename isShow to isOpen

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
