### PR TITLE
feat(KAlert): add more border options

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -79,15 +79,60 @@ Adds border around alert. Used for [KToaster]().
 ### Left Border
 Adds border to the left side. Typically used for alerts that show info that may link away like documentation.
 
-- `hasLeftBorder`  
+- `has-left-border`
 
 <KAlert
-  hasLeftBorder
+  has-left-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
-  hasLeftBorder
+  has-left-border
+  alert-message="Bordered alert"/>
+```
+
+### Right Border
+Adds border to the right side. Typically used for alerts that show info that may link away like documentation.
+
+- `has-right-border`
+
+<KAlert
+  has-right-border
+  alert-message="Bordered alert"/>
+
+```vue
+<KAlert
+  has-right-border
+  alert-message="Bordered alert"/>
+```
+
+### Top Border
+Adds border to the top.
+
+- `has-top-border`
+
+<KAlert
+  has-top-border
+  alert-message="Bordered alert"/>
+
+```vue
+<KAlert
+  has-top-border
+  alert-message="Bordered alert"/>
+```
+
+### Bottom Border
+Adds border to the bottom.
+
+- `has-bottom-border`
+
+<KAlert
+  has-bottom-border
+  alert-message="Bordered alert"/>
+
+```vue
+<KAlert
+  has-bottom-border
   alert-message="Bordered alert"/>
 ```
 

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -11,8 +11,8 @@
 ### Appearances
 What color and purpose the Alert should be. Shares similar appearances to those of [KButton](/components/button).
 
-- `info`  
-- `warning`   
+- `info`
+- `warning`
 - `success`
 - `danger`
 
@@ -47,7 +47,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 ### Dismissible
 KAlert allows for dismissal of the banner.
 
-- `is-dismissible`  
+- `is-dismissible`
 
 <KAlert
   class="dismissible"
@@ -63,7 +63,7 @@ KAlert allows for dismissal of the banner.
 ### Bordered
 Adds border around alert. Used for [KToaster]().
 
-- `is-bordered`  
+- `is-bordered`
 
 <KAlert
   is-bordered
@@ -139,7 +139,7 @@ Adds border to the bottom.
 ### Size
 Controls size of alert. Currently only *small* is supported.
 
-- `small`  
+- `small`
 
 <KAlert
   style="width:250px"
@@ -246,7 +246,7 @@ Fixes KAlert to the top of the container.
 
 \
 An Example of changing the success KAlert variant to lime instead of Kong's green might
-look like.  
+look like.
 
 > Note: We are scoping the overrides to a wrapper in this example
 
@@ -275,7 +275,7 @@ look like.
 .k-alert {
   &:not(:last-of-type) {
     margin-bottom: 1rem;
-  }  
+  }
 }
 .alert-wrapper {
   --KAlertSuccessBackground: lime;

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -37,4 +37,36 @@ describe('KAlert', () => {
 
     expect(wrapper.isEmpty()).toBe(true)
   })
+
+  it('renders borders on the expected sides', () => {
+    const wrapperBorderLeft = mount(KAlert, {
+      propsData: {
+        message: 'Hello world',
+        hasLeftBorder: true
+      }
+    })
+    const wrapperBorderRight = mount(KAlert, {
+      propsData: {
+        message: 'Hello world',
+        hasRightBorder: true
+      }
+    })
+    const wrapperBorderBottom = mount(KAlert, {
+      propsData: {
+        message: 'Hello world',
+        hasBottomBorder: true
+      }
+    })
+    const wrapperBorderTop = mount(KAlert, {
+      propsData: {
+        message: 'Hello world',
+        hasTopBorder: true
+      }
+    })
+
+    expect(wrapperBorderLeft.attributes('class')).toContain('hasLeftBorder')
+    expect(wrapperBorderRight.attributes('class')).toContain('hasRightBorder')
+    expect(wrapperBorderBottom.attributes('class')).toContain('hasBottomBorder')
+    expect(wrapperBorderTop.attributes('class')).toContain('hasTopBorder')
+  })
 })

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -218,20 +218,20 @@ export default {
     justify-content: center;
   }
   &.hasLeftBorder {
-   border-left: 3px solid;
-   border-radius: 0;
+    border-left: 3px solid;
+    border-radius: 0;
   }
   &.hasRightBorder {
-   border-right: 3px solid;
-   border-radius: 0;
+    border-right: 3px solid;
+    border-radius: 0;
   }
   &.hasTopBorder {
-   border-top: 3px solid;
-   border-radius: 0;
+    border-top: 3px solid;
+    border-radius: 0;
   }
   &.hasBottomBorder {
-   border-bottom: 3px solid;
-   border-radius: 0;
+    border-bottom: 3px solid;
+    border-radius: 0;
   }
   &.small {
     font-size: var(--type-sm, type(sm));

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -1,7 +1,17 @@
 <template>
   <div
     v-if="isShowing"
-    :class="[appearance, size, {'isBordered':isBordered}, {'hasLeftBorder':hasLeftBorder}, {'isCentered': isCentered}, {'isFixed': isFixed}]"
+    :class="[
+      appearance,
+      size,
+      {'isBordered':isBordered},
+      {'hasLeftBorder':hasLeftBorder},
+      {'hasRightBorder':hasRightBorder},
+      {'hasTopBorder':hasTopBorder},
+      {'hasBottomBorder':hasBottomBorder},
+      {'isCentered': isCentered},
+      {'isFixed': isFixed}
+    ]"
     class="k-alert"
     role="alert">
     <button
@@ -80,6 +90,27 @@ export default {
      * Sets whether or not alert has left border
      */
     hasLeftBorder: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Sets whether or not alert has right border
+     */
+    hasRightBorder: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Sets whether or not alert has top border
+     */
+    hasTopBorder: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Sets whether or not alert has bottom border
+     */
+    hasBottomBorder: {
       type: Boolean,
       default: false
     },
@@ -188,6 +219,18 @@ export default {
   }
   &.hasLeftBorder {
    border-left: 3px solid;
+   border-radius: 0;
+  }
+  &.hasRightBorder {
+   border-right: 3px solid;
+   border-radius: 0;
+  }
+  &.hasTopBorder {
+   border-top: 3px solid;
+   border-radius: 0;
+  }
+  &.hasBottomBorder {
+   border-bottom: 3px solid;
    border-radius: 0;
   }
   &.small {


### PR DESCRIPTION
### Summary
Adds more border options for KAlert component via three new props:
1. `has-border-right`
2. `has-border-top`
3. `has-border-bottom`

These additions are in preparation for upcoming work on the KToaster component.

#### Changes made:
* Adds three new props, `has-border-right`, `has-border-top`, `has-border-bottom`
* Adds documentation examples for the new border props

#### Screenshots:
![Screen Shot 2021-07-14 at 11 52 08 AM](https://user-images.githubusercontent.com/2080476/125677111-1c3cc20d-71be-4d92-8a7c-409c9f9f57ca.png)
![Screen Shot 2021-07-14 at 11 52 22 AM](https://user-images.githubusercontent.com/2080476/125677113-7d28e6ec-6d48-42b0-8258-2001af29591b.png)
![Screen Shot 2021-07-14 at 11 52 36 AM](https://user-images.githubusercontent.com/2080476/125677115-961ef14e-be27-4798-9613-e771a2b1277f.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
