### PR TITLE
feat(kooltip)!: refactor to kpop and restyle

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -1,9 +1,9 @@
 # Popover
 
-**KPop** is a popover component that is used when you need something with more 
-detailed content then fits inside a tooltip. KPop has three slots; only two is 
+**KPop** is a popover component that is used when you need something with more
+detailed content then fits inside a tooltip. KPop has three slots; only two is
 necessary is to be filled to populate the component with content. The title prop
-must be passed in and the main slot and the content slot must be populated in 
+must be passed in and the main slot and the content slot must be populated in
 for the popover to display anything.
 
 For example a button:
@@ -23,13 +23,14 @@ For example a button:
 ## Props
 
 ### Target
+
 This is the target `element` that the <code>popover</code> is appended to. By default its the body tag.
 
 
 <KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
   <div slot="content">
-    I am a popover, inside the <code>.theme-default-content</code> selector so 
+    I am a popover, inside the <code>.theme-default-content</code> selector so
     I can get some of the stylings inside the theme!
   </div>
 </KPop>
@@ -45,6 +46,7 @@ This is the target `element` that the <code>popover</code> is appended to. By de
 ```
 
 ### Tag
+
 This is the tag that the popover is wrapped around. By default its the div tag.
 
 ```vue
@@ -60,6 +62,7 @@ This is the tag that the popover is wrapped around. By default its the div tag.
 </KPop>
 
 ### Title
+
 This is the Title of the popover. Either this or the title slot needs to be filled.
 
 <KPop title="I am a new sample header">
@@ -91,6 +94,7 @@ or alternatively, via the slot:
 ```
 
 ### Trigger
+
 What the popover is triggered by - by default it's triggered on click.
 Here are the different options:
 
@@ -110,6 +114,7 @@ Here are the different options:
 ```
 
 ### Placement
+
 The position of where the popover appears - by default it appears on top.
 Here are the different options:
 
@@ -127,7 +132,7 @@ Here are the different options:
   <option
     v-for="p in positions"
     :key="p"
-    :value="p">{{ p }}</option> 
+    :value="p">{{ p }}</option>
 </select>
 
 <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
