### PR TITLE
feat(kinput): fun with labels

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -36,10 +36,10 @@ String to be used as the input label. Make sure that if you are using the built 
 
 - `label`
 
-<KInput label="Name" />
+<KInput label="Name" placeholder="I'm labelled!" />
 
 ```vue
-<KInput label="Name" />
+<KInput label="Name" placeholder="I'm labelled!" />
 ```
 
 If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KInput** and will be styled appropriately. 
@@ -54,7 +54,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 </template>
 ```
 
-### Bound attributes
+### Attribute Binding
 You can pass any input attribute and it will get properly bound to the element.
 
 <KInput class="mb-2" placeholder="placeholder" />

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -8,6 +8,53 @@
 ```
 
 ## Props
+### Help
+String to be displayed as help text.
+
+- `help`
+
+<KInput help="I can help with that" placeholder="Need help?" />
+
+```
+<KInput help="I can help with that" placeholder="Need help?" />
+```
+
+You also have the option of using the `.help` utility class. This is meant to be used after **KInput** and will be styled appropriately. 
+
+<KInput type="text" placeholder="Need help?" />
+<p class="help">I can help with that</p>
+
+```vue
+<template>
+  <KInput type="text" placeholder="Need help?" />
+  <p class="help">I can help with that</p>
+</template>
+```
+
+### Label
+String to be used as the input label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element. 
+
+- `label`
+
+<KInput label="Name" />
+
+```vue
+<KInput label="Name" />
+```
+
+If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KInput** and will be styled appropriately. 
+
+<KLabel for="my-input">Label</KLabel>
+<KInput id="my-input" type="text" placeholder="I have a label" />
+
+```vue
+<template>
+  <KLabel for="my-input">Label</KLabel>
+  <KInput id="my-input" type="text" placeholder="I have a label" />
+</template>
+```
+
+### Bound attributes
 You can pass any input attribute and it will get properly bound to the element.
 
 <KInput class="mb-2" placeholder="placeholder" />
