### PR TITLE
style(kcheckbox,kradio): fix label space

### DIFF
--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -82,11 +82,11 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ```vue
 <KCheckbox v-model="checkbox1">
-  Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}
+  <span>Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}</span>
 </KCheckbox>
 
 <KCheckbox v-model="checkbox2">
-  I agree to the <a :href="privacyPolicyURL">privacy policy</a>.
+  <span>I agree to the <a :href="privacyPolicyURL">privacy policy</a>.</span>
 </KCheckbox>
 ```
 
@@ -94,12 +94,12 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
   <template slot="body">
     <div class="mb-2">
       <KCheckbox v-model="slots1">
-        Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}
+        <span>Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}</span>
       </KCheckbox>
     </div>
     <div>
       <KCheckbox v-model="slots2">
-        I agree to the <a href="#slots">privacy policy</a>.
+        <span>I agree to the <a href="#slots">privacy policy</a>.</span>
       </KCheckbox>
     </div>
   </template>

--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -82,11 +82,11 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ```vue
 <KCheckbox v-model="checkbox1">
-  <span>Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}</span>
+  Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}
 </KCheckbox>
 
 <KCheckbox v-model="checkbox2">
-  <span>I agree to the <a :href="privacyPolicyURL">privacy policy</a>.</span>
+  I agree to the <a :href="privacyPolicyURL">privacy policy</a>.
 </KCheckbox>
 ```
 
@@ -94,12 +94,12 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
   <template slot="body">
     <div class="mb-2">
       <KCheckbox v-model="slots1">
-        <span>Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}</span>
+        Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}
       </KCheckbox>
     </div>
     <div>
       <KCheckbox v-model="slots2">
-        <span>I agree to the <a href="#slots">privacy policy</a>.</span>
+        I agree to the <a href="#slots">privacy policy</a>.
       </KCheckbox>
     </div>
   </template>

--- a/docs/components/input-radio.md
+++ b/docs/components/input-radio.md
@@ -84,9 +84,19 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ```vue
 <KRadio v-model="selected" :value="true">
-  Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}
+  <span>Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}</span>
 </KRadio>
 ```
+
+<KCard>
+  <template slot="body">
+    <div class="mb-2">
+      <KRadio v-model="selected" :value="true">
+        <span>Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}</span>
+      </KRadio>
+    </div>
+  </template>
+</KCard>
 
 ## Theming
 | Variable | Purpose
@@ -126,6 +136,7 @@ export default {
       objB: { name: 'b' },
       radio: true,
       radioState: true,
+      selected: false
     }
   }
 }

--- a/docs/components/input-radio.md
+++ b/docs/components/input-radio.md
@@ -84,7 +84,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ```vue
 <KRadio v-model="selected" :value="true">
-  <span>Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}</span>
+  Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}
 </KRadio>
 ```
 
@@ -92,7 +92,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
   <template slot="body">
     <div class="mb-2">
       <KRadio v-model="selected" :value="true">
-        <span>Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}</span>
+        Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}
       </KRadio>
     </div>
   </template>

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -6,9 +6,9 @@
       type="checkbox"
       class="k-input"
       v-on="listeners">
-    <span>
-      <slot> {{ label }}</slot>
-    </span>
+    <slot>
+      <span>{{ label }}</span>
+    </slot>
   </label>
 </template>
 

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -1,12 +1,15 @@
 <template>
-  <label class="k-checkbox">
-    <input
-      :checked="value"
-      v-bind="$attrs"
-      type="checkbox"
-      class="k-input float-left"
-      v-on="listeners"><span class="float-left"><slot>{{ label }}</slot></span>
-  </label>
+  <div class="d-inline-block">
+    <label class="k-checkbox">
+      <input
+        :checked="value"
+        v-bind="$attrs"
+        type="checkbox"
+        class="k-input float-left"
+        v-on="listeners">
+      <span class="float-left label-text"><slot>{{ label }}</slot></span>
+    </label>
+  </div>
 </template>
 
 <script>