@@ -177,6 +182,7 @@ export default {
 ```
 
 ### Width
+
 The width of the popover body - by default it is 200px.
 
 <KPop title="Cool header" width="300">
@@ -192,16 +198,18 @@ The width of the popover body - by default it is 200px.
 ```
 
 ### Popover Classes
+
 Custom classes that you want to append to the popover - by default it has a `k-popover` class on it.
 
 ```vue
-<KPop title="Cool header" popoverClass="my-class">
+<KPop title="Cool header" popoverClasses="my-class">
   <KButton>button</KButton>
   <div slot="content">I have a custom my-class class on me!</div>
 </KPop>
 ```
 
 ### Popover Transitions
+
 Custom transitions that you want the popover to have - by default it uses a `fade` transition.
 
 ```vue
@@ -212,7 +220,8 @@ Custom transitions that you want the popover to have - by default it uses a `fad
 ```
 
 ### Popover Timeout
-Custom timeout setting that you want the popover to have - by default it is set 
+
+Custom timeout setting that you want the popover to have - by default it is set
 to 300 milliseconds.
 
 <KPop title="Cool header" :popover-timeout="1000" trigger="hover">
@@ -228,6 +237,7 @@ to 300 milliseconds.
 ```
 
 ### Hide Popover Flag
+
 You can pass in an optional flag to trigger the popover to hide - useful for external events like zooming or panning - by default it is set to `false`.
 
 ```vue
@@ -238,6 +248,7 @@ You can pass in an optional flag to trigger the popover to hide - useful for ext
 ```
 
 ### Disabled Flag
+
 You can pass in an optional flag to disable the popover - by default it is set to `false`.
 
 ```vue
@@ -248,6 +259,7 @@ You can pass in an optional flag to disable the popover - by default it is set t
 ```
 
 ### Hide Caret
+
 You can pass in an optional flag to not show the caret on the edge of the popover.
 
 <KPop title="Cool header" hide-caret placement="right">
@@ -263,6 +275,7 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 ```
 
 ### onPopoverClick
+
 You can pass in an optional callback function to trigger when the popup is already open and the trigger method is click.
 The callback function can optionally return a boolean, which will show or hide the popup depending on the value of the boolean.
 
@@ -298,6 +311,7 @@ The callback function can optionally return a boolean, which will show or hide t
 ```
 
 ### isSVG Flag
+
 To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` prop.
 This will wrap the content of the KPop in a `<foreignObject>` tag, so that normal
 HTML content can be injected into the popover.
@@ -504,9 +518,10 @@ This is the slot that takes in the content of the popover.
 
 
 ## Theming
+
 | Variable | Purpose
 |:-------- |:-------
-| `--KPopBackground `| Primary background color
+| `--KPopBackground`| Primary background color
 | `--KPopBorder`| Primary border color
 | `--KPopBodySize`| Font size of the body content
 | `--KPopColor`| Text color of the content
@@ -517,7 +532,7 @@ This is the slot that takes in the content of the popover.
 ## Browser Compatibility
 
 ::: warning
-For Internet Explorer 11 and below, the Popover component will not work due to `Node.contains` not being supported by the browser. 
+For Internet Explorer 11 and below, the Popover component will not work due to `Node.contains` not being supported by the browser.
 You will have to manually polyfill this functionality if you choose to support IE11 or below.
 :::
 

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -1,38 +1,40 @@
 # ToolTip
 
-**KoolTip** is a tooltip component that is used when you need a simple message to be displayed when hovering over an element.
+**KoolTip** is a tooltip component that is used when you need a simple label to be displayed when hovering over an element.
 KoolTip has a single slot that takes in the element that you want the tooltip to trigger over.
-At least the message prop must be passed in for the tooltip to display anything. For example a button:
+At least the label prop must be passed in for the tooltip to display anything. For example a button:
 
-<KoolTip message="I am a sample message">
-  <KButton>Sample Button</KButton>
+<KoolTip label="Video Games">
+  <KButton>&nbsp;🎮</KButton>
 </KoolTip>
 
 ```vue
-<KoolTip message="I am a sample message">
-  <KButton>Sample Button</KButton>
+<KoolTip label="Video Games">
+  <KButton>&nbsp;🎮</KButton>
 </KoolTip>
 ```
 
 ## Props
 
-### Message
+### Label
+
 Here you can pass in the text to display in the toolip.
 
-- `I am a new sample message`
+- `I am a new sample label`
 
-<KoolTip message="I am a new sample message">
+<KoolTip label="I am a new sample label">
   <KButton>Sample Button</KButton>
 </KoolTip>
 
 ```vue
-<KoolTip message="I am a new sample message">
+<KoolTip label="I am a new sample label">
   <KButton>Sample Button</KButton>
 </KoolTip>
 ```
 
 ### Position
-This is where the tooltip will appear - by default it appears on top. 
+
+This is where the tooltip will appear - by default it appears on top.
 Here are the different options:
 
 - `top`  
@@ -40,30 +42,24 @@ Here are the different options:
 - `left`
 - `right`
 
-<KoolTip position="bottom" message="A message that appears on the bottom">
-  <KButton>Sample Button</KButton>
+<div class="d-flex justify-content-around">
+<KoolTip placement="bottom" label="A label that appears on the bottom">
+  <KButton>bottom</KButton>
 </KoolTip>
+<KoolTip placement="top" label="A label that appears on the top">
+  <KButton>top</KButton>
+</KoolTip>
+<KoolTip placement="left" label="A label that appears on the left">
+  <KButton>left</KButton>
+</KoolTip>
+<KoolTip placement="right" label="A label that appears on the right">
+  <KButton>right</KButton>
+</KoolTip>
+</div>
+
 
 ```vue
-<KoolTip position="bottom" message="A message that appears on the bottom">
-  <KButton>Sample Button</KButton>
-</KoolTip>
-```
-
-### Alignment
-This is how the text in the tooltip is aligned. By default it is left aligned.
-Here are the different options:
-
-- `left`  
-- `right`  
-- `center`
-
-<KoolTip alignment="right" message="A message that is aligned to the right">
-  <KButton>Sample Button</KButton>
-</KoolTip>
-
-```vue
-<KoolTip alignment="right" message="A message that is aligned to the right">
+<KoolTip position="bottom" label="A label that appears on the bottom">
   <KButton>Sample Button</KButton>
 </KoolTip>
 ```
@@ -73,8 +69,60 @@ Here are the different options:
 - `Default` There is a main slot that takes in the element you want the popover to be triggered over.
 
 ```vue
-<KoolTip message="a cool message">
+<KoolTip label="a cool label">
   <!-- Your element goes here -->
   <KButton>button</KButton>
 </KPop>
 ```
+
+- `Content` This allows you to slot in any html content
+
+<KoolTip label="Video Games">
+  <KButton>&nbsp;✌🏻</KButton>
+  <template slot="content">
+    <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
+  </template>
+</KoolTip>
+
+```vue
+<KoolTip>
+  <KButton>&nbsp;✌🏻</KButton>
+  <template slot="content">
+    <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
+  </template>
+</KoolTip>
+```
+
+## Theming
+
+| Variable | Purpose
+|:-------- |:-------
+| `--KPopBackground`| Background color
+| `--KoolTipColor`| Color of text
+
+Example:
+
+<KoolTip class="tooltip-blue" label="Video Games">
+  <KButton>themed tooltip</KButton>
+</KoolTip>
+
+```vue
+<template>
+<KoolTip class="tooltip-blue" label="Video Games">
+  <KButton class="primary">themed tooltip</KButton>
+</KoolTip>
+</template>
+<style>
+.tooltip-blue {
+  --KPopBackground: var(--blue-300);
+  --KoolTipColor: var(--blue-500);
+}
+</style>
+```
+
+<style>
+.tooltip-blue {
+  --KoolTipBackground: var(--blue-500);
+  --KoolTipColor: var(--blue-200);
+}
+</style>

--- a/docs/style-guide/colors.md
+++ b/docs/style-guide/colors.md
@@ -7,14 +7,16 @@
     :key="i"
     class="color-group">
     <h4>{{ key }}</h4>
-    <p v-if="key === 'Black'">Unlike the other colors which follow a naming style numbered lightest to darkest, blacks are named by their opacity.</p>
+    <p v-if="key === 'Black'">
+      Unlike the other colors which follow a naming style numbered lightest to darkest, blacks include variants that are
+      named by their opacity that roughly equate their hex counterparts.</p>
     <div class="colors">
       <swatch
         v-for="(color, i) in group"
         :key="i"
         :color="color"/>
     </div>
-  </div> 
+  </div>
 </section>
 
 <script>
@@ -56,7 +58,7 @@ export default {
   margin-bottom: 2rem;
   h4 {
     margin: 0;
-    border-bottom: 1px solid 
+    border-bottom: 1px solid
   }
   .colors {
     display: grid;

--- a/packages/KoolTip/KoolTip.spec.js
+++ b/packages/KoolTip/KoolTip.spec.js
@@ -2,45 +2,55 @@ import { mount } from '@vue/test-utils'
 import KoolTip from '@/KoolTip/KoolTip'
 
 const positions = ['top', 'right', 'bottom', 'left']
-const alignments = ['left', 'center', 'right']
 
 const rendersCorrectPosition = (variant) => {
   it(`renders tooltip to the ${variant} side`, () => {
     const wrapper = mount(KoolTip, {
       propsData: {
-        'position': variant,
-        'message': `I'm on the ${variant} side!`
+        'placement': variant,
+        'label': `I'm on the ${variant} side!`
       }
     })
 
