### PR TITLE
fix(kbutton): add null check for kicon mounting

### DIFF
--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -104,7 +104,7 @@ export default {
   },
 
   mounted () {
-    this.hasIcon && this.$slots.icon[0].elm.setAttribute('viewBox', '0 0 16 16')
+    this.hasIcon && this.$slots.icon[0].elm && this.$slots.icon[0].elm.setAttribute('viewBox', '0 0 16 16')
   }
 }
 </script>


### PR DESCRIPTION
### Summary
Adds a null check for mounting non kicon svg icons

#### Changes made:
*Adds a null check for mounting non kicon svg icons

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
