### PR TITLE
feat(KTable): add cellAttrs prop for customization

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -282,19 +282,6 @@ export default {
       }
 
       /**
-       * Sets cell max-width based on the column headerKey
-       */
-      const colWidth = () => {
-        if (headerKey === 'description') {
-          return '50ch'
-        } else if (headerKey === 'name') {
-          return '22ch'
-        }
-
-        return '25ch'
-      }
-
-      /**
        * Returns an object of attributes to be applied to cells
        */
       return {
@@ -303,7 +290,7 @@ export default {
         },
         'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
         style: {
-          'maxWidth': colWidth(),
+          'maxWidth': headerKey==='description' ? '50ch' : headerKey === 'name' ? '22ch' : '25ch',
           'backgroundColor': backgroundColor(),
         },
       }
@@ -879,19 +866,6 @@ export default {
       }
 
       /**
-       * Sets cell max-width based on the column headerKey
-       */
-      const colWidth = () => {
-        if (headerKey === 'description') {
-          return '50ch'
-        } else if (headerKey === 'name') {
-          return '22ch'
-        }
-
-        return '25ch'
-      }
-
-      /**
        * Returns an object of attributes to be applied to cells
        */
       return {
@@ -900,7 +874,7 @@ export default {
         },
         'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
         style: {
-          'maxWidth': colWidth(),
+          'maxWidth': headerKey==='description' ? '50ch' : headerKey === 'name' ? '22ch' : '25ch',
           'backgroundColor': backgroundColor(),
         },
       }

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -199,11 +199,9 @@ export default {
 
 Add custom properties to individual table cells or groups of cells. The cell attributes object is passed as a param.
 
-### `cellAttrs` Description
+`cellAttrs` - A function that returns an object comprising the attributes.
 
-A function that returns an object comprising the attributes.
-
-### `cellAttrs` Function Parameters
+**Parameters**
 
 | Parameter | Description
 |:-------- |:-------
@@ -304,7 +302,7 @@ export default {
           'truncate': headerKey === 'description' || headerKey === 'name',
         },
         'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
-        style : {
+        style: {
           'maxWidth': colWidth(),
           'backgroundColor': backgroundColor(),
         },
@@ -901,7 +899,7 @@ export default {
           'truncate': headerKey === 'description' || headerKey === 'name',
         },
         'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
-        style : {
+        style: {
           'maxWidth': colWidth(),
           'backgroundColor': backgroundColor(),
         },

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -195,6 +195,125 @@ export default {
 </style>
 ```
 
+## Cell Attributes
+
+Add custom properties to individual table cells or groups of cells. The cell attributes object is passed as a param.
+
+### `cellAttrs` Description
+
+A function that returns an object comprising the attributes.
+
+### `cellAttrs` Function Parameters
+
+| Parameter | Description
+|:-------- |:-------
+| `headerKey`| The header key of the column containing the cell
+| `row` | The contents of the row containing the cell
+| `rowIndex` | The zero-based index of the row containing the cell
+| `colIndex`| The zero-based index of the cell within a row
+
+<template>
+  <KTable
+    :options="tableOptionsCellAttrs"
+    :cellAttrs="cellAttrsFn"
+    />
+</template>
+
+```vue
+<template>
+  <KTable
+    :options="tableOptions"
+    :cellAttrs="cellAttrsFn"
+    />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      row: null,
+      eventType: '',
+      tableOptions: {
+        headers: [
+          { label: 'Name', key: 'name' },
+          { label: 'Company', key: 'company' },
+          { label: 'Description', key: 'description' }
+        ],
+        data: [
+          {
+            name: 'SageMaker',
+            company: 'Amazon',
+            description: 'Amazon SageMaker is a fully-managed service that enables developers and data scientists to quickly and easily build, train, and deploy machine learning models at any scale. Amazon SageMaker removes all the barriers that typically slow down developers who want to use machine learning.',
+          },
+          {
+            name: 'Azure Machine Learning Studio',
+            company: 'Microsoft',
+            description: 'Azure Machine Learning Studio is a GUI-based integrated development environment for constructing and operationalizing Machine Learning workflow on Azure.',
+          },
+          {
+            name: 'IBM Watson Machine Learning',
+            company: 'IBM',
+            description: 'IBM Watson Studio accelerates the machine and deep learning workflows required to infuse AI into your business to drive innovation.',
+          },
+          {
+            name: 'TensorFlow',
+            company: 'Google',
+            description: 'TensorFlow is an open source software library for numerical computation using data flow graphs.',
+          },
+        ]
+      }
+    }
+  },
+  methods: {
+    cellAttrsFn ({ headerKey, row, rowIndex, colIndex }) {
+      /**
+       * Sets cell background color based on data returned in
+       * the row parameter and the index of the cell
+       */
+      const backgroundColor = () => {
+        if (row.company && row.company === 'Google') {
+          if (colIndex === 0) {
+            return '#4285F4'
+          } else if (colIndex === 1) {
+            return '#DB4437'
+          } else {
+            return '#F4B400'
+          }
+        }
+
+        return ''
+      }
+
+      /**
+       * Sets cell max-width based on the column headerKey
+       */
+      const colWidth = () => {
+        if (headerKey === 'description') {
+          return '50ch'
+        } else if (headerKey === 'name') {
+          return '22ch'
+        }
+
+        return '25ch'
+      }
+
+      /**
+       * Returns an object of attributes to be applied to cells
+       */
+      return {
+        class: {
+          'truncate': headerKey === 'description' || headerKey === 'name',
+        },
+        'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
+        style : {
+          'maxWidth': colWidth(),
+          'backgroundColor': backgroundColor(),
+        },
+      }
+    }
+  }
+}
+</script>
+```
 ## Events
 Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to
 various parts of the table. We support events on both table rows and cells in addition to click elements inside a row (ie. buttons or hyperlinks) without triggering the a row or cell event. You can also add logic to check for `metakey` to support cmd/ctrl when clicking. Examples highlighted below.
@@ -673,6 +792,35 @@ export default {
           { company: { href: 'http://www.bose.com', label: 'Bose'} },
           { company: { href: 'http://www.sennheiser.com', label: 'Sennheiser'} }
         ]
+      },
+      tableOptionsCellAttrs: {
+        headers: [
+          { label: 'Name', key: 'name' },
+          { label: 'Company', key: 'company' },
+          { label: 'Description', key: 'description' }
+        ],
+        data: [
+          {
+            name: 'SageMaker',
+            company: 'Amazon',
+            description: 'Amazon SageMaker is a fully-managed service that enables developers and data scientists to quickly and easily build, train, and deploy machine learning models at any scale. Amazon SageMaker removes all the barriers that typically slow down developers who want to use machine learning.',
+          },
+          {
+            name: 'Azure Machine Learning Studio',
+            company: 'Microsoft',
+            description: 'Azure Machine Learning Studio is a GUI-based integrated development environment for constructing and operationalizing Machine Learning workflow on Azure.',
+          },
+          {
+            name: 'IBM Watson Machine Learning',
+            company: 'IBM',
+            description: 'IBM Watson Studio accelerates the machine and deep learning workflows required to infuse AI into your business to drive innovation.',
+          },
+          {
+            name: 'TensorFlow',
+            company: 'Google',
+            description: 'TensorFlow is an open source software library for numerical computation using data flow graphs.',
+          },
+        ]
       }
     }
   },
@@ -712,7 +860,53 @@ export default {
         'data-testid': 'row-item'
       }
     },
-    defaultSorter
+    defaultSorter,
+    cellAttrsFn ({ headerKey, row, rowIndex, colIndex }) {
+      /**
+       * Sets cell background color based on data returned in
+       * the row parameter and the index of the cell
+       */
+      const backgroundColor = () => {
+        if (row.company && row.company === 'Google') {
+          if (colIndex === 0) {
+            return '#4285F4'
+          } else if (colIndex === 1) {
+            return '#DB4437'
+          } else {
+            return '#F4B400'
+          }
+        }
+
+        return ''
+      }
+
+      /**
+       * Sets cell max-width based on the column headerKey
+       */
+      const colWidth = () => {
+        if (headerKey === 'description') {
+          return '50ch'
+        } else if (headerKey === 'name') {
+          return '22ch'
+        }
+
+        return '25ch'
+      }
+
+      /**
+       * Returns an object of attributes to be applied to cells
+       */
+      return {
+        class: {
+          'truncate': headerKey === 'description' || headerKey === 'name',
+        },
+        'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
+        style : {
+          'maxWidth': colWidth(),
+          'backgroundColor': backgroundColor(),
+        },
+      }
+    }
   }
 }
 </script>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -31,7 +31,8 @@
           <td
             v-for="(value, index) in options.headers"
             :key="index"
-            v-on="tdlisteners(row[value.key], 'cell')">
+            v-on="tdlisteners(row[value.key], 'cell')"
+            v-bind="cellAttrs({ headerKey: value.key, row, rowIndex, colIndex: index })">
             <slot
               :name="value.key"
               :row="row"
@@ -186,6 +187,13 @@ export default {
     hasSideBorder: {
       type: Boolean,
       default: true
+    },
+    /**
+     * A function that conditionally specifies cell attributes
+     */
+    cellAttrs: {
+      type: Function,
+      default: () => ({})
     }
   },
 

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -31,8 +31,8 @@
           <td
             v-for="(value, index) in options.headers"
             :key="index"
-            v-on="tdlisteners(row[value.key], 'cell')"
-            v-bind="cellAttrs({ headerKey: value.key, row, rowIndex, colIndex: index })">
+            v-bind="cellAttrs({ headerKey: value.key, row, rowIndex, colIndex: index })"
+            v-on="tdlisteners(row[value.key], 'cell')">
             <slot
               :name="value.key"
               :row="row"


### PR DESCRIPTION
### Summary
Add `cellAttrs` prop for greater table customization

This allows customization at a much more granular level. Cells, columns and rows can be customized via this new prop.

Here's an example I've added to the docs. This table has been customized in the following ways:
1. Two columns of cells,`Name` and `Description`, have been given different `max-width` values.
2. Two columns of cells, `Name` and `Description`, have been given the `truncate` class.
3. The cells in the last row have been given different background colors based on data in the row (in this case, based on Google being the value in the `Company` column)

![Screen Shot 2021-04-29 at 12 56 28 PM](https://user-images.githubusercontent.com/2080476/116610909-97f28880-a8ea-11eb-9db3-c44ee0653698.png)


#### Changes made:
* Add `cellAttrs` prop to KTable component
* Update docs to include details about new `cellAttrs` prop

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