-    expect(wrapper.find('.k-tooltip').classes()).toContain(`k-tooltip-${variant}`)
-  })
-}
-
-let rendersCorrectAlignment = (variant) => {
-  it(`renders tooltip text aligned to the ${variant}`, () => {
-    const wrapper = mount(KoolTip, {
-      propsData: {
-        'alignment': variant,
-        'message': `I'm aligned to the ${variant}!`
-      }
-    })
-
-    expect(wrapper.element.style['text-align']).toEqual(variant)
+    expect(wrapper.html()).toMatchSnapshot()
   })
 }
 
 describe('KoolTip', () => {
   positions.map(p => rendersCorrectPosition(p))
-  alignments.map(a => rendersCorrectAlignment(a))
 
   it('matches snapshot', () => {
     const wrapper = mount(KoolTip, {
       propsData: {
-        'message': `I'm inside the tooltip!`
+        'label': `I'm inside the tooltip!`
       }
     })
 
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('allow class to be passed through', async () => {
+    const Component = {
+      template: `
+        <KoolTip :class="theClass" label="hey">
+          <button>click</button>
+        </Kooltip>
+      `,
+      props: {
+        theClass: {
+          type: String
+        }
+      }
+    }
+    const wrapper = mount(Component, {
+      components: {KoolTip},
+      propsData: {
+        theClass: 'color-blue'
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.kooltip').classes()).toContain('color-blue')
   })
 })

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -71,10 +71,10 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .kooltip {
-  --KPopColor: var(--KoolTipColor, var(--white));
-  --KPopBackground: var(--KoolTipBackground, var(--black-400));
+  --KPopColor: var(--KoolTipColor, var(--white, color(white)));
+  --KPopBackground: var(--KoolTipBackground, var(--black-400, color(black-400)));
   --KPopBodySize: var(--type-sm);
   --KPopPaddingX: var(--spacing-xs);
   --KPopPaddingY: var(--spacing-xs);

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -1,35 +1,42 @@
 <template>
-  <div
-    :aria-hidden="isHovering ? 'true' : 'false'"
-    :data-message="message"
-    :class="positionClass"
-    :style="{'text-align': alignment}"
-    class="k-tooltip"
-    role="tooltip"
-    @mouseout="isHovering(false)"
-    @mouseover="isHovering(true)">
-    <slot/>
-  </div>
+  <KPop
+    :placement="placement"
+    :popover-classes="`kooltip ${computedClass} ${className}`"
+    trigger="hover"
+    width="auto"
+    hide-caret>
+    <slot />
+    <div slot="content">
+      <slot
+        :label="label"
+        name="content">{{ label }}</slot>
+    </div>
+  </KPop>
 </template>
 
 <script>
+import KPop from '@kongponents/kpop/KPop.vue'
+
 export default {
   name: 'KoolTip',
+  components: { KPop },
+  inheritAttrs: false,
   props: {
     /**
-     * Message to show in tooltip
+     * Text to show in tooltip
      */
-    message: {
+    label: {
       type: String,
       required: true
     },
+
     /**
      * Define which side the tooltip displays<br>
      * 'top' | 'bottom' | 'left' | 'right'
      */
-    position: {
+    placement: {
       type: String,
-      default: 'top',
+      default: 'bottom',
       validator: function (value) {
         return [
           'top',
@@ -38,156 +45,37 @@ export default {
           'right'
         ].indexOf(value) !== -1
       }
-    },
-    /**
-     * Sets the text alignment of the tooltip<br>
-     * 'left' | 'center' | 'right'
-     */
-    alignment: {
-      type: String,
-      default: 'left',
-      validator: function (value) {
-        return [
-          'left',
-          'right',
-          'center'
-        ].indexOf(value) !== -1
-      }
     }
   },
-
   data () {
     return {
-      hovering: false
+      className: ''
     }
   },
-
   computed: {
-    positionClass () {
-      return `k-tooltip-${this.position}`
+    computedClass () {
+      return {
+        top: 'mb-2',
+        right: 'ml-2',
+        bottom: 'mt-2',
+        left: 'mr-2'
+      }[this.placement]
     }
   },
-
-  methods: {
-    isHovering (isHovering) {
-      this.hovering = isHovering
-    }
+  mounted () {
+    this.className = this.$el && this.$el.className
   }
 }
 </script>
 
 <style>
-.k-tooltip {
-  display: inline-block;
-  position: relative;
-  cursor: pointer;
-}
-.k-tooltip:before,
-.k-tooltip:after {
-  position: absolute;
-  visibility: hidden;
-  opacity: 0;
+.kooltip {
+  --KPopColor: var(--KoolTipColor, var(--white));
+  --KPopBackground: var(--KoolTipBackground, var(--black-400));
+  --KPopBodySize: var(--type-sm);
+  --KPopPaddingX: var(--spacing-xs);
+  --KPopPaddingY: var(--spacing-xs);
+  --KPopBorder: none;
   pointer-events: none;
-  z-index: 1090;
-  transition: all 0.15s cubic-bezier(0.5, 1, 0.25, 1);
-}
-.k-tooltip:before {
-  min-width: 275px;
-  padding: .5rem .75rem;
-  font-size: .875rem;
-  font-weight: normal;
-  border-radius: 3px;
-  background: #fff;
-  box-shadow: 0 0 12px 2px rgba(0, 0, 0, 0.15);
-  content: attr(data-message);
-}
-.k-tooltip:after {
-  width: 0;
-  border: 8px solid transparent;
-  content: "";
-}
-.k-tooltip:hover:before,
-.k-tooltip:hover:after {
-  visibility: visible;
-  opacity: 1;
-}
-
-  /* position styling */
-.k-tooltip.k-tooltip-top:before,
-.k-tooltip.k-tooltip-top:after {
-  bottom: 100%;
-  transform: translateX(-50%);
-}
-.k-tooltip.k-tooltip-top:before {
-  left: 100%;
-  margin-bottom: 5px;
-}
-.k-tooltip.k-tooltip-top:after {
-  left: 50%;
-  border-top: 8px solid #fff;
-  border-bottom: none;
-  margin-bottom: -3px;
-}
-.k-tooltip.k-tooltip-top:hover:before,
-.k-tooltip.k-tooltip-top:hover:after {
-  transform: translateX(-50%) translateY(-5px);
-}
-
-.k-tooltip.k-tooltip-right:before,
-.k-tooltip.k-tooltip-right:after {
-  top: 50%;
-  left: 100%;
-  transform: translateY(-50%)
-}
-.k-tooltip.k-tooltip-right:before {
-  margin-left: 5px;
-}
-.k-tooltip.k-tooltip-right:after {
-  border-right: 8px solid #fff;
-  border-left: none;
-  margin-left: -3px;
-}
-.k-tooltip.k-tooltip-right:hover:before,
-.k-tooltip.k-tooltip-right:hover:after {
-  transform: translateX(5px) translateY(-50%);
-}
-
-.k-tooltip.k-tooltip-bottom:before,
-.k-tooltip.k-tooltip-bottom:after {
-  top: 100%;
-  transform: translateX(-50%);
-}
-.k-tooltip.k-tooltip-bottom:before {
-  left: 100%;
-  margin-top: 5px;
-}
-.k-tooltip.k-tooltip-bottom:after {
-  left: 50%;
-  border-bottom: 8px solid #fff;
-  border-top: none;
-  margin-top: -3px;
-}
-.k-tooltip.k-tooltip-bottom:hover:before,
-.k-tooltip.k-tooltip-bottom:hover:after {
-  transform: translateX(-50%) translateY(5px);
-}
-
-.k-tooltip.k-tooltip-left:before,
-.k-tooltip.k-tooltip-left:after {
-  top: 50%;
-  right: 100%;
-  transform: translateY(-50%);
-}
-.k-tooltip.k-tooltip-left:before {
-  margin-right: 5px;
-}
-.k-tooltip.k-tooltip-left:after {
-  border-left: 8px solid #fff;
-  border-right: none;
-  margin-right: -3px;
-}
-.k-tooltip.k-tooltip-left:hover:before,
-.k-tooltip.k-tooltip-left:hover:after {
-  transform: translateX(-5px) translateY(-50%);
 }
 </style>

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -6,7 +6,9 @@
     width="auto"
     hide-caret>
     <slot />
-    <div slot="content">
+    <div
+      slot="content"
+      role="tooltip">
       <slot
         :label="label"
         name="content">{{ label }}</slot>
@@ -27,7 +29,8 @@ export default {
      */
     label: {
       type: String,
-      required: true
+      required: false,
+      default: ''
     },
 
     /**

--- a/packages/KoolTip/__snapshots__/KoolTip.spec.js.snap
+++ b/packages/KoolTip/__snapshots__/KoolTip.spec.js.snap
@@ -1,3 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KoolTip matches snapshot 1`] = `<div aria-hidden="true" data-message="I'm inside the tooltip!" role="tooltip" class="k-tooltip k-tooltip-top" style="text-align: left;"></div>`;
+exports[`KoolTip matches snapshot 1`] = `
+<div>
+  <div class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <!---->
+    <div class="k-popover-content">
+      <div role="tooltip">I'm inside the tooltip!</div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KoolTip renders tooltip to the bottom side 1`] = `
+<div>
+  <div class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <!---->
+    <div class="k-popover-content">
+      <div role="tooltip">I'm on the bottom side!</div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KoolTip renders tooltip to the left side 1`] = `
+<div>
+  <div class="k-popover kooltip mr-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <!---->
+    <div class="k-popover-content">
+      <div role="tooltip">I'm on the left side!</div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KoolTip renders tooltip to the right side 1`] = `
+<div>
+  <div class="k-popover kooltip ml-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <!---->
+    <div class="k-popover-content">
+      <div role="tooltip">I'm on the right side!</div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KoolTip renders tooltip to the top side 1`] = `
+<div>
+  <div class="k-popover kooltip mb-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <!---->
+    <div class="k-popover-content">
+      <div role="tooltip">I'm on the top side!</div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/KoolTip/package.json
+++ b/packages/KoolTip/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kpop": "^1.1.0"
   }
 }

--- a/packages/styles/_variables.scss
+++ b/packages/styles/_variables.scss
@@ -46,6 +46,12 @@ $colors: (
   black-25: rgba(0, 0, 0, .25),
   black-10: rgba(0, 0, 0, .10),
 
+  black-100: #DFDFDF,
+  black-200: #B1B2B1,
+  black-300: #797979,
+  black-400: #3B3B3B,
+  black-500: #1D1D1D,
+  
   white: #ffffff
 );
 $spacing: (


### PR DESCRIPTION
### Summary
Adds new design for tooltips and composes `KPop` to take advantage of positioning and appending to the DOM functionality `KPop` has. We also didn't have opaque black colors, so I add those to our styles. I aligned our props so that it makes a bit more sense re: `message` -> `label`, and `position` -> `placement`. The "alignment" prop was used to align text, but we weren't ever using it. Users can now slot the content if they want to text align.

![image](https://user-images.githubusercontent.com/5770711/102569476-8c2cc500-40b3-11eb-95f4-7e784e01fd80.png)

#### Changes made:
- feat(style) add solid black colors
- feat(kooltip)!: kooltip implemented with kpop
  * fixes issues with placement
  * uses new styling and adds kpop as a dependency
  * adds ability to have slotted html content
 
  BREAKING CHANGE: props and styles completely updated
- docs(kpop) typos

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate

Fixes #262 