### PR TITLE
feat(kemptystate): redesign [khcp-1990]

### DIFF
--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -189,6 +189,17 @@ KEmptyState has 3 named slots used, `title`, `message`, and `cta`. You can use t
 </template>
 ```
 
+## Theming
+| Variable | Purpose
+|:-------- |:-------
+| `--KEmptyTitleColor`| Replaces title color
+| `--KEmptyContentColor`| Replaces content color
+| `--KEmptyBackground`| Replaces background color of the empty state
+
+
+\
+An Example of changing the background might look like.
+
 <script>
 export default {
   methods: {

--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -141,6 +141,33 @@ A flag denoting whether or not the message is an error message. If so, a warning
 </template>
 ```
 
+### icon
+- `icon`
+
+A string for the `KIcon` name to be displayed directly above the title. Specifying a value for `icon` will automatically indicate that it should be visible.
+
+<template>
+  <KEmptyState :cta-is-hidden="true" icon="support">
+    <template v-slot:message>
+      <h5>
+        Call me!
+      </h5>
+    </template>
+  </KEmptyState>
+</template>
+
+```vue
+<template>
+  <KEmptyState :cta-is-hidden="true" icon="support">
+    <template v-slot:message>
+      <h5>
+        Call me!
+      </h5>
+    </template>
+  </KEmptyState>
+</template>
+```
+
 ### icon-size
 - `icon-size`
 
@@ -192,13 +219,47 @@ KEmptyState has 3 named slots used, `title`, `message`, and `cta`. You can use t
 ## Theming
 | Variable | Purpose
 |:-------- |:-------
-| `--KEmptyTitleColor`| Replaces title color
-| `--KEmptyContentColor`| Replaces content color
+| `--KEmptyTitleColor`| Replaces title text color
+| `--KEmptyContentColor`| Replaces content text color
 | `--KEmptyBackground`| Replaces background color of the empty state
 
+An Example of what using theming might look like.
 
