### PR TITLE
fix(KCheckbox) wrap label text in span

### DIFF
--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -6,7 +6,9 @@
       type="checkbox"
       class="k-input"
       v-on="listeners">
-    <slot>{{ label }}</slot>
+    <slot>
+      <span>{{ label }}</span>
+    </slot>
   </label>
 </template>
 

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> </label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> <span></span></label>`;


### PR DESCRIPTION
### Summary
Wrap the text of a KCheckbox label in a span tag to remove unwanted whitespace

#### Changes made:
* Wrap the text of KCheckbox label in a span tag

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
