### PR TITLE
style(kcheckbox): fix label alignment

### DIFF
--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -118,15 +118,6 @@ like:
 .KCheckbox-wrapper {
   --KCheckboxPrimary: blueviolet;
 }
-
-.k-checkbox {
-  .k-input + span {
-    &.float-left {
-      position: relative;
-      padding: 3px;
-    }
-  }
-}
 </style>
 
 <script>

--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -40,33 +40,6 @@ state of the input. You can read more about passing values via `v-model`
 ```vue
 <KCheckbox v-model="checked" />
 ```
-
-### label
-
-Will place label text to the right of the input. Can also be [slotted](#slots).
-
-- `label`
-
-```vue
-<KCheckbox
-  v-model="checkbox1"
-  :label="checkbox1 ? 'on' : 'off'" />
-<KCheckbox
-  v-model="checkbox2"
-  :label="checkbox2 ? 'on' : 'off'" />
-<KCheckbox
-  v-model="checkbox3"
-  :label="checkbox3 ? 'on' : 'off'" />
-```
-
-<KCard>
-  <template v-slot:body>
-    <KCheckbox class="mr-3" v-model="labelPropChecked1" :label="labelPropChecked1 ? 'on' : 'off'" /> 
-    <KCheckbox class="mr-3" v-model="labelPropChecked2" :label="labelPropChecked2 ? 'on' : 'off'" />
-    <KCheckbox v-model="labelPropChecked3" :label="labelPropChecked3 ? 'on' : 'off'" />
-  </template>
-</KCard>
-
 ### html attributes
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/v2/api/#vm-attrs).

--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -145,6 +145,13 @@ like:
 .KCheckbox-wrapper {
   --KCheckboxPrimary: blueviolet;
 }
+
+span {
+  &.float-left {
+    position: relative;
+    padding: 3px;
+  }
+}
 </style>
 
 <script>

--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -146,10 +146,12 @@ like:
   --KCheckboxPrimary: blueviolet;
 }
 
-span {
-  &.float-left {
-    position: relative;
-    padding: 3px;
+.k-checkbox {
+  .k-input + span {
+    &.float-left {
+      position: relative;
+      padding: 3px;
+    }
   }
 }
 </style>

--- a/docs/components/input-radio.md
+++ b/docs/components/input-radio.md
@@ -42,28 +42,6 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The
 state of the input. You can read more about passing values via `v-model`
 [here](https://vuejs.org/v2/guide/components.html#Using-v-model-on-Components).
 
-### label
-
-Will place label text to the right of the input. Can also be [slotted](#slots).
-
-- `label`
-
-```vue
-<KRadio
-  :value="true"
-  v-model="radioState"
-  label="Label passed as prop" />
-```
-
-<KCard>
-  <template v-slot:body>
-    <KRadio
-      :value="true"
-      v-model="radioState"
-      label="Label passed as prop" />
-  </template>
-</KCard>
-
 ### html attributes
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/v2/api/#vm-attrs).
@@ -72,13 +50,16 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 <KRadio
   v-model="checked"
   :value="true"
-  label="disabled"
-  disabled />
+  disabled>
+  {{ label="disabled" }}
+</KRadio> 
 ```
 
 <KCard>
   <template v-slot:body>
-    <KRadio v-model="radioState" label="disabled" disabled />
+    <KRadio v-model="radioState" disabled>
+    {{ label="disabled" }}
+    </KRadio>
   </template>
 </KCard>
 

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -6,7 +6,7 @@
       type="checkbox"
       class="k-input float-left"
       v-on="listeners">
-    <span class="float-left label-text"><slot>{{ label }}</slot></span>
+    <span class="float-left"><slot>{{ label }}</slot></span>
   </label>
 </template>
 

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -1,12 +1,12 @@
 <template>
-  <label class="k-checkbox d-inline-block">
+  <label class="k-checkbox">
     <input
       :checked="value"
       v-bind="$attrs"
       type="checkbox"
-      class="k-input float-left"
+      class="k-input"
       v-on="listeners">
-    <span class="float-left"><slot>{{ label }}</slot></span>
+    <slot />
   </label>
 </template>
 
@@ -21,13 +21,6 @@ export default {
       type: Boolean,
       default: false,
       required: true
-    },
-    /**
-     * Sets label text
-     */
-    label: {
-      type: String,
-      default: ''
     }
   },
   computed: {
@@ -52,9 +45,4 @@ export default {
 <style lang="scss" scoped>
 @import '~@kongponents/styles/_variables.scss';
 @import '~@kongponents/styles/forms/_checkbox-radio.scss';
-
-.label-text {
-  position: relative;
-  top: 4px;
-}
 </style>

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox d-inline-block"><input type="checkbox" class="k-input float-left"> <span class="float-left label-text"></span></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox d-inline-block"><input type="checkbox" class="k-input float-left"> <span class="float-left"></span></label>`;

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox d-inline-block"><input type="checkbox" class="k-input float-left"> <span class="float-left"></span></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"></label>`;

--- a/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
+++ b/packages/KCheckbox/__snapshots__/KCheckbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"></label>`;
+exports[`KCheckbox matches snapshot 1`] = `<label class="k-checkbox"><input type="checkbox" class="k-input"> </label>`;

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -1,12 +1,12 @@
 <template>
-  <label class="k-radio d-inline-block">
+  <label class="k-radio">
     <input
       :checked="isSelected"
       v-bind="$attrs"
       type="radio"
-      class="k-input float-left"
+      class="k-input"
       @click="handleClick">
-    <span class="float-left"><slot>{{ label }}</slot></span>
+    <slot/>
   </label>
 </template>
 
@@ -30,13 +30,6 @@ export default {
     value: {
       type: [String, Number, Boolean, Object],
       default: 'on'
-    },
-    /**
-     * Sets label text
-     */
-    label: {
-      type: String,
-      default: ''
     }
   },
 

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -6,7 +6,7 @@
       type="radio"
       class="k-input"
       @click="handleClick">
-    <slot/>
+    <slot />
   </label>
 </template>
 

--- a/packages/KRadio/__snapshots__/KRadio.spec.js.snap
+++ b/packages/KRadio/__snapshots__/KRadio.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"></label>`;
+exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"> </label>`;

--- a/packages/KRadio/__snapshots__/KRadio.spec.js.snap
+++ b/packages/KRadio/__snapshots__/KRadio.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KRadio matches snapshot 1`] = `<label class="k-radio d-inline-block"><input type="radio" class="k-input float-left"> <span class="float-left"></span></label>`;
+exports[`KRadio matches snapshot 1`] = `<label class="k-radio"><input type="radio" class="k-input"></label>`;


### PR DESCRIPTION
### Summary
Konnect Registration page has Checkbox input/span alignment issue.
#### Changes made:
*

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
