### PR TITLE
feat(KIcon): add svgElements slot

### DIFF
--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -76,6 +76,83 @@ You can read more about the viewBox attribute
 <KIcon icon="portal" viewBox="0 0 10 10" />
 ```
 
+
+## Slots
+- `svgElements` - Used to add svg customization elements
+
+<KIcon icon="check" size="50" color="url('#linear-gradient')">
+  <template slot="svgElements">
+    <defs>
+      <linearGradient id="linear-gradient" x1="0" x2="1">
+        <stop offset="0%" stop-color="#16BDCC" />
+        <stop offset="30%" stop-color="#16BDCC" />
+        <stop offset="100%" stop-color="#1BC263" />
+      </linearGradient>
+    </defs>
+  </template>
+</KIcon>
+
+<KIcon icon="services" size="50" color="url('#linear-gradient2')">
+  <template slot="svgElements">
+    <defs>
+      <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
+        <stop offset="10%"  stop-color="gold" />
+        <stop offset="90%" stop-color="red" />
+      </linearGradient>
+    </defs>
+  </template>
+</KIcon>
+
+<KIcon icon="gear" size="50" color="dark-grey">
+  <template slot="svgElements">
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      from="0 0 0"
+      to="360 0 0"
+      dur="5s"
+      repeatCount="indefinite"
+    />
+  </template>
+</KIcon>
+
+```vue
+<KIcon icon="check" size="50" color="url('#linear-gradient')">
+  <template slot="svgElements">
+    <defs>
+      <linearGradient id="linear-gradient" x1="0" x2="1">
+        <stop offset="0%" stop-color="#16BDCC" />
+        <stop offset="30%" stop-color="#16BDCC" />
+        <stop offset="100%" stop-color="#1BC263" />
+      </linearGradient>
+    </defs>
+  </template>
+</KIcon>
+
+<KIcon icon="services" size="50" color="url('#linear-gradient2')">
+  <template slot="svgElements">
+    <defs>
+      <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
+        <stop offset="10%"  stop-color="gold" />
+        <stop offset="90%" stop-color="red" />
+      </linearGradient>
+    </defs>
+  </template>
+</KIcon>
+
+<KIcon icon="gear" size="50" color="dark-grey">
+  <template slot="svgElements">
+    <animateTransform
+      attributeName="transform"
+      type="rotate"
+      from="0 0 0"
+      to="360 0 0"
+      dur="5s"
+      repeatCount="indefinite"
+    />
+  </template>
+</KIcon>
+```
 ## Usage
 :::warning
 KIcon imports .svg file types directly, so a loader is needed in order to render in your application such as the webpack

--- a/packages/KIcon/KIcon.vue
+++ b/packages/KIcon/KIcon.vue
@@ -9,7 +9,7 @@
     role="img"
   >
     <title>{{ title || icon }}</title>
-    <slot name="svgElements"></slot>
+    <slot name="svgElements"/>
     <g>
       <path
         v-for="(path, idx) in paths"

--- a/packages/KIcon/KIcon.vue
+++ b/packages/KIcon/KIcon.vue
@@ -9,6 +9,7 @@
     role="img"
   >
     <title>{{ title || icon }}</title>
+    <slot name="svgElements"></slot>
     <g>
       <path
         v-for="(path, idx) in paths"

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close"><title>close</title> <g><path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path></g></svg></button> <!----> <span><div class="message">hey toasty</div></span></div>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close"><title>close</title>  <g><path fill="#000" d="M0 1l1-1h.5L6 4.49993896 10.5 0h.5l1 1v.5L7.5 6l4.5 4.5v.5l-1 1h-.5L6 7.5 1.5 12H1l-1-1v-.5L4.5 6 0 1.5z" fill-rule="evenodd" fill-opacity=".25"></path></g></svg></button> <!----> <span><div class="message">hey toasty</div></span></div>
 </div>
 <div class="toaster-item">
   <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">


### PR DESCRIPTION
### Summary
We have a requirement for an icon with a linear-gradient color. This PR adds a new slot `svgElements` to not only allow adding a `<linearGradient />` svg element to a KIcon, but other customizations as well.

#### Changes made:
* Add `svgElements` slot to allow for customizing the svg of a KIcon
* Add documentation for new `svgElements` slot in KIcon kongponent

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