@@ -51,4 +54,9 @@ export default {
 <style lang="scss" scoped>
 @import '~@kongponents/styles/_variables.scss';
 @import '~@kongponents/styles/forms/_checkbox-radio.scss';
+
+.label-text {
+  position: relative;
+  top: 4px;
+}
 </style>

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -4,11 +4,8 @@
       :checked="value"
       v-bind="$attrs"
       type="checkbox"
-      class="k-input"
-      v-on="listeners">
-    <slot>
-      <span>{{ label }}</span>
-    </slot>
+      class="k-input float-left"
+      v-on="listeners"><span class="float-left"><slot>{{ label }}</slot></span>
   </label>
 </template>
 

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -7,7 +7,7 @@
       class="k-input"
       v-on="listeners">
     <span>
-      <slot>{{ label }}</slot>
+      <slot> {{ label }}</slot>
     </span>
   </label>
 </template>

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -1,15 +1,13 @@
 <template>
-  <div class="d-inline-block">
-    <label class="k-checkbox">
-      <input
-        :checked="value"
-        v-bind="$attrs"
-        type="checkbox"
-        class="k-input float-left"
-        v-on="listeners">
-      <span class="float-left label-text"><slot>{{ label }}</slot></span>
-    </label>
-  </div>
+  <label class="k-checkbox d-inline-block">
+    <input
+      :checked="value"
+      v-bind="$attrs"
+      type="checkbox"
+      class="k-input float-left"
+      v-on="listeners">
+    <span class="float-left label-text"><slot>{{ label }}</slot></span>
+  </label>
 </template>
 
 <script>

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> <span> </span></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> <span></span></label>`;

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> <span></span></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> <span> </span></label>`;

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> <span></span></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input float-left"><span class="float-left"></span></label>`;

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input float-left"><span class="float-left"></span></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox d-inline-block"><input type="checkbox" class="k-input float-left"> <span class="float-left label-text"></span></label>`;

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -1,14 +1,11 @@
 <template>
-  <label class="k-radio">
+  <label class="k-radio testclass">
     <input
       :checked="isSelected"
       v-bind="$attrs"
       type="radio"
-      class="k-input"
-      @click="handleClick">
-    <slot>
-      <span>{{ label }}</span>
-    </slot>
+      class="k-input float-left"
+      @click="handleClick"><span class="float-left"><slot>{{ label }}</slot></span>
   </label>
 </template>
 

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -1,15 +1,13 @@
 <template>
-  <div class="d-inline-block">
-    <label class="k-radio">
-      <input
-        :checked="isSelected"
-        v-bind="$attrs"
-        type="radio"
-        class="k-input float-left"
-        @click="handleClick">
-      <span class="float-left"><slot>{{ label }}</slot></span>
-    </label>
-  </div>
+  <label class="k-radio d-inline-block">
+    <input
+      :checked="isSelected"
+      v-bind="$attrs"
+      type="radio"
+      class="k-input float-left"
+      @click="handleClick">
+    <span class="float-left"><slot>{{ label }}</slot></span>
+  </label>
 </template>
 
 <script>

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -6,7 +6,9 @@
       type="radio"
       class="k-input"
       @click="handleClick">
-    <slot>{{ label }}</slot>
+    <span>
+      <slot> {{ label }}</slot>
+    </span>
   </label>
 </template>
 

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -6,9 +6,9 @@
       type="radio"
       class="k-input"
       @click="handleClick">
-    <span>
-      <slot> {{ label }}</slot>
-    </span>
+    <slot>
+      <span>{{ label }}</span>
+    </slot>
   </label>
 </template>
 

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -1,12 +1,15 @@
 <template>
-  <label class="k-radio">
-    <input
-      :checked="isSelected"
-      v-bind="$attrs"
-      type="radio"
-      class="k-input float-left"
-      @click="handleClick"><span class="float-left"><slot>{{ label }}</slot></span>
-  </label>
+  <div class="d-inline-block">
+    <label class="k-radio">
+      <input
+        :checked="isSelected"
+        v-bind="$attrs"
+        type="radio"
+        class="k-input float-left"
+        @click="handleClick">
+      <span class="float-left"><slot>{{ label }}</slot></span>
+    </label>
+  </div>
 </template>
 
 <script>

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -1,5 +1,5 @@
 <template>
-  <label class="k-radio testclass">
+  <label class="k-radio">
     <input
       :checked="isSelected"
       v-bind="$attrs"

--- a/packages/KRadio/__snapshots__/KRadio.spec.js.snap
+++ b/packages/KRadio/__snapshots__/KRadio.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"> </label>`;
+exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"> <span> </span></label>`;

--- a/packages/KRadio/__snapshots__/KRadio.spec.js.snap
+++ b/packages/KRadio/__snapshots__/KRadio.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"> <span></span></label>`;
+exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input float-left"><span class="float-left"></span></label>`;

--- a/packages/KRadio/__snapshots__/KRadio.spec.js.snap
+++ b/packages/KRadio/__snapshots__/KRadio.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input float-left"><span class="float-left"></span></label>`;
+exports[`KRadio matches snapshot 1`] = `<label class="k-radio d-inline-block"><input type="radio" class="k-input float-left"> <span class="float-left"></span></label>`;

--- a/packages/KRadio/__snapshots__/KRadio.spec.js.snap
+++ b/packages/KRadio/__snapshots__/KRadio.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"> <span> </span></label>`;
+exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"> <span></span></label>`;


### PR DESCRIPTION
### Summary

Radio and Checkbox button has different spacing between button and label depending on how the label is specified. When the label is passed through the prop, the spacing is smaller:  
```
<KRadio label="Option 1" />
<KCheckbox :label="checkbox1 ? 'on' : 'off'" />
```

When the label is passed through a slot, the spacing is bigger:
```
<KRadio>Option 1</KRadio>
<KCheckbox v-model="checkbox1">Label goes here.</KCheckbox>
```

#### Changes made:
* Added `d-inline-block` class for label
* Added `float-left` class for input and span
* Added `label-text` class for checkbox span

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
