### PR TITLE
chore(*): update deprecated slots to new v-slot syntax

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -171,20 +171,20 @@ Fixes KAlert to the top of the container.
 - `alertMessage` - Default message slot
 
 <KAlert appearance="info">
-  <template slot="alertIcon">
+  <template v-slot:alertIcon>
     <KIcon icon="portal" />
   </template>
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     I have an icon and a <a href="">Link</a>!
   </template>
 </KAlert>
 
 ```vue
 <KAlert appearance="info">
-  <template slot="alertIcon">
+  <template v-slot:alertIcon>
     <KIcon icon="portal" />
   </template>
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     I have an icon and a <a href="">Link</a>!
   </template>
 </KAlert>
@@ -195,7 +195,7 @@ Fixes KAlert to the top of the container.
 ### Long Content / Prose
 
 <KAlert appearance="info" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
@@ -203,7 +203,7 @@ Fixes KAlert to the top of the container.
 
 ```vue
 <KAlert appearance="info" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
@@ -213,14 +213,14 @@ Fixes KAlert to the top of the container.
 ### Word Wrap long urls
 
 <KAlert appearance="warning" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 
 ```vue
 <KAlert appearance="info" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -117,27 +117,28 @@ KButton also supports the disabled attribute with both Button and Anchor types.
 KButton supports using an icon either before the text or without text.  
 
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />With Text
+  <template v-slot:icon>
+    <KIcon icon="externalLink" />
+  </template>
+  With Text
 </KButton>
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />
+  <template v-slot:icon>
+    <KIcon icon="gear" />
+  </template>
 </KButton>
 
 ```vue
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />
+  <template v-slot:icon>
+    <KIcon icon="externalLink" />
+  </template>
   With Text
 </KButton>
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />
+  <template v-slot:icon>
+    <KIcon icon="gear" />
+  </template>
 </KButton>
 ```
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -16,14 +16,14 @@ String to be used in the title slot.
 - `title`
 
 <KCard title="Title">
-  <template slot="body">
+  <template v-slot:body>
     I am the body.
   </template>
 </KCard>
 
 ```vue
 <KCard title="Title">
-  <template slot="body">
+  <template v-slot:body>
     I am the body.
   </template>
 </KCard>
@@ -32,14 +32,14 @@ String to be used in the title slot.
 If the title is omitted, then KCard acts as a generic Box element.
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     I am a box. I have padding and a border. Useful for composing other components
   </template>
 </KCard>
 
 ```vue
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     I am a box. I have padding and a border. Useful for composing other components
   </template>
 </KCard>
@@ -48,7 +48,7 @@ If the title is omitted, then KCard acts as a generic Box element.
 Example composing `KCard` with other Kongponents to make another component:
 
 <KCard :hasHover="true">
-  <template slot="body">
+  <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
     <div class="mx-4">
       <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -67,7 +67,7 @@ Example composing `KCard` with other Kongponents to make another component:
 
 ```vue
 <KCard :hasHover="true">
-  <template slot="body">
+  <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
     <div class="mx-4">
       <div>
@@ -94,7 +94,7 @@ String positioned closely under the title to serve as help text
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -108,7 +108,7 @@ String positioned closely under the title to serve as help text
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -121,14 +121,14 @@ String positioned closely under the title to serve as help text
 Example of a KCard with helpText slot
 
 <KCard title="Invite a New User">
