### PR TITLE
fix(KCard): adjust helpText margins

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -118,6 +118,44 @@ String positioned closely under the title to serve as help text
 </KCard>
 ```
 
+Example of a KCard with helpText slot
+
+<KCard title="Invite a New User">
+  <template slot="helpText">
+    <div class="d-flex align-items-center">
+      A confirmation email will be sent to the specified email address
+      <a class="ml-3 mr-2" href="#help-text">Learn More</a>
+      <KIcon icon="externalLink" color="var(--blue-500)" size="14"/>
+    </div>
+  </template>
+  <template slot="body">
+    <div>
+      <KLabel>Email Address</KLabel>
+      <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
+      <KButton appearance="primary">Invite User</KButton>
+    </div>
+  </template>
+</KCard>
+
+```vue
+<KCard title="Invite a New User">
+  <template slot="helpText">
+    <div class="d-flex align-items-center">
+      A confirmation email will be sent to the specified email address
+      <a class="ml-3 mr-2" href="#help-text">Learn More</a>
+      <KIcon icon="externalLink" color="var(--blue-500)" size="14"/>
+    </div>
+  </template>
+  <template slot="body">
+    <div>
+      <KLabel>Email Address</KLabel>
+      <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
+      <KButton appearance="primary">Invite User</KButton>
+    </div>
+  </template>
+</KCard>
+```
+
 Example of a KCard with both helpText and an action
 
 <KCard

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -4,7 +4,7 @@
     class="kong-card">
     <div
       v-if="title || $scopedSlots.title || $scopedSlots.actions || $slots.title"
-      :class="helpText && 'mb-0' || 'mb-4'"
+      :class="(helpText || $scopedSlots.helpText !== undefined) && 'mb-0' || 'mb-4'"
       class="k-card-header">
       <div class="k-card-title">
         <h4>
@@ -19,7 +19,7 @@
     </div>
     <div
       v-if="helpText || $scopedSlots.helpText"
-      class="k-card-help-text mb-4">
+      class="k-card-help-text mb-5">
       <!-- @slot Use this slot to pass help text under the title -->
       <slot name="helpText">
         <span>{{ helpText }}</span>

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -26,13 +26,13 @@ exports[`KCard matches snapshot 1`] = `
 
 exports[`KCard renders slots when passed 1`] = `
 <div class="kong-card border">
-  <div class="k-card-header mb-4">
+  <div class="k-card-header mb-0">
     <div class="k-card-title">
       <h4><span>Card Title</span></h4>
     </div>
     <div class="k-card-actions"></div>
   </div>
-  <div class="k-card-help-text mb-4"><span>Card Help Text</span></div>
+  <div class="k-card-help-text mb-5"><span>Card Help Text</span></div>
   <div class="k-card-body">
     <div>Card Body</div>
   </div>


### PR DESCRIPTION
### Summary
Adjusts KCard helpText margins. Fixes an issue where unwanted margin was added when helpText was used via component slot rather than a prop. Adds `24px` bottom margin to the helpText element.

#### Changes made:
* Fixes an issue where unwanted margin was added when helpText was used via component slot rather than a prop
* Adds `24px` bottom margin to the helpText element
* Adds an example of using helpText via slot
* Updates test snapshot

#### Screenshots:
**Before:**
![Screen Shot 2021-07-07 at 3 08 55 PM](https://user-images.githubusercontent.com/2080476/124834930-607d0980-df35-11eb-90ac-f4d7a96cc02d.png)

**After:**
![Screen Shot 2021-07-07 at 3 07 54 PM](https://user-images.githubusercontent.com/2080476/124834906-5824ce80-df35-11eb-9488-8b1f2dae2c2b.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
