### PR TITLE
feat(klabel): add for attribute for label

### DIFF
--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -44,6 +44,18 @@
 <KLabel info="This is an example">Input Title</KLabel>
 ```
 
+## With for attribute
+
+<br />
+
+<KLabel for="service">Service Name</KLabel>
+<KInput id="service"/>
+
+```vue
+<KLabel for="service" help="A service is an API that you want to offer">Service Name</KLabel>
+<KInput id="service"/>
+```
+
 ## Sample input with a tooltip
 
 <br />
@@ -55,3 +67,4 @@
 <KLabel help="A service is an API that you want to offer">Service Name</KLabel>
 <KInput />
 ```
+

--- a/packages/KLabel/KLabel.spec.js
+++ b/packages/KLabel/KLabel.spec.js
@@ -37,4 +37,17 @@ describe('KLabel', () => {
 
     expect(wrapper.html()).toMatchSnapshot()
   })
+
+  it('passes the `for` attribute to label when `for` is provided', () => {
+    const wrapper = mount(KLabel, {
+      propsData: {
+        for: 'test-id'
+      },
+      slots: {
+        default: 'Full Name'
+      }
+    })
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -1,5 +1,7 @@
 <template functional>
-  <label class="k-input-label">
+  <label
+    :for="props.for"
+    class="k-input-label">
     <KoolTip
       v-if="props.help"
       :label="props.help"
@@ -39,6 +41,10 @@ export default {
       default: undefined
     },
     info: {
+      type: String,
+      default: undefined
+    },
+    for: {
       type: String,
       default: undefined
     }

--- a/packages/KLabel/__snapshots__/KLabel.spec.js.snap
+++ b/packages/KLabel/__snapshots__/KLabel.spec.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KLabel passes the \`for\` attribute to label when \`for\` is provided 1`] = `<label class="k-input-label" for="test-id">Full Name</label>`;
+
 exports[`KLabel renders a tooltip when \`help\` is provided 1`] = `<label class="k-input-label" help="This is a tooltip">Full Name</label>`;
 
 exports[`KLabel renders a tooltip when \`info\` is provided 1`] = `<label class="k-input-label" info="This is a tooltip">Full Name</label>`;


### PR DESCRIPTION
### Summary

Klabel was expected to implement the html label's `for` attribute and was used in many places that way, but was not previously implemented. This PR implements this behavior.

#### Changes made:

* Adds `for` prop that is passed as a label attribute
* Adds documentation example with the new prop
* Adds snapshot test

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
