### PR TITLE
style(kbadge) auto width by default, add vars, truncate

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -36,14 +36,16 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 
 <KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>
 <KBadge color="var(--red-100)" background-color="var(--red-400)">Badge</KBadge>
-<KBadge color="var(--blue-200)" background-color="var(--blue-500)">👋🏻 Hello</KBadge>
+<KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
+<KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 
 ```vue
 <KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>
 <KBadge color="var(--red-100)" background-color="var(--red-400)">Badge</KBadge>
-<KBadge color="var(--blue-200)" background-color="var(--blue-500)">👋🏻 Hello</KBadge>
+<KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
+<KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 ```
 
 ## Slots
@@ -60,6 +62,9 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 | :---------------------      | :---------------------------- |
 | `--KBadgeBorderRadius`      |                               |
 | `--KBadgeFontSize`          |                               |
+| `--KBadgeMinWidth`          |                               |
+| `--KBadgeMaxWidth`          |                               |
+| `--KBadgeWidth`             |                               |
 | `--KBadgePaddingY`          | Vertical top/bottom spacing   |
 | `--KBadgePaddingX`          | Horizontal left/right spacing |
 | `--KBadgeSuccessColor`      |                               |

--- a/packages/KBadge/KBadge.vue
+++ b/packages/KBadge/KBadge.vue
@@ -2,7 +2,7 @@
   <div
     :class="[appearance !== 'custom' && `kbadge-${appearance}`]"
     :style="color && backgroundColor && {backgroundColor, color}"
-    class="k-badge"
+    class="k-badge truncate"
   >
     <slot />
   </div>
@@ -49,14 +49,17 @@ export default {
 @import '~@kongponents/styles/_variables.scss';
 
 .k-badge {
-  display: inline-flex;
+  display: inline-block;
   justify-content: center;
   font-weight: 500;
+  vertical-align: top;
   font-size: var(--KBadgeFontSize, var(--type-sm, type(sm)));
-  height: 27px;
-  align-items: center;
-  width: var(--KBadgeWidth, 71px);
-  padding: var(--KBadgePaddingY, 2px) var(--KBadgePaddingX, 4px);
+  height: auto;
+  text-align: center;
+  min-width: var(--KBadgeMinWidth, 71px);
+  max-width: var(--KBadgeMaxWidth, 200px);
+  width: var(--KBadgeWidth, auto);
+  padding: var(--KBadgePaddingY, 4px) var(--KBadgePaddingX, var(--spacing-xxs));
   font-family: var(--font-family-sans, font(sans));
   border-radius: var(--KBadgeBorderRadius, 3px);
 

--- a/packages/KBadge/KBadge.vue
+++ b/packages/KBadge/KBadge.vue
@@ -50,7 +50,6 @@ export default {
 
 .k-badge {
   display: inline-block;
-  justify-content: center;
   font-weight: 500;
   vertical-align: top;
   font-size: var(--KBadgeFontSize, var(--type-sm, type(sm)));

--- a/packages/KBadge/__snapshots__/KBadge.spec.js.snap
+++ b/packages/KBadge/__snapshots__/KBadge.spec.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KBadge handles custom colors 1`] = `<div class="k-badge" style="background-color: red; color: white;">Hello!</div>`;
+exports[`KBadge handles custom colors 1`] = `<div class="k-badge truncate" style="background-color: red; color: white;">Hello!</div>`;
 
-exports[`KBadge matches snapshot 1`] = `<div class="k-badge"></div>`;
+exports[`KBadge matches snapshot 1`] = `<div class="k-badge truncate"></div>`;
 
-exports[`KBadge renders KBadge with the danger appearance 1`] = `<div class="k-badge kbadge-danger">danger</div>`;
+exports[`KBadge renders KBadge with the danger appearance 1`] = `<div class="k-badge truncate kbadge-danger">danger</div>`;
 
-exports[`KBadge renders KBadge with the success appearance 1`] = `<div class="k-badge kbadge-success">success</div>`;
+exports[`KBadge renders KBadge with the success appearance 1`] = `<div class="k-badge truncate kbadge-success">success</div>`;
 
-exports[`KBadge renders KBadge with the warning appearance 1`] = `<div class="k-badge kbadge-warning">warning</div>`;
+exports[`KBadge renders KBadge with the warning appearance 1`] = `<div class="k-badge truncate kbadge-warning">warning</div>`;


### PR DESCRIPTION
### Summary

Add width "auto" + sane min/max widths by default. Add css vars support for overriding, and truncate with ellipsis.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate

Demo

![image](https://user-images.githubusercontent.com/5770711/100694684-8fa71900-335d-11eb-81d0-2ce5b81d7e43.png)
