### PR TITLE
feat(KSwitch) add optional tooltip when disabled

### DIFF
--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -41,7 +41,7 @@ state of toggle switch. You can read more about passing values via `v-model`
 
 ### label
 
-Will place label text to the right of the switch. Can also be [slotted](#slots). You can also add `disabled` to the input to disallow interactivity. 
+Will place label text to the right of the switch. Can also be [slotted](#slots).  
 
 - `label`
 
@@ -51,11 +51,29 @@ Will place label text to the right of the switch. Can also be [slotted](#slots).
 
 <KInputSwitch v-model="labelPropChecked" :label="labelPropChecked ? 'on' : 'off'" />
 
+### disabled
+
+You can add `disabled` to the input to disallow interactivity.
+
+- `disabled`
+
 ```vue
 <KInputSwitch v-model="checked" label="disabled" disabled />
 ```
 
 <KInputSwitch v-model="labelPropChecked" label="disabled" disabled />
+
+### disabledTooltipText
+
+You can specify tooltip text to be displayed when the switch is disabled.
+
+- `disabledTooltipText`
+
+```vue
+<KInputSwitch v-model="checked" label="disabled" disabled disabledTooltipText="I'm disabled!" />
+```
+
+<KInputSwitch v-model="labelPropChecked" label="disabled" disabled disabledTooltipText="I'm disabled!" />
 
 ## Slots
 

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -70,10 +70,20 @@ You can specify tooltip text to be displayed when the switch is disabled.
 - `disabledTooltipText`
 
 ```vue
-<KInputSwitch v-model="checked" label="disabled" disabled disabledTooltipText="I'm disabled!" />
+<KInputSwitch 
+  v-model="checked" 
+  label="disabled" 
+  disabled 
+  disabledTooltipText="I'm disabled!" 
+/>
 ```
 
-<KInputSwitch v-model="labelPropChecked" label="disabled" disabled disabledTooltipText="I'm disabled!" />
+<KInputSwitch 
+  v-model="labelPropChecked" 
+  label="disabled" 
+  disabled 
+  disabledTooltipText="I'm disabled!" 
+/>
 
 ## Slots
 

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -1,5 +1,24 @@
 <template>
-  <label class="k-switch">
+  <KoolTip
+    v-if="$attrs.disabled !== undefined && disabledTooltipText"
+    :label="disabledTooltipText"
+  >
+    <label class="k-switch">
+      <input
+        :checked="value"
+        v-bind="$attrs"
+        type="checkbox"
+        v-on="listeners">
+      <div class="switch-control"/>
+      <span v-if="label || $scopedSlots.label">
+        <slot name="label">{{ label }}</slot>
+      </span>
+    </label>
+  </KoolTip>
+
+  <label
+    v-else
+    class="k-switch">
     <input
       :checked="value"
       v-bind="$attrs"
@@ -13,8 +32,11 @@
 </template>
 
 <script>
+import KoolTip from '@kongponents/kooltip/KoolTip.vue'
+
 export default {
   name: 'KInputSwitch',
+  components: { KoolTip },
   props: {
     /**
      * Sets whether or not toggle is checked
@@ -29,6 +51,14 @@ export default {
      * Overrides default on/off label text
      */
     label: {
+      type: String,
+      default: ''
+    },
+
+    /**
+     * Tooltip text to be displayed if the switch is disabled
+     */
+    disabledTooltipText: {
       type: String,
       default: ''
     }

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -3,7 +3,9 @@
     v-if="$attrs.disabled !== undefined && disabledTooltipText"
     :label="disabledTooltipText"
   >
-    <label class="k-switch">
+    <label
+      v-bind="$attrs"
+      class="k-switch">
       <input
         :checked="value"
         v-bind="$attrs"


### PR DESCRIPTION
### Summary
Add the ability to display a tooltip on hover if `KSwitch` is `disabled`.

#### Changes made:
* Add new property `disabledTooltipText`
* Added separate section in docs for `disabled` property

![image](https://user-images.githubusercontent.com/67973710/120857374-2cd24c80-c54f-11eb-96f7-afd0dac8da6d.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
