### PR TITLE
feat(KInputSwitch): add enabled icon

### DIFF
--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -95,7 +95,7 @@ Display a check icon when switch is enabled
 <KInputSwitch
   v-model="enabledIconChecked"
   :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
-  :enabledIcon="true"
+  enabled-icon
 />
 ```
 

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -85,6 +85,26 @@ You can specify tooltip text to be displayed when the switch is disabled.
   disabledTooltipText="I'm disabled!"
 />
 
+### enabledIcon
+
+Display a check icon when switch is enabled
+
+- `enabledIcon`
+
+```vue
+<KInputSwitch
+  v-model="enabledIconChecked"
+  :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
+  enabledIcon="true"
+/>
+```
+
+<KInputSwitch
+  v-model="enabledIconChecked"
+  :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
+  enabledIcon="true"
+/>
+
 ## Slots
 
 - `label`
@@ -175,7 +195,8 @@ export default {
       labelPropChecked: false,
       defaultChecked: false,
       labelChecked: false,
-      themeChecked: true
+      themeChecked: true,
+      enabledIconChecked: true,
     }
   },
   computed: {

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -95,14 +95,14 @@ Display a check icon when switch is enabled
 <KInputSwitch
   v-model="enabledIconChecked"
   :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
-  enabledIcon="true"
+  :enabledIcon="true"
 />
 ```
 
 <KInputSwitch
   v-model="enabledIconChecked"
   :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
-  enabledIcon="true"
+  :enabledIcon="true"
 />
 
 ## Slots

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -102,7 +102,7 @@ Display a check icon when switch is enabled
 <KInputSwitch
   v-model="enabledIconChecked"
   :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
-  :enabledIcon="true"
+  enabled-icon
 />
 
 ## Slots

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -41,7 +41,7 @@ state of toggle switch. You can read more about passing values via `v-model`
 
 ### label
 
-Will place label text to the right of the switch. Can also be [slotted](#slots).  
+Will place label text to the right of the switch. Can also be [slotted](#slots).
 
 - `label`
 
@@ -70,19 +70,19 @@ You can specify tooltip text to be displayed when the switch is disabled.
 - `disabledTooltipText`
 
 ```vue
-<KInputSwitch 
-  v-model="checked" 
-  label="disabled" 
-  disabled 
-  disabledTooltipText="I'm disabled!" 
+<KInputSwitch
+  v-model="checked"
+  label="disabled"
+  disabled
+  disabledTooltipText="I'm disabled!"
 />
 ```
 
-<KInputSwitch 
-  v-model="labelPropChecked" 
-  label="disabled" 
-  disabled 
-  disabledTooltipText="I'm disabled!" 
+<KInputSwitch
+  v-model="labelPropChecked"
+  label="disabled"
+  disabled
+  disabledTooltipText="I'm disabled!"
 />
 
 ## Slots
@@ -184,7 +184,7 @@ export default {
         ? 'Yay!'
         : 'Boo'
     },
-    
+
   },
   methods: {
     handleToggle (isChecked) {

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -205,7 +205,6 @@ export default {
         ? 'Yay!'
         : 'Boo'
     },
-
   },
   methods: {
     handleToggle (isChecked) {

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -27,6 +27,10 @@
       type="checkbox"
       v-on="listeners">
     <div class="switch-control"/>
+    <KIcon
+      v-if="enabledIcon && value === true"
+      icon="check"
+      color="white"/>
     <span v-if="label || $scopedSlots.label">
       <slot name="label">{{ label }}</slot>
     </span>
@@ -35,10 +39,11 @@
 
 <script>
 import KoolTip from '@kongponents/kooltip/KoolTip.vue'
+import KIcon from '@kongponents/kicon/KIcon.vue'
 
 export default {
   name: 'KInputSwitch',
-  components: { KoolTip },
+  components: { KoolTip, KIcon },
   props: {
     /**
      * Sets whether or not toggle is checked
@@ -63,6 +68,14 @@ export default {
     disabledTooltipText: {
       type: String,
       default: ''
+    },
+
+    /**
+     * Sets whether or not to display a check icon if the switch is enabled
+     */
+    enabledIcon: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -94,4 +107,14 @@ export default {
 <style lang="scss" scoped>
 @import '~@kongponents/styles/_variables.scss';
 @import '~@kongponents/styles/forms/_switch.scss';
+
+.k-switch {
+  position: relative;
+
+  svg {
+    transform: translateX(-54px);
+    position: absolute;
+    left: 60px;
+  }
+}
 </style>

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -30,7 +30,7 @@
     <KIcon
       v-if="enabledIcon && value === true"
       icon="check"
-      color="white"/>
+     :color="var(--white)" />
     <span v-if="label || $scopedSlots.label">
       <slot name="label">{{ label }}</slot>
     </span>

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -29,8 +29,8 @@
     <div class="switch-control"/>
     <KIcon
       v-if="enabledIcon && value === true"
-      icon="check"
-     :color="var(--white)" />
+      :color="var(--white)"
+      icon="check" />
     <span v-if="label || $scopedSlots.label">
       <slot name="label">{{ label }}</slot>
     </span>

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -29,7 +29,7 @@
     <div class="switch-control"/>
     <KIcon
       v-if="enabledIcon && value === true"
-      :color="var(--white)"
+      color="var(--white)"
       icon="check" />
     <span v-if="label || $scopedSlots.label">
       <slot name="label">{{ label }}</slot>

--- a/packages/KInputSwitch/__snapshots__/KInputSwitch.spec.js.snap
+++ b/packages/KInputSwitch/__snapshots__/KInputSwitch.spec.js.snap
@@ -4,5 +4,6 @@ exports[`KInputSwitch matches snapshot 1`] = `
 <label class="k-switch"><input type="checkbox">
   <div class="switch-control"></div>
   <!---->
+  <!---->
 </label>
 `;


### PR DESCRIPTION
### Summary
Adds a prop to add a check icon to the switch when enabled

#### Changes made:
* Added a check icon to KInputSwitch component that can be enabled via a prop
* Updated `switch` docs to include a usage example for the new `enabledIcon` prop
* Doc linting and component snapshot update

#### Screenshot:
![Screen Shot 2021-06-23 at 9 03 53 AM](https://user-images.githubusercontent.com/2080476/123130874-02630900-d402-11eb-9367-36c7afc69864.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
