### PR TITLE
fix(kpopover): fast button toggle fix

### DIFF
--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -248,9 +248,10 @@ export default {
     },
 
     async createInstance () {
-      this.showPopper()
       // destroy any previous poppers before creating new one
       this.destroy()
+
+      this.showPopper()
       const placement = placements[this.placement] ? placements[this.placement] : 'auto'
       const popperEl = this.$refs.popper
 


### PR DESCRIPTION
### Summary
The KPopover was breaking every time somebody was toggling it too fast. 

The problem was found in the `createInstance` function. `showPopper()` was called before `destroy()`.

This was a time bomb of course, but it sneaked under the radars for a lot of time, because of a forgiving race condition. During the normal interaction the popper had enough time to be already destroyed and the `destroy()` method didn't do anything. 
```
    destroy () {
      if (this.popper) {
        this.isOpen = false
        this.popper.destroy()
        this.popper = null
      }
    }
```


Though if there still WAS a popper in place (i.e. during fast clicking) it immediately set `isOpen` flag back to `false`.

Now the order of operations is correct and it should not cause any problems anymore.

#### Changes made:
* Fixes fast toggling without breaking the KPopover component

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
