### PR TITLE
Update deprecated slots to new v-slot syntax

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -171,20 +171,20 @@ Fixes KAlert to the top of the container.
 - `alertMessage` - Default message slot
 
 <KAlert appearance="info">
-  <template slot="alertIcon">
+  <template v-slot:alertIcon>
     <KIcon icon="portal" />
   </template>
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     I have an icon and a <a href="">Link</a>!
   </template>
 </KAlert>
 
 ```vue
 <KAlert appearance="info">
-  <template slot="alertIcon">
+  <template v-slot:alertIcon>
     <KIcon icon="portal" />
   </template>
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     I have an icon and a <a href="">Link</a>!
   </template>
 </KAlert>
@@ -195,7 +195,7 @@ Fixes KAlert to the top of the container.
 ### Long Content / Prose
 
 <KAlert appearance="info" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
@@ -203,7 +203,7 @@ Fixes KAlert to the top of the container.
 
 ```vue
 <KAlert appearance="info" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
@@ -213,14 +213,14 @@ Fixes KAlert to the top of the container.
 ### Word Wrap long urls
 
 <KAlert appearance="warning" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 
 ```vue
 <KAlert appearance="info" class="mt-5">
-  <template slot="alertMessage">
+  <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -117,27 +117,28 @@ KButton also supports the disabled attribute with both Button and Anchor types.
 KButton supports using an icon either before the text or without text.  
 
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />With Text
+  <template v-slot:icon>
+    <KIcon icon="externalLink" />
+  </template>
+  With Text
 </KButton>
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />
+  <template v-slot:icon>
+    <KIcon icon="gear" />
+  </template>
 </KButton>
 
 ```vue
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />
+  <template v-slot:icon>
+    <KIcon icon="externalLink" />
+  </template>
   With Text
 </KButton>
 <KButton appearance="secondary">
-  <KIcon
-    slot="icon"
-    icon="gear" />
+  <template v-slot:icon>
+    <KIcon icon="gear" />
+  </template>
 </KButton>
 ```
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -16,14 +16,14 @@ String to be used in the title slot.
 - `title`
 
 <KCard title="Title">
-  <template slot="body">
+  <template v-slot:body>
     I am the body.
   </template>
 </KCard>
 
 ```vue
 <KCard title="Title">
-  <template slot="body">
+  <template v-slot:body>
     I am the body.
   </template>
 </KCard>
@@ -32,14 +32,14 @@ String to be used in the title slot.
 If the title is omitted, then KCard acts as a generic Box element.
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     I am a box. I have padding and a border. Useful for composing other components
   </template>
 </KCard>
 
 ```vue
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     I am a box. I have padding and a border. Useful for composing other components
   </template>
 </KCard>
@@ -48,7 +48,7 @@ If the title is omitted, then KCard acts as a generic Box element.
 Example composing `KCard` with other Kongponents to make another component:
 
 <KCard :hasHover="true">
-  <template slot="body">
+  <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
     <div class="mx-4">
       <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -67,7 +67,7 @@ Example composing `KCard` with other Kongponents to make another component:
 
 ```vue
 <KCard :hasHover="true">
-  <template slot="body">
+  <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
     <div class="mx-4">
       <div>
@@ -94,7 +94,7 @@ String positioned closely under the title to serve as help text
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -108,7 +108,7 @@ String positioned closely under the title to serve as help text
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -121,14 +121,14 @@ String positioned closely under the title to serve as help text
 Example of a KCard with helpText slot
 
 <KCard title="Invite a New User">
