### PR TITLE
feat(KCard): add help text prop

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -84,6 +84,76 @@ Example composing `KCard` with other Kongponents to make another component:
 </KCard>
 ```
 
+### Help Text
+
+String positioned closely under the title to serve as help text
+
+- `helpText`
+
+<KCard
+  title="Invite a New User"
+  help-text="A confirmation email will be sent to the specified email address"
+>
+  <template slot="body">
+    <div class="mt-5">
+      <KLabel>Email Address</KLabel>
+      <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
+      <KButton appearance="primary">Invite User</KButton>
+    </div>
+  </template>
+</KCard>
+
+```vue
+<KCard
+  title="Invite a New User"
+  help-text="A confirmation email will be sent to the specified email address"
+>
+  <template slot="body">
+    <div class="mt-5">
+      <KLabel>Email Address</KLabel>
+      <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
+      <KButton appearance="primary">Invite User</KButton>
+    </div>
+  </template>
+</KCard>
+```
+
+Example of a KCard with both helpText and an action
+
+<KCard
+  title="Invite a New User"
+  help-text="A confirmation email will be sent to the specified email address"
+>
+  <template slot="body">
+    <div class="mt-5">
+      <KLabel>Email Address</KLabel>
+      <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
+      <KButton appearance="primary">Invite User</KButton>
+    </div>
+  </template>
+  <template slot="actions">
+    <KButton>View Invites</KButton>
+  </template>
+</KCard>
+
+```vue
+<KCard
+  title="Invite a New User"
+  help-text="A confirmation email will be sent to the specified email address"
+>
+  <template slot="body">
+    <div class="mt-54">
+      <KLabel>Email Address</KLabel>
+      <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
+      <KButton appearance="primary">Invite User</KButton>
+    </div>
+  </template>
+  <template slot="actions">
+    <KButton>View Invites</KButton>
+  </template>
+</KCard>
+```
+
 ### Body
 String to be used in the body slot.
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -10,7 +10,7 @@
 ```
 
 ## Props
-### title
+### Title
 String to be used in the title slot.
 
 - `title`

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -331,7 +331,7 @@ An Example of changing the background might look like.
 <div class="card-wrapper">
   <KCard
     title="Card Title"
-    body="Body Content" 
+    body="Body Content"
     hasShadow />
 </div>
 
@@ -339,7 +339,7 @@ An Example of changing the background might look like.
 <template>
   <KCard
     title="Card Title"
-    body="Body Content" 
+    body="Body Content"
     hasShadow />
 </template>
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -142,7 +142,7 @@ Example of a KCard with both helpText and an action
   help-text="A confirmation email will be sent to the specified email address"
 >
   <template slot="body">
-    <div class="mt-54">
+    <div class="mt-4">
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>

