### PR TITLE
feat(klabel): add help property with icon + tooltip

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -49,6 +49,7 @@ module.exports = {
               '/components/icon',
               '/components/inline-edit',
               '/components/input',
+              '/components/label',
               '/components/modal',
               '/components/multiselect',
               '/components/popover',

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -1,0 +1,57 @@
+# Label
+
+**KLabel** provides a wrapper around general `label` tags.
+
+## Standard Input
+
+<br />
+
+<KLabel>Input Title</KLabel>
+
+```vue
+<KLabel>Input Title</KLabel>
+```
+
+## With Help
+
+<br />
+
+<KLabel help="This is an example">Input Title</KLabel>
+
+```vue
+<KLabel help="This is an example">Input Title</KLabel>
+```
+
+<br />
+
+<KLabel help="This is a really long tooltip. Hopefully we won't have anything this long but we might. I wonder how it handles long inputs">Long Input Title</KLabel>
+
+```vue
+<KLabel
+  help="This is a really long tooltip. Hopefully we won't have anything this long but we might. I wonder how it handles long inputs"
+>
+  Long Input Title
+</KLabel>
+```
+
+## With Info
+
+<br />
+
+<KLabel info="This is an example">Input Title</KLabel>
+
+```vue
+<KLabel info="This is an example">Input Title</KLabel>
+```
+
+## Sample input with a tooltip
+
+<br />
+
+<KLabel help="A service is an API that you want to offer">Service Name</KLabel>
+<KInput />
+
+```vue
+<KLabel help="A service is an API that you want to offer">Service Name</KLabel>
+<KInput />
+```

--- a/packages/KIcon/KIcon.vue
+++ b/packages/KIcon/KIcon.vue
@@ -8,7 +8,7 @@
     class="kong-icon"
     role="img"
   >
-    <title>{{ title || icon }}</title>
+    <title v-if="!hideTitle">{{ title || icon }}</title>
     <slot name="svgElements"/>
     <g>
       <path
@@ -69,6 +69,13 @@ export default {
     title: {
       type: String,
       default: ''
+    },
+    /**
+     * Optional - Prevents title from being shown on hover. Used by KoolTip
+     */
+    hideTitle: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/packages/KLabel/KLabel.spec.js
+++ b/packages/KLabel/KLabel.spec.js
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import KLabel from '@/KLabel/KLabel'
+
+describe('KLabel', () => {
+  it('renders a plain label by default', () => {
+    const wrapper = mount(KLabel, {
+      slots: {
+        default: 'Full Name'
+      }
+    })
+
+    expect(wrapper.find('label').text()).toBe('Full Name')
+  })
+
+  it('renders a tooltip when `help` is provided', () => {
+    const wrapper = mount(KLabel, {
+      propsData: {
+        help: 'This is a tooltip'
+      },
+      slots: {
+        default: 'Full Name'
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders a tooltip when `info` is provided', () => {
+    const wrapper = mount(KLabel, {
+      propsData: {
+        info: 'This is a tooltip'
+      },
+      slots: {
+        default: 'Full Name'
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -23,7 +23,6 @@
         icon="info"
         height="16"
         width="16"
-        color="black"
         hide-title />
     </Kooltip>
     <slot v-else />

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -1,12 +1,48 @@
 <template functional>
   <label class="k-input-label">
-    <slot />
+    <KoolTip
+      v-if="props.help"
+      :label="props.help"
+      class="label-tooltip"
+    >
+      <slot />
+      <KIcon
+        icon="help"
+        height="16"
+        width="16"
+        view-box="0 0 16 16"
+      />
+    </Kooltip>
+    <KoolTip
+      v-else-if="props.info"
+      :label="props.info"
+      class="label-tooltip"
+    >
+      <slot />
+      <KIcon
+        icon="info"
+        height="16"
+        width="16"
+        color="black"
+      />
+    </Kooltip>
+    <slot v-else />
   </label>
 </template>
 
 <script>
 export default {
-  name: 'KLabel'
+  name: 'KLabel',
+  props: {
+    help: {
+      type: String,
+      default: undefined
+    },
+    info: {
+      type: String,
+      default: undefined
+    }
+  }
 }
 </script>
 

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -23,6 +23,7 @@
         icon="info"
         height="16"
         width="16"
+        color="#A3BBCC"
         hide-title />
     </Kooltip>
     <slot v-else />

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -11,7 +11,7 @@
         height="16"
         width="16"
         view-box="0 0 16 16"
-      />
+        hide-title />
     </Kooltip>
     <KoolTip
       v-else-if="props.info"
@@ -24,7 +24,7 @@
         height="16"
         width="16"
         color="black"
-      />
+        hide-title />
     </Kooltip>
     <slot v-else />
   </label>

--- a/packages/KLabel/__snapshots__/KLabel.spec.js.snap
+++ b/packages/KLabel/__snapshots__/KLabel.spec.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KLabel renders a tooltip when \`help\` is provided 1`] = `<label class="k-input-label" help="This is a tooltip">Full Name</label>`;
+
+exports[`KLabel renders a tooltip when \`info\` is provided 1`] = `<label class="k-input-label" info="This is a tooltip">Full Name</label>`;

--- a/packages/styles/forms/_labels.scss
+++ b/packages/styles/forms/_labels.scss
@@ -6,6 +6,15 @@
   font-size: var(--KInputLabelSize, var(--type-sm, type(sm)));
   line-height: var(--KInputLabelLineHeight, var(--type-lg, type(lg)));
   margin-bottom: var(--KInputLabelMargin, var(--spacing-xs, spacing(xs)));
+
+  .label-tooltip {
+    display: flex;
+    align-items: center;
+  }
+
+  .kong-icon {
+    margin-left: var(--spacing-xxs);
+  }
 }
 
 .k-inputCheckbox,


### PR DESCRIPTION
### Summary
Some inputs require additional context to explain what the user should provide. This feature uses `KIcon` to add a help icon and `KoolTip` to show a tooltip if the `help` property is provided.

`KoolTip` uses the prop `label` to provide the text. I have chosen `help` in this component so that there is no confusion between the `KLabel` slot and the `KoolTip` prop.

[Demo](https://deploy-preview-306--kongponents.netlify.app/components/label.html#with-help)

#### Changes made:
* Add `help` property to `KLabel`
* Add tests for `KLabel`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
