### PR TITLE
ci: drop Node 8 & 10 support, add Node 14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
        matrix:
-        node-version: [12.x, 14.x]
+        node: [12.x, 14.x]
         include:
-        - node-version: 16.x
-          experimental: true
+          - node: 16.x
+            experimental: true
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - name: install and lint
       run: |
         yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: setup git
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         node: [12.x, 14.x]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
-       matrix:
+      matrix:
         node: [12.x, 14.x]
+        experimental: [false]
         include:
           - node: 16.x
             experimental: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
+       matrix:
+        node-version: [12.x, 14.x]
+        include:
+        - node: 16
+          experimental: true
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
        matrix:
         node-version: [12.x, 14.x]
         include:
-        - node: 16
+        - node-version: 16.x
           experimental: true
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         node: [12.x, 14.x]
-        experimental: [false]
-        include:
-          - node: 16.x
-            experimental: true
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         node: [12.x, 14.x]
-        experimental: [false]
-        include:
-          - node: 16.x
-            experimental: true
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
-        node: [12.x, 14.x, 16.x]
+        node: [12.x, 14.x]
+        experimental: [false]
         include:
           - node: 16.x
             experimental: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x]
+        include:
+        - node: 16
+          experimental: true
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node: [12.x, 14.x, 16.x]
         include:
-        - node-version: 16.x
-          experimental: true
+          - node: 16.x
+            experimental: true
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }} 
+        node-version: ${{ matrix.node }} 
     - name: install, lint
       run: |
         yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
         include:
-        - node: 16
+        - node-version: 16.x
           experimental: true
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Fixes #297

### Summary

bump the version of Node used to test and publish to drop unsupported versions and add LTS.

#### Changes made:
* change node matrix

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