@@ -78,28 +125,13 @@ KInput transparently binds to events:
 </Komponent>
 ```
 
-## Labels
-
-Additionally you you can use in conjunction with **KLabel** and or a paragraph with the utility class of `.help`. These are meant to be used before and after KInput and will be styled appropriately. 
-
-<KLabel for="my-input">Label</KLabel>
-<KInput id="my-input" type="text" placeholder="I have a label & help" />
-<p class="help">Help text</p>
-
-```vue
-<template>
-  <KLabel for="my-input">Label</KLabel>
-  <KInput id="my-input" type="text" placeholder="I have a label & help" />
-  <p class="help">help</p>
-</template>
-```
-
 ## Theming
 | Variable | Purpose
 |:-------- |:-------
 | `--KInputColor` | Input text color
+| `--KInputLabelColor` | Input label color
 | `--KInputBorder` | Input border color
-| `--KInputBackground` | Input background color
+| `--KInputBackground` | Input and label background color
 | `--KInputFocus` | Input focus border color
 | `--KInputDisabledBackground` | Input disabled background color
 | `--KInputError` | Input error border color

--- a/packages/KInput/KInput.spec.js
+++ b/packages/KInput/KInput.spec.js
@@ -12,6 +12,26 @@ describe('KInput', () => {
     expect(wrapper.find('input').element.value).toBe('Hello')
   })
 
+  it('renders label when value is passed', () => {
+    const wrapper = mount(KInput, {
+      propsData: {
+        label: 'A Label!'
+      }
+    })
+
+    expect(wrapper.find('.text-on-input label').element.innerHTML).toContain('A Label!')
+  })
+
+  it('renders help when value is passed', () => {
+    const wrapper = mount(KInput, {
+      propsData: {
+        help: 'I am helpful'
+      }
+    })
+
+    expect(wrapper.find('.k-input-wrapper .help').element.innerHTML).toContain('I am helpful')
+  })
+
   it('reacts to text changes', () => {
     const wrapper = mount(KInput, {
       propsData: {

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -1,9 +1,39 @@
 <template>
-  <input
-    :value="value"
-    class="form-control k-input"
-    @input="e => $emit('input', e.target.value)"
-    v-on="listeners">
+  <div
+    v-bind="attrs"
+    class="k-input-wrapper">
+    <input
+      v-if="!label"
+      :value="value"
+      v-bind="attrs"
+      class="form-control k-input"
+      @input="e => $emit('input', e.target.value)"
+      v-on="listeners">
+
+    <div
+      v-else
+      class="col-md-4 mt-5">
+      <div class="text-on-input">
+        <label :class="{ focused: isFocused }">
+          {{ label }}
+        </label>
+        <input
+          :value="value"
+          v-bind="attrs"
+          class="form-control k-input"
+          @input="e => $emit('input', e.target.value)"
+          @focus="() => isFocused = true"
+          @blur="() => isFocused = false"
+          v-on="listeners">
+      </div>
+    </div>
+
+    <p
+      v-if="help"
+      class="help">
+      {{ help }}
+    </p>
+  </div>
 </template>
 
 <script>
@@ -13,9 +43,25 @@ export default {
     value: {
       type: String,
       default: ''
+    },
+    label: {
+      type: String,
+      default: ''
+    },
+    help: {
+      type: String,
+      default: ''
+    }
+  },
+  data () {
+    return {
+      isFocused: false
     }
   },
   computed: {
+    attrs () {
+      return this.$attrs
+    },
     listeners () {
       const listeners = { ...this.$listeners }
 
@@ -31,4 +77,49 @@ export default {
 <style scoped lang="scss">
 @import '~@kongponents/styles/_variables.scss';
 @import '~@kongponents/styles/forms/_inputs.scss';
+
+.text-on-input {
+  position: relative;
+
+  .focused {
+    color: var(--KInputLabelColor, var(--KInputBorder, var(--blue-500)));
+  }
+
+  label {
+    position: absolute;
+    top: -8px;
+    left: 13px;
+    padding: 2px;
+    z-index: 1;
+
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--KInputBorder, var(--gray-300));
+    background-color: var(--KInputBackground, var(--white));
+    display: inline-block;
+    margin-bottom: .5rem;
+  }
+
+  &:after {
+    content: " ";
+    background-color: var(--white);
+    width: 100%;
+    height: 13px;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    z-index: -1;
+  }
+}
+
+.form-control {
+  box-shadow: none !important;
+}
+
+.help {
+  display: block;
+  margin: var(--spacing-xs, spacing(xs)) 0 0;
+  font-size: var(--type-sm, type(sm));
+  color: var(--black-45, color(black-45));
+}
 </style>

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    v-bind="attrs"
-    class="k-input-wrapper">
+  <div class="k-input-wrapper">
     <input
       v-if="!label"
       :value="value"

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -97,17 +97,6 @@ export default {
     display: inline-block;
     margin-bottom: .5rem;
   }
-
-  &:after {
-    content: " ";
-    background-color: var(--white);
-    width: 100%;
-    height: 13px;
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    z-index: -1;
-  }
 }
 
 .form-control {

--- a/packages/KInput/__snapshots__/KInput.spec.js.snap
+++ b/packages/KInput/__snapshots__/KInput.spec.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KInput matches snapshot 1`] = `<input class="form-control k-input" placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input">`;
+exports[`KInput matches snapshot 1`] = `
+<div placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="k-input-wrapper"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input">
+  <!---->
+</div>
+`;

--- a/packages/KInput/__snapshots__/KInput.spec.js.snap
+++ b/packages/KInput/__snapshots__/KInput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KInput matches snapshot 1`] = `
-<div placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="k-input-wrapper"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input">
+<div class="k-input-wrapper" placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input">
   <!---->
 </div>
 `;

--- a/packages/styles/forms/_general.scss
+++ b/packages/styles/forms/_general.scss
@@ -10,7 +10,8 @@
   }
 }
 
-.k-input + .help {
+.k-input + .help,
+.k-input-wrapper + .help {
   display: block;
   margin: var(--spacing-xs, spacing(xs)) 0 0;
   font-size: var(--type-sm, type(sm));

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -1,5 +1,10 @@
 @import "labels";
 
+.k-input-wrapper.input-error .k-input {
+  outline: none !important;
+  border: 1px solid var(--KInputError, var(--red-400, color(red-400)));
+}
+
 .k-input,
 .form-control {
   $borderColor: var(--KInputBorder, var(--grey-300, color(grey-300)));


### PR DESCRIPTION
### Summary

#### Changes made:
* Parameterize `help` text and add a built in `label` prop
* Maintain support for `.help` utility class and combining with `KLabel`
* Maintain attribute binding
* Update snapshots

Help section:

![image](https://user-images.githubusercontent.com/67973710/125999483-386d3898-f0a1-4b5d-a990-2b8b56a77da2.png)


Labeling options:

![image](https://user-images.githubusercontent.com/67973710/125999998-d1bd67c6-9438-4ff4-b6db-2191d41c778c.png)

![image](https://user-images.githubusercontent.com/67973710/126000025-fa267619-409b-4cc8-bdb9-5b232864e840.png)




### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
