### PR TITLE
feat(KModal): add support for help text

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -41,6 +41,7 @@ export default {
 **Content**
 - `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the close/cancel
 - `title` - Text to display in header if not using slot
+- `helpText` - Help text to display below header if not using slot
 - `content` - Text to display in content if not using slot
 
 **Buttons & Appearance**
@@ -53,6 +54,7 @@ There are 3 designated slots you can use to display content in the modal.
 
 `header-content`
 `body-content`  
+`help`
 `footer-content` - Contains action buttons by default.
 
 ---
@@ -70,6 +72,7 @@ Using both the provided props and slot options we will now demonstrate how to cu
     actionButtonAppearance="danger"
     @canceled="slottedIsOpen = false">
     <template slot="header-content">Delete Item</template>
+    <template slot="help">Take this action to delete</template>
     <template slot="body-content">Are you sure you want to delete this item? This action can not be undone.</template>
   </KModal>
 </template>
@@ -82,6 +85,7 @@ Using both the provided props and slot options we will now demonstrate how to cu
     actionButtonAppearance="danger"
     @canceled="slottedIsOpen = false">
     <template slot="header-content">Delete Item</template>
+    <template slot="help">Take this action to delete</template>
     <template slot="body-content">Are you sure you want to delete this item? This action can not be undone.</template>
   </KModal>
 </template>

--- a/packages/KModal/KModal.spec.js
+++ b/packages/KModal/KModal.spec.js
@@ -4,6 +4,7 @@ import KModal from '@/KModal/KModal'
 describe('KModal', () => {
   it('renders proper content when using slots', () => {
     const headerText = 'This is some header text'
+    const helpText = 'This is some help text'
     const bodyText = 'This is some body text'
     const footerText = 'This is some footer text'
     const wrapper = mount(KModal, {
@@ -12,12 +13,14 @@ describe('KModal', () => {
       },
       slots: {
         'header-content': `<div>${headerText}</div>`,
+        'help': `<div>${helpText}</div>`,
         'body-content': `<div>${bodyText}</div>`,
         'footer-content': `<div>${footerText}</div>`
       }
     })
 
     expect(wrapper.find('.modal-header').html()).toEqual(expect.stringContaining(headerText))
+    expect(wrapper.find('.modal-help').html()).toEqual(expect.stringContaining(helpText))
     expect(wrapper.find('.modal-body').html()).toEqual(expect.stringContaining(bodyText))
     expect(wrapper.find('.modal-footer').html()).toEqual(expect.stringContaining(footerText))
     expect(wrapper.html()).toMatchSnapshot()
@@ -25,16 +28,19 @@ describe('KModal', () => {
 
   it('renders proper content when using props', () => {
     const title = 'Sweet prop title'
+    const helpText = 'Sweet prop help text'
     const content = 'Sweet prop content'
     const wrapper = mount(KModal, {
       propsData: {
         isVisible: true,
         title,
+        helpText,
         content
       }
     })
 
     expect(wrapper.find('.modal-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.modal-help').html()).toEqual(expect.stringContaining(helpText))
     expect(wrapper.find('.modal-body').html()).toEqual(expect.stringContaining(content))
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -12,7 +12,10 @@
         class="modal-dialog"
         @click.stop>
         <div class="modal-content">
-          <div class="modal-header">
+          <div
+            :class="helpText ? 'mb-3' : 'mb-4'"
+            class="modal-header"
+          >
             <slot name="header-content">{{ title }}</slot>
           </div>
           <div
@@ -169,7 +172,6 @@ export default {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: var(--spacing-md, spacing(md));
     color: var(--KModalHeaderColor, var(--black-85, color(black-85)));
     font-size: var(--KModalHeaderSize, var(--type-lg, type(lg)));
     font-weight: var(--KModalHeaderWeight, 500);

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -15,6 +15,11 @@
           <div class="modal-header">
             <slot name="header-content">{{ title }}</slot>
           </div>
+          <div
+            v-if="$scopedSlots.help || helpText"
+            class="modal-help">
+            <slot name="help">{{ helpText }}</slot>
+          </div>
           <div class="modal-body">
             <slot name="body-content">{{ content }}</slot>
           </div>
@@ -53,6 +58,13 @@ export default {
        */
       type: String,
       default: 'Modal Title'
+    },
+    helpText: {
+      /**
+       * Set help text to be displayed under the title
+       */
+      type: String,
+      default: ''
     },
     /**
      * Set the text of the body content
@@ -161,6 +173,11 @@ export default {
     color: var(--KModalHeaderColor, var(--black-85, color(black-85)));
     font-size: var(--KModalHeaderSize, var(--type-lg, type(lg)));
     font-weight: var(--KModalHeaderWeight, 500);
+  }
+
+  .modal-help {
+    color: var(--black-45);
+    margin-bottom: var(--spacing-xl);
   }
 
   .modal-body {

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -27,7 +27,7 @@ exports[`KModal renders proper content when using props 1`] = `
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">Sweet prop title</div>
-        <!---->
+        <div class="modal-help">Sweet prop help text</div>
         <div class="modal-body">Sweet prop content</div>
         <div class="modal-footer"><button type="button" class="k-button primary">
             Proceed
@@ -48,7 +48,9 @@ exports[`KModal renders proper content when using slots 1`] = `
         <div class="modal-header">
           <div>This is some header text</div>
         </div>
-        <!---->
+        <div class="modal-help">
+          <div>This is some help text</div>
+        </div>
         <div class="modal-body">
           <div>This is some body text</div>
         </div>

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -7,7 +7,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
   <div class="modal-backdrop">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header">Modal Title</div>
+        <div class="modal-header mb-4">Modal Title</div>
         <!---->
         <div class="modal-body">Modal Content</div>
         <div class="modal-footer"><button type="button" class="k-button outline-primary">
@@ -26,7 +26,7 @@ exports[`KModal renders proper content when using props 1`] = `
   <div class="modal-backdrop">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header">Sweet prop title</div>
+        <div class="modal-header mb-3">Sweet prop title</div>
         <div class="modal-help">Sweet prop help text</div>
         <div class="modal-body">Sweet prop content</div>
         <div class="modal-footer"><button type="button" class="k-button primary">
@@ -45,7 +45,7 @@ exports[`KModal renders proper content when using slots 1`] = `
   <div class="modal-backdrop">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header">
+        <div class="modal-header mb-4">
           <div>This is some header text</div>
         </div>
         <div class="modal-help">

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -8,6 +8,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">Modal Title</div>
+        <!---->
         <div class="modal-body">Modal Content</div>
         <div class="modal-footer"><button type="button" class="k-button outline-primary">
             click to continue
@@ -26,6 +27,7 @@ exports[`KModal renders proper content when using props 1`] = `
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">Sweet prop title</div>
+        <!---->
         <div class="modal-body">Sweet prop content</div>
         <div class="modal-footer"><button type="button" class="k-button primary">
             Proceed
@@ -46,6 +48,7 @@ exports[`KModal renders proper content when using slots 1`] = `
         <div class="modal-header">
           <div>This is some header text</div>
         </div>
+        <!---->
         <div class="modal-body">
           <div>This is some body text</div>
         </div>


### PR DESCRIPTION
### Summary
Allow users to specify help text to display under the modal title.

#### Changes made:
* Add new slot `help` and property `helpText`

![image](https://user-images.githubusercontent.com/67973710/123453489-9e7d4380-d5ad-11eb-83e6-5bac4e156754.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
