### PR TITLE
fix(segmentedcontrol) color and selectors

### DIFF
--- a/packages/KSegmentedControl/KSegmentedControl.vue
+++ b/packages/KSegmentedControl/KSegmentedControl.vue
@@ -68,40 +68,41 @@ export default {
   }
 }
 </script>
-<style scoped>
+<style lang="scss" scoped>
 .segmented-control .k-button {
   border-radius: 0;
-  flex: 1;
   margin-left: -1px;
+  flex: 1;
   color: var(--blue-600);
   --KButtonPrimaryBase: var(--blue-100);
   --KButtonPrimaryHover: var(--blue-100);
-}
-.segmented-control .k-button.primary {
-  z-index: 1;
-  border-color: var(--blue-600);
-}
-.segmented-control .k-button:hover {
-  z-index: 2;
-  border-color: var(--blue-600);
-}.segmented-control .k-button:active {
-  z-index: 2;
-  border-color: var(--blue-600);
-}
-.segmented-control .k-button:focus {
-  z-index: 3;
-  border-color: var(--blue-600);
-  box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--blue-600);
-}
-.segmented-control .k-button:first-child {
-  border-radius: 3px 0 0 3px;
-  margin-left: 0;
-}
-.segmented-control .k-button:last-child {
-  border-radius: 0 3px 3px 0;
-}
-.segmented-control .k-button:only-child {
-  border-radius: 3px;
-  margin-left: 0;
+  &.primary {
+    z-index: 1;
+    border-color: var(--blue-600);
+  }
+  &:hover {
+    z-index: 2;
+    border-color: var(--blue-600);
+  }
+  &:active {
+    z-index: 2;
+    border-color: var(--blue-600);
+  }
+  &:focus {
+    z-index: 3;
+    border-color: var(--blue-600);
+    box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--blue-600);
+  }
+  &:first-child {
+    border-radius: 3px 0 0 3px;
+    margin-left: 0;
+  }
+  &:last-child {
+    border-radius: 0 3px 3px 0;
+  }
+  &:only-child {
+    border-radius: 3px;
+    margin-left: 0;
+  }
 }
 </style>

--- a/packages/KSegmentedControl/KSegmentedControl.vue
+++ b/packages/KSegmentedControl/KSegmentedControl.vue
@@ -69,28 +69,29 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+@import '~@kongponents/styles/_variables.scss';
+
 .segmented-control .k-button {
+  --KButtonPrimaryBase: var(--blue-100);
+  --KButtonPrimaryHover: var(--blue-100);
+
+  color: var(--KSegementedControlPrimary, var(--blue-600, color(blue-600)));
   border-radius: 0;
   margin-left: -1px;
   flex: 1;
-  color: var(--blue-600);
-  --KButtonPrimaryBase: var(--blue-100);
-  --KButtonPrimaryHover: var(--blue-100);
+
   &.primary {
     z-index: 1;
     border-color: var(--blue-600);
   }
   &:hover {
     z-index: 2;
-    border-color: var(--blue-600);
   }
   &:active {
     z-index: 2;
-    border-color: var(--blue-600);
   }
   &:focus {
     z-index: 3;
-    border-color: var(--blue-600);
     box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--blue-600);
   }
   &:first-child {

--- a/packages/KSegmentedControl/KSegmentedControl.vue
+++ b/packages/KSegmentedControl/KSegmentedControl.vue
@@ -71,11 +71,27 @@ export default {
 <style scoped>
 .segmented-control .k-button {
   border-radius: 0;
-  margin-left: -1px;
   flex: 1;
+  margin-left: -1px;
+  color: var(--blue-600);
+  --KButtonPrimaryBase: var(--blue-100);
+  --KButtonPrimaryHover: var(--blue-100);
+}
+.segmented-control .k-button.primary {
+  z-index: 1;
+  border-color: var(--blue-600);
+}
+.segmented-control .k-button:hover {
+  z-index: 2;
+  border-color: var(--blue-600);
+}.segmented-control .k-button:active {
+  z-index: 2;
+  border-color: var(--blue-600);
 }
 .segmented-control .k-button:focus {
-  z-index: 1;
+  z-index: 3;
+  border-color: var(--blue-600);
+  box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--blue-600);
 }
 .segmented-control .k-button:first-child {
   border-radius: 3px 0 0 3px;

--- a/packages/KSegmentedControl/package.json
+++ b/packages/KSegmentedControl/package.json
@@ -20,8 +20,7 @@
   },
   "homepage": "https://github.com/Kong/kongponents#readme",
   "dependencies": {
-    "@kongponents/kbutton": "^1.0.2",
-    "@kongponents/ktoggle": "^0.1.5"
+    "@kongponents/kbutton": "^1.0.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Summary
Before:
![image](https://user-images.githubusercontent.com/3679927/96243392-fbe3de00-0fa4-11eb-8540-d99bf9b658fe.png)

After:
![image](https://user-images.githubusercontent.com/3679927/96243301-d9ea5b80-0fa4-11eb-8d64-1314fa5cb369.png)

#### Changes made:
* mute colors to suit konnect design
* fix hover active and focus borders and box shadows

NOTE: in previous version hover focus and active states were all handled gracefully by kbutton, in this design they have to be overriden
![image](https://user-images.githubusercontent.com/3679927/96244440-5a5d8c00-0fa6-11eb-8c1e-b95bf7996278.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