-  <template slot="helpText">
+  <template v-slot:helpText>
     <div class="d-flex align-items-center">
       A confirmation email will be sent to the specified email address
       <a class="ml-3 mr-2" href="#help-text">Learn More</a>
       <KIcon icon="externalLink" color="var(--blue-500)" size="14"/>
     </div>
   </template>
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -139,14 +139,14 @@ Example of a KCard with helpText slot
 
 ```vue
 <KCard title="Invite a New User">
-  <template slot="helpText">
+  <template v-slot:helpText>
     <div class="d-flex align-items-center">
       A confirmation email will be sent to the specified email address
       <a class="ml-3 mr-2" href="#help-text">Learn More</a>
       <KIcon icon="externalLink" color="var(--blue-500)" size="14"/>
     </div>
   </template>
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
@@ -162,14 +162,14 @@ Example of a KCard with both helpText and an action
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
     </div>
   </template>
-  <template slot="actions">
+  <template v-slot:actions>
     <KButton>View Invites</KButton>
   </template>
 </KCard>
@@ -179,14 +179,14 @@ Example of a KCard with both helpText and an action
   title="Invite a New User"
   help-text="A confirmation email will be sent to the specified email address"
 >
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KLabel>Email Address</KLabel>
       <KInput class="mb-6" type="email" placeholder="Enter a valid email"/>
       <KButton appearance="primary">Invite User</KButton>
     </div>
   </template>
-  <template slot="actions">
+  <template v-slot:actions>
     <KButton>View Invites</KButton>
   </template>
 </KCard>
@@ -277,7 +277,7 @@ Cards can be arranged with flex box.
     class="w-auto mx-5"
     body="This card always has a icon button"
   >
-    <template slot="actions">
+    <template v-slot:actions>
       <KButton>
         <KIcon
             icon="gearFilled"
@@ -293,7 +293,9 @@ Cards can be arranged with flex box.
     class="w-auto"
     body="This card always has a button"
   >
-    <template slot="actions"><KButton>View All</KButton></template>
+    <template v-slot:actions>
+      <KButton>View All</KButton>
+    </template>
   </KCard>
 </div>
 
@@ -309,7 +311,7 @@ Cards can be arranged with flex box.
     class="w-auto mx-5"
     body="This card always has a icon button"
   >
-    <template slot="actions">
+    <template v-slot:actions>
       <KButton>
         <KIcon
             icon="gearFilled"
@@ -325,7 +327,9 @@ Cards can be arranged with flex box.
     class="w-auto"
     body="This card always has a button"
   >
-    <template slot="actions"><KButton>View All</KButton></template>
+    <template v-slot:actions>
+      <KButton>View All</KButton>
+    </template>
   </KCard>
 </div>
 ```
@@ -337,18 +341,16 @@ Cards can be arranged with flex box.
 
 &nbsp;
 <KCard>
-  <template slot="title">Look Mah!</template>
-  <template slot="actions"><a href="#">View All</a></template>
-  <span slot="body">Body slot content here</span>
+  <template v-slot:title>Look Mah!</template>
+  <template v-slot:actions><a href="#">View All</a></template>
+  <template v-slot:body>Body slot content here</template>
 </KCard>
 
 ```vue
 <KCard>
-  <template slot="title">Look Mah!</template>
-  <template slot="actions">
-    <a href="#">View All</a>
-  </template>
-  <span slot="body">Body slot content here</span>
+  <template v-slot:title>Look Mah!</template>
+  <template v-slot:actions><a href="#">View All</a></template>
+  <template v-slot:body>Body slot content here</template>
 </KCard>
 ```
 

--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -121,18 +121,22 @@ A flag denoting whether or not the message is an error message. If so, a warning
 
 <template>
   <KEmptyState :cta-is-hidden="true" :is-error="true">
-    <h5 slot="message">
-      Error: Something broke
-    </h5>
+    <template v-slot:message>
+      <h5>
+        Error: Something broke
+      </h5>
+    </template>
   </KEmptyState>
 </template>
 
 ```vue
 <template>
   <KEmptyState :cta-is-hidden="true" :is-error="true">
-    <h5 slot="message">
-      Error: Something broke
-    </h5>
+    <template v-slot:message>
+      <h5>
+        Error: Something broke
+      </h5>
+    </template>
   </KEmptyState>
 </template>
 ```
@@ -144,19 +148,23 @@ A number denoting the size of the warning icon to be displayed above the error m
 
 <template>
   <KEmptyState :cta-is-hidden="true" :is-error="true" icon-size="40">
-    <h5 slot="message">
-      Error: Something broke and now this size 40 warning icon is displayed.
-    </h5>
+    <template v-slot:message>
+      <h5>
+        Error: Something broke and now this size 40 warning icon is displayed.
+      </h5>
+    </template>
   </KEmptyState>
 </template>
 
 ```vue
 <template>
   <KEmptyState :cta-is-hidden="true" :is-error="true" icon-size="40">
-     <h5 slot="message">
-      Error: Something broke and now this size 40 warning icon is displayed.
-    </h5>
-    </KEmptyState>
+    <template v-slot:message>
+      <h5>
+        Error: Something broke and now this size 40 warning icon is displayed.
+      </h5>
+    </template>
+  </KEmptyState>
 </template>
 ```
 

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -82,7 +82,7 @@ You can read more about the viewBox attribute
 - `svgElements` - Used to add svg customization elements
 
 <KIcon icon="check" size="50" color="url('#linear-gradient')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient" x1="0" x2="1">
         <stop offset="0%" stop-color="#16BDCC" />
@@ -94,7 +94,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="services" size="50" color="url('#linear-gradient2')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
         <stop offset="10%"  stop-color="gold" />
@@ -105,7 +105,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="gear" size="50" color="dark-grey">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <animateTransform
       attributeName="transform"
       type="rotate"