-\
-An Example of changing the background might look like.
+<template>
+  <div class="custom-empty-state">
+    <KEmptyState cta-text="CTA Button">
+      <template v-slot:title>Title</template>
+      <template v-slot:message>Message</template>
+    </KEmptyState>
+  </div>
+</template>
+
+```vue
+<template>
+  <div class="custom-empty-state">
+    <KEmptyState cta-text="CTA Button">
+      <template v-slot:title>EmptyState Title</template>
+      <template v-slot:message>EmptyState Message</template>
+    </KEmptyState>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.custom-empty-state {
+  --KEmptyTitleColor: red;
+  --KEmptyContentColor: blue;
+  --KEmptyBackground: grey;
+}
+</style>
+```
+
+<style scoped lang="scss">
+.custom-empty-state {
+  --KEmptyTitleColor: red;
+  --KEmptyContentColor: blue;
+  --KEmptyBackground: grey;
+}
+</style>
 
 <script>
 export default {

--- a/packages/KEmptyState/KEmptyState.spec.js
+++ b/packages/KEmptyState/KEmptyState.spec.js
@@ -40,6 +40,22 @@ describe('KEmptyState', () => {
     expect(wrapper.find('.empty-state-content').html()).toEqual(expect.stringContaining(errorMessage))
   })
 
+  it('renders custom icon when icon prop passed', () => {
+    const errorMessage = 'Support me'
+    const wrapper = mount(KEmptyState, {
+      propsData: {
+        icon: 'support',
+        ctaIsHidden: true
+      },
+      slots: {
+        'message': `<div>${errorMessage}</div>`
+      }
+    })
+
+    expect(wrapper.find('.kong-icon-support').exists()).toBe(true)
+    expect(wrapper.find('.empty-state-content').html()).toEqual(expect.stringContaining(errorMessage))
+  })
+
   it('remains empty when no slots are passed', () => {
     const emptyTitle = ''
     const emptyMessage = ''

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -72,7 +72,7 @@ export default {
   padding: 42px 0;
   text-align: center;
   border-radius: 3px;
-  background-color: var(--KEmptyBackground);
+  background-color: var(--KEmptyBackground, var(--white));
 }
 .empty-state-wrapper h5 {
   color: var(--KEmptyTitleColor, var(--black-500));

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -3,11 +3,11 @@
     <div class="empty-state-title">
       <div
         v-if="isError"
-        class="warning-icon card-icon mb-4"
+        class="warning-icon empty-state-icon card-icon mb-4"
       >
         <KIcon
           :size="iconSize"
-          icon="warning"
+          :icon="icon"
           view-box="0 0 50 50" />
       </div>
       <h5>
@@ -22,7 +22,6 @@
         <slot name="cta">
           <KButton
             v-if="!ctaIsHidden"
-            :is-rounded="true"
             appearance="outline"
             @click.native="() => handleClick && handleClick()">
             {{ ctaText }}
@@ -48,6 +47,14 @@ export default {
       type: String,
       default: '50'
     },
+    icon: {
+      type: String,
+      default: 'warning'
+    },
+    showIcon: {
+      type: Boolean,
+      default: false
+    },
     ctaIsHidden: {
       type: Boolean,
       default: false
@@ -65,22 +72,23 @@ export default {
 </script>
 
 <style scoped>
-  .empty-state-wrapper {
-  padding: 4rem 0;
+.empty-state-wrapper {
+  padding: 42px 0;
   text-align: center;
-  color: rgba(0,0,0,.70);
   border: 1px solid rgba(151,151,151,.1);
   border-radius: 3px;
-  background-color: rgba(0,0,0,.03);
+  background-color: var(--KEmptyBackground, var(--white));
 }
 .empty-state-wrapper h5 {
-  margin: 0 0 .75rem;
+  color: var(--KEmptyTitleColor, var(--black-500));
+  margin: 0 0 14px;
   font-size: 18px;
   font-weight: 500;
   line-height: 21px;
 }
 .empty-state-wrapper p {
-  margin: 0 auto 1.5rem;
+  color: var(--KEmptyContentColor, var(--black-400));
+  margin: 0 auto 14px;
   font-size: 1rem;
   line-height: 1.375rem;
   font-weight: 400;

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="empty-state-wrapper">
+  <section class="empty-state-wrapper">
     <div class="empty-state-title">
       <div
         v-if="isError || icon"
@@ -29,7 +29,7 @@
         </slot>
       </p>
     </div>
-  </div>
+  </section>
 </template>
 
 <script>

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -2,13 +2,13 @@
   <div class="empty-state-wrapper">
     <div class="empty-state-title">
       <div
-        v-if="isError"
-        class="warning-icon empty-state-icon card-icon mb-4"
+        v-if="isError || icon"
+        :class="{ 'warning-icon': isError }"
+        class="empty-state-icon card-icon mb-4"
       >
         <KIcon
           :size="iconSize"
-          :icon="icon"
-          view-box="0 0 50 50" />
+          :icon="icon ? icon : 'warning'" />
       </div>
       <h5>
         <slot name="title"/>
@@ -49,11 +49,7 @@ export default {
     },
     icon: {
       type: String,
-      default: 'warning'
-    },
-    showIcon: {
-      type: Boolean,
-      default: false
+      default: ''
     },
     ctaIsHidden: {
       type: Boolean,
@@ -75,9 +71,8 @@ export default {
 .empty-state-wrapper {
   padding: 42px 0;
   text-align: center;
-  border: 1px solid rgba(151,151,151,.1);
   border-radius: 3px;
-  background-color: var(--KEmptyBackground, var(--white));
+  background-color: var(--KEmptyBackground);
 }
 .empty-state-wrapper h5 {
   color: var(--KEmptyTitleColor, var(--black-500));

--- a/packages/KEmptyState/__snapshots__/KEmptyState.spec.js.snap
+++ b/packages/KEmptyState/__snapshots__/KEmptyState.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KEmptyState matches snapshot 1`] = `
-<div class="empty-state-wrapper">
+<section class="empty-state-wrapper">
   <div class="empty-state-title">
     <!---->
     <h5></h5>
@@ -12,5 +12,5 @@ exports[`KEmptyState matches snapshot 1`] = `
 
       </button></p>
   </div>
-</div>
+</section>
 `;


### PR DESCRIPTION
### Summary
Update `KEmptyState` design.

#### Changes made:
* Add `icon` prop for customizing the displayed icon
* Add theming support for `--KEmptyTitleColor`, `--KEmptyContentColor`, `--KEmptyBackground`
* Update tests

Figma: https://www.figma.com/file/sfSZhMfpzCzddEhd8tdk9s/Kong_Design-library?node-id=257%3A1640

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
