### PR TITLE
fix(KCard) card header spacing

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -161,15 +161,31 @@ Cards can be arranged with flex box.
 <div class="d-flex flex-row">
   <KCard
     title="Left"
-    class="w-50"
+    class="w-auto"
     body="This card only has a title"
   />
   <KCard
+    title="Center"
+    class="w-auto"
+    body="This card always has a icon button"
+  >
+    <template slot="actions">
+      <KButton>
+        <KIcon
+            icon="gearFilled"
+            width="16px"
+            view-box="0 0 16 16"
+            class="pr-0"
+          />
+      </KButton>
+    </template>
+  </KCard>
+  <KCard
     title="Right"
-    class="w-50"
+    class="w-auto"
     body="This card always has a button"
   >
-    <template slot="actions"><KButton href="#">View All</KButton></template>
+    <template slot="actions"><KButton>View All</KButton></template>
   </KCard>
 </div>
 
@@ -177,15 +193,31 @@ Cards can be arranged with flex box.
 <div class="d-flex flex-row">
   <KCard
     title="Left"
-    class="w-50"
+    class="w-auto"
     body="This card only has a title"
   />
   <KCard
+    title="Center"
+    class="w-auto"
+    body="This card always has a icon button"
+  >
+    <template slot="actions">
+      <KButton>
+        <KIcon
+            icon="gearFilled"
+            width="16px"
+            view-box="0 0 16 16"
+            class="pr-0"
+          />
+      </KButton>
+    </template>
+  </KCard>
+  <KCard
     title="Right"
-    class="w-50"
+    class="w-auto"
     body="This card always has a button"
   >
-    <template slot="actions"><KButton href="#">View All</KButton></template>
+    <template slot="actions"><KButton>View All</KButton></template>
   </KCard>
 </div>
 ```

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -155,6 +155,41 @@ Sets if card has shadow state (shadow)
   hasShadow/>
 ```
 
+### Side by side
+Cards can be arranged with flex box.
+
+<div class="d-flex flex-row">
+  <KCard
+    title="Left"
+    class="w-50"
+    body="This card only has a title"
+  />
+  <KCard
+    title="Right"
+    class="w-50"
+    body="This card always has a button"
+  >
+    <template slot="actions"><KButton href="#">View All</KButton></template>
+  </KCard>
+</div>
+
+```vue
+<div class="d-flex flex-row">
+  <KCard
+    title="Left"
+    class="w-50"
+    body="This card only has a title"
+  />
+  <KCard
+    title="Right"
+    class="w-50"
+    body="This card always has a button"
+  >
+    <template slot="actions"><KButton href="#">View All</KButton></template>
+  </KCard>
+</div>
+```
+
 ## Slots
 - `title`
 - `body`

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -166,7 +166,7 @@ Cards can be arranged with flex box.
   />
   <KCard
     title="Center"
-    class="w-auto"
+    class="w-auto mx-5"
     body="This card always has a icon button"
   >
     <template slot="actions">
@@ -198,7 +198,7 @@ Cards can be arranged with flex box.
   />
   <KCard
     title="Center"
-    class="w-auto"
+    class="w-auto mx-5"
     body="This card always has a icon button"
   >
     <template slot="actions">

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -96,7 +96,7 @@ export default {
     align-items: center;
     margin-bottom: 1rem;
     min-height: 38px;
-    
+
     .k-button {
       min-height: 38px;
     }

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -95,6 +95,7 @@ export default {
     display: flex;
     align-items: center;
     margin-bottom: 1rem;
+    min-height: 38px;
   }
 
   .k-card-title h4 {

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -96,6 +96,10 @@ export default {
     align-items: center;
     margin-bottom: 1rem;
     min-height: 38px;
+    
+    .k-button {
+      min-height: 38px;
+    }
   }
 
   .k-card-title h4 {


### PR DESCRIPTION
### Summary

- trying to get card header spacing to be equal whether there are actions or not, so we can put cards side by side without janky padding

#### Changes made:
* add demo in docs
* slapped min-height on card header

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