-  <template slot="helpText">
+  <template v-slot:helpText>
     <div class="d-flex align-items-center">
       A confirmation email will be sent to the specified email address
       <a class="ml-3 mr-2" href="#help-text">Learn More</a>
       <KIcon icon="externalLink" color="var(--blue-500)" size="14"/>
     </div>
   </template>
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -139,14 +139,14 @@ Example of a KCard with helpText slot
 
 ```vue
 <KCard title="Invite a New User">
-  <template slot="helpText">
+  <template v-slot:helpText>
     <div class="d-flex align-items-center">
       A confirmation email will be sent to the specified email address
       <a class="ml-3 mr-2" href="#help-text">Learn More</a>
       <KIcon icon="externalLink" color="var(--blue-500)" size="14"/>
     </div>
   </template>
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -162,14 +162,14 @@ Example of a KCard with both helpText and an action
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
     </div>
   </template>
-  <template slot="actions">
+  <template v-slot:actions>
     <KButton>View Invites</KButton>
   </template>
 </KCard>
@@ -179,14 +179,14 @@ Example of a KCard with both helpText and an action
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
     </div>
   </template>
-  <template slot="actions">
+  <template v-slot:actions>
     <KButton>View Invites</KButton>
   </template>
 </KCard>
@@ -277,7 +277,7 @@ Cards can be arranged with flex box.
     class="w-auto mx-5"
     body="This card always has a icon button"
   >
-    <template slot="actions">
+    <template v-slot:actions>
       <KButton>
         <KIcon
             icon="gearFilled"
@@ -293,7 +293,7 @@ Cards can be arranged with flex box.
     class="w-auto"
     body="This card always has a button"
   >
-    <template slot="actions"><KButton>View All</KButton></template>
+    <template v-slot:actions><KButton>View All</KButton></template>
   </KCard>
 </div>
 
@@ -309,7 +309,7 @@ Cards can be arranged with flex box.
     class="w-auto mx-5"
     body="This card always has a icon button"
   >
-    <template slot="actions">
+    <template v-slot:actions>
       <KButton>
         <KIcon
             icon="gearFilled"
@@ -325,7 +325,7 @@ Cards can be arranged with flex box.
     class="w-auto"
     body="This card always has a button"
   >
-    <template slot="actions"><KButton>View All</KButton></template>
+    <template v-slot:actions><KButton>View All</KButton></template>
   </KCard>
 </div>
 ```
@@ -337,15 +337,15 @@ Cards can be arranged with flex box.
 
 &nbsp;
 <KCard>
-  <template slot="title">Look Mah!</template>
-  <template slot="actions"><a href="#">View All</a></template>
+  <template v-slot:title>Look Mah!</template>
+  <template v-slot:actions><a href="#">View All</a></template>
   <span slot="body">Body slot content here</span>
 </KCard>
 
 ```vue
 <KCard>
-  <template slot="title">Look Mah!</template>
-  <template slot="actions">
+  <template v-slot:title>Look Mah!</template>
+  <template v-slot:actions>
     <a href="#">View All</a>
   </template>
   <span slot="body">Body slot content here</span>

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -82,7 +82,7 @@ You can read more about the viewBox attribute
 - `svgElements` - Used to add svg customization elements
 
 <KIcon icon="check" size="50" color="url('#linear-gradient')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient" x1="0" x2="1">
         <stop offset="0%" stop-color="#16BDCC" />
@@ -94,7 +94,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="services" size="50" color="url('#linear-gradient2')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
         <stop offset="10%"  stop-color="gold" />
@@ -105,7 +105,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="gear" size="50" color="dark-grey">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <animateTransform
       attributeName="transform"
       type="rotate"
@@ -119,7 +119,7 @@ You can read more about the viewBox attribute
 
 ```vue
 <KIcon icon="check" size="50" color="url('#linear-gradient')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient" x1="0" x2="1">
         <stop offset="0%" stop-color="#16BDCC" />
@@ -131,7 +131,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="services" size="50" color="url('#linear-gradient2')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
         <stop offset="10%"  stop-color="gold" />
@@ -142,7 +142,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="gear" size="50" color="dark-grey">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <animateTransform
       attributeName="transform"
       type="rotate"

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -68,7 +68,7 @@ While the component itself does not protect against returning empty an empty val
 :::
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     <Komponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
       <div>
         Updated: {{ data.inlineText }}

--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -3,7 +3,9 @@
 **KCheckbox** - KCheckbox is a wrapper around a Kong styled checkbox input.
 
 <KCard>
-  <KCheckbox slot="body" v-model="defaultChecked"/>
+  <template v-slot:body>
+    <KCheckbox v-model="defaultChecked"/>
+  </template>
 </KCard>
 
 ```vue
@@ -58,9 +60,11 @@ Will place label text to the right of the input. Can also be [slotted](#slots).
 ```
 
 <KCard>
