### PR TITLE
fix(KCard): add bottom margin to help text element

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -95,7 +95,7 @@ String positioned closely under the title to serve as help text
   help-text="A confirmation email will be sent to the specified email address"
 >
   <template slot="body">
-    <div class="mt-5">
+    <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
@@ -109,7 +109,7 @@ String positioned closely under the title to serve as help text
   help-text="A confirmation email will be sent to the specified email address"
 >
   <template slot="body">
-    <div class="mt-5">
+    <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
@@ -125,7 +125,7 @@ Example of a KCard with both helpText and an action
   help-text="A confirmation email will be sent to the specified email address"
 >
   <template slot="body">
-    <div class="mt-5">
+    <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
@@ -142,7 +142,7 @@ Example of a KCard with both helpText and an action
   help-text="A confirmation email will be sent to the specified email address"
 >
   <template slot="body">
-    <div class="mt-4">
+    <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -19,7 +19,7 @@
     </div>
     <div
       v-if="helpText || $scopedSlots.helpText"
-      class="k-card-help-text">
+      class="k-card-help-text mb-4">
       <!-- @slot Use this slot to pass help text under the title -->
       <slot name="helpText">
         <span>{{ helpText }}</span>

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -32,7 +32,7 @@ exports[`KCard renders slots when passed 1`] = `
     </div>
     <div class="k-card-actions"></div>
   </div>
-  <div class="k-card-help-text"><span>Card Help Text</span></div>
+  <div class="k-card-help-text mb-4"><span>Card Help Text</span></div>
   <div class="k-card-body">
     <div>Card Body</div>
   </div>


### PR DESCRIPTION
### Summary
This adds `16px` bottom margin to the KCard help text element. This way, users of the prop won't always have to add top margin to KCard body content.

#### Changes made:
* Adds bottom margin to KCard help text element

(no screenshot because it looks the same)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