--- a/packages/KCard/KCard.spec.js
+++ b/packages/KCard/KCard.spec.js
@@ -4,15 +4,18 @@ import KCard from '@/KCard/KCard'
 describe('KCard', () => {
   it('renders slots when passed', () => {
     const cardTitle = 'Card Title'
+    const cardHelpText = 'Card Help Text'
     const cardBody = 'Card Body'
     const wrapper = mount(KCard, {
       slots: {
         'title': `<span>${cardTitle}</span>`,
+        'helpText': `<span>${cardHelpText}</span>`,
         'body': `<div>${cardBody}</div>`
       }
     })
 
     expect(wrapper.find('.k-card-title').html()).toEqual(expect.stringContaining(cardTitle))
+    expect(wrapper.find('.k-card-help-text').html()).toEqual(expect.stringContaining(cardHelpText))
     expect(wrapper.find('.k-card-body').html()).toEqual(expect.stringContaining(cardBody))
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -17,7 +17,7 @@
         <slot name="actions"/>
       </div>
     </div>
-    <div class="k-card-help-text">
+    <div v-if="helpText || $scopedSlots.helpText" class="k-card-help-text">
       <!-- @slot Use this slot to pass help text under the title -->
       <slot name="helpText">
         <span>{{ helpText }}</span>

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -17,7 +17,9 @@
         <slot name="actions"/>
       </div>
     </div>
-    <div v-if="helpText || $scopedSlots.helpText" class="k-card-help-text">
+    <div
+      v-if="helpText || $scopedSlots.helpText"
+      class="k-card-help-text">
       <!-- @slot Use this slot to pass help text under the title -->
       <slot name="helpText">
         <span>{{ helpText }}</span>

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -4,6 +4,7 @@
     class="kong-card">
     <div
       v-if="title || $scopedSlots.title || $scopedSlots.actions || $slots.title"
+      :class="helpText && 'mb-0' || 'mb-4'"
       class="k-card-header">
       <div class="k-card-title">
         <h4>
@@ -15,6 +16,12 @@
         <!-- @slot Use this slot to pass actions to right side of header -->
         <slot name="actions"/>
       </div>
+    </div>
+    <div class="k-card-help-text">
+      <!-- @slot Use this slot to pass help text under the title -->
+      <slot name="helpText">
+        <span>{{ helpText }}</span>
+      </slot>
     </div>
     <div class="k-card-body">
       <!-- @slot Use this slot to pass in body content -->
@@ -61,6 +68,14 @@ export default {
     hasShadow: {
       type: Boolean,
       default: false
+    },
+
+    /**
+      * Adds help text positioned closely under the card title
+      */
+    helpText: {
+      type: String,
+      default: ''
     }
   }
 }
@@ -111,6 +126,10 @@ export default {
 
   .k-card-actions  {
     margin-left: auto;
+  }
+
+  .k-card-help-text {
+    color: var(--black-45);
   }
 }
 </style>

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`KCard has hover class when passed 1`] = `
 <div class="kong-card border hover">
   <!---->
+  <div class="k-card-help-text"><span></span></div>
   <div class="k-card-body"></div>
 </div>
 `;
@@ -10,6 +11,7 @@ exports[`KCard has hover class when passed 1`] = `
 exports[`KCard has shadow class when passed 1`] = `
 <div class="kong-card border kcard-shadow">
   <!---->
+  <div class="k-card-help-text"><span></span></div>
   <div class="k-card-body"></div>
 </div>
 `;
@@ -17,18 +19,20 @@ exports[`KCard has shadow class when passed 1`] = `
 exports[`KCard matches snapshot 1`] = `
 <div class="kong-card border">
   <!---->
+  <div class="k-card-help-text"><span></span></div>
   <div class="k-card-body"></div>
 </div>
 `;
 
 exports[`KCard renders slots when passed 1`] = `
 <div class="kong-card border">
-  <div class="k-card-header">
+  <div class="k-card-header mb-4">
     <div class="k-card-title">
       <h4><span>Card Title</span></h4>
     </div>
     <div class="k-card-actions"></div>
   </div>
+  <div class="k-card-help-text"><span></span></div>
   <div class="k-card-body">
     <div>Card Body</div>
   </div>

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`KCard has hover class when passed 1`] = `
 <div class="kong-card border hover">
   <!---->
-  <div class="k-card-help-text"><span></span></div>
+  <!---->
   <div class="k-card-body"></div>
 </div>
 `;
@@ -11,7 +11,7 @@ exports[`KCard has hover class when passed 1`] = `
 exports[`KCard has shadow class when passed 1`] = `
 <div class="kong-card border kcard-shadow">
   <!---->
-  <div class="k-card-help-text"><span></span></div>
+  <!---->
   <div class="k-card-body"></div>
 </div>
 `;
@@ -19,7 +19,7 @@ exports[`KCard has shadow class when passed 1`] = `
 exports[`KCard matches snapshot 1`] = `
 <div class="kong-card border">
   <!---->
-  <div class="k-card-help-text"><span></span></div>
+  <!---->
   <div class="k-card-body"></div>
 </div>
 `;
@@ -32,7 +32,7 @@ exports[`KCard renders slots when passed 1`] = `
     </div>
     <div class="k-card-actions"></div>
   </div>
-  <div class="k-card-help-text"><span></span></div>
+  <div class="k-card-help-text"><span>Card Help Text</span></div>
   <div class="k-card-body">
     <div>Card Body</div>
   </div>


### PR DESCRIPTION
### Summary
Adds a `help-text` prop to the KCard component

#### Changes made:
* Add a `help-text` prop to the KCard component
* Add some examples to the KCard docs
* Small KCard doc linting changes
* Update KCard snapshot

#### Screenshots:
![Screen Shot 2021-06-23 at 9 42 53 AM](https://user-images.githubusercontent.com/2080476/123145351-98eaf680-d411-11eb-8783-2d659d758f6b.png)
![Screen Shot 2021-06-23 at 9 43 10 AM](https://user-images.githubusercontent.com/2080476/123145353-9a1c2380-d411-11eb-84d6-0a384bf4bf68.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