@@ -119,7 +119,7 @@ You can read more about the viewBox attribute
 
 ```vue
 <KIcon icon="check" size="50" color="url('#linear-gradient')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient" x1="0" x2="1">
         <stop offset="0%" stop-color="#16BDCC" />
@@ -131,7 +131,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="services" size="50" color="url('#linear-gradient2')">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <defs>
       <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
         <stop offset="10%"  stop-color="gold" />
@@ -142,7 +142,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="gear" size="50" color="dark-grey">
-  <template slot="svgElements">
+  <template v-slot:svgElements>
     <animateTransform
       attributeName="transform"
       type="rotate"

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -68,7 +68,7 @@ While the component itself does not protect against returning empty an empty val
 :::
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     <Komponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
       <div>
         Updated: {{ data.inlineText }}

--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -3,7 +3,9 @@
 **KCheckbox** - KCheckbox is a wrapper around a Kong styled checkbox input.
 
 <KCard>
-  <KCheckbox slot="body" v-model="defaultChecked"/>
+  <template v-slot:body>
+    <KCheckbox v-model="defaultChecked"/>
+  </template>
 </KCard>
 
 ```vue
@@ -58,9 +60,11 @@ Will place label text to the right of the input. Can also be [slotted](#slots).
 ```
 
 <KCard>
-  <KCheckbox class="mr-3" slot="body" v-model="labelPropChecked1" :label="labelPropChecked1 ? 'on' : 'off'" /> 
-  <KCheckbox class="mr-3" slot="body" v-model="labelPropChecked2" :label="labelPropChecked2 ? 'on' : 'off'" />
-  <KCheckbox slot="body" v-model="labelPropChecked3" :label="labelPropChecked3 ? 'on' : 'off'" />
+  <template v-slot:body>
+    <KCheckbox class="mr-3" v-model="labelPropChecked1" :label="labelPropChecked1 ? 'on' : 'off'" /> 
+    <KCheckbox class="mr-3" v-model="labelPropChecked2" :label="labelPropChecked2 ? 'on' : 'off'" />
+    <KCheckbox v-model="labelPropChecked3" :label="labelPropChecked3 ? 'on' : 'off'" />
+  </template>
 </KCard>
 
 ### html attributes
@@ -74,7 +78,9 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 ```
 
 <KCard>
-  <KCheckbox slot="body" v-model="defaultChecked" disabled />
+  <template v-slot:body>
+    <KCheckbox v-model="defaultChecked" disabled />
+  </template>
 </KCard>
 
 ## Slots
@@ -91,7 +97,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 ```
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     <div class="mb-2">
       <KCheckbox v-model="slots1">
         Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}

--- a/docs/components/input-radio.md
+++ b/docs/components/input-radio.md
@@ -3,7 +3,7 @@
 **KRadio** - KRadio is a wrapper around a Kong styled radio input.
 
 <KCard>
-  <template slot="body">
+  <template v-slot:body>
     <div>
       <KRadio name="test" :value="true" v-model="radio">Boolean</KRadio>
       <KRadio name="test" value="string" v-model="radio">String</KRadio>
@@ -56,11 +56,12 @@ Will place label text to the right of the input. Can also be [slotted](#slots).
 ```
 
 <KCard>
-  <KRadio
-    slot="body"
-    :value="true"
-    v-model="radioState"
-    label="Label passed as prop" />
+  <template v-slot:body>
+    <KRadio
+      :value="true"
+      v-model="radioState"
+      label="Label passed as prop" />
+  </template>
 </KCard>
 
 ### html attributes
@@ -76,7 +77,9 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 ```
 
 <KCard>
-  <KRadio slot="body" v-model="radioState" label="disabled" disabled />
+  <template v-slot:body>
+    <KRadio v-model="radioState" label="disabled" disabled />
+  </template>
 </KCard>
 
 ## Slots

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -71,9 +71,9 @@ Using both the provided props and slot options we will now demonstrate how to cu
     actionButtonText="Delete"
     actionButtonAppearance="danger"
     @canceled="slottedIsOpen = false">
-    <template slot="header-content">Delete Item</template>
-    <template slot="help">Take this action to delete</template>
-    <template slot="body-content">Are you sure you want to delete this item? This action can not be undone.</template>
+    <template v-slot:header-content>Delete Item</template>
+    <template v-slot:help>Take this action to delete</template>
+    <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
   </KModal>
 </template>
 
@@ -84,9 +84,9 @@ Using both the provided props and slot options we will now demonstrate how to cu
     actionButtonText="Delete"
     actionButtonAppearance="danger"
     @canceled="slottedIsOpen = false">
-    <template slot="header-content">Delete Item</template>
-    <template slot="help">Take this action to delete</template>
-    <template slot="body-content">Are you sure you want to delete this item? This action can not be undone.</template>
+    <template v-slot:header-content>Delete Item</template>
+    <template v-slot:help>Take this action to delete</template>
+    <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
   </KModal>
 </template>
 ```

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -10,13 +10,17 @@ For example a button:
 
 <KPop title="Cool header">
   <KButton>button</KButton>
-  <div slot="content">I am some sample text!</div>
+  <template v-slot:content>
+    I am some sample text!
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header">
   <KButton>button</KButton>
-  <div slot="content">I am some sample text!</div>
+  <template v-slot:content>
+    I am some sample text!
+  </template>
 </KPop>
 ```
 
@@ -29,19 +33,19 @@ This is the target `element` that the <code>popover</code> is appended to. By de
 
 <KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
-  <div slot="content">
+  <template v-slot:content>
     I am a popover, inside the <code>.theme-default-content</code> selector so
     I can get some of the stylings inside the theme!
-  </div>
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
-  <div slot="content">
-  I am a popover, inside the <code>.theme-default-content</code> selector so 
-  I can get some of the stylings inside the theme!
-  </div>
+  <template v-slot:content>
+    I am a popover, inside the <code>.theme-default-content</code> selector so
+    I can get some of the stylings inside the theme!
+  </template>
 </KPop>
 ```
 
@@ -52,13 +56,15 @@ This is the tag that the popover is wrapped around. By default its the div tag.
 ```vue
 <KPop title="Cool header" tag="details">
   <KButton>button</KButton>
-  <div slot="content">I am inside a &lt;details/&gt; block!</div>
+  <template v-slot:content>I am inside a &lt;details/&gt; block!</template>
 </KPop>
 ```
 
 <KPop title="Cool header" tag="details">
   <KButton>button</KButton>
-  <div slot="content">I am inside a &lt;details/&gt; block!</div>
+  <template v-slot:content>
+    I am inside a &lt;details/&gt; block!
+  </template>
 </KPop>
 
 ### Title
@@ -67,29 +73,37 @@ This is the Title of the popover. Either this or the title slot needs to be fill
 
 <KPop title="I am a new sample header">
   <KButton>button</KButton>
-  <div slot="content">I am some sample text!</div>
+  <template v-slot:content>
+    I am some sample text!
+  </template>
 </KPop>
 
 ```vue
 <KPop title="I am a new sample header">
   <KButton>button</KButton>
-  <div slot="content">I am some sample text!</div>
+  <template v-slot:content>
+    I am some sample text!
+  </template>
 </KPop>
 ```
 
 or alternatively, via the slot:
 
 <KPop>
-  <KButton>button</KButton>
-  <div slot="title">I am a new sample header</div>
-  <div slot="content">I am some sample text!</div>
+  <template v-slot:default>
+    <KButton>button</KButton>
+  </template>
+  <template v-slot:title>I am a new sample header</template>
+  <template v-slot:content>I am some sample text!</template>
 </KPop>
 
 ```vue
 <KPop>
-  <KButton>button</KButton>
-  <div slot="title">I am a new sample header</div>
-  <div slot="content">I am some sample text!</div>
+  <template>
+    <KButton>button</KButton>
+  </template>
+  <template v-slot:title>I am a new sample header</template>
+  <template v-slot:content>I am some sample text!</template>
 </KPop>
 ```
 
@@ -103,13 +117,17 @@ Here are the different options:
 
 <KPop title="Cool header" trigger="hover">
   <KButton>button</KButton>
-  <div slot="content">I am triggered on hover!</div>
+  <template v-slot:content>
+    I am triggered on hover!
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header" trigger="hover">
   <KButton>button</KButton>
-  <div slot="content">I am triggered on hover!</div>
+  <template v-slot:content>
+    I am triggered on hover!
+  </template>
 </KPop>
 ```
 
@@ -137,7 +155,9 @@ Here are the different options:
 
 <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
   <KButton>button</KButton>
-  <div slot="content">I am placed on the {{ selectedPosition }}!</div>
+  <template v-slot:content>
+    I am placed on the {{ selectedPosition }}!
+  </template>
 </KPop>
 
 ```vue
@@ -151,7 +171,9 @@ Here are the different options:
 
 <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
   <KButton>button</KButton>
-  <div slot="content">I am placed on the {{ selectedPosition }}!</div>
+  <template v-slot:content>
+    I am placed on the {{ selectedPosition }}!
+  </template>
 </KPop>
 </template>
 
@@ -187,13 +209,17 @@ The width of the popover body - by default it is 200px.
 
 <KPop title="Cool header" width="300">
   <KButton>button</KButton>
-  <div slot="content">I am 300 pixels wide!</div>
+  <template v-slot:content>
+    I am 300 pixels wide!
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header" width="300">
   <KButton>button</KButton>
-  <div slot="content">I am some 300 pixels wide!</div>
+  <template v-slot:content>
+    I am 300 pixels wide!
+  </template>
 </KPop>
 ```
 
@@ -204,7 +230,9 @@ Custom classes that you want to append to the popover - by default it has a `k-p
 ```vue
 <KPop title="Cool header" popoverClasses="my-class">
   <KButton>button</KButton>
-  <div slot="content">I have a custom my-class class on me!</div>
+  <template v-slot:content>
+    I have a custom my-class class on me!
+  </template>
 </KPop>
 ```
 
@@ -215,7 +243,9 @@ Custom transitions that you want the popover to have - by default it uses a `fad
 ```vue
 <KPop title="Cool header" popoverTransitions="slide">
   <KButton>button</KButton>
-  <div slot="content">I use a slide transition!</div>
+  <template v-slot:content>
+    I use a slide transition!
+  </template>
 </KPop>
 ```
 
@@ -226,13 +256,17 @@ to 300 milliseconds.
 
 <KPop title="Cool header" :popover-timeout="1000" trigger="hover">
   <KButton>button</KButton>
-  <div slot="content">I have a 1 second timeout!</div>
+  <template v-slot:content>
+    I have a 1 second timeout!
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header" :popover-timeout="1000">
   <KButton>button</KButton>
-  <div slot="content">I have a 1 second timeout!</div>
+  <template v-slot:content>
+    I have a 1 second timeout!
+  </template>
 </KPop>
 ```
 
@@ -243,7 +277,9 @@ You can pass in an optional flag to trigger the popover to hide - useful for ext
 ```vue
 <KPop title="Cool header" hidePopover="zoom()">
   <KButton>button</KButton>
-  <div slot="content">I am hidden depending on the outcome of the zoom function!</div>
+  <template v-slot:content>
+  I am hidden depending on the outcome of the zoom function!
+  </template>
 </KPop>
 ```
 
@@ -254,7 +290,9 @@ You can pass in an optional flag to disable the popover - by default it is set t
 ```vue
 <KPop title="Cool header" disabled="true">
   <KButton>button</KButton>
-  <div slot="content">I do not trigger because I am disabled!</div>
+  <template v-slot:content>
+    I do not trigger because I am disabled!
+  </template>
 </KPop>
 ```
 
@@ -264,13 +302,17 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 
 <KPop title="Cool header" hide-caret placement="right">
   <KButton>button</KButton>
-  <div slot="content">Look ma, no caret!</div>
+  <template v-slot:content>
+    Look ma, no caret!
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header" hide-caret placement="right">
   <KButton>button</KButton>
-  <div slot="content">Look ma, no caret!</div>
+  <template v-slot:content>
+    Look ma, no caret!
+  </template>
 </KPop>
 ```
 
@@ -281,18 +323,21 @@ The callback function can optionally return a boolean, which will show or hide t
 
 <KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
-  <div slot="content">
-  The first time you click the button, I will close when you click here once.
-  The second time you click the button, I will close when you click here twice.</div>
+  <template v-slot:content>
+    The first time you click the button, I will close when you click here once.
+    The second time you click the button, I will close when you click here twice.
+  </template>
 </KPop>
 
 ```vue
 <KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
-  <div slot="content">
-  The first time you click the button, I will close when you click here once.
-  The second time you click the button, I will close when you click here twice.</div>
+  <template v-slot:content>
+    The first time you click the button, I will close when you click here once.
+    The second time you click the button, I will close when you click here twice.
+  </template>
 </KPop>
+
 <script>
   export default {
     data () {
@@ -318,7 +363,7 @@ HTML content can be injected into the popover.
 
 <svg style="cursor: pointer; height: 20px; width: 20px; margin-right: 1rem;" v-for="light in [{ color: 'red', value: 'red-500'}, { color: 'yellow', value: 'yellow-200'}, { color: 'green', value: 'green-500'}]">
   <KPop trigger="hover" :title="light.color" :is-svg="true" tag="g" :popover-timeout="10">
-    <template slot="content">
+    <template v-slot:content>
       <p>{{ light.color }} means {{ light.color == 'green' ? 'GO!' : (light.color == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
     </template>
     <rect :fill="`var(--${light.value})`" width="20" height="20" rx="20" ry="20"></rect>
@@ -328,7 +373,7 @@ HTML content can be injected into the popover.
 ```vue
 <svg v-for="light in ['red', 'yellow', 'green']">
   <KPop trigger="hover" title="Light" :is-svg="true" tag="g" :popover-timeout="10">
-    <template slot="content">
+    <template v-slot:content>
       <p>{{ light }} means {{ light == 'green' ? 'GO!' : (light == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
     </template>
     <rect :fill="`var(--${light})`" width="20" height="20" rx="20" ry="20"></rect>
@@ -355,9 +400,9 @@ There is an optional title slot that can take in an element for the title. The t
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your title goes here -->
-  <div slot="title">
+  <template v-slot:title>
     My Title
-  </div>
+  </template>
 </KPop>
 ```
 
@@ -369,9 +414,9 @@ This is the slot that takes in the content of the popover.
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your content goes here -->
-  <div slot="content">
+  <template v-slot:content>
     I am some cool content
-  </div>
+  </template>
 </KPop>
 ```
 
@@ -384,10 +429,12 @@ This is the slot that takes in the content of the popover.
 
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
-  <div slot="content" style="display: flex; justify-content: center;">
-    <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
-    <div>{{ message }}</div>
-  </div>
+  <template v-slot:content>
+    <div style="display: flex; justify-content: center;">
+      <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
+      <div>{{ message }}</div>
+    </div>
+  </template>
 </KPop>
 
 <script>
@@ -463,10 +510,12 @@ This is the slot that takes in the content of the popover.
 ```vue
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
-  <div slot="content" style="display: flex; justify-content: center;">
-    <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
-    <div>{{ message }}</div>
-  </div>
+  <template v-slot:content>
+    <div style="display: flex; justify-content: center;">
+      <KIcon v-if="currentState == 'pending'" icon="spinner" viewBox="0 0 20 20" size="20" color="var(--black90)"/>
+      <div>{{ message }}</div>
+    </div>
+  </template>
 </KPop>
 
 <script>

--- a/docs/components/renderless/kclipboard.md
+++ b/docs/components/renderless/kclipboard.md
@@ -3,15 +3,15 @@
 `<KClipboardProvider />` Provide clipboard functionality to components.
 
 <KCard>
-<div slot="body">
-  <KInput :value="dataToCopy1" @input="dataToCopy1 = $event.target.value" type="text" class="mb-2 w-100" />
-  <KClipboardProvider v-slot="{ copyToClipboard }">
-    <KButton
-      @click="() => { if(copyToClipboard(dataToCopy1)){ alert(`copied to the clipboard: '${dataToCopy1}'`) } }">
-      copy to clipboard
-    </KButton>
-  </KClipboardProvider>
-</div>
+  <template v-slot:body>
+    <KInput :value="dataToCopy1" @input="dataToCopy1 = $event.target.value" type="text" class="mb-2 w-100" />
+    <KClipboardProvider v-slot="{ copyToClipboard }">
+      <KButton
+        @click="() => { if(copyToClipboard(dataToCopy1)){ alert(`copied to the clipboard: '${dataToCopy1}'`) } }">
+        copy to clipboard
+      </KButton>
+    </KClipboardProvider>
+  </template>
 </KCard>
 
 ```vue

--- a/docs/components/renderless/komponent.md
+++ b/docs/components/renderless/komponent.md
@@ -52,7 +52,7 @@ them and placing them inside `Komponent`'s default slot.
 ### Select
 
 <KCard class="mt-2" style="min-height: 100px;">
-  <div slot="body">
+  <template v-slot:body>
     <Komponent :data="{ selected: '' }" v-slot="{ data }">
       <div>
         <label for="apes">What's your favorite great ape?</label>
@@ -66,12 +66,12 @@ them and placing them inside `Komponent`'s default slot.
         <i v-if="data.selected">{{ data.selected }} are neat!</i>
       </div>
     </Komponent>
-  </div>
+  </template>
 </KCard>
 
 ```vue
 <KCard class="mt-2" style="min-height: 100px;">
-  <div slot="body">
+  <template v-slot:body>
     <Komponent :data="{ selected: '' }" v-slot="{ data }">
       <div>
         <label for="apes">What's your favorite great ape?</label>
@@ -85,6 +85,6 @@ them and placing them inside `Komponent`'s default slot.
         <i v-if="data.selected">{{ data.selected }} are neat!</i>
       </div>
     </Komponent>
-  </div>
+  </template>
 </KCard>
 ```

--- a/docs/components/renderless/ktoggle.md
+++ b/docs/components/renderless/ktoggle.md
@@ -80,11 +80,11 @@ For instance, here we are toggling the state on `mouseover` and toggling back on
 | `toggled` | `isToggled` Boolean |
 
 <KCard>
-  <div slot="body">
+  <template v-slot:body>
     <KToggle v-slot="{ toggle }" @toggled="sayHello">
       <KButton @click="toggle">keep clicking me</KButton>
     </KToggle>
-  </div>
+  </template>
 </KCard>
 
 ```vue
@@ -113,7 +113,7 @@ them and placing them inside `KToggle`'s default slot.
 ### KModal
 
 <KCard class="mt-3">
-  <div slot="body">
+  <template v-slot:body>
     <KToggle v-slot="{ isToggled, toggle }">
       <div>
         <KButton @click="toggle">
@@ -125,7 +125,7 @@ them and placing them inside `KToggle`'s default slot.
           @canceled="toggle" />
       </div>
     </KToggle>
-  </div>
+  </template>
 </KCard>
 
 ```vue
@@ -145,7 +145,7 @@ them and placing them inside `KToggle`'s default slot.
 ### Collapse/Expand
 
 <KCard class="mt-2" style="min-height: 100px;">
-  <div slot="body">
+  <template v-slot:body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
         <KButton @click="toggle">
@@ -157,7 +157,7 @@ them and placing them inside `KToggle`'s default slot.
           alertMessage="Every day, once a day, give yourself a present." />
       </div>
     </KToggle>
-  </div>
+  </template>
 </KCard>
 
 ```vue
@@ -177,7 +177,7 @@ them and placing them inside `KToggle`'s default slot.
 #### Toggle with Animation
 
 <KCard class="mt-2" style="min-height: 100px;">
-  <div slot="body">
+  <template v-slot:body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
         <KButton @click="toggle">
@@ -191,22 +191,22 @@ them and placing them inside `KToggle`'s default slot.
         </transition>
       </div>
     </KToggle>
-  </div>
+  </template>
 </KCard>
 
 ```vue
 <KToggle v-slot="{isToggled, toggle}">
-  <div>
-    <KButton @click="toggle">
-      {{ isToggled ? 'collapse' : 'expand' }}
-    </KButton>
-    <transition name="expand">
-      <KAlert
-        v-if="isToggled" 
-        class="mt-3"
-        alertMessage="Every day, once a day, give yourself a present." />
-    </transition>
-  </div>
+      <div>
+        <KButton @click="toggle">
+          {{ isToggled ? 'collapse' : 'expand' }}
+        </KButton>
+        <transition name="expand">
+          <KAlert
+            v-if="isToggled" 
+            class="mt-3"
+            alertMessage="Every day, once a day, give yourself a present." />
+        </transition>
+      </div>
 </KToggle>
 ```
 

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -245,7 +245,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 
 <template>
   <KSkeleton class="k-skeleton-modified" type="card" :card-count="3">
-    <template slot="card-header">
+    <template v-slot:card-header>
       <div class="w-100">
         <div class="justify-content-center pb-3">
           <KSkeletonBox width="5" />
@@ -253,10 +253,10 @@ For example, here is a card skeleton with different arrangement of placeholders:
         <hr>
       </div>
     </template>
-    <template slot="card-content">
+    <template v-slot:card-content>
       <KSkeletonBox width="100"/>
     </template>
-    <template slot="card-footer">
+    <template v-slot:card-footer>
       <div class="w-100">
         <div class="d-flex justify-content-center">
           <KSkeletonBox width="5" />
@@ -268,7 +268,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 
 ```vue
 <KSkeleton type="card" :card-count="3">
-  <template slot="card-header">
+  <template v-slot:card-header>
     <div class="w-100">
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
@@ -276,7 +276,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
       <hr>
     </div>
   </template>
-  <template slot="card-footer">
+  <template v-slot:card-footer>
     <div class="w-100">
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
@@ -290,7 +290,7 @@ And another example:
 
 <template>
   <KSkeleton type="card">
-    <template slot="card-header">
+    <template v-slot:card-header>
       <div>
         <div class="d-flex justify-content-center pb-2">
           <KSkeletonBox width="5" />
@@ -298,7 +298,7 @@ And another example:
         <hr>
       </div>
     </template>
-    <template slot="card-content">
+    <template v-slot:card-content>
       <div class="d-block">
         <template v-for="i in 8">
           <KSkeletonBox width="5" />
@@ -308,7 +308,7 @@ And another example:
         </template>
       </div>
     </template>
-    <template slot="card-footer">
+    <template v-slot:card-footer>
       <KSkeletonBox width="100" />
     </template>
   </KSkeleton>
@@ -317,7 +317,7 @@ And another example:
 
 ```vue
 <KSkeleton type="card">
-  <template slot="card-header">
+  <template v-slot:card-header>
     <div>
       <div class="d-flex justify-content-center pb-2">
         <KSkeletonBox width="5" />
@@ -325,7 +325,7 @@ And another example:
       <hr>
     </div>
   </template>
-  <template slot="card-content">
+  <template v-slot:card-content>
     <div class="d-block">
       <template v-for="i in 8">
         <KSkeletonBox width="5" />
@@ -335,7 +335,7 @@ And another example:
       </template>
     </div>
   </template>
-  <template slot="card-footer">
+  <template v-slot:card-footer>
     <KSkeletonBox width="100" />
   </template>
 </KSkeleton>

--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -109,14 +109,18 @@ Display a check icon when switch is enabled
 
 - `label`
 
-<KInputSwitch
-  v-model="labelChecked"> <template slot="label">{{ labelText}}</template>
+<KInputSwitch v-model="labelChecked">
+  <template v-slot:label>
+    {{ labelText}}
+  </template>
 </KInputSwitch>
 
 ```vue
 <template>
   <KInputSwitch v-model="checked">
-    <template slot="label">{{ labelText }}</template>
+    <template v-slot:label>
+      {{ labelText }}
+    </template>
   </KInputSwitch>
 </template>
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -432,7 +432,7 @@ export default {
 </template>
 <template>
   <KCard>
-    <div slot="body">
+    <template v-slot:body>
       <div v-if="eventType">
         {{eventType}} on: {{row}}
       </div>
@@ -444,7 +444,7 @@ export default {
         @row:click="actionRow"
         @cell:mouseover="actionRow"
       />
-    </div>
+    </template>
   </KCard>
 </template>
 <script>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -79,7 +79,7 @@ Here are the different options:
 
 <KoolTip label="Video Games">
   <KButton>&nbsp;✌🏻</KButton>
-  <template slot="content">
+  <template v-slot:content>
     <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
   </template>
 </KoolTip>
@@ -87,7 +87,7 @@ Here are the different options:
 ```vue
 <KoolTip>
   <KButton>&nbsp;✌🏻</KButton>
-  <template slot="content">
+  <template v-slot:content>
     <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
   </template>
 </KoolTip>

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -40,7 +40,9 @@ An Example of changing the color of KPopover text
 <template>
   <KPop title="email">
     <button>Click me</button>
-    <div slot="content">I have different colored text.</div>
+    <template v-slot:content>
+      I have different colored text.
+    </template>
   </KPop>
 </template>
 
@@ -51,7 +53,12 @@ An Example of changing the color of KPopover text
 </style>
 ```
 <div id="theme-page-kpop">
-<KPop title="email" target="#theme-page-kpop"><button>Click me</button><div slot="content">I have different colored text.</div></KPop>
+<KPop title="email" target="#theme-page-kpop">
+  <button>Click me</button>
+  <template v-slot:content>
+    I have different colored text.
+  </template>
+  </KPop>
 </div>
 
 <style scoped>

--- a/packages/KSkeleton/KSkeleton.vue
+++ b/packages/KSkeleton/KSkeleton.vue
@@ -5,13 +5,13 @@
     <CardSkeleton
       v-if="type === 'card'"
       :card-count="cardCount ">
-      <template slot="card-header">
+      <template v-slot:card-header>
         <slot name="card-header" />
       </template>
-      <template slot="card-content">
+      <template v-slot:card-content>
         <slot name="card-content" />
       </template>
-      <template slot="card-footer">
+      <template v-slot:card-footer>
         <slot name="card-footer" />
       </template>
     </CardSkeleton>

--- a/packages/KTable/README.md
+++ b/packages/KTable/README.md
@@ -30,6 +30,6 @@ const options = {
 }
 
 <KTable :options=options :isStriped='true' :hasHover='true'>
-  <template slot="actions" slot-scope="{row, rowKey, rowValue}"><a href="">Edit</a></template>
+  <template v-slot:actions="{row, rowKey, rowValue}"><a href="">Edit</a></template>
 </KTable>
 ```

--- a/packages/KToggle/KToggle.js
+++ b/packages/KToggle/KToggle.js
@@ -39,7 +39,7 @@ Example usage:
   <button 
       ^------add slotted content
 
-    slot-scope="{isToggled, toggle}"
+    v-slot:default="{isToggled, toggle}"
     @click="toggle">
     {{ isToggled ? 'hello' : 'goodbye' }}
   </button>

--- a/packages/KToggle/README.md
+++ b/packages/KToggle/README.md
@@ -6,7 +6,7 @@ Provide toggle functionality to components.
 
 ```vue
 <KToggle>
-  <template slot-scope="{isToggled, toggle}">
+  <template v-slot:default="{isToggled, toggle}">
     <KButton @click="toggle">
       {{ isToggled ? 'toggled' : 'not toggled' }}
     </KButton>

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -6,13 +6,13 @@
     width="auto"
     hide-caret>
     <slot />
-    <div
-      slot="content"
-      role="tooltip">
-      <slot
-        :label="label"
-        name="content">{{ label }}</slot>
-    </div>
+    <template v-slot:content>
+      <div role="tooltip">
+        <slot
+          :label="label"
+          name="content">{{ label }}</slot>
+      </div>
+    </template>
   </KPop>
 </template>
 


### PR DESCRIPTION
### Summary
    
> In 2.6.0, we introduced a new unified syntax (the v-slot directive) for named and scoped slots. It replaces the slot and slot-scope attributes, which are now deprecated, but have not been removed and are still documented here. The rationale for introducing the new syntax is described in this RFC.

    https://vuejs.org/v2/guide/components-slots.html

Kongponents is using the old scope syntax.

This will make Kongponents compatible with Vue 2.6+ and Vue 3 for slots.

#### Changes made:
* `slot="name"` syntax were switched to `<template v-slot:name>`
* structural and non-functional `div`s and `spans` has been simplified

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