-  <KCheckbox class="mr-3" slot="body" v-model="labelPropChecked1" :label="labelPropChecked1 ? 'on' : 'off'" /> 
-  <KCheckbox class="mr-3" slot="body" v-model="labelPropChecked2" :label="labelPropChecked2 ? 'on' : 'off'" />
-  <KCheckbox slot="body" v-model="labelPropChecked3" :label="labelPropChecked3 ? 'on' : 'off'" />
+  <template v-slot:body>
+    <KCheckbox class="mr-3" v-model="labelPropChecked1" :label="labelPropChecked1 ? 'on' : 'off'" /> 
+    <KCheckbox class="mr-3" v-model="labelPropChecked2" :label="labelPropChecked2 ? 'on' : 'off'" />
+    <KCheckbox v-model="labelPropChecked3" :label="labelPropChecked3 ? 'on' : 'off'" />
+  </template>
 </KCard>
 
 ### html attributes
@@ -74,7 +78,9 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 ```
 
 <KCard>
-  <KCheckbox slot="body" v-model="defaultChecked" disabled />
+  <template v-slot:body>
+    <KCheckbox v-model="defaultChecked" disabled />
+  </template>
 </KCard>
 
 ## Slots
@@ -91,7 +97,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 ```
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     <div class="mb-2">
       <KCheckbox v-model="slots1">
         Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}

--- a/docs/components/input-radio.md
+++ b/docs/components/input-radio.md
@@ -3,7 +3,7 @@
 **KRadio** - KRadio is a wrapper around a Kong styled radio input.
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KRadio name="test" :value="true" v-model="radio">Boolean</KRadio>
       <KRadio name="test" value="string" v-model="radio">String</KRadio>
