### PR TITLE
feat(kmodal): style redesign [khcp-1897]

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -43,8 +43,8 @@ export default {
 - `@canceled` - Emitted when cancel/close button is clicked
 
 **Content**
-- `title` - Text to display in header if not using slot
-- `helpText` - Help text to display below header if not using slot
+- `title` - Text displayed in header if not using slot (**Note**: this field is still required for accessibility reasons even if using the slot)
+- `hideTitle` - If not using the `header-content` slot, tells the component whether or not to display the title
 - `content` - Text to display in content if not using slot
 
 **Buttons & Appearance**
@@ -54,10 +54,9 @@ export default {
 - `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel
 
 ## Slots
-There are 5 designated slots you can use to display content in the modal.
+There are 4 designated slots you can use to display content in the modal.
 
 - `header-content`
-- `help` - Light text between title and content.
 - `body-content`  
 - `footer-content` - Contains cancel & action buttons by default.
 - `action-buttons` - Contains action buttons which are right-aligned. This slot will not exist if using `footer-content` slot.
@@ -65,7 +64,8 @@ There are 5 designated slots you can use to display content in the modal.
 ---
 ### Usage
 
-Using both the provided props and slot options we will now demonstrate how to customize the modal for a delete confirmation.
+Using both the provided props and slot options we will now demonstrate how to customize the modal for a delete confirmation. 
+Notice that even though we are using the `header-content` slot we still specify the `title` attribute for accessibility.
 
 <KButton @click="slottedIsOpen = true">Open Delete Modal</KButton>
 <template>
@@ -73,9 +73,12 @@ Using both the provided props and slot options we will now demonstrate how to cu
     :isVisible="slottedIsOpen"
     actionButtonText="Delete"
     actionButtonAppearance="danger"
-    @canceled="slottedIsOpen = false">
-    <template v-slot:header-content>Delete Item</template>
-    <template v-slot:help>Take this action to delete</template>
+    @canceled="slottedIsOpen = false"
+    title="Delete Item">
+    <template v-slot:header-content>
+      <KIcon icon="dangerCircle" color="red" class="mr-2" />
+      Delete Item
+    </template>
     <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
     <template v-slot:action-buttons>
       <KButton appearance="outline" class="mr-2">Back</KButton>
@@ -91,9 +94,12 @@ Using both the provided props and slot options we will now demonstrate how to cu
     :isVisible="isVisible"
     actionButtonText="Delete"
     actionButtonAppearance="danger"
-    @canceled="slottedIsOpen = false">
-    <template v-slot:header-content>Delete Item</template>
-    <template v-slot:help>Take this action to delete</template>
+    @canceled="slottedIsOpen = false"
+    title="Delete Item">
+    <template v-slot:header-content>
+      <KIcon icon="dangerCircle" color="red" class="mr-2" />
+      Delete Item
+    </template>
     <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
     <template v-slot:action-buttons>
       <KButton appearance="outline" class="mr-2">Back</KButton>

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -49,7 +49,7 @@ export default {
 
 **Buttons & Appearance**
 - `actionButtonText` - Change the text content of the submit/proceed button
-- `actionButtonAppearance` - Change the [appearance](/components/button.html#props) of the submit/proceed
+- `actionButtonAppearance` - Change the [appearance](/components/button.html#props) of the submit/proceed button
 - `cancelButtonText` - Change the text content of the close/cancel button
 - `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -2,10 +2,12 @@
 
 The **KModal** component is used to show content on top of existing UI. Typically used when confirming changes or while during a delete action. 
 
-<KButton @click="defaultIsOpen = true">Open Modal</KButton>
+<KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
 
 <template>
   <KModal
+    title="Look Mah!"
+    content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est."
     :isVisible="defaultIsOpen"
     @canceled="defaultIsOpen = false" />
 </template>
@@ -14,6 +16,8 @@ The **KModal** component is used to show content on top of existing UI. Typicall
 <template>
   <div>
     <KModal
+      title="Look Mah!"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est."
       :isVisible="isVisible"
       @canceled="isVisible = false" />
     
@@ -39,7 +43,6 @@ export default {
 - `@canceled` - Emitted when cancel/close button is clicked
 
 **Content**
-- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the close/cancel
 - `title` - Text to display in header if not using slot
 - `helpText` - Help text to display below header if not using slot
 - `content` - Text to display in content if not using slot
@@ -48,23 +51,23 @@ export default {
 - `actionButtonText` - Change the text content of the submit/proceed button
 - `actionButtonAppearance` - Change the [appearance](/components/button.html#props) of the submit/proceed
 - `cancelButtonText` - Change the text content of the close/cancel button
+- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel
 
 ## Slots
-There are 3 designated slots you can use to display content in the modal.
+There are 5 designated slots you can use to display content in the modal.
 
-`header-content`
-`body-content`  
-`help`
-`footer-content` - Contains action buttons by default.
+- `header-content`
+- `help` - Light text between title and content.
+- `body-content`  
+- `footer-content` - Contains cancel & action buttons by default.
+- `action-buttons` - Contains action buttons which are right-aligned. This slot will not exist if using `footer-content` slot.
 
 ---
 ### Usage
 
 Using both the provided props and slot options we will now demonstrate how to customize the modal for a delete confirmation.
 
-<KButton
-  appearance="secondary"
-  @click="slottedIsOpen = true">Open Delete Modal</KButton>
+<KButton @click="slottedIsOpen = true">Open Delete Modal</KButton>
 <template>
   <KModal
     :isVisible="slottedIsOpen"
@@ -74,6 +77,11 @@ Using both the provided props and slot options we will now demonstrate how to cu
     <template v-slot:header-content>Delete Item</template>
     <template v-slot:help>Take this action to delete</template>
     <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
+    <template v-slot:action-buttons>
+      <KButton appearance="outline" class="mr-2">Back</KButton>
+      <KButton appearance="secondary" class="mr-2">Skip</KButton>
+      <KButton appearance="danger">Delete</KButton>
+    </template>
   </KModal>
 </template>
 
@@ -87,6 +95,11 @@ Using both the provided props and slot options we will now demonstrate how to cu
     <template v-slot:header-content>Delete Item</template>
     <template v-slot:help>Take this action to delete</template>
     <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
+    <template v-slot:action-buttons>
+      <KButton appearance="outline" class="mr-2">Back</KButton>
+      <KButton appearance="secondary" class="mr-2">Skip</KButton>
+      <KButton appearance="danger">Delete</KButton>
+    </template>
   </KModal>
 </template>
 ```
@@ -110,6 +123,8 @@ An Example of changing the the colors of KModal might look like.
   <div class="modal-wrapper">
     <KModal
       :isVisible="themeIsOpen"
+      title="Look Mah!"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula."
       @canceled="themeIsOpen = false" />
     <KButton @click="themeIsOpen = true">Open Modal</KButton>
   </div>
@@ -119,7 +134,9 @@ An Example of changing the the colors of KModal might look like.
 <template>
   <div class="modal-wrapper">
     <KModal
-      class="modal-wrapper
+      class="modal-wrapper"
+      title="Look Mah!"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula."
       :isVisible="isVisible"
       @canceled="isVisible = false" />
   </div>

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -51,7 +51,7 @@ export default {
 - `actionButtonText` - Change the text content of the submit/proceed button
 - `actionButtonAppearance` - Change the [appearance](/components/button.html#props) of the submit/proceed button
 - `cancelButtonText` - Change the text content of the close/cancel button
-- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel
+- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel button
 
 ## Slots
 There are 4 designated slots you can use to display content in the modal.

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -45,7 +45,7 @@ export default {
       */
     appearance: {
       type: String,
-      default: 'secondary',
+      default: 'outline',
       validator: function (value) {
         return Object.values(appearances).indexOf(value) !== -1
       }

--- a/packages/KButton/__snapshots__/KButton.spec.js.snap
+++ b/packages/KButton/__snapshots__/KButton.spec.js.snap
@@ -16,4 +16,4 @@ exports[`KButton renders kbutton with the primary appearance 1`] = `<button type
 
 exports[`KButton renders kbutton with the secondary appearance 1`] = `<button type="button" class="k-button medium rounded secondary">secondary</button>`;
 
-exports[`KButton sets small class when size passed 1`] = `<button type="button" class="k-button small rounded secondary">Small Button</button>`;
+exports[`KButton sets small class when size passed 1`] = `<button type="button" class="k-button small rounded outline">Small Button</button>`;

--- a/packages/KModal/KModal.spec.js
+++ b/packages/KModal/KModal.spec.js
@@ -4,25 +4,37 @@ import KModal from '@/KModal/KModal'
 describe('KModal', () => {
   it('renders proper content when using slots', () => {
     const headerText = 'This is some header text'
-    const helpText = 'This is some help text'
     const bodyText = 'This is some body text'
     const footerText = 'This is some footer text'
     const wrapper = mount(KModal, {
       propsData: {
-        isVisible: true
+        isVisible: true,
+        title: headerText
       },
       slots: {
         'header-content': `<div>${headerText}</div>`,
-        'help': `<div>${helpText}</div>`,
         'body-content': `<div>${bodyText}</div>`,
         'footer-content': `<div>${footerText}</div>`
       }
     })
 
     expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(headerText))
-    expect(wrapper.find('.k-modal-help').html()).toEqual(expect.stringContaining(helpText))
     expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(bodyText))
     expect(wrapper.find('.k-modal-footer').html()).toEqual(expect.stringContaining(footerText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('hides the title when using hideTitle prop', () => {
+    const titleText = "You can't see me"
+    const wrapper = mount(KModal, {
+      propsData: {
+        isVisible: true,
+        title: titleText,
+        hideTitle: true
+      }
+    })
+
+    expect(wrapper.find('.k-modal-header').exists()).toBeFalsy()
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -30,7 +42,8 @@ describe('KModal', () => {
     const actionButtonsText = 'This is some action buttons text'
     const wrapper = mount(KModal, {
       propsData: {
-        isVisible: true
+        isVisible: true,
+        title: 'Test Me'
       },
       slots: {
         'action-buttons': `<div>${actionButtonsText}</div>`
@@ -43,19 +56,16 @@ describe('KModal', () => {
 
   it('renders proper content when using props', () => {
     const title = 'Sweet prop title'
-    const helpText = 'Sweet prop help text'
     const content = 'Sweet prop content'
     const wrapper = mount(KModal, {
       propsData: {
         isVisible: true,
         title,
-        helpText,
         content
       }
     })
 
     expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(title))
-    expect(wrapper.find('.k-modal-help').html()).toEqual(expect.stringContaining(helpText))
     expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(content))
     expect(wrapper.html()).toMatchSnapshot()
   })
@@ -69,7 +79,8 @@ describe('KModal', () => {
         actionButtonAppearance: 'outline',
         actionButtonText: confirmText,
         cancelButtonAppearance: 'danger',
-        cancelButtonText: cancelText
+        cancelButtonText: cancelText,
+        title: 'Test Me'
       }
     })
 
@@ -85,6 +96,7 @@ describe('KModal', () => {
   it('proceeds when clicking action button', () => {
     const wrapper = mount(KModal, {
       propsData: {
+        title: 'Test Me',
         isVisible: true
       },
       attachToDocument: true
@@ -98,6 +110,7 @@ describe('KModal', () => {
   it('emits close when backdrop is clicked', () => {
     const wrapper = mount(KModal, {
       propsData: {
+        title: 'Test Me',
         isVisible: true
       }
     })
@@ -111,6 +124,7 @@ describe('KModal', () => {
   it('emits close when hitting escape', () => {
     const wrapper = mount(KModal, {
       propsData: {
+        title: 'Test Me',
         isVisible: true
       },
       attachToDocument: true
@@ -128,6 +142,9 @@ describe('KModal', () => {
     window.document.removeEventListener = REL
 
     const wrapper = mount(KModal, {
+      propsData: {
+        title: 'Test Me'
+      },
       attachToDocument: true
     })
 
@@ -137,7 +154,11 @@ describe('KModal', () => {
   })
 
   it('matches snapshot', () => {
-    const wrapper = mount(KModal)
+    const wrapper = mount(KModal, {
+      propsData: {
+        title: 'Test Me'
+      }
+    })
 
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/packages/KModal/KModal.spec.js
+++ b/packages/KModal/KModal.spec.js
@@ -19,10 +19,25 @@ describe('KModal', () => {
       }
     })
 
-    expect(wrapper.find('.modal-header').html()).toEqual(expect.stringContaining(headerText))
-    expect(wrapper.find('.modal-help').html()).toEqual(expect.stringContaining(helpText))
-    expect(wrapper.find('.modal-body').html()).toEqual(expect.stringContaining(bodyText))
-    expect(wrapper.find('.modal-footer').html()).toEqual(expect.stringContaining(footerText))
+    expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(headerText))
+    expect(wrapper.find('.k-modal-help').html()).toEqual(expect.stringContaining(helpText))
+    expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(bodyText))
+    expect(wrapper.find('.k-modal-footer').html()).toEqual(expect.stringContaining(footerText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders proper content when using action-buttons slot', () => {
+    const actionButtonsText = 'This is some action buttons text'
+    const wrapper = mount(KModal, {
+      propsData: {
+        isVisible: true
+      },
+      slots: {
+        'action-buttons': `<div>${actionButtonsText}</div>`
+      }
+    })
+
+    expect(wrapper.find('.k-modal-action-buttons').html()).toEqual(expect.stringContaining(actionButtonsText))
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -39,9 +54,9 @@ describe('KModal', () => {
       }
     })
 
-    expect(wrapper.find('.modal-header').html()).toEqual(expect.stringContaining(title))
-    expect(wrapper.find('.modal-help').html()).toEqual(expect.stringContaining(helpText))
-    expect(wrapper.find('.modal-body').html()).toEqual(expect.stringContaining(content))
+    expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.k-modal-help').html()).toEqual(expect.stringContaining(helpText))
+    expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(content))
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -60,10 +75,10 @@ describe('KModal', () => {
 
     const buttons = wrapper.findAll('button')
 
-    expect(buttons.at(0).text()).toBe(confirmText)
-    expect(buttons.at(0).classes()).toContain('outline')
-    expect(buttons.at(1).text()).toBe(cancelText)
-    expect(buttons.at(1).classes()).toContain('danger')
+    expect(buttons.at(0).text()).toBe(cancelText)
+    expect(buttons.at(0).classes()).toContain('danger')
+    expect(buttons.at(1).text()).toBe(confirmText)
+    expect(buttons.at(1).classes()).toContain('outline')
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -75,7 +90,7 @@ describe('KModal', () => {
       attachToDocument: true
     })
 
-    wrapper.find('.modal-footer button').trigger('click')
+    wrapper.find('.k-modal-footer .k-modal-action-buttons button').trigger('click')
 
     expect(wrapper.emitted().proceed).toHaveLength(1)
   })
@@ -87,7 +102,7 @@ describe('KModal', () => {
       }
     })
 
-    const backdrop = wrapper.find('.modal-backdrop')
+    const backdrop = wrapper.find('.k-modal-backdrop')
 
     backdrop.trigger('click')
     expect(wrapper.emitted().canceled).toHaveLength(1)

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -16,7 +16,8 @@
         <div class="k-modal-content modal-content">
           <div
             v-if="$scopedSlots.title || !hideTitle"
-            class="k-modal-header modal-header mb-5">
+            class="k-modal-header modal-header mb-5"
+            role="heading">
             <slot name="header-content">{{ title }}</slot>
           </div>
           <div class="k-modal-body modal-body">

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -15,15 +15,9 @@
         @click.stop>
         <div class="k-modal-content modal-content">
           <div
-            :class="$scopedSlots.help || helpText ? 'mb-4' : 'mb-5'"
-            class="k-modal-header modal-header"
-          >
+            v-if="$scopedSlots.title || !hideTitle"
+            class="k-modal-header modal-header mb-5">
             <slot name="header-content">{{ title }}</slot>
-          </div>
-          <div
-            v-if="$scopedSlots.help || helpText"
-            class="k-modal-help modal-help">
-            <slot name="help">{{ helpText }}</slot>
           </div>
           <div class="k-modal-body modal-body">
             <slot name="body-content">{{ content }}</slot>
@@ -63,19 +57,19 @@ export default {
   components: { KButton },
 
   props: {
+    /**
+     * Set the text of the title, if using title slot, this text is for the aria-label
+     */
     title: {
-      /**
-       * Set the text of the title
-       */
       type: String,
-      default: ''
+      required: true
     },
-    helpText: {
-      /**
-       * Set help text to be displayed under the title
-       */
-      type: String,
-      default: ''
+    /**
+     * Title is required for aria-labelling, toggle if the title is visible on the modal
+     */
+    hideTitle: {
+      type: Boolean,
+      default: false
     },
     /**
      * Set the text of the body content
@@ -179,16 +173,10 @@ export default {
   .k-modal-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     color: var(--KModalHeaderColor, var(--black-500, color(black-500)));
     font-size: var(--KModalHeaderSize, 20px);
     font-weight: var(--KModalHeaderWeight, 500);
-  }
-
-  .k-modal-help {
-    font-size: var(--KModalFontSize, 13px);
-    color: var(--black-45);
-    margin-bottom: var(--spacing-lg);
   }
 
   .k-modal-body {

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -5,39 +5,43 @@
     class="k-modal"
     role="dialog">
     <div
-      class="modal-backdrop"
+      class="k-modal-backdrop modal-backdrop"
       @click="close">
 
       <div
-        class="modal-dialog"
+        class="k-modal-dialog modal-dialog"
         @click.stop>
-        <div class="modal-content">
+        <div class="k-modal-content modal-content">
           <div
-            :class="helpText ? 'mb-3' : 'mb-4'"
-            class="modal-header"
+            :class="$scopedSlots.help || helpText ? 'mb-4' : 'mb-5'"
+            class="k-modal-header modal-header"
           >
             <slot name="header-content">{{ title }}</slot>
           </div>
           <div
             v-if="$scopedSlots.help || helpText"
-            class="modal-help">
+            class="k-modal-help modal-help">
             <slot name="help">{{ helpText }}</slot>
           </div>
-          <div class="modal-body">
+          <div class="k-modal-body modal-body">
             <slot name="body-content">{{ content }}</slot>
           </div>
-          <div class="modal-footer">
+          <div class="k-modal-footer modal-footer d-flex">
             <slot name="footer-content">
-              <KButton
-                :appearance="actionButtonAppearance"
-                @click="proceed">
-                {{ actionButtonText }}
-              </KButton>
               <KButton
                 :appearance="cancelButtonAppearance"
                 @click="close">
                 {{ cancelButtonText }}
               </KButton>
+              <div class="k-modal-action-buttons">
+                <slot name="action-buttons">
+                  <KButton
+                    :appearance="actionButtonAppearance"
+                    @click="proceed">
+                    {{ actionButtonText }}
+                  </KButton>
+                </slot>
+              </div>
             </slot>
           </div>
         </div>
@@ -60,7 +64,7 @@ export default {
        * Set the text of the title
        */
       type: String,
-      default: 'Modal Title'
+      default: ''
     },
     helpText: {
       /**
@@ -74,7 +78,7 @@ export default {
      */
     content: {
       type: String,
-      default: 'Modal Content'
+      default: ''
     },
     /**
       *  Pass whether or not the modal should be visible
@@ -88,7 +92,7 @@ export default {
      */
     actionButtonText: {
       type: String,
-      default: 'Proceed'
+      default: 'Submit'
     },
     /**
      * Set the appearance of the action/proceed button
@@ -109,7 +113,7 @@ export default {
      */
     cancelButtonAppearance: {
       type: String,
-      default: 'secondary'
+      default: 'outline'
     }
   },
 
@@ -140,7 +144,7 @@ export default {
 <style scoped lang="scss">
 @import '~@kongponents/styles/_variables.scss';
 
-.modal-backdrop {
+.k-modal-backdrop {
   position: fixed;
   top: 0;
   bottom: 0;
@@ -150,7 +154,7 @@ export default {
   z-index: 1100;
 }
 
-.modal-dialog {
+.k-modal-dialog {
   position: relative;
   width: auto;
   max-width: var(--KModalMaxWidth, 500px);
@@ -163,35 +167,36 @@ export default {
   z-index: 9999;
 }
 
-.modal-content {
+.k-modal-content {
   position: relative;
   display: flex;
   flex-direction: column;
 
-  .modal-header {
+  .k-modal-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    color: var(--KModalHeaderColor, var(--black-85, color(black-85)));
-    font-size: var(--KModalHeaderSize, var(--type-lg, type(lg)));
+    color: var(--KModalHeaderColor, var(--black-500, color(black-500)));
+    font-size: var(--KModalHeaderSize, 20px);
     font-weight: var(--KModalHeaderWeight, 500);
   }
 
-  .modal-help {
+  .k-modal-help {
+    font-size: var(--KModalFontSize, 13px);
     color: var(--black-45);
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: var(--spacing-lg);
   }
 
-  .modal-body {
+  .k-modal-body {
     position: relative;
     flex: 1 1 auto;
-    margin-bottom: var(--KModalBottomMargin, var(--spacing-xl, spacing(xl)));
-    color: var(--KModalColor, var(--black-70, color(black-70)));
-    font-size: var(--KModalFontSize, var(--type-md, type(md)));
+    margin-bottom: var(--KModalBottomMargin, var(--spacing-lg, spacing(lg)));
+    color: var(--KModalColor, var(--grey-500, color(grey-500)));
+    font-size: var(--KModalFontSize, 13px);
   }
 
-  .modal-footer button {
-    margin-right: var(--spacing-sm, spacing(sm));
+  .k-modal-footer .k-modal-action-buttons {
+    margin-left: auto;
   }
 }
 </style>

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -2,8 +2,10 @@
   <div
     v-if="isVisible"
     :aria-hidden="!isVisible ? 'true' : 'false'"
+    :aria-label="title"
     class="k-modal"
-    role="dialog">
+    role="dialog"
+    aria-modal>
     <div
       class="k-modal-backdrop modal-backdrop"
       @click="close">
@@ -30,14 +32,16 @@
             <slot name="footer-content">
               <KButton
                 :appearance="cancelButtonAppearance"
-                @click="close">
+                @click="close"
+                @keyup.esc="close">
                 {{ cancelButtonText }}
               </KButton>
               <div class="k-modal-action-buttons">
                 <slot name="action-buttons">
                   <KButton
                     :appearance="actionButtonAppearance"
-                    @click="proceed">
+                    @click="proceed"
+                    @keyup.enter="proceed">
                     {{ actionButtonText }}
                   </KButton>
                 </slot>

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`KModal matches snapshot 1`] = `undefined`;
 
 exports[`KModal renders custom button text & appearance 1`] = `
-<div aria-hidden="false" role="dialog" class="k-modal">
+<div aria-hidden="false" aria-label="" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -24,7 +24,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
 `;
 
 exports[`KModal renders proper content when using action-buttons slot 1`] = `
-<div aria-hidden="false" role="dialog" class="k-modal">
+<div aria-hidden="false" aria-label="" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -45,7 +45,7 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
 `;
 
 exports[`KModal renders proper content when using props 1`] = `
-<div aria-hidden="false" role="dialog" class="k-modal">
+<div aria-hidden="false" aria-label="Sweet prop title" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -66,7 +66,7 @@ exports[`KModal renders proper content when using props 1`] = `
 `;
 
 exports[`KModal renders proper content when using slots 1`] = `
-<div aria-hidden="false" role="dialog" class="k-modal">
+<div aria-hidden="false" aria-label="" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -27,7 +27,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
@@ -47,7 +47,7 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -67,7 +67,7 @@ exports[`KModal renders proper content when using props 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-5">Sweet prop title</div>
+        <div role="heading" class="k-modal-header modal-header mb-5">Sweet prop title</div>
         <div class="k-modal-body modal-body">Sweet prop content</div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -87,7 +87,7 @@ exports[`KModal renders proper content when using slots 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-5">
+        <div role="heading" class="k-modal-header modal-header mb-5">
           <div>This is some header text</div>
         </div>
         <div class="k-modal-body modal-body">

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -1,14 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KModal matches snapshot 1`] = `undefined`;
-
-exports[`KModal renders custom button text & appearance 1`] = `
-<div aria-hidden="false" aria-label="" role="dialog" aria-modal="" class="k-modal">
+exports[`KModal hides the title when using hideTitle prop 1`] = `
+<div aria-hidden="false" aria-label="You can't see me" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-5"></div>
         <!---->
+        <div class="k-modal-body modal-body"></div>
+        <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
+            Cancel
+          </button>
+          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
+              Submit
+            </button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KModal matches snapshot 1`] = `undefined`;
+
+exports[`KModal renders custom button text & appearance 1`] = `
+<div aria-hidden="false" aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
@@ -24,12 +43,11 @@ exports[`KModal renders custom button text & appearance 1`] = `
 `;
 
 exports[`KModal renders proper content when using action-buttons slot 1`] = `
-<div aria-hidden="false" aria-label="" role="dialog" aria-modal="" class="k-modal">
+<div aria-hidden="false" aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-5"></div>
-        <!---->
+        <div class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -49,8 +67,7 @@ exports[`KModal renders proper content when using props 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-4">Sweet prop title</div>
-        <div class="k-modal-help modal-help">Sweet prop help text</div>
+        <div class="k-modal-header modal-header mb-5">Sweet prop title</div>
         <div class="k-modal-body modal-body">Sweet prop content</div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -66,15 +83,12 @@ exports[`KModal renders proper content when using props 1`] = `
 `;
 
 exports[`KModal renders proper content when using slots 1`] = `
-<div aria-hidden="false" aria-label="" role="dialog" aria-modal="" class="k-modal">
+<div aria-hidden="false" aria-label="This is some header text" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div class="k-modal-header modal-header mb-4">
+        <div class="k-modal-header modal-header mb-5">
           <div>This is some header text</div>
-        </div>
-        <div class="k-modal-help modal-help">
-          <div>This is some help text</div>
         </div>
         <div class="k-modal-body modal-body">
           <div>This is some body text</div>

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -4,17 +4,40 @@ exports[`KModal matches snapshot 1`] = `undefined`;
 
 exports[`KModal renders custom button text & appearance 1`] = `
 <div aria-hidden="false" role="dialog" class="k-modal">
-  <div class="modal-backdrop">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header mb-4">Modal Title</div>
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div class="k-modal-header modal-header mb-5"></div>
         <!---->
-        <div class="modal-body">Modal Content</div>
-        <div class="modal-footer"><button type="button" class="k-button medium rounded outline">
-            click to continue
-          </button> <button type="button" class="k-button medium rounded danger">
+        <div class="k-modal-body modal-body"></div>
+        <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
-          </button></div>
+          </button>
+          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded outline">
+              click to continue
+            </button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KModal renders proper content when using action-buttons slot 1`] = `
+<div aria-hidden="false" role="dialog" class="k-modal">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div class="k-modal-header modal-header mb-5"></div>
+        <!---->
+        <div class="k-modal-body modal-body"></div>
+        <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
+            Cancel
+          </button>
+          <div class="k-modal-action-buttons">
+            <div>This is some action buttons text</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -23,17 +46,19 @@ exports[`KModal renders custom button text & appearance 1`] = `
 
 exports[`KModal renders proper content when using props 1`] = `
 <div aria-hidden="false" role="dialog" class="k-modal">
-  <div class="modal-backdrop">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header mb-3">Sweet prop title</div>
-        <div class="modal-help">Sweet prop help text</div>
-        <div class="modal-body">Sweet prop content</div>
-        <div class="modal-footer"><button type="button" class="k-button medium rounded primary">
-            Proceed
-          </button> <button type="button" class="k-button medium rounded secondary">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div class="k-modal-header modal-header mb-4">Sweet prop title</div>
+        <div class="k-modal-help modal-help">Sweet prop help text</div>
+        <div class="k-modal-body modal-body">Sweet prop content</div>
+        <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
-          </button></div>
+          </button>
+          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
+              Submit
+            </button></div>
+        </div>
       </div>
     </div>
   </div>
@@ -42,19 +67,19 @@ exports[`KModal renders proper content when using props 1`] = `
 
 exports[`KModal renders proper content when using slots 1`] = `
 <div aria-hidden="false" role="dialog" class="k-modal">
-  <div class="modal-backdrop">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header mb-4">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div class="k-modal-header modal-header mb-4">
           <div>This is some header text</div>
         </div>
-        <div class="modal-help">
+        <div class="k-modal-help modal-help">
           <div>This is some help text</div>
         </div>
-        <div class="modal-body">
+        <div class="k-modal-body modal-body">
           <div>This is some body text</div>
         </div>
-        <div class="modal-footer">
+        <div class="k-modal-footer modal-footer d-flex">
           <div>This is some footer text</div>
         </div>
       </div>


### PR DESCRIPTION
### Summary
Update KModal with new design.
For khcp-1897.

#### Changes made:
* Default `KButton` `appearance` property to `outline`
* Remove default values for modal `title` and `content`
* Make `title` required for accessibility
* Add `hideTitle` prop if they don't want the title displayed
* Remove `helpText` prop and `help` slot
* Swap order of action and cancel buttons (cancel comes first)
* Add `action-buttons` slot
* Update style classes to prefix with `k-` (class without `k-` left in for backwards compatibility)
* Update snaps

Figma: https://www.figma.com/file/sfSZhMfpzCzddEhd8tdk9s/Kong_Design-library?node-id=209%3A1086

![image](https://user-images.githubusercontent.com/67973710/134697983-90b44f57-4188-4b29-b023-9b3b07ec81df.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
