### PR TITLE
feat(kskeleton) override transparency

### DIFF
--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -28,8 +28,10 @@ The number of milliseconds to wait before showing the skeleton state. Defaults t
 <template>
   <Komponent :data="{ isLoading: false }" v-slot="{ data }">
     <div>
-      <k-button @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</k-button>
-        <p v-if="!data.isLoading">lorum ipsum</p>
+      <k-button class="mb-2" @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</k-button>
+        <div v-if="!data.isLoading">
+          <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
+        </div>
         <KSkeleton v-else="data.isLoading" />
     </div>
   </Komponent>
@@ -39,8 +41,10 @@ The number of milliseconds to wait before showing the skeleton state. Defaults t
 <template>
   <Komponent :data="{ isLoading: false }" v-slot="{ data }">
     <div>
-      <k-button @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</k-button>
-        <div v-if="!data.isLoading">lorum ipsum</div>
+      <k-button class="mb-2" @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</k-button>
+        <div v-if="!data.isLoading">
+          <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
+        </div>
         <KSkeleton v-else="data.isLoading" />
     </div>
   </Komponent>

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -25,6 +25,28 @@ state. The following example shows a Form type KSKeleton.
 
 The number of milliseconds to wait before showing the skeleton state. Defaults to 750.
 
+<template>
+  <Komponent :data="{ isLoading: false }" v-slot="{ data }">
+    <div>
+      <k-button @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</k-button>
+        <p v-if="!data.isLoading">lorum ipsum</p>
+        <KSkeleton v-else="data.isLoading" />
+    </div>
+  </Komponent>
+</template>
+
+```vue
+<template>
+  <Komponent :data="{ isLoading: false }" v-slot="{ data }">
+    <div>
+      <k-button @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</k-button>
+        <div v-if="!data.isLoading">lorum ipsum</div>
+        <KSkeleton v-else="data.isLoading" />
+    </div>
+  </Komponent>
+</template>
+```
+
 ## Generic Loading State
 By default, **KSkeleton** will load a generic loading state. There are no props for this state.
 

--- a/packages/KSkeleton/KSkeleton.vue
+++ b/packages/KSkeleton/KSkeleton.vue
@@ -1,7 +1,6 @@
 <template>
   <div
-    v-if="isVisible || delayMilliseconds === 0"
-    :class="{ 'w-100': type !== 'spinner' }"
+    :class="{ 'w-100': type !== 'spinner', 'transparent': !isVisible }"
     class="d-flex flex-wrap">
     <CardSkeleton
       v-if="type === 'card'"
@@ -104,3 +103,8 @@ export default {
   }
 }
 </script>
+<style>
+.transparent .box {
+  background: transparent;
+}
+</style>

--- a/packages/KSkeleton/KSkeleton.vue
+++ b/packages/KSkeleton/KSkeleton.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="{ 'w-100': type !== 'spinner', 'transparent': !isVisible }"
+    :class="{ 'w-100': type !== 'spinner', 'opacity-0': !isVisible }"
     class="d-flex flex-wrap">
     <CardSkeleton
       v-if="type === 'card'"
@@ -104,7 +104,7 @@ export default {
 }
 </script>
 <style>
-.transparent .box {
-  background: transparent;
+.opacity-0 .box {
+  opacity: 0;
 }
 </style>

--- a/packages/KSkeleton/KSkeletonBox.vue
+++ b/packages/KSkeleton/KSkeletonBox.vue
@@ -42,6 +42,7 @@ export default {
     repeat;
   background-size: 400% 100%;
   animation: gradient 1s ease infinite;
+  transition: 1s;
 
   // Provided box widths
   &.width {

--- a/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
+++ b/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
@@ -5,7 +5,7 @@ exports[`KSkeleton KSkeletonBox renders width and height 1`] = `<div class="box 
 exports[`KSkeleton KSkeletonBox renders width and height 2`] = `<div class="box width-100 height-2"></div>`;
 
 exports[`KSkeleton variants matches snapshot 1`] = `
-<div class="d-flex flex-wrap w-100">
+<div class="d-flex flex-wrap w-100 transparent">
   <div class="skeleton-loader">
     <div class="box width-100 height-1"></div>
     <div class="box width-100 height-1"></div>

--- a/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
+++ b/packages/KSkeleton/__snapshots__/KSkeleton.spec.js.snap
@@ -5,7 +5,7 @@ exports[`KSkeleton KSkeletonBox renders width and height 1`] = `<div class="box 
 exports[`KSkeleton KSkeletonBox renders width and height 2`] = `<div class="box width-100 height-2"></div>`;
 
 exports[`KSkeleton variants matches snapshot 1`] = `
-<div class="d-flex flex-wrap w-100 transparent">
+<div class="d-flex flex-wrap w-100 opacity-0">
   <div class="skeleton-loader">
     <div class="box width-100 height-1"></div>
     <div class="box width-100 height-1"></div>


### PR DESCRIPTION
### Summary

The delay-milliseconds implementation currently handles the skeleton flashing by conditionally rendering after a timeout.
I propose to change this in favour of rendering transparently until after the timeout.

This way I do not need to approximate the pixel height of the skeleton and presented data to avoid components that flow vertically below from jumping up and down.

#### Changes made:
* added a css class
* moved isVisible condition to css class
* added example in docs to demonstrate the problem
* added a fade in

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
