### PR TITLE
fix(KTable) fix side border display

### DIFF
--- a/docs/.vuepress/styles/prism-theme.min.css
+++ b/docs/.vuepress/styles/prism-theme.min.css
@@ -133,11 +133,11 @@ pre[class*="language-"] > code[class*="language-"] {
 }
 div[class*="language-"] .highlight-lines .highlighted,
 div[class*="language-"].line-numbers-mode .highlight-lines .highlighted:before {
-  background-color: var(--steal-100) !important;
+  background-color: var(--steel-100) !important;
 }
 div[class*="language-"].line-numbers-mode .line-numbers-wrapper {
   color: var(--black-70) !important;
 }
 div[class*="language-"].line-numbers-mode::after {
-  border-right: 1px solid var(--steal-100) !important;
+  border-right: 1px solid var(--steel-100) !important;
 }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -306,12 +306,12 @@ export default {
 
     tbody tr {
       border: none;
-      box-shadow: -2px 0 0 var(--KTableBorder, var(--steel-200, color(steal-200)));
+      box-shadow: -2px 0 0 var(--KTableBorder, var(--steel-200, color(steel-200)));
     }
 
     &.has-hover {
       tbody tr:hover {
-        box-shadow: -2px 0 0 var(--KTableBorder, var(--steel-300, color(steal-300)));
+        box-shadow: -2px 0 0 var(--KTableBorder, var(--steel-300, color(steel-300)));
       }
     }
   }


### PR DESCRIPTION
### Summary
Fix CSS color variable name so that side border will display on rows.

#### Changes made:
*

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