@@ -56,11 +56,12 @@ Will place label text to the right of the input. Can also be [slotted](#slots).
 ```
 
 <KCard>
+  <template v-slot:body>
   <KRadio
-    slot="body"
     :value="true"
     v-model="radioState"
     label="Label passed as prop" />
+  </template>
 </KCard>
 
 ### html attributes
@@ -76,7 +77,9 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 ```
 
 <KCard>
-  <KRadio slot="body" v-model="radioState" label="disabled" disabled />
+<template v-slot:body>
+  <KRadio v-model="radioState" label="disabled" disabled />
+  </template>
 </KCard>
 
 ## Slots

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -71,9 +71,9 @@ Using both the provided props and slot options we will now demonstrate how to cu
     actionButtonText="Delete"
     actionButtonAppearance="danger"
     @canceled="slottedIsOpen = false">
-    <template slot="header-content">Delete Item</template>
-    <template slot="help">Take this action to delete</template>
-    <template slot="body-content">Are you sure you want to delete this item? This action can not be undone.</template>
+    <template v-slot:header-content>Delete Item</template>
+    <template v-slot:help>Take this action to delete</template>
+    <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
   </KModal>
 </template>
 
@@ -84,9 +84,9 @@ Using both the provided props and slot options we will now demonstrate how to cu
     actionButtonText="Delete"
     actionButtonAppearance="danger"
     @canceled="slottedIsOpen = false">
-    <template slot="header-content">Delete Item</template>
-    <template slot="help">Take this action to delete</template>
-    <template slot="body-content">Are you sure you want to delete this item? This action can not be undone.</template>
+    <template v-slot:header-content>Delete Item</template>
+    <template v-slot:help>Take this action to delete</template>
+    <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
   </KModal>
 </template>
 ```

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -318,7 +318,7 @@ HTML content can be injected into the popover.
 
 <svg style="cursor: pointer; height: 20px; width: 20px; margin-right: 1rem;" v-for="light in [{ color: 'red', value: 'red-500'}, { color: 'yellow', value: 'yellow-200'}, { color: 'green', value: 'green-500'}]">
   <KPop trigger="hover" :title="light.color" :is-svg="true" tag="g" :popover-timeout="10">
-    <template slot="content">
+    <template v-slot:content>
       <p>{{ light.color }} means {{ light.color == 'green' ? 'GO!' : (light.color == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
     </template>
     <rect :fill="`var(--${light.value})`" width="20" height="20" rx="20" ry="20"></rect>
@@ -328,7 +328,7 @@ HTML content can be injected into the popover.
 ```vue
 <svg v-for="light in ['red', 'yellow', 'green']">
   <KPop trigger="hover" title="Light" :is-svg="true" tag="g" :popover-timeout="10">
-    <template slot="content">
+    <template v-slot:content>
       <p>{{ light }} means {{ light == 'green' ? 'GO!' : (light == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
     </template>
     <rect :fill="`var(--${light})`" width="20" height="20" rx="20" ry="20"></rect>

--- a/docs/components/renderless/ktoggle.md
+++ b/docs/components/renderless/ktoggle.md
@@ -196,17 +196,17 @@ them and placing them inside `KToggle`'s default slot.
 
 ```vue
 <KToggle v-slot="{isToggled, toggle}">
-  <div>
-    <KButton @click="toggle">
-      {{ isToggled ? 'collapse' : 'expand' }}
-    </KButton>
-    <transition name="expand">
-      <KAlert
-        v-if="isToggled" 
-        class="mt-3"
-        alertMessage="Every day, once a day, give yourself a present." />
-    </transition>
-  </div>
+      <div>
+        <KButton @click="toggle">
+          {{ isToggled ? 'collapse' : 'expand' }}
+        </KButton>
+        <transition name="expand">
+          <KAlert
+            v-if="isToggled" 
+            class="mt-3"
+            alertMessage="Every day, once a day, give yourself a present." />
+        </transition>
+      </div>
 </KToggle>
 ```
 

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -245,7 +245,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 
 <template>
   <KSkeleton class="k-skeleton-modified" type="card" :card-count="3">
-    <template slot="card-header">
+    <template v-slot:card-header>
       <div class="w-100">
         <div class="justify-content-center pb-3">
           <KSkeletonBox width="5" />
@@ -253,10 +253,10 @@ For example, here is a card skeleton with different arrangement of placeholders:
         <hr>
       </div>
     </template>
-    <template slot="card-content">
+    <template v-slot:card-content>
       <KSkeletonBox width="100"/>
     </template>
-    <template slot="card-footer">
+    <template v-slot:card-footer>
       <div class="w-100">
         <div class="d-flex justify-content-center">
           <KSkeletonBox width="5" />
@@ -268,7 +268,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 
 ```vue
 <KSkeleton type="card" :card-count="3">
-  <template slot="card-header">
+  <template v-slot:card-header>
     <div class="w-100">
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
@@ -276,7 +276,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
       <hr>
     </div>
   </template>
-  <template slot="card-footer">
+  <template v-slot:card-footer>
     <div class="w-100">
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
@@ -290,7 +290,7 @@ And another example:
 
 <template>
   <KSkeleton type="card">
-    <template slot="card-header">
+    <template v-slot:card-header>
       <div>
         <div class="d-flex justify-content-center pb-2">
           <KSkeletonBox width="5" />
@@ -298,7 +298,7 @@ And another example:
         <hr>
       </div>
     </template>
-    <template slot="card-content">
+    <template v-slot:card-content>
       <div class="d-block">
         <template v-for="i in 8">
           <KSkeletonBox width="5" />
@@ -308,7 +308,7 @@ And another example:
         </template>
       </div>
     </template>
-    <template slot="card-footer">
+    <template v-slot:card-footer>
       <KSkeletonBox width="100" />
     </template>
   </KSkeleton>
@@ -317,7 +317,7 @@ And another example:
 
 ```vue
 <KSkeleton type="card">
-  <template slot="card-header">
+  <template v-slot:card-header>
     <div>
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
@@ -325,7 +325,7 @@ And another example:
       <hr>
     </div>
   </template>
-  <template slot="card-content">
+  <template v-slot:card-content>
     <div class="d-block">
       <template v-for="i in 8">
         <KSkeletonBox width="5" />
@@ -335,7 +335,7 @@ And another example:
       </template>
     </div>
   </template>
-  <template slot="card-footer">
+  <template v-slot:card-footer>
     <KSkeletonBox width="100" />
   </template>
 </KSkeleton>

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -110,13 +110,13 @@ Display a check icon when switch is enabled
 - `label`
 
 <KInputSwitch
-  v-model="labelChecked"> <template slot="label">{{ labelText}}</template>
+  v-model="labelChecked"> <template v-slot:label>{{ labelText}}</template>
 </KInputSwitch>
 
 ```vue
 <template>
   <KInputSwitch v-model="checked">
-    <template slot="label">{{ labelText }}</template>
+    <template v-slot:label>{{ labelText }}</template>
   </KInputSwitch>
 </template>
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -432,7 +432,7 @@ export default {
 </template>
 <template>
   <KCard>
-    <div slot="body">
+    <div v-slot:body>
       <div v-if="eventType">
         {{eventType}} on: {{row}}
       </div>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -79,7 +79,7 @@ Here are the different options:
 
 <KoolTip label="Video Games">
   <KButton>&nbsp;✌🏻</KButton>
-  <template slot="content">
+  <template v-slot:content>
     <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
   </template>
 </KoolTip>
@@ -87,7 +87,7 @@ Here are the different options:
 ```vue
 <KoolTip>
   <KButton>&nbsp;✌🏻</KButton>
-  <template slot="content">
+  <template v-slot:content>
     <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
   </template>
 </KoolTip>

--- a/packages/KSkeleton/KSkeleton.vue
+++ b/packages/KSkeleton/KSkeleton.vue
@@ -5,13 +5,13 @@
     <CardSkeleton
       v-if="type === 'card'"
       :card-count="cardCount ">
-      <template slot="card-header">
+      <template v-slot:card-header>
         <slot name="card-header" />
       </template>
-      <template slot="card-content">
+      <template v-slot:card-content>
         <slot name="card-content" />
       </template>
-      <template slot="card-footer">
+      <template v-slot:card-footer>
         <slot name="card-footer" />
       </template>
     </CardSkeleton>

--- a/packages/KTable/README.md
+++ b/packages/KTable/README.md
@@ -30,6 +30,6 @@ const options = {
 }
 
 <KTable :options=options :isStriped='true' :hasHover='true'>
-  <template slot="actions" slot-scope="{row, rowKey, rowValue}"><a href="">Edit</a></template>
+  <template v-slot:actions="{row, rowKey, rowValue}"><a href="">Edit</a></template>
 </KTable>
 ```

--- a/packages/KToggle/KToggle.js
+++ b/packages/KToggle/KToggle.js
@@ -39,7 +39,7 @@ Example usage:
   <button 
       ^------add slotted content
 
-    slot-scope="{isToggled, toggle}"
+    v-slot:default="{isToggled, toggle}"
     @click="toggle">
     {{ isToggled ? 'hello' : 'goodbye' }}
   </button>

--- a/packages/KToggle/README.md
+++ b/packages/KToggle/README.md
@@ -6,7 +6,7 @@ Provide toggle functionality to components.
 
 ```vue
 <KToggle>
-  <template slot-scope="{isToggled, toggle}">
+  <template v-slot:default="{isToggled, toggle}">
     <KButton @click="toggle">
       {{ isToggled ? 'toggled' : 'not toggled' }}
     </KButton>


### PR DESCRIPTION
### Summary
    
> In 2.6.0, we introduced a new unified syntax (the v-slot directive) for named and scoped slots. It replaces the slot and slot-scope attributes, which are now deprecated, but have not been removed and are still documented here. The rationale for introducing the new syntax is described in this RFC.

    https://vuejs.org/v2/guide/components-slots.html

Kongponents is using the old scope syntax.

This will make Kongponents compatible with Vue 2.6+ and Vue 3 for slots.

#### Changes made:
* Usage of `slots` in the Docs has been replaced with a `v-slot:name` syntax
* Similar changes has been made to some nested components: `KSkeleton, KToggle`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
