### PR TITLE
ci: add conventional prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:styles": "yarn node-sass packages/styles/styles.scss -o packages/styles && yarn build:postcss",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
-    "publish:ci": "lerna publish --canary --conventional-commits --yes --force-publish",
+    "publish:ci": "lerna publish --canary --conventional-commits --conventional-prerelease --yes --force-publish",
     "test": "yarn jest",
     "test-coverage": "yarn jest --coverage",
     "cli": "./cli/kongponent-cli",


### PR DESCRIPTION
### Summary

The publishing step on the release branch failed as it didn't bump the prerelease version. Switch to conventional prerelease.

#### Changes made:
* update lerna publish config

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
