### PR TITLE
fix(kempty): use correct warning icon

### DIFF
--- a/packages/KEmptyState/KEmptyState.spec.js
+++ b/packages/KEmptyState/KEmptyState.spec.js
@@ -23,6 +23,7 @@ describe('KEmptyState', () => {
   })
 
   it('renders icon when error flag passed', () => {
+    const spy = jest.spyOn(console, 'error')
     const errorMessage = 'I got a bad feeling about this'
     const wrapper = mount(KEmptyState, {
       propsData: {
@@ -35,6 +36,7 @@ describe('KEmptyState', () => {
     })
 
     expect(wrapper.find('.warning-icon').exists()).toBe(true)
+    expect(spy).not.toHaveBeenCalledWith(expect.stringContaining('[Vue warn]')) // uses correct kicon
     expect(wrapper.find('.empty-state-content').html()).toEqual(expect.stringContaining(errorMessage))
   })
 

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -7,7 +7,7 @@
       >
         <KIcon
           :size="iconSize"
-          icon="warning2"
+          icon="warning"
           view-box="0 0 50 50" />
       </div>
       <h5>


### PR DESCRIPTION
### Summary

* warning2 -> warning

A side effect is that this closes #286 

#### Changes made:

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
