### PR TITLE
feat(kalert): redesign [khcp-2008]

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -51,10 +51,10 @@ What purpose the Alert should be.
 - `banner`
 - `alert`
 
-<KAlert alert-message="I'm an alert" type="banner" />
+<KAlert alert-message="I'm a banner type alert" type="banner" />
 
 ```vue
-<KAlert alert-message="I'm an alert" type="banner" />
+<KAlert alert-message="I'm a banner type alert" type="banner" />
 ```
 
 <KAlert alert-message="I'm an alert" type="alert" />
@@ -64,22 +64,22 @@ What purpose the Alert should be.
 ```
 
 ### Dismiss Type
-KAlert allows for dismissal of the banner.
+KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed
 
 - `none`
 - `icon`
 - `button`
 
-<KAlert alert-message="I'm an alert" type="alert" dismissType="none" />
+<KAlert alert-message="Alert that can not be dismissed" type="alert" dismissType="none" />
 
 ```vue
-<KAlert alert-message="I'm an alert" 
+<KAlert alert-message="Alert that can not be dismissed" 
   type="alert" 
   dismissType="none" />
 ```
 
 <KAlert 
-  alert-message="Info alert message" 
+  alert-message="Info alert message that is dismissible" 
   appearance="info" 
   type="alert" 
   dismissType="icon" 
@@ -88,7 +88,7 @@ KAlert allows for dismissal of the banner.
 
 ```vue
 <KAlert 
-  alert-message="Info alert message" 
+  alert-message="Info alert message that is dismissible" 
   appearance="info" 
   type="alert" 
   dismissType="icon" 
@@ -97,7 +97,7 @@ KAlert allows for dismissal of the banner.
 ```
 
 <KAlert 
-  alert-message="Warning alert message" 
+  alert-message="Warning alert message that is dismissible" 
   appearance="warning" 
   type="alert" 
   ismissType="icon" 
@@ -106,7 +106,7 @@ KAlert allows for dismissal of the banner.
 
 ```vue
 <KAlert 
-  alert-message="Warning alert message" 
+  alert-message="Warning alert message that is dismissible" 
   appearance="warning" 
   type="alert" 
   ismissType="icon" 
@@ -115,7 +115,7 @@ KAlert allows for dismissal of the banner.
 ```
 
 <KAlert 
-  alert-message="Success alert message" 
+  alert-message="Success alert message that is dismissible" 
   appearance="success" 
   type="alert" 
   dismissType="icon" 
@@ -124,7 +124,7 @@ KAlert allows for dismissal of the banner.
 
 ```vue
 <KAlert 
-  alert-message="Success alert message" 
+  alert-message="Success alert message that is dismissible" 
   appearance="success" 
   type="alert" 
   dismissType="icon" 
@@ -133,7 +133,7 @@ KAlert allows for dismissal of the banner.
 ```
 
 <KAlert 
-  alert-message="Danger alert message" 
+  alert-message="Danger alert message that is dismissible" 
   appearance="danger" 
   type="alert" 
   dismissType="icon" 
@@ -143,7 +143,7 @@ KAlert allows for dismissal of the banner.
 
 ```vue
 <KAlert 
-  alert-message="Danger alert message" 
+  alert-message="Danger alert message that is dismissible" 
   appearance="danger" 
   type="alert" 
   dismissType="icon" 
@@ -151,11 +151,11 @@ KAlert allows for dismissal of the banner.
   @closed="dangerIsOpen = false" />
 ```
 
-<KAlert alert-message="I'm an alert ?" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
+<KAlert alert-message="Alert with dismiss type as button" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
 
 ```vue
 <KAlert 
-  alert-message="I'm an alert ?" 
+  alert-message="Alert with dismiss type as button" 
   type="banner" 
   dismissType="button" 
   :isShowing="dismissTypeBtn" 
@@ -268,10 +268,54 @@ Fixes KAlert to the top of the container.
   alert-message="Info bordered"/>
 ```
 
+### Large
+To have an icon on the left(customizable), alertmessage(default/additional), along with the buttons on right, KAlert has to have: <br>*is-large**<br>*dismissType="button"*<br>*type="banner"* <br><br>
+To have an ellipse on left, alertmessage(default), along with the buttons on right, KAlert has to have: <br>*is-large*<br>*type="banner"*
+
+- `is-large`
+
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="warning" 
+  icon="support" 
+  is-large
+  :isShowing="extraMsg" 
+  @closed="extraMsg = false">
+  <template v-slot:extraButtons>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
+  <template v-slot:alertMessage>
+    You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:additionalAlertMessage>
+    across 3 services
+  </template>
+</KAlert>
+
+```vue
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="warning" 
+  is-large 
+  icon="support" >
+  <template v-slot:extraButtons>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
+  <template v-slot:alertMessage>
+    You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:additionalAlertMessage>
+    across 3 services
+  </template>
+</KAlert> 
+```
+
 ## Slots
-- `extraButtons` - Slot specifically meant for adding buttons other than Dismiss
+- `extraButtons` - Slot specifically meant for adding buttons other than Dismiss button
 - `alertMessage` - Default message slot
-- `additionalAlertMessage` - Additional message slot available when alerty type is banner and has isLarge prop
+- `additionalAlertMessage` - Additional message slot available when alert type is banner, has *is-large* prop and the alertMessage slot is rendered
 
 
 <KAlert 
@@ -311,7 +355,6 @@ Fixes KAlert to the top of the container.
   dismissType="button" 
   appearance="warning" 
   is-large 
-  icon="support" 
   :isShowing="extraMsg" 
   @closed="extraMsg = false">
   <template v-slot:extraButtons>
@@ -331,7 +374,8 @@ Fixes KAlert to the top of the container.
   dismissType="button" 
   appearance="warning" 
   is-large 
-  icon="support" >
+  :isShowing="extraMsg" 
+  @closed="extraMsg = false">
   <template v-slot:extraButtons>
     <KButton appearance="primary" size="small">Review</KButton>
   </template>

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,6 +2,7 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
+
 <KAlert alert-message="I'm an alert" />
 ```vue
 <KAlert alert-message="I'm an alert" />
@@ -16,16 +17,60 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 - `success`
 - `danger`
 
+
 <KAlert
+  hasButton
+  appearance="info"
+  alert-message="Info alert message">
+  <template v-slot:actionButtons>
+    <KButton size="small">Review</KButton>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+ </KAlert>
+<KAlert
+  hasButton
+  appearance="warning"
+  alert-message="Warning alert message">
+  <template v-slot:actionButtons>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+</KAlert>
+<KAlert
+  hasButton
+  appearance="success"
+  alert-message="Success alert message">
+  <template v-slot:actionButtons>
+    <KButton size="small">Review</KButton>
+  </template>
+</KAlert>
+<KAlert
+  hasButton
+  appearance="danger"
+  alert-message="Danger alert message">
+  <template v-slot:actionButtons>
+    <KButton size="small">Review</KButton>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+</KAlert> 
+
+<KAlert
+  class="dismissible"
+  is-dismissible
   appearance="info"
   alert-message="Info alert message" />
 <KAlert
   appearance="warning"
+  class="dismissible"
+  is-dismissible
   alert-message="Warning alert message" />
 <KAlert
+class="dismissible"
+  is-dismissible
   appearance="success"
   alert-message="Success alert message" />
 <KAlert
+class="dismissible"
+  is-dismissible
   appearance="danger"
   alert-message="Danger alert message" />
 

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -459,7 +459,7 @@ Fixes KAlert to the top of the container.
 
 - `actionButtons` - Slot specifically meant for adding buttons other than Dismiss button
 - `alertMessage` - Default message slot
-- `description` - Additional message slot available when these conditions are met: `type='banner'`, `size='large'` and `alertMessage` slot is rendered
+- `description` - Alert message description slot available when these conditions are met: `type='banner'`, `size='large'` and `alertMessage` slot is rendered
 
 
 <KAlert
@@ -469,7 +469,7 @@ Fixes KAlert to the top of the container.
   :isShowing="extraBtnSlot"
   @closed="extraBtnSlot = false">
   <template v-slot:alertMessage>
-    I'm an alert with multiple buttons
+    I'm an alert with action buttons
   </template>
  <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Upgrade</KButton>
@@ -485,7 +485,7 @@ Fixes KAlert to the top of the container.
   :isShowing="extraBtnSlot" 
   @closed="extraBtnSlot = false">
     <template v-slot:alertMessage>
-    I'm an alert with multiple buttons
+    I'm an alert with action buttons
   </template>
  <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Upgrade</KButton>

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,10 +2,10 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert alert-message="I'm an alert" />
+<KAlert is-dismissible alert-message="I'm an alert" />
 
 ```vue
-<KAlert alert-message="I'm an alert" />
+<KAlert is-dismissible alert-message="I'm an alert" />
 ```
 
 ## Props
@@ -66,8 +66,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="info"
   alert-message="Info alert message">
   <template v-slot:actionButtons>
-    <KButton size="small">Review</KButton>
-    <KButton size="small">Dismiss</KButton>
+    <KButton appearance="primary" size="small">Primary</KButton>
+    <KButton appearance="outline" size="small">Outline</KButton>
   </template>
  </KAlert>
 <KAlert
@@ -76,7 +76,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="warning"
   alert-message="Warning alert message">
   <template v-slot:actionButtons>
-    <KButton size="small">Dismiss</KButton>
+    <KButton appearance="primary" size="small">Warning</KButton>
+    <KButton appearance="outline" size="small">Outline</KButton>
   </template>
 </KAlert>
 <KAlert
@@ -85,7 +86,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="success"
   alert-message="Success alert message">
   <template v-slot:actionButtons>
-    <KButton size="small">Review</KButton>
+    <KButton appearance="primary" size="small">Success</KButton>
+    <KButton appearance="outline" size="small">Outline</KButton>
   </template>
 </KAlert>
 <KAlert
@@ -94,10 +96,10 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="danger"
   alert-message="Danger alert message">
   <template v-slot:actionButtons>
-    <KButton size="small">Review</KButton>
-    <KButton size="small">Dismiss</KButton>
+    <KButton appearance="primary" size="small">Warning</KButton>
+    <KButton appearance="outline" size="small">Outline</KButton>
   </template>
-</KAlert> 
+</KAlert>
 ```
 
 ### Dismissible
@@ -270,8 +272,8 @@ Fixes KAlert to the top of the container.
 
 ```vue
 <KAlert is-wide-banner>
-  <template v-slot:alertNotificationIcon>
-    <KIcon icon="notificationInbox" color: var(--red-500); size="32" />
+  <template v-slot:alertIcon>
+    <KIcon icon="notificationInbox" color="var(--red-500)" size="32" />
   </template>
   <template v-slot:mainMessageText>
    You’ve had 12 new mentions since you last logged in
@@ -280,7 +282,7 @@ Fixes KAlert to the top of the container.
     across 3 services  
   </template>
   <template v-slot:actionButtons>
-    <KButton size="small" appearance='outline'>Review</KButton>
+    <KButton size="small" appearance='secondary'>Review</KButton>
     <KButton size="small">Dismiss</KButton>
   </template>
 </KAlert>
@@ -295,7 +297,7 @@ Fixes KAlert to the top of the container.
   appearance="warning"
   alert-message="Warning alert message">
   <template v-slot:actionButtons>
-    <KButton size="small">Dismiss</KButton>
+    <KButton appearance="primary" size="small">Dismiss</KButton>
   </template>
 </KAlert>
 
@@ -306,7 +308,7 @@ Fixes KAlert to the top of the container.
   appearance="warning"
   alert-message="Warning alert message">
   <template v-slot:actionButtons>
-    <KButton size="small">Dismiss</KButton>
+    <KButton appearance="primary" size="small">Dismiss</KButton>
   </template>
 </KAlert>
 ```
@@ -393,7 +395,6 @@ look like.
 
 <style lang="scss">
 .k-alert {
-  box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));
   &:not(:last-of-type) {
     margin-bottom: 1rem;
   }
@@ -406,5 +407,62 @@ look like.
 .alert-wrapper {
   --KAlertSuccessBackground: lime;
   --KAlertSuccessColor: forestgreen;
+}
+
+.alert-action {
+  &.info button.primary {
+    color: var(--blue-500);
+    background-color: var(--blue-100);
+    --KButtonPrimaryBase: var(--blue-300);
+    --KButtonPrimaryHover: var(--blue-300);
+  }
+  &.info button.outline {
+    color: var(--blue-400);
+    border: 1px solid var(--blue-400);
+    --KButtonOutlineBorder: var(--blue-300);
+    --KButtonOutlineHoverBorder: var(--blue-300);
+    --KButtonOutlineActiveBorder: var(--blue-300);
+  }
+  &.warning button.primary {
+    color: var(--yellow-500);
+    background-color: var(--yellow-100);
+    --KButtonPrimaryBase: var(--yellow-300);
+    --KButtonPrimaryHover: var(--yellow-300);
+  }
+  &.warning button.outline {
+    color: var(--yellow-400);
+    border: 1px solid var(--yellow-400);
+    --KButtonOutlineBorder: var(--yellow-300);
+    --KButtonOutlineHoverBorder: var(--yellow-300);
+    --KButtonOutlineActiveBorder: var(--yellow-300);
+  }
+  &.success button.primary {
+    color: var(--green-600);
+    background-color: var(--green-100);
+    border: var(--green-100);
+    --KButtonPrimaryBase: var(--green-300);
+    --KButtonPrimaryHover: var(--green-300);
+  }
+  &.success button.outline {
+    color: var(--green-600);
+    border: 1px solid var(--green-600);
+    --KButtonOutlineBorder: var(--green-400);
+    --KButtonOutlineHoverBorder: var(--green-400);
+    --KButtonOutlineActiveBorder: var(--green-400);
+  }
+  &.danger button.primary {
+    color: var(--red-700);
+    background-color: var(--red-100);
+    border: var(--red-100);
+    --KButtonPrimaryBase: var(--red-500);
+    --KButtonPrimaryHover: var(--red-500);
+  }
+  &.danger button.outline {
+    color: var(--red-700);
+    border: 1px solid var(--red-700);
+    --KButtonOutlineBorder: var(--red-500);
+    --KButtonOutlineHoverBorder: var(--red-500);
+    --KButtonOutlineActiveBorder: var(--red-500);
+  }
 }
 </style>

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -46,23 +46,67 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 ```
 
 ### Type
-What purpose the Alert should be.
+The display type of the alert.
 
 - `banner`
+
+`type="banner"` will have a white background and display an ellipse on the left to indicate appearance.
+
+> Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
+
+<KAlert alert-message="I'm a banner type alert" type="banner" />
+
+```vue
+<KAlert alert-message="I'm a banner type alert" type="banner" />
+```
+
+<KAlert alert-message="I'm a banner type alert" appearance="success" type="banner" />
+
+```vue
+<KAlert alert-message="I'm a banner type alert" appearance="success" type="banner" />
+```
+
+<KAlert alert-message="I'm a banner type alert" appearance="danger" type="banner" />
+
+```vue
+<KAlert alert-message="I'm a banner type alert" appearance="danger" type="banner" />
+```
+
+
+<KAlert alert-message="I'm a banner type alert" appearance="warning" type="banner" />
+
+```vue
+<KAlert alert-message="I'm a banner type alert" appearance="warning" type="banner" />
+```
+
 - `alert`
 
-<KAlert alert-message="I'm a banner type alert" type="banner" />
+`type="alert"` will have a background based on `appearance`.
 
-```vue
-<KAlert alert-message="I'm a banner type alert" type="banner" />
-```
+> Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
 
 <KAlert alert-message="I'm an alert" type="alert" />
 
 ```vue
 <KAlert alert-message="I'm an alert" type="alert" />
 ```
+<KAlert alert-message="I'm an alert" appearance="success" type="alert" />
 
+```vue
+<KAlert alert-message="I'm an alert" appearance="success" type="alert" />
+```
+
+<KAlert alert-message="I'm an alert" appearance="danger" type="alert" />
+
+```vue
+<KAlert alert-message="I'm an alert" appearance="danger" type="alert" />
+```
+
+<KAlert alert-message="I'm an alert" appearance="warning" type="alert" />
+
+```vue
+<KAlert alert-message="I'm an alert" appearance="warning" type="alert" />
+```
 ### Dismiss Type
 KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed
 
@@ -100,7 +144,7 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   alert-message="Warning alert message that is dismissible" 
   appearance="warning" 
   type="alert" 
-  ismissType="icon" 
+  dismissType="icon" 
   :isShowing="warningIsOpen" 
   @closed="warningIsOpen = false" />
 
@@ -109,7 +153,7 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   alert-message="Warning alert message that is dismissible" 
   appearance="warning" 
   type="alert" 
-  ismissType="icon" 
+  dismissType="icon" 
   :isShowing="warningIsOpen" 
   @closed="warningIsOpen = false" />
 ```
@@ -151,7 +195,7 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   @closed="dangerIsOpen = false" />
 ```
 
-<KAlert alert-message="Alert with dismiss type as button" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
+<KAlert alert-message="Alert with dismiss type as button TEST" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
 
 ```vue
 <KAlert 
@@ -160,6 +204,25 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   dismissType="button" 
   :isShowing="dismissTypeBtn" 
   @closed="defaultIdismissTypeBtnsOpen = false"/>
+```
+
+### Hide/Display
+Hides/display the alert. By default isShowing is set to true.  
+- `isShowing` 
+
+<KAlert
+  alert-message="isShowing: true by default"/>
+```vue
+<KAlert
+  alert-message="isShowing: true by default"/>
+```
+
+<KAlert
+  :is-showing=false
+  alert-message="isShowing set to false"/>
+```vue
+<KAlert
+  alert-message="isShowing set to false"/>
 ```
 
 ### Bordered
@@ -239,7 +302,7 @@ Adds border to the bottom.
 ```
 
 ### Size
-Controls size of alert. Currently only *small* is supported.
+Controls size of alert.
 
 - `small`
 
@@ -255,6 +318,29 @@ Controls size of alert. Currently only *small* is supported.
   alert-message="Small alert"/>
 ```
 
+- `large`
+
+`size="large" type="banner"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` property/slot and additional buttons using the `actionButtons` slot.
+
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="warning" 
+  icon="support" 
+  size="large"
+  :isShowing="extraMsg" 
+  @closed="extraMsg = false">
+  <template v-slot:actionButtons>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
+  <template v-slot:alertMessage>
+    You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:description>
+    across 3 services
+  </template>
+</KAlert>
+
 ### Fixed
 Fixes KAlert to the top of the container.
 
@@ -268,54 +354,10 @@ Fixes KAlert to the top of the container.
   alert-message="Info bordered"/>
 ```
 
-### Large
-To have an icon on the left(customizable), alertmessage(default/additional), along with the buttons on right, KAlert has to have: <br>*is-large**<br>*dismissType="button"*<br>*type="banner"* <br><br>
-To have an ellipse on left, alertmessage(default), along with the buttons on right, KAlert has to have: <br>*is-large*<br>*type="banner"*
-
-- `is-large`
-
-<KAlert 
-  type="banner" 
-  dismissType="button" 
-  appearance="warning" 
-  icon="support" 
-  is-large
-  :isShowing="extraMsg" 
-  @closed="extraMsg = false">
-  <template v-slot:extraButtons>
-    <KButton appearance="primary" size="small">Review</KButton>
-  </template>
-  <template v-slot:alertMessage>
-    You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:additionalAlertMessage>
-    across 3 services
-  </template>
-</KAlert>
-
-```vue
-<KAlert 
-  type="banner" 
-  dismissType="button" 
-  appearance="warning" 
-  is-large 
-  icon="support" >
-  <template v-slot:extraButtons>
-    <KButton appearance="primary" size="small">Review</KButton>
-  </template>
-  <template v-slot:alertMessage>
-    You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:additionalAlertMessage>
-    across 3 services
-  </template>
-</KAlert> 
-```
-
 ## Slots
-- `extraButtons` - Slot specifically meant for adding buttons other than Dismiss button
+- `actionButtons` - Slot specifically meant for adding buttons other than Dismiss button
 - `alertMessage` - Default message slot
-- `additionalAlertMessage` - Additional message slot available when alert type is banner, has *is-large* prop and the alertMessage slot is rendered
+- `description` - Additional message slot available when alert type is banner, has *is-large* prop and the alertMessage slot is rendered
 
 
 <KAlert 
@@ -327,7 +369,7 @@ To have an ellipse on left, alertmessage(default), along with the buttons on rig
   <template v-slot:alertMessage>
     I'm an alert with multiple buttons
   </template>
- <template v-slot:extraButtons>
+ <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Upgrade</KButton>
     <KButton appearance="primary" size="small">Downgrade</KButton>
   </template>
@@ -343,30 +385,30 @@ To have an ellipse on left, alertmessage(default), along with the buttons on rig
     <template v-slot:alertMessage>
     I'm an alert with multiple buttons
   </template>
- <template v-slot:extraButtons>
+ <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Upgrade</KButton>
     <KButton appearance="primary" size="small">Downgrade</KButton>
   </template>
 </KAlert>
 ```
 
-<KAlert 
+<!-- <KAlert 
   type="banner" 
   dismissType="button" 
   appearance="warning" 
   is-large 
   :isShowing="extraMsg" 
   @closed="extraMsg = false">
-  <template v-slot:extraButtons>
+  <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Review</KButton>
   </template>
   <template v-slot:alertMessage>
     You’ve had 12 new mentions since you last logged in
   </template>
-  <template v-slot:additionalAlertMessage>
+  <template v-slot:description>
     across 3 services
   </template>
-</KAlert>
+</KAlert> -->
 
 ```vue
 <KAlert 
@@ -376,13 +418,13 @@ To have an ellipse on left, alertmessage(default), along with the buttons on rig
   is-large 
   :isShowing="extraMsg" 
   @closed="extraMsg = false">
-  <template v-slot:extraButtons>
+  <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Review</KButton>
   </template>
   <template v-slot:alertMessage>
     You’ve had 12 new mentions since you last logged in
   </template>
-  <template v-slot:additionalAlertMessage>
+  <template v-slot:description>
     across 3 services
   </template>
 </KAlert> 

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,24 +2,10 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert isWideBanner>
-  <template v-slot:alertRedIcon>
-    <KIcon icon="notificationInbox" color="#D44324" size="32" />
-  </template>
-  <template v-slot:mainMessageText>
-   You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:secMessageText>
-    across 3 services  
-  </template>
-  <template v-slot:actionButtons>
-    <KButton size="small" appearance='outline'>Review</KButton>
-    <KButton size="small">Dismiss</KButton>
-  </template>
-</KAlert>
+<KAlert is-showing alert-message="I'm an alert" />
 
 ```vue
-<KAlert alert-message="I'm an alert" />
+<KAlert is-showing alert-message="I'm an alert" />
 ```
 
 ## Props
@@ -31,10 +17,52 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 - `success`
 - `danger`
 
-
 <KAlert
-  hasButton
-  hasEllipse
+  has-button
+  has-ellipse
+  appearance="info"
+  alert-message="Info alert message">
+  <template v-slot:actionButtons>
+    <KButton appearance="outline" size="small">Outline</KButton>
+    <KButton appearance="primary" size="small">Dismiss</KButton>
+  </template>
+ </KAlert>
+<KAlert
+  has-button
+  has-ellipse
+  appearance="warning"
+  alert-message="Warning alert message">
+  <template v-slot:actionButtons>
+  <KButton appearance="outline" size="small">Outline</KButton>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+</KAlert>
+<KAlert
+  has-button
+  has-ellipse
+  appearance="success"
+  alert-message="Success alert message">
+  <template v-slot:actionButtons>
+  <KButton appearance="outline" size="small">Outline</KButton>
+    <KButton appearance="creation" size="small">Review</KButton>
+  </template>
+</KAlert>
+<KAlert
+  has-button
+  has-ellipse
+  appearance="danger"
+  alert-message="Danger alert message">
+  <template v-slot:actionButtons>
+    <KButton appearance="outline" size="small">Outline</KButton>
+    <KButton appearance="danger" size="small">Dismiss</KButton>
+  </template>
+</KAlert>
+
+
+```vue
+<KAlert
+  has-button
+  has-ellipse
   appearance="info"
   alert-message="Info alert message">
   <template v-slot:actionButtons>
@@ -43,8 +71,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   </template>
  </KAlert>
 <KAlert
-  hasButton
-  hasEllipse
+  has-button
+  has-ellipse
   appearance="warning"
   alert-message="Warning alert message">
   <template v-slot:actionButtons>
@@ -52,8 +80,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   </template>
 </KAlert>
 <KAlert
-  hasButton
-  hasEllipse
+  has-button
+  has-ellipse
   appearance="success"
   alert-message="Success alert message">
   <template v-slot:actionButtons>
@@ -61,8 +89,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   </template>
 </KAlert>
 <KAlert
-  hasButton
-  hasEllipse
+  has-button
+  has-ellipse
   appearance="danger"
   alert-message="Danger alert message">
   <template v-slot:actionButtons>
@@ -70,41 +98,6 @@ What color and purpose the Alert should be. Shares similar appearances to those 
     <KButton size="small">Dismiss</KButton>
   </template>
 </KAlert> 
-
-<KAlert
-  isShowing
-  is-dismissible
-  appearance="info"
-  alert-message="Info alert message" />
-<KAlert
-  isShowing
-  is-dismissible
-  appearance="warning"
-  alert-message="Warning alert message" />
-<KAlert
-  isShowing
-  is-dismissible
-  appearance="success"
-  alert-message="Success alert message" />
-<KAlert
-  isShowing
-  is-dismissible
-  appearance="danger"
-  alert-message="Danger alert message" />
-
-```vue
-<KAlert
-  appearance="info"
-  alert-message="Info alert message" />
-<KAlert
-  appearance="warning"
-  alert-message="Warning alert message" />
-<KAlert
-  appearance="success"
-  alert-message="Success alert message" />
-<KAlert
-  appearance="danger"
-  alert-message="Danger alert message" />
 ```
 
 ### Dismissible
@@ -113,14 +106,47 @@ KAlert allows for dismissal of the banner.
 - `is-dismissible`
 
 <KAlert
-  class="dismissible"
+  is-showing
   is-dismissible
-  alert-message="I can be dismissed!"/>
+  appearance="info"
+  alert-message="Info alert message" />
+<KAlert
+  is-showing
+  is-dismissible
+  appearance="warning"
+  alert-message="Warning alert message" />
+<KAlert
+  is-showing
+  is-dismissible
+  appearance="success"
+  alert-message="Success alert message" />
+<KAlert
+  is-showing
+  is-dismissible
+  appearance="danger"
+  alert-message="Danger alert message" />
+
 ```vue
 <KAlert
-  class="dismissible"
+  is-showing
   is-dismissible
-  alert-message="I can be dismissed!"/>
+  appearance="info"
+  alert-message="Info alert message" />
+<KAlert
+  is-showing
+  is-dismissible
+  appearance="warning"
+  alert-message="Warning alert message" />
+<KAlert
+  is-showing
+  is-dismissible
+  appearance="success"
+  alert-message="Success alert message" />
+<KAlert
+  is-showing
+  is-dismissible
+  appearance="danger"
+  alert-message="Danger alert message" />
 ```
 
 ### Bordered
@@ -129,11 +155,13 @@ Adds border around alert. Used for [KToaster]().
 - `is-bordered`
 
 <KAlert
+  is-showing
   is-bordered
   appearance="info"
   alert-message="Info bordered"/>
 ```vue
 <KAlert
+  is-showing
   is-bordered
   appearance="info"
   alert-message="Info bordered"/>
@@ -145,11 +173,13 @@ Adds border to the left side. Typically used for alerts that show info that may 
 - `has-left-border`
 
 <KAlert
+  is-showing
   has-left-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
+  is-showing
   has-left-border
   alert-message="Bordered alert"/>
 ```
@@ -160,11 +190,13 @@ Adds border to the right side. Typically used for alerts that show info that may
 - `has-right-border`
 
 <KAlert
+  is-showing
   has-right-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
+  is-showing
   has-right-border
   alert-message="Bordered alert"/>
 ```
@@ -175,11 +207,13 @@ Adds border to the top.
 - `has-top-border`
 
 <KAlert
+  is-showing
   has-top-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
+  is-showing
   has-top-border
   alert-message="Bordered alert"/>
 ```
@@ -190,11 +224,13 @@ Adds border to the bottom.
 - `has-bottom-border`
 
 <KAlert
+  is-showing
   has-bottom-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
+  is-showing
   has-bottom-border
   alert-message="Bordered alert"/>
 ```
@@ -205,12 +241,14 @@ Controls size of alert. Currently only *small* is supported.
 - `small`
 
 <KAlert
+  is-showing
   style="width:250px"
   size="small"
   alert-message="Small alert"/>
 
 ```vue
 <KAlert
+  is-showing
   style="width:250px"
   size="small"
   alert-message="Small alert"/>
@@ -225,30 +263,71 @@ Fixes KAlert to the top of the container.
 
 ```vue
 <KAlert
+  is-showing
   is-fixed
   alert-message="Info bordered"/>
 ```
 
 ## Slots
 - `alertIcon` - Slot specifically meant for adding an icon
-- `alertMessage` - Default message slot
+- `mainMessageText` - Primary message slot
+- `secMessageText` - Secondary message slot
 
-<KAlert appearance="info">
+<KAlert is-wide-banner>
   <template v-slot:alertIcon>
-    <KIcon icon="portal" />
+    <KIcon icon="notificationInbox" color="var(--red-500)" size="32" />
   </template>
-  <template v-slot:alertMessage>
-    I have an icon and a <a href="">Link</a>!
+  <template v-slot:mainMessageText>
+   You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:secMessageText>
+    across 3 services  
+  </template>
+  <template v-slot:actionButtons>
+    <KButton size="small" appearance='outline'>Review</KButton>
+    <KButton size="small">Dismiss</KButton>
   </template>
 </KAlert>
 
 ```vue
-<KAlert appearance="info">
-  <template v-slot:alertIcon>
-    <KIcon icon="portal" />
+<KAlert is-wide-banner>
+  <template v-slot:alertNotificationIcon>
+    <KIcon icon="notificationInbox" color: var(--red-500); size="32" />
   </template>
-  <template v-slot:alertMessage>
-    I have an icon and a <a href="">Link</a>!
+  <template v-slot:mainMessageText>
+   You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:secMessageText>
+    across 3 services  
+  </template>
+  <template v-slot:actionButtons>
+    <KButton size="small" appearance='outline'>Review</KButton>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+</KAlert>
+```
+
+- `alertMessage` - Default message slot
+- `actionButtons` - Default button slot
+
+<KAlert
+  has-button
+  has-ellipse
+  appearance="warning"
+  alert-message="Warning alert message">
+  <template v-slot:actionButtons>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+</KAlert>
+
+```vue
+<KAlert
+  has-button
+  has-ellipse
+  appearance="warning"
+  alert-message="Warning alert message">
+  <template v-slot:actionButtons>
+    <KButton size="small">Dismiss</KButton>
   </template>
 </KAlert>
 ```
@@ -257,7 +336,7 @@ Fixes KAlert to the top of the container.
 
 ### Long Content / Prose
 
-<KAlert appearance="info" class="mt-5">
+<KAlert isShowing appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
@@ -265,7 +344,7 @@ Fixes KAlert to the top of the container.
 </KAlert>
 
 ```vue
-<KAlert appearance="info" class="mt-5">
+<KAlert isShowing appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
@@ -275,17 +354,16 @@ Fixes KAlert to the top of the container.
 
 ### Word Wrap long urls
 
-<KAlert appearance="warning" class="mt-5">
+<KAlert isShowing appearance="warning" class="mt-5">
   <template v-slot:alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 
 ```vue
-<KAlert appearance="info" class="mt-5">
+<KAlert isShowing appearance="warning" class="mt-5">
   <template v-slot:alertMessage>
-    <div class="mt-2 bold">Failure Modes</div>
-    <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
+    Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 ```

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,47 +2,8 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert alert-message="I'm an alert" type="banner"/>
-<KAlert alert-message="I'm an alert" type="alert" dismissType="none" appearance="danger" />
-<KAlert alert-message="I'm an alert" type="alert" dismissType="icon" />
-<KAlert alert-message="I'm an alert" type="alert" dismissType="icon" appearance="warning" />
-<KAlert alert-message="I'm an alert" type="alert" dismissType="icon" appearance="success" />
+<KAlert alert-message="I'm an alert"/>
 
-<KAlert alert-message="I'm an alert" type="banner" dismissType="button" />
-<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="warning"> 
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Here</KButton>
-  </template>
-  </KAlert>
-<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="danger" icon="support" >
-  <template v-slot:additionalAlertMessage>
-    across 3 services
-  </template>
-</KAlert>
-<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="success" />
-
-<KAlert alert-message="I'm an alert with multiple buttons" type="banner" appearance="success" >
- <template>
-    <KButton appearance="primary" size="small">Here</KButton>
-    <KButton size="small">There</KButton>
-    <KButton size="small">Where</KButton>
-  </template>
-  </KAlert>
-<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="warning" is-large />
-<KAlert alert-message="You’ve had 12 new mentions since you last logged in" type="banner" dismissType="button" appearance="warning" is-large icon="support" >
-  <template v-slot:additionalAlertMessage>
-    across 3 services
-  </template>
-</KAlert>
-<KAlert alert-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Orci dapibus ultrices in iaculis. Diam maecenas ultricies mi eget mauris pharetra. Facilisis sed odio morbi quis commodo." type="banner" dismissType="button" appearance="warning" is-large icon="support" >
- <template>
-    <KButton size="small">Review</KButton>
-    <KButton size="small">Dismiss</KButton>
-  </template>
-  <template v-slot:additionalAlertMessage>
-   across 30 services
-  </template>
-</KAlert>
 ```vue
 <KAlert alert-message="I'm an alert" />
 ```
@@ -84,20 +45,121 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   alert-message="Danger alert message" />
 ```
 
-### Dismissible
+### Type
+What purpose the Alert should be.
+
+- `banner`
+- `alert`
+
+<KAlert alert-message="I'm an alert" type="banner" />
+
+```vue
+<KAlert alert-message="I'm an alert" type="banner" />
+```
+
+<KAlert alert-message="I'm an alert" type="alert" />
+
+```vue
+<KAlert alert-message="I'm an alert" type="alert" />
+```
+
+### Dismiss Type
 KAlert allows for dismissal of the banner.
 
-- `is-dismissible`
+- `none`
+- `icon`
+- `button`
 
-<KAlert
-  class="dismissible"
-  is-dismissible
-  alert-message="I can be dismissed!"/>
+<KAlert alert-message="I'm an alert" type="alert" dismissType="none" />
+
 ```vue
-<KAlert
-  class="dismissible"
-  is-dismissible
-  alert-message="I can be dismissed!"/>
+<KAlert alert-message="I'm an alert" 
+  type="alert" 
+  dismissType="none" />
+```
+
+<KAlert 
+  alert-message="Info alert message" 
+  appearance="info" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="infoIsOpen" 
+  @closed="infoIsOpen = false" />
+
+```vue
+<KAlert 
+  alert-message="Info alert message" 
+  appearance="info" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="infoIsOpen" 
+  @closed="infoIsOpen = false" />
+```
+
+<KAlert 
+  alert-message="Warning alert message" 
+  appearance="warning" 
+  type="alert" 
+  ismissType="icon" 
+  :isShowing="warningIsOpen" 
+  @closed="warningIsOpen = false" />
+
+```vue
+<KAlert 
+  alert-message="Warning alert message" 
+  appearance="warning" 
+  type="alert" 
+  ismissType="icon" 
+  :isShowing="warningIsOpen" 
+  @closed="warningIsOpen = false" />
+```
+
+<KAlert 
+  alert-message="Success alert message" 
+  appearance="success" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="successIsOpen" 
+  @closed="successIsOpen = false" />
+
+```vue
+<KAlert 
+  alert-message="Success alert message" 
+  appearance="success" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="successIsOpen" 
+  @closed="successIsOpen = false" />
+```
+
+<KAlert 
+  alert-message="Danger alert message" 
+  appearance="danger" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="dangerIsOpen" 
+  @closed="dangerIsOpen = false" />
+
+
+```vue
+<KAlert 
+  alert-message="Danger alert message" 
+  appearance="danger" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="dangerIsOpen" 
+  @closed="dangerIsOpen = false" />
+```
+
+<KAlert alert-message="I'm an alert ?" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
+
+```vue
+<KAlert 
+  alert-message="I'm an alert ?" 
+  type="banner" 
+  dismissType="button" 
+  :isShowing="dismissTypeBtn" 
+  @closed="defaultIdismissTypeBtnsOpen = false"/>
 ```
 
 ### Bordered
@@ -207,34 +269,85 @@ Fixes KAlert to the top of the container.
 ```
 
 ## Slots
-- `alertIcon` - Slot specifically meant for adding an icon
+- `extraButtons` - Slot specifically meant for adding buttons other than Dismiss
 - `alertMessage` - Default message slot
+- `additionalAlertMessage` - Additional message slot available when alerty type is banner and has isLarge prop
 
-<KAlert appearance="info">
-  <template v-slot:alertIcon>
-    <KIcon icon="portal" />
-  </template>
+
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="success"  
+  :isShowing="extraBtnSlot" 
+  @closed="extraBtnSlot = false">
   <template v-slot:alertMessage>
-    I have an icon and a <a href="">Link</a>!
+    I'm an alert with multiple buttons
+  </template>
+ <template v-slot:extraButtons>
+    <KButton appearance="primary" size="small">Upgrade</KButton>
+    <KButton appearance="primary" size="small">Downgrade</KButton>
   </template>
 </KAlert>
 
 ```vue
-<KAlert appearance="info">
-  <template v-slot:alertIcon>
-    <KIcon icon="portal" />
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="success"  
+  :isShowing="extraBtnSlot" 
+  @closed="extraBtnSlot = false">
+    <template v-slot:alertMessage>
+    I'm an alert with multiple buttons
   </template>
-  <template v-slot:alertMessage>
-    I have an icon and a <a href="">Link</a>!
+ <template v-slot:extraButtons>
+    <KButton appearance="primary" size="small">Upgrade</KButton>
+    <KButton appearance="primary" size="small">Downgrade</KButton>
   </template>
 </KAlert>
 ```
 
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="warning" 
+  is-large 
+  icon="support" 
+  :isShowing="extraMsg" 
+  @closed="extraMsg = false">
+  <template v-slot:extraButtons>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
+  <template v-slot:alertMessage>
+    You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:additionalAlertMessage>
+    across 3 services
+  </template>
+</KAlert>
+
+```vue
+<KAlert 
+  type="banner" 
+  dismissType="button" 
+  appearance="warning" 
+  is-large 
+  icon="support" >
+  <template v-slot:extraButtons>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
+  <template v-slot:alertMessage>
+    You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:additionalAlertMessage>
+    across 3 services
+  </template>
+</KAlert> 
+```
 ## Variations
 
 ### Long Content / Prose
 
-<KAlert appearance="info" class="mt-5">
+<KAlert appearance="success" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
@@ -310,6 +423,24 @@ look like.
 }
 </style>
 ```
+
+<script>
+  export default {
+      data () {
+    return {
+      infoIsOpen: true,
+      warningIsOpen: true,
+      successIsOpen: true,
+      dangerIsOpen: true,
+      defaultIsClosed: true,
+      defaultClosed: true,
+      dismissTypeBtn: true,
+      extraBtnSlot: true,
+      extraMsg: true
+    }
+  }
+}
+</script>
 
 <style lang="scss">
 .k-alert {

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -23,8 +23,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="info"
   alert-message="Info alert message">
   <template v-slot:actionButtons>
+    <KButton appearance="primary" size="small">Primary</KButton>
     <KButton appearance="outline" size="small">Outline</KButton>
-    <KButton appearance="primary" size="small">Dismiss</KButton>
   </template>
  </KAlert>
 <KAlert
@@ -33,8 +33,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="warning"
   alert-message="Warning alert message">
   <template v-slot:actionButtons>
-  <KButton appearance="outline" size="small">Outline</KButton>
-    <KButton size="small">Dismiss</KButton>
+    <KButton appearance="primary" size="small">Warning</KButton>
+    <KButton appearance="outline" size="small">Outline</KButton>
   </template>
 </KAlert>
 <KAlert
@@ -43,8 +43,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="success"
   alert-message="Success alert message">
   <template v-slot:actionButtons>
-  <KButton appearance="outline" size="small">Outline</KButton>
-    <KButton appearance="creation" size="small">Review</KButton>
+    <KButton appearance="primary" size="small">Success</KButton>
+    <KButton appearance="outline" size="small">Outline</KButton>
   </template>
 </KAlert>
 <KAlert
@@ -53,8 +53,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
   appearance="danger"
   alert-message="Danger alert message">
   <template v-slot:actionButtons>
+    <KButton appearance="primary" size="small">Warning</KButton>
     <KButton appearance="outline" size="small">Outline</KButton>
-    <KButton appearance="danger" size="small">Dismiss</KButton>
   </template>
 </KAlert>
 
@@ -263,7 +263,7 @@ Fixes KAlert to the top of the container.
     across 3 services  
   </template>
   <template v-slot:actionButtons>
-    <KButton size="small" appearance='outline'>Review</KButton>
+    <KButton size="small" appearance='secondary'>Review</KButton>
     <KButton size="small">Dismiss</KButton>
   </template>
 </KAlert>
@@ -393,6 +393,7 @@ look like.
 
 <style lang="scss">
 .k-alert {
+  box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));
   &:not(:last-of-type) {
     margin-bottom: 1rem;
   }

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -103,9 +103,9 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 ```
 
 ### Dismissible
-KAlert allows for dismissal of the banner.
+KAlert allows for dismissal of the banner. 
 
-- `is-dismissible`
+- `is-dismissible` is `false` by default
 
 <KAlert
   is-dismissible
@@ -254,10 +254,7 @@ Fixes KAlert to the top of the container.
 - `mainMessageText` - Primary message slot
 - `secMessageText` - Secondary message slot
 
-<KAlert is-wide-banner>
-  <template v-slot:alertIcon>
-    <KIcon icon="notificationInbox" color="var(--red-500)" size="32" />
-  </template>
+<KAlert is-wide-banner has-icon>
   <template v-slot:mainMessageText>
    You’ve had 12 new mentions since you last logged in
   </template>
@@ -317,7 +314,7 @@ Fixes KAlert to the top of the container.
 
 ### Long Content / Prose
 
-<KAlert isShowing appearance="info" class="mt-5">
+<KAlert appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
@@ -325,7 +322,7 @@ Fixes KAlert to the top of the container.
 </KAlert>
 
 ```vue
-<KAlert isShowing appearance="info" class="mt-5">
+<KAlert appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
@@ -335,14 +332,14 @@ Fixes KAlert to the top of the container.
 
 ### Word Wrap long urls
 
-<KAlert isShowing appearance="warning" class="mt-5">
+<KAlert appearance="warning" class="mt-5">
   <template v-slot:alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 
 ```vue
-<KAlert isShowing appearance="warning" class="mt-5">
+<KAlert appearance="warning" class="mt-5">
   <template v-slot:alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
@@ -395,6 +392,7 @@ look like.
 
 <style lang="scss">
 .k-alert {
+  box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));
   &:not(:last-of-type) {
     margin-bottom: 1rem;
   }
@@ -413,56 +411,58 @@ look like.
   &.info button.primary {
     color: var(--blue-500);
     background-color: var(--blue-100);
-    --KButtonPrimaryBase: var(--blue-300);
-    --KButtonPrimaryHover: var(--blue-300);
+    --KButtonPrimaryBase: var(--blue-500);
+    --KButtonPrimaryHover: var(--blue-200);
   }
   &.info button.outline {
-    color: var(--blue-400);
-    border: 1px solid var(--blue-400);
-    --KButtonOutlineBorder: var(--blue-300);
-    --KButtonOutlineHoverBorder: var(--blue-300);
-    --KButtonOutlineActiveBorder: var(--blue-300);
+    color: var(--blue-500);
+    border: 1px solid var(--blue-200);
+    --KButtonOutlineBorder: var(--blue-500);
+    --KButtonOutlineHoverBorder: var(--blue-500);
+     --KButtonOutlineActive: var(--blue-100);
+    --KButtonOutlineActiveBorder: var(--blue-500);
   }
   &.warning button.primary {
     color: var(--yellow-500);
     background-color: var(--yellow-100);
-    --KButtonPrimaryBase: var(--yellow-300);
-    --KButtonPrimaryHover: var(--yellow-300);
+    --KButtonPrimaryBase: var(--yellow-500);
+    --KButtonPrimaryHover: var(--yellow-200);
   }
   &.warning button.outline {
-    color: var(--yellow-400);
-    border: 1px solid var(--yellow-400);
-    --KButtonOutlineBorder: var(--yellow-300);
-    --KButtonOutlineHoverBorder: var(--yellow-300);
-    --KButtonOutlineActiveBorder: var(--yellow-300);
+    color: var(--yellow-500);
+    border: 1px solid var(--yellow-300);
+    --KButtonOutlineBorder: var(--yellow-500);
+    --KButtonOutlineHoverBorder: var(--yellow-500);
+    --KButtonOutlineActive: var(--yellow-100);
+    --KButtonOutlineActiveBorder: var(--yellow-500);
   }
   &.success button.primary {
     color: var(--green-600);
     background-color: var(--green-100);
-    border: var(--green-100);
-    --KButtonPrimaryBase: var(--green-300);
-    --KButtonPrimaryHover: var(--green-300);
+    --KButtonPrimaryBase: var(--green-600);
+    --KButtonPrimaryHover: var(--green-200);
   }
   &.success button.outline {
     color: var(--green-600);
-    border: 1px solid var(--green-600);
-    --KButtonOutlineBorder: var(--green-400);
-    --KButtonOutlineHoverBorder: var(--green-400);
-    --KButtonOutlineActiveBorder: var(--green-400);
+    border: 1px solid var(--green-400);
+    --KButtonOutlineBorder: var(--green-600);
+    --KButtonOutlineHoverBorder: var(--green-600);
+     --KButtonOutlineActive: var(--green-100);
+    --KButtonOutlineActiveBorder: var(--green-600);
   }
   &.danger button.primary {
     color: var(--red-700);
     background-color: var(--red-100);
-    border: var(--red-100);
-    --KButtonPrimaryBase: var(--red-500);
-    --KButtonPrimaryHover: var(--red-500);
+    --KButtonPrimaryHover: var(--red-200);
+    --KButtonPrimaryBase: var(--red-700);
   }
   &.danger button.outline {
-    color: var(--red-700);
-    border: 1px solid var(--red-700);
-    --KButtonOutlineBorder: var(--red-500);
-    --KButtonOutlineHoverBorder: var(--red-500);
-    --KButtonOutlineActiveBorder: var(--red-500);
+    border: 1px solid var(--red-500);
+    --KButtonOutlineBorder: var(--red-700);
+    --KButtonOutlineColor: var(--red-700);
+    --KButtonOutlineHoverBorder: var(--red-700);
+    --KButtonOutlineActive: var(--red-100);
+    --KButtonOutlineActiveBorder: var(--red-700);
   }
 }
 </style>

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,10 +2,49 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert is-dismissible alert-message="I'm an alert" />
+<KAlert alert-message="I'm an alert" type="banner"/>
+<KAlert alert-message="I'm an alert" type="alert" dismissType="none" appearance="danger" />
+<KAlert alert-message="I'm an alert" type="alert" dismissType="icon" />
+<KAlert alert-message="I'm an alert" type="alert" dismissType="icon" appearance="warning" />
+<KAlert alert-message="I'm an alert" type="alert" dismissType="icon" appearance="success" />
 
+<KAlert alert-message="I'm an alert" type="banner" dismissType="button" />
+<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="warning"> 
+  <template v-slot:actionButtons>
+    <KButton appearance="primary" size="small">Here</KButton>
+  </template>
+  </KAlert>
+<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="danger" icon="support" >
+  <template v-slot:additionalAlertMessage>
+    across 3 services
+  </template>
+</KAlert>
+<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="success" />
+
+<KAlert alert-message="I'm an alert with multiple buttons" type="banner" appearance="success" >
+ <template>
+    <KButton appearance="primary" size="small">Here</KButton>
+    <KButton size="small">There</KButton>
+    <KButton size="small">Where</KButton>
+  </template>
+  </KAlert>
+<KAlert alert-message="I'm an alert" type="banner" dismissType="button" appearance="warning" is-large />
+<KAlert alert-message="You’ve had 12 new mentions since you last logged in" type="banner" dismissType="button" appearance="warning" is-large icon="support" >
+  <template v-slot:additionalAlertMessage>
+    across 3 services
+  </template>
+</KAlert>
+<KAlert alert-message="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Orci dapibus ultrices in iaculis. Diam maecenas ultricies mi eget mauris pharetra. Facilisis sed odio morbi quis commodo." type="banner" dismissType="button" appearance="warning" is-large icon="support" >
+ <template>
+    <KButton size="small">Review</KButton>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+  <template v-slot:additionalAlertMessage>
+   across 30 services
+  </template>
+</KAlert>
 ```vue
-<KAlert is-dismissible alert-message="I'm an alert" />
+<KAlert alert-message="I'm an alert" />
 ```
 
 ## Props
@@ -18,129 +57,47 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 - `danger`
 
 <KAlert
-  has-button
-  has-ellipse
   appearance="info"
-  alert-message="Info alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Primary</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
- </KAlert>
+  alert-message="Info alert message" />
 <KAlert
-  has-button
-  has-ellipse
   appearance="warning"
-  alert-message="Warning alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Warning</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
-</KAlert>
+  alert-message="Warning alert message" />
 <KAlert
-  has-button
-  has-ellipse
   appearance="success"
-  alert-message="Success alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Success</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
-</KAlert>
+  alert-message="Success alert message" />
 <KAlert
-  has-button
-  has-ellipse
   appearance="danger"
-  alert-message="Danger alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Warning</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
-</KAlert>
-
+  alert-message="Danger alert message" />
 
 ```vue
 <KAlert
-  has-button
-  has-ellipse
   appearance="info"
-  alert-message="Info alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Primary</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
- </KAlert>
+  alert-message="Info alert message" />
 <KAlert
-  has-button
-  has-ellipse
   appearance="warning"
-  alert-message="Warning alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Warning</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
-</KAlert>
+  alert-message="Warning alert message" />
 <KAlert
-  has-button
-  has-ellipse
   appearance="success"
-  alert-message="Success alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Success</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
-</KAlert>
+  alert-message="Success alert message" />
 <KAlert
-  has-button
-  has-ellipse
   appearance="danger"
-  alert-message="Danger alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Warning</KButton>
-    <KButton appearance="outline" size="small">Outline</KButton>
-  </template>
-</KAlert>
+  alert-message="Danger alert message" />
 ```
 
 ### Dismissible
-KAlert allows for dismissal of the banner. 
+KAlert allows for dismissal of the banner.
 
-- `is-dismissible` is `false` by default
+- `is-dismissible`
 
 <KAlert
+  class="dismissible"
   is-dismissible
-  appearance="info"
-  alert-message="Info alert message" />
-<KAlert
-  is-dismissible
-  appearance="warning"
-  alert-message="Warning alert message" />
-<KAlert
-  is-dismissible
-  appearance="success"
-  alert-message="Success alert message" />
-<KAlert
-  is-dismissible
-  appearance="danger"
-  alert-message="Danger alert message" />
-
+  alert-message="I can be dismissed!"/>
 ```vue
 <KAlert
+  class="dismissible"
   is-dismissible
-  appearance="info"
-  alert-message="Info alert message" />
-<KAlert
-  is-dismissible
-  appearance="warning"
-  alert-message="Warning alert message" />
-<KAlert
-  is-dismissible
-  appearance="success"
-  alert-message="Success alert message" />
-<KAlert
-  is-dismissible
-  appearance="danger"
-  alert-message="Danger alert message" />
+  alert-message="I can be dismissed!"/>
 ```
 
 ### Bordered
@@ -251,61 +208,24 @@ Fixes KAlert to the top of the container.
 
 ## Slots
 - `alertIcon` - Slot specifically meant for adding an icon
-- `mainMessageText` - Primary message slot
-- `secMessageText` - Secondary message slot
-
-<KAlert is-wide-banner has-icon>
-  <template v-slot:mainMessageText>
-   You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:secMessageText>
-    across 3 services  
-  </template>
-  <template v-slot:actionButtons>
-    <KButton size="small" appearance='secondary'>Review</KButton>
-    <KButton size="small">Dismiss</KButton>
-  </template>
-</KAlert>
-
-```vue
-<KAlert is-wide-banner>
-  <template v-slot:alertIcon>
-    <KIcon icon="notificationInbox" color="var(--red-500)" size="32" />
-  </template>
-  <template v-slot:mainMessageText>
-   You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:secMessageText>
-    across 3 services  
-  </template>
-  <template v-slot:actionButtons>
-    <KButton size="small" appearance='secondary'>Review</KButton>
-    <KButton size="small">Dismiss</KButton>
-  </template>
-</KAlert>
-```
-
 - `alertMessage` - Default message slot
-- `actionButtons` - Default button slot
 
-<KAlert
-  has-button
-  has-ellipse
-  appearance="warning"
-  alert-message="Warning alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Dismiss</KButton>
+<KAlert appearance="info">
+  <template v-slot:alertIcon>
+    <KIcon icon="portal" />
+  </template>
+  <template v-slot:alertMessage>
+    I have an icon and a <a href="">Link</a>!
   </template>
 </KAlert>
 
 ```vue
-<KAlert
-  has-button
-  has-ellipse
-  appearance="warning"
-  alert-message="Warning alert message">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Dismiss</KButton>
+<KAlert appearance="info">
+  <template v-slot:alertIcon>
+    <KIcon icon="portal" />
+  </template>
+  <template v-slot:alertMessage>
+    I have an icon and a <a href="">Link</a>!
   </template>
 </KAlert>
 ```
@@ -339,9 +259,10 @@ Fixes KAlert to the top of the container.
 </KAlert>
 
 ```vue
-<KAlert appearance="warning" class="mt-5">
+<KAlert appearance="info" class="mt-5">
   <template v-slot:alertMessage>
-    Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
+    <div class="mt-2 bold">Failure Modes</div>
+    <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
 </KAlert>
 ```
@@ -397,72 +318,8 @@ look like.
     margin-bottom: 1rem;
   }
 }
-
-.k-alert.isWideBanner {
-  right: 20%;
-}
-
 .alert-wrapper {
   --KAlertSuccessBackground: lime;
   --KAlertSuccessColor: forestgreen;
-}
-
-.alert-action {
-  &.info button.primary {
-    color: var(--blue-500);
-    background-color: var(--blue-100);
-    --KButtonPrimaryBase: var(--blue-500);
-    --KButtonPrimaryHover: var(--blue-200);
-  }
-  &.info button.outline {
-    color: var(--blue-500);
-    border: 1px solid var(--blue-200);
-    --KButtonOutlineBorder: var(--blue-500);
-    --KButtonOutlineHoverBorder: var(--blue-500);
-     --KButtonOutlineActive: var(--blue-100);
-    --KButtonOutlineActiveBorder: var(--blue-500);
-  }
-  &.warning button.primary {
-    color: var(--yellow-500);
-    background-color: var(--yellow-100);
-    --KButtonPrimaryBase: var(--yellow-500);
-    --KButtonPrimaryHover: var(--yellow-200);
-  }
-  &.warning button.outline {
-    color: var(--yellow-500);
-    border: 1px solid var(--yellow-300);
-    --KButtonOutlineBorder: var(--yellow-500);
-    --KButtonOutlineHoverBorder: var(--yellow-500);
-    --KButtonOutlineActive: var(--yellow-100);
-    --KButtonOutlineActiveBorder: var(--yellow-500);
-  }
-  &.success button.primary {
-    color: var(--green-600);
-    background-color: var(--green-100);
-    --KButtonPrimaryBase: var(--green-600);
-    --KButtonPrimaryHover: var(--green-200);
-  }
-  &.success button.outline {
-    color: var(--green-600);
-    border: 1px solid var(--green-400);
-    --KButtonOutlineBorder: var(--green-600);
-    --KButtonOutlineHoverBorder: var(--green-600);
-     --KButtonOutlineActive: var(--green-100);
-    --KButtonOutlineActiveBorder: var(--green-600);
-  }
-  &.danger button.primary {
-    color: var(--red-700);
-    background-color: var(--red-100);
-    --KButtonPrimaryHover: var(--red-200);
-    --KButtonPrimaryBase: var(--red-700);
-  }
-  &.danger button.outline {
-    border: 1px solid var(--red-500);
-    --KButtonOutlineBorder: var(--red-700);
-    --KButtonOutlineColor: var(--red-700);
-    --KButtonOutlineHoverBorder: var(--red-700);
-    --KButtonOutlineActive: var(--red-100);
-    --KButtonOutlineActiveBorder: var(--red-700);
-  }
 }
 </style>

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,14 +2,17 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert alert-message="I'm an alert"/>
+<KAlert
+  alert-message="I'm an alert" />
 
 ```vue
 <KAlert alert-message="I'm an alert" />
 ```
 
 ## Props
+
 ### Appearances
+
 What color and purpose the Alert should be. Shares similar appearances to those of [KButton](/components/button).
 
 - `info`
@@ -46,6 +49,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 ```
 
 ### Type
+
 The display type of the alert.
 
 - `banner`
@@ -54,29 +58,51 @@ The display type of the alert.
 
 > Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
 
-<KAlert alert-message="I'm a banner type alert" type="banner" />
+<KAlert
+  alert-message="I'm a banner type alert"
+  type="banner" />
 
 ```vue
-<KAlert alert-message="I'm a banner type alert" type="banner" />
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  type="banner" />
 ```
 
-<KAlert alert-message="I'm a banner type alert" appearance="success" type="banner" />
+<KAlert
+  alert-message="I'm a banner type alert"
+  appearance="success"
+  type="banner" />
 
 ```vue
-<KAlert alert-message="I'm a banner type alert" appearance="success" type="banner" />
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  appearance="success" 
+  type="banner" />
 ```
 
-<KAlert alert-message="I'm a banner type alert" appearance="danger" type="banner" />
+<KAlert
+  alert-message="I'm a banner type alert"
+  appearance="danger"
+  type="banner" />
 
 ```vue
-<KAlert alert-message="I'm a banner type alert" appearance="danger" type="banner" />
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  appearance="danger" 
+  type="banner" />
 ```
 
 
-<KAlert alert-message="I'm a banner type alert" appearance="warning" type="banner" />
+<KAlert
+  alert-message="I'm a banner type alert" 
+  appearance="warning" 
+  type="banner" />
 
 ```vue
-<KAlert alert-message="I'm a banner type alert" appearance="warning" type="banner" />
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  appearance="warning" 
+  type="banner" />
 ```
 
 - `alert`
@@ -85,49 +111,78 @@ The display type of the alert.
 
 > Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
 
-<KAlert alert-message="I'm an alert" type="alert" />
+<KAlert
+  alert-message="I'm an alert"
+  type="alert" />
 
 ```vue
-<KAlert alert-message="I'm an alert" type="alert" />
+<KAlert
+  alert-message="I'm an alert"
+  type="alert" />
 ```
-<KAlert alert-message="I'm an alert" appearance="success" type="alert" />
+
+<KAlert
+  alert-message="I'm an alert"
+  appearance="success"
+  type="alert" />
 
 ```vue
-<KAlert alert-message="I'm an alert" appearance="success" type="alert" />
+<KAlert
+  alert-message="I'm an alert"
+  appearance="success"
+  type="alert" />
 ```
 
-<KAlert alert-message="I'm an alert" appearance="danger" type="alert" />
+<KAlert
+  alert-message="I'm an alert"
+  appearance="danger"
+  type="alert" />
 
 ```vue
-<KAlert alert-message="I'm an alert" appearance="danger" type="alert" />
+<KAlert 
+  alert-message="I'm an alert"
+  appearance="danger"
+  type="alert" />
 ```
 
-<KAlert alert-message="I'm an alert" appearance="warning" type="alert" />
+<KAlert
+  alert-message="I'm an alert"
+  appearance="warning"
+  type="alert" />
 
 ```vue
-<KAlert alert-message="I'm an alert" appearance="warning" type="alert" />
+<KAlert
+  alert-message="I'm an alert"
+  appearance="warning"
+  type="alert" />
 ```
+
 ### Dismiss Type
+
 KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed
 
 - `none`
 - `icon`
 - `button`
 
-<KAlert alert-message="Alert that can not be dismissed" type="alert" dismissType="none" />
+<KAlert
+  alert-message="Alert that can not be dismissed"
+  type="alert"
+  dismissType="none" />
 
 ```vue
-<KAlert alert-message="Alert that can not be dismissed" 
-  type="alert" 
+<KAlert
+  alert-message="Alert that can not be dismissed"
+  type="alert"
   dismissType="none" />
 ```
 
 <KAlert 
-  alert-message="Info alert message that is dismissible" 
-  appearance="info" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="infoIsOpen" 
+  alert-message="Info alert message that is dismissible"
+  appearance="info"
+  type="alert"
+  dismissType="icon"
+  :isShowing="infoIsOpen"
   @closed="infoIsOpen = false" />
 
 ```vue
@@ -140,12 +195,12 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   @closed="infoIsOpen = false" />
 ```
 
-<KAlert 
-  alert-message="Warning alert message that is dismissible" 
-  appearance="warning" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="warningIsOpen" 
+<KAlert
+  alert-message="Warning alert message that is dismissible"
+  appearance="warning"
+  type="alert"
+  dismissType="icon"
+  :isShowing="warningIsOpen"
   @closed="warningIsOpen = false" />
 
 ```vue
@@ -159,11 +214,11 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 ```
 
 <KAlert 
-  alert-message="Success alert message that is dismissible" 
-  appearance="success" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="successIsOpen" 
+  alert-message="Success alert message that is dismissible"
+  appearance="success"
+  type="alert"
+  dismissType="icon"
+  :isShowing="successIsOpen"
   @closed="successIsOpen = false" />
 
 ```vue
@@ -177,11 +232,11 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 ```
 
 <KAlert 
-  alert-message="Danger alert message that is dismissible" 
-  appearance="danger" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="dangerIsOpen" 
+  alert-message="Danger alert message that is dismissible"
+  appearance="danger"
+  type="alert"
+  dismissType="icon"
+  :isShowing="dangerIsOpen"
   @closed="dangerIsOpen = false" />
 
 
@@ -195,7 +250,11 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   @closed="dangerIsOpen = false" />
 ```
 
-<KAlert alert-message="Alert with dismiss type as button TEST" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
+<KAlert 
+  alert-message="Alert with dismiss type as button TEST"
+  type="banner" dismissType="button"
+  :isShowing="dismissTypeBtn"
+  @closed="dismissTypeBtn = false"/>
 
 ```vue
 <KAlert 
@@ -207,11 +266,14 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 ```
 
 ### Hide/Display
+
 Hides/display the alert. By default isShowing is set to true.  
-- `isShowing` 
+
+- `isShowing`
 
 <KAlert
   alert-message="isShowing: true by default"/>
+
 ```vue
 <KAlert
   alert-message="isShowing: true by default"/>
@@ -220,6 +282,7 @@ Hides/display the alert. By default isShowing is set to true.
 <KAlert
   :is-showing=false
   alert-message="isShowing set to false"/>
+
 ```vue
 <KAlert
   alert-message="isShowing set to false"/>
@@ -234,6 +297,7 @@ Adds border around alert. Used for [KToaster]().
   is-bordered
   appearance="info"
   alert-message="Info bordered"/>
+
 ```vue
 <KAlert
   is-bordered
@@ -242,6 +306,7 @@ Adds border around alert. Used for [KToaster]().
 ```
 
 ### Left Border
+
 Adds border to the left side. Typically used for alerts that show info that may link away like documentation.
 
 - `has-left-border`
@@ -257,6 +322,7 @@ Adds border to the left side. Typically used for alerts that show info that may 
 ```
 
 ### Right Border
+
 Adds border to the right side. Typically used for alerts that show info that may link away like documentation.
 
 - `has-right-border`
@@ -272,6 +338,7 @@ Adds border to the right side. Typically used for alerts that show info that may
 ```
 
 ### Top Border
+
 Adds border to the top.
 
 - `has-top-border`
@@ -287,6 +354,7 @@ Adds border to the top.
 ```
 
 ### Bottom Border
+
 Adds border to the bottom.
 
 - `has-bottom-border`
@@ -302,6 +370,7 @@ Adds border to the bottom.
 ```
 
 ### Size
+
 Controls size of alert.
 
 - `small`
@@ -322,17 +391,16 @@ Controls size of alert.
 
 `size="large" type="banner"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` property/slot and additional buttons using the `actionButtons` slot.
 
-<KAlert 
-  type="banner" 
-  dismissType="button" 
-  appearance="warning" 
-  icon="support" 
+<KAlert
+  type="banner"
+  dismissType="button"
+  appearance="warning"
+  icon="support"
   size="large"
-  :isShowing="extraMsg" 
+  :isShowing="extraMsg"
   @closed="extraMsg = false">
   <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Review</KButton>
-  </template>
+    <KButton appearance="primary" size="small">Review</KButton></template>
   <template v-slot:alertMessage>
     You’ve had 12 new mentions since you last logged in
   </template>
@@ -342,6 +410,7 @@ Controls size of alert.
 </KAlert>
 
 ### Fixed
+
 Fixes KAlert to the top of the container.
 
 > Note: Not demoed
@@ -355,16 +424,17 @@ Fixes KAlert to the top of the container.
 ```
 
 ## Slots
+
 - `actionButtons` - Slot specifically meant for adding buttons other than Dismiss button
 - `alertMessage` - Default message slot
 - `description` - Additional message slot available when alert type is banner, has *is-large* prop and the alertMessage slot is rendered
 
 
-<KAlert 
-  type="banner" 
-  dismissType="button" 
+<KAlert
+  type="banner"
+  dismissType="button"
   appearance="success"  
-  :isShowing="extraBtnSlot" 
+  :isShowing="extraBtnSlot"
   @closed="extraBtnSlot = false">
   <template v-slot:alertMessage>
     I'm an alert with multiple buttons
@@ -392,24 +462,6 @@ Fixes KAlert to the top of the container.
 </KAlert>
 ```
 
-<!-- <KAlert 
-  type="banner" 
-  dismissType="button" 
-  appearance="warning" 
-  is-large 
-  :isShowing="extraMsg" 
-  @closed="extraMsg = false">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Review</KButton>
-  </template>
-  <template v-slot:alertMessage>
-    You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:description>
-    across 3 services
-  </template>
-</KAlert> -->
-
 ```vue
 <KAlert 
   type="banner" 
@@ -429,6 +481,7 @@ Fixes KAlert to the top of the container.
   </template>
 </KAlert> 
 ```
+
 ## Variations
 
 ### Long Content / Prose
@@ -481,7 +534,6 @@ Fixes KAlert to the top of the container.
 | `--KAlertWarningColor `| Warning variant text  color
 | `--KAlertWarningBorder`| Warning variant border
 | `--KAlertWarningBackground` | Warning variant background color
-
 
 \
 An Example of changing the success KAlert variant to lime instead of Kong's green might

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -115,46 +115,54 @@ The display type of the alert.
 
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   type="alert" />
 
 ```vue
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   type="alert" />
 ```
 
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   appearance="success"
   type="alert" />
 
 ```vue
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   appearance="success"
   type="alert" />
 ```
 
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   appearance="danger"
   type="alert" />
 
 ```vue
 <KAlert 
   alert-message="I'm an alert"
+  dismissType="button"
   appearance="danger"
   type="alert" />
 ```
 
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   appearance="warning"
   type="alert" />
 
 ```vue
 <KAlert
   alert-message="I'm an alert"
+  dismissType="button"
   appearance="warning"
   type="alert" />
 ```

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,8 +2,22 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
+<KAlert isWideBanner>
+  <template v-slot:alertRedIcon>
+    <KIcon icon="notificationInbox" color="#D44324" size="32" />
+  </template>
+  <template v-slot:alertLongMessageFirst>
+   You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:alertLongMessageSec>
+    across 3 services  
+  </template>
+  <template v-slot:actionButtons>
+    <KButton size="small" appearance='outline'>Review</KButton>
+    <KButton size="small">Dismiss</KButton>
+  </template>
+</KAlert>
 
-<KAlert alert-message="I'm an alert" />
 ```vue
 <KAlert alert-message="I'm an alert" />
 ```
@@ -19,6 +33,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 
 
 <KAlert
+hasEllipse
   hasButton
   appearance="info"
   alert-message="Info alert message">
@@ -29,6 +44,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
  </KAlert>
 <KAlert
   hasButton
+  hasEllipse
   appearance="warning"
   alert-message="Warning alert message">
   <template v-slot:actionButtons>
@@ -37,6 +53,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 </KAlert>
 <KAlert
   hasButton
+  hasEllipse
   appearance="success"
   alert-message="Success alert message">
   <template v-slot:actionButtons>
@@ -45,6 +62,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 </KAlert>
 <KAlert
   hasButton
+  hasEllipse
   appearance="danger"
   alert-message="Danger alert message">
   <template v-slot:actionButtons>

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -6,10 +6,10 @@
   <template v-slot:alertRedIcon>
     <KIcon icon="notificationInbox" color="#D44324" size="32" />
   </template>
-  <template v-slot:alertLongMessageFirst>
+  <template v-slot:mainMessageText>
    You’ve had 12 new mentions since you last logged in
   </template>
-  <template v-slot:alertLongMessageSec>
+  <template v-slot:secMessageText>
     across 3 services  
   </template>
   <template v-slot:actionButtons>
@@ -33,8 +33,8 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 
 
 <KAlert
-hasEllipse
   hasButton
+  hasEllipse
   appearance="info"
   alert-message="Info alert message">
   <template v-slot:actionButtons>
@@ -72,22 +72,22 @@ hasEllipse
 </KAlert> 
 
 <KAlert
-  class="dismissible"
+  isShowing
   is-dismissible
   appearance="info"
   alert-message="Info alert message" />
 <KAlert
-  appearance="warning"
-  class="dismissible"
+  isShowing
   is-dismissible
+  appearance="warning"
   alert-message="Warning alert message" />
 <KAlert
-class="dismissible"
+  isShowing
   is-dismissible
   appearance="success"
   alert-message="Success alert message" />
 <KAlert
-class="dismissible"
+  isShowing
   is-dismissible
   appearance="danger"
   alert-message="Danger alert message" />
@@ -340,6 +340,11 @@ look like.
     margin-bottom: 1rem;
   }
 }
+
+.k-alert.isWideBanner {
+  right: 20%;
+}
+
 .alert-wrapper {
   --KAlertSuccessBackground: lime;
   --KAlertSuccessColor: forestgreen;

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,10 +2,10 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert is-showing alert-message="I'm an alert" />
+<KAlert alert-message="I'm an alert" />
 
 ```vue
-<KAlert is-showing alert-message="I'm an alert" />
+<KAlert alert-message="I'm an alert" />
 ```
 
 ## Props
@@ -106,44 +106,36 @@ KAlert allows for dismissal of the banner.
 - `is-dismissible`
 
 <KAlert
-  is-showing
   is-dismissible
   appearance="info"
   alert-message="Info alert message" />
 <KAlert
-  is-showing
   is-dismissible
   appearance="warning"
   alert-message="Warning alert message" />
 <KAlert
-  is-showing
   is-dismissible
   appearance="success"
   alert-message="Success alert message" />
 <KAlert
-  is-showing
   is-dismissible
   appearance="danger"
   alert-message="Danger alert message" />
 
 ```vue
 <KAlert
-  is-showing
   is-dismissible
   appearance="info"
   alert-message="Info alert message" />
 <KAlert
-  is-showing
   is-dismissible
   appearance="warning"
   alert-message="Warning alert message" />
 <KAlert
-  is-showing
   is-dismissible
   appearance="success"
   alert-message="Success alert message" />
 <KAlert
-  is-showing
   is-dismissible
   appearance="danger"
   alert-message="Danger alert message" />
@@ -155,13 +147,11 @@ Adds border around alert. Used for [KToaster]().
 - `is-bordered`
 
 <KAlert
-  is-showing
   is-bordered
   appearance="info"
   alert-message="Info bordered"/>
 ```vue
 <KAlert
-  is-showing
   is-bordered
   appearance="info"
   alert-message="Info bordered"/>
@@ -173,13 +163,11 @@ Adds border to the left side. Typically used for alerts that show info that may 
 - `has-left-border`
 
 <KAlert
-  is-showing
   has-left-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
-  is-showing
   has-left-border
   alert-message="Bordered alert"/>
 ```
@@ -190,13 +178,11 @@ Adds border to the right side. Typically used for alerts that show info that may
 - `has-right-border`
 
 <KAlert
-  is-showing
   has-right-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
-  is-showing
   has-right-border
   alert-message="Bordered alert"/>
 ```
@@ -207,13 +193,11 @@ Adds border to the top.
 - `has-top-border`
 
 <KAlert
-  is-showing
   has-top-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
-  is-showing
   has-top-border
   alert-message="Bordered alert"/>
 ```
@@ -224,13 +208,11 @@ Adds border to the bottom.
 - `has-bottom-border`
 
 <KAlert
-  is-showing
   has-bottom-border
   alert-message="Bordered alert"/>
 
 ```vue
 <KAlert
-  is-showing
   has-bottom-border
   alert-message="Bordered alert"/>
 ```
@@ -241,14 +223,12 @@ Controls size of alert. Currently only *small* is supported.
 - `small`
 
 <KAlert
-  is-showing
   style="width:250px"
   size="small"
   alert-message="Small alert"/>
 
 ```vue
 <KAlert
-  is-showing
   style="width:250px"
   size="small"
   alert-message="Small alert"/>
@@ -263,7 +243,6 @@ Fixes KAlert to the top of the container.
 
 ```vue
 <KAlert
-  is-showing
   is-fixed
   alert-message="Info bordered"/>
 ```

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -13,7 +13,9 @@
 
 ### Appearances
 
-What color and purpose the Alert should be. Shares similar appearances to those of [KButton](/components/button).
+What color and purpose the Alert should be. Shares similar appearances to those of [KButton](/components/button).  
+
+> Note: `appearance` is `info` by default.
 
 - `info`
 - `warning`
@@ -159,7 +161,7 @@ The display type of the alert.
 
 ### Dismiss Type
 
-KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed
+KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed.
 
 - `none`
 - `icon`
@@ -251,7 +253,7 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 ```
 
 <KAlert 
-  alert-message="Alert with dismiss type as button TEST"
+  alert-message="Alert with dismiss type as button"
   type="banner" dismissType="button"
   :isShowing="dismissTypeBtn"
   @closed="dismissTypeBtn = false"/>
@@ -267,7 +269,9 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 
 ### Hide/Display
 
-Hides/display the alert. By default isShowing is set to true.  
+Set whether or not the alert box is shown.
+
+> Note: By default isShowing is set to true.  
 
 - `isShowing`
 
@@ -389,7 +393,7 @@ Controls size of alert.
 
 - `large`
 
-`size="large" type="banner"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` property/slot and additional buttons using the `actionButtons` slot.
+`size="large" type="banner"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` slot and additional buttons using the `actionButtons` slot.
 
 <KAlert
   type="banner"
@@ -409,6 +413,26 @@ Controls size of alert.
   </template>
 </KAlert>
 
+```vue
+<KAlert
+  type="banner"
+  dismissType="button"
+  appearance="warning"
+  icon="support"
+  size="large"
+  :isShowing="extraMsg"
+  @closed="extraMsg = false">
+  <template v-slot:actionButtons>
+    <KButton appearance="primary" size="small">Review</KButton></template>
+  <template v-slot:alertMessage>
+    You’ve had 12 new mentions since you last logged in
+  </template>
+  <template v-slot:description>
+    across 3 services
+  </template>
+</KAlert>
+```
+
 ### Fixed
 
 Fixes KAlert to the top of the container.
@@ -427,7 +451,7 @@ Fixes KAlert to the top of the container.
 
 - `actionButtons` - Slot specifically meant for adding buttons other than Dismiss button
 - `alertMessage` - Default message slot
-- `description` - Additional message slot available when alert type is banner, has *is-large* prop and the alertMessage slot is rendered
+- `description` - Additional message slot available when these conditions are met: `type='banner'`, `size='large'` and `alertMessage` slot is rendered
 
 
 <KAlert
@@ -460,26 +484,6 @@ Fixes KAlert to the top of the container.
     <KButton appearance="primary" size="small">Downgrade</KButton>
   </template>
 </KAlert>
-```
-
-```vue
-<KAlert 
-  type="banner" 
-  dismissType="button" 
-  appearance="warning" 
-  is-large 
-  :isShowing="extraMsg" 
-  @closed="extraMsg = false">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Review</KButton>
-  </template>
-  <template v-slot:alertMessage>
-    You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:description>
-    across 3 services
-  </template>
-</KAlert> 
 ```
 
 ## Variations

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -64,43 +64,33 @@ The display type of the alert.
   alert-message="I'm a banner type alert"
   type="banner" />
 
-```vue
-<KAlert 
-  alert-message="I'm a banner type alert" 
-  type="banner" />
-```
-
 <KAlert
   alert-message="I'm a banner type alert"
   appearance="success"
   type="banner" />
 
-```vue
-<KAlert 
-  alert-message="I'm a banner type alert" 
-  appearance="success" 
-  type="banner" />
-```
-
-<KAlert
+  <KAlert
   alert-message="I'm a banner type alert"
   appearance="danger"
   type="banner" />
 
-```vue
-<KAlert 
-  alert-message="I'm a banner type alert" 
-  appearance="danger" 
-  type="banner" />
-```
-
-
-<KAlert
+  <KAlert
   alert-message="I'm a banner type alert" 
   appearance="warning" 
   type="banner" />
 
 ```vue
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  type="banner" />
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  appearance="success" 
+  type="banner" />
+<KAlert 
+  alert-message="I'm a banner type alert" 
+  appearance="danger" 
+  type="banner" />
 <KAlert 
   alert-message="I'm a banner type alert" 
   appearance="warning" 
@@ -116,55 +106,65 @@ The display type of the alert.
 <KAlert
   alert-message="I'm an alert"
   dismissType="button"
-  type="alert" />
-
-```vue
-<KAlert
-  alert-message="I'm an alert"
-  dismissType="button"
-  type="alert" />
-```
+  type="alert" 
+  :isShowing="alert1IsOpen"
+  @closed="alert1IsOpen = false" />
 
 <KAlert
   alert-message="I'm an alert"
   dismissType="button"
   appearance="success"
-  type="alert" />
+  type="alert"
+  :isShowing="alert2IsOpen"
+  @closed="alert2IsOpen = false" />
+
+<KAlert
+  alert-message="I'm an alert"
+  dismissType="button"
+  appearance="danger"
+  type="alert" 
+  :isShowing="alert3IsOpen"
+  @closed="alert3IsOpen = false" />
+
+<KAlert
+  alert-message="I'm an alert"
+  dismissType="button"
+  appearance="warning"
+  type="alert" 
+  :isShowing="alert4IsOpen"
+  @closed="alert4IsOpen = false" />
 
 ```vue
+<KAlert
+  alert-message="I'm an alert"
+  dismissType="button"
+  type="alert" 
+  :isShowing="alert1IsOpen"
+  @closed="alert1IsOpen = false" />
+
 <KAlert
   alert-message="I'm an alert"
   dismissType="button"
   appearance="success"
-  type="alert" />
-```
+  type="alert"
+  :isShowing="alert2IsOpen"
+  @closed="alert2IsOpen = false" />
 
 <KAlert
   alert-message="I'm an alert"
   dismissType="button"
   appearance="danger"
-  type="alert" />
-
-```vue
-<KAlert 
-  alert-message="I'm an alert"
-  dismissType="button"
-  appearance="danger"
-  type="alert" />
-```
+  type="alert" 
+  :isShowing="alert3IsOpen"
+  @closed="alert4IsOpen = false" />
 
 <KAlert
   alert-message="I'm an alert"
   dismissType="button"
   appearance="warning"
-  type="alert" />
-
-```vue
-<KAlert
-  alert-message="I'm an alert"
-  dismissType="button"
-  appearance="warning"
-  type="alert" />
+  type="alert" 
+  :isShowing="alert5IsOpen"
+  @closed="alert5IsOpen = false" />
 ```
 
 ### Dismiss Type
@@ -180,13 +180,6 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   type="alert"
   dismissType="none" />
 
-```vue
-<KAlert
-  alert-message="Alert that can not be dismissed"
-  type="alert"
-  dismissType="none" />
-```
-
 <KAlert 
   alert-message="Info alert message that is dismissible"
   appearance="info"
@@ -194,16 +187,6 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   dismissType="icon"
   :isShowing="infoIsOpen"
   @closed="infoIsOpen = false" />
-
-```vue
-<KAlert 
-  alert-message="Info alert message that is dismissible" 
-  appearance="info" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="infoIsOpen" 
-  @closed="infoIsOpen = false" />
-```
 
 <KAlert
   alert-message="Warning alert message that is dismissible"
@@ -213,16 +196,6 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   :isShowing="warningIsOpen"
   @closed="warningIsOpen = false" />
 
-```vue
-<KAlert 
-  alert-message="Warning alert message that is dismissible" 
-  appearance="warning" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="warningIsOpen" 
-  @closed="warningIsOpen = false" />
-```
-
 <KAlert 
   alert-message="Success alert message that is dismissible"
   appearance="success"
@@ -230,16 +203,6 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   dismissType="icon"
   :isShowing="successIsOpen"
   @closed="successIsOpen = false" />
-
-```vue
-<KAlert 
-  alert-message="Success alert message that is dismissible" 
-  appearance="success" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="successIsOpen" 
-  @closed="successIsOpen = false" />
-```
 
 <KAlert 
   alert-message="Danger alert message that is dismissible"
@@ -249,17 +212,6 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   :isShowing="dangerIsOpen"
   @closed="dangerIsOpen = false" />
 
-
-```vue
-<KAlert 
-  alert-message="Danger alert message that is dismissible" 
-  appearance="danger" 
-  type="alert" 
-  dismissType="icon" 
-  :isShowing="dangerIsOpen" 
-  @closed="dangerIsOpen = false" />
-```
-
 <KAlert 
   alert-message="Alert with dismiss type as button"
   type="banner" dismissType="button"
@@ -267,6 +219,43 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
   @closed="dismissTypeBtn = false"/>
 
 ```vue
+<KAlert
+  alert-message="Alert that can not be dismissed"
+  type="alert"
+  dismissType="none" />
+
+<KAlert 
+  alert-message="Info alert message that is dismissible" 
+  appearance="info" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="infoIsOpen" 
+  @closed="infoIsOpen = false" />
+
+<KAlert 
+  alert-message="Warning alert message that is dismissible" 
+  appearance="warning" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="warningIsOpen" 
+  @closed="warningIsOpen = false" />
+
+<KAlert 
+  alert-message="Success alert message that is dismissible" 
+  appearance="success" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="successIsOpen" 
+  @closed="successIsOpen = false" />
+
+<KAlert 
+  alert-message="Danger alert message that is dismissible" 
+  appearance="danger" 
+  type="alert" 
+  dismissType="icon" 
+  :isShowing="dangerIsOpen" 
+  @closed="dangerIsOpen = false" />
+
 <KAlert 
   alert-message="Alert with dismiss type as button" 
   type="banner" 
@@ -283,20 +272,9 @@ Set whether or not the alert box is shown.
 
 - `isShowing`
 
-<KAlert
-  alert-message="isShowing: true by default"/>
-
 ```vue
 <KAlert
-  alert-message="isShowing: true by default"/>
-```
-
-<KAlert
-  :is-showing=false
-  alert-message="isShowing set to false"/>
-
-```vue
-<KAlert
+  :is-showing="false"
   alert-message="isShowing set to false"/>
 ```
 
@@ -586,7 +564,11 @@ look like.
       defaultClosed: true,
       dismissTypeBtn: true,
       extraBtnSlot: true,
-      extraMsg: true
+      extraMsg: true,
+      alert1IsOpen: true,
+      alert2IsOpen: true,
+      alert3IsOpen: true,
+      alert4IsOpen: true
     }
   }
 }

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -576,7 +576,6 @@ look like.
 
 <style lang="scss">
 .k-alert {
-  box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));
   &:not(:last-of-type) {
     margin-bottom: 1rem;
   }

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -70,27 +70,37 @@ describe('KAlert', () => {
     expect(wrapperBorderTop.attributes('class')).toContain('hasTopBorder')
   })
 
-  it('show alert with white background and button(s)', () => {
-    const wrapper = mount(KAlert, {
+  it('renders large alert box', () => {
+    const wrapperLargeAlert = mount(KAlert, {
       propsData: {
-        'hasButton': true,
-        message: 'Hello world'
+        message: 'Hello world',
+        isLarge: true
       }
     })
 
-    expect(wrapper.find('.k-alert').classes()).toContain('hasButton')
-    expect(wrapper.html()).toMatchSnapshot()
+    expect(wrapperLargeAlert.attributes('class')).toContain('isLarge')
   })
 
-  it('show alert/banner with isWideBanner class styles for white background, buttons and notification icon', () => {
-    const wrapper = mount(KAlert, {
-      propsData: {
-        'isWideBanner': true,
-        message: 'Hello world'
-      }
-    })
+  // it('renders slots when passed', () => {
+  //   const alertButtons = 'Extra button'
+  //   const alertMessage = 'Hello World'
+  //   const additionalAlertMessage = 'I am an alert'
+  //   const wrapper = mount(KAlert, {
+  //     propsData: {
+  //       dismissType: 'button',
+  //       isLarge: true,
+  //       hasExtraButtons:
+  //     },
+  //     slots: {
+  //       'alertButtons': `<span>${alertButtons}</span>`,
+  //       'alertMessage': `<span>${alertMessage}</span>`,
+  //       'additionalAlertMessage': `<span>${additionalAlertMessage}</span>`
+  //     }
+  //   })
 
-    expect(wrapper.find('.k-alert').classes()).toContain('isWideBanner')
-    expect(wrapper.html()).toMatchSnapshot()
-  })
+  //   expect(wrapper.find('.k-alert div.alert-action').html()).toEqual(expect.stringContaining(alertButtons))
+  //   expect(wrapper.find('.alert-msg').html()).toEqual(expect.stringContaining(alertMessage))
+  //   expect(wrapper.find('.additionalAlertMessage').html()).toEqual(expect.stringContaining(additionalAlertMessage))
+  //   expect(wrapper.html()).toMatchSnapshot()
+  // })
 })

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -74,34 +74,34 @@ describe('KAlert', () => {
     const wrapperLargeAlert = mount(KAlert, {
       propsData: {
         message: 'Hello world',
-        isLarge: true
+        size: 'large'
       }
     })
 
-    expect(wrapperLargeAlert.attributes('class')).toContain('isLarge')
+    expect(wrapperLargeAlert.attributes('class')).toContain('large')
   })
 
   it('renders slots when passed', () => {
-    const extraButtons = 'Extra button'
+    const actionButtons = 'Action button'
     const alertMessage = 'Hello World'
-    const additionalAlertMessage = 'I am an alert'
+    const description = 'I am an alert'
     const wrapper = mount(KAlert, {
       propsData: {
         dismissType: 'button',
-        isLarge: true,
-        hasExtraButtons: true,
+        size: 'large',
+        hasActionButtons: true,
         type: 'banner'
       },
       slots: {
-        'extraButtons': `<span>${extraButtons}</span>`,
+        'actionButtons': `<span>${actionButtons}</span>`,
         'alertMessage': `<span>${alertMessage}</span>`,
-        'additionalAlertMessage': `<span>${additionalAlertMessage}</span>`
+        'description': `<span>${description}</span>`
       }
     })
 
-    expect(wrapper.find('.k-alert-action').html()).toEqual(expect.stringContaining(extraButtons))
+    expect(wrapper.find('.k-alert-action').html()).toEqual(expect.stringContaining(actionButtons))
     expect(wrapper.find('.k-alert-msg').html()).toEqual(expect.stringContaining(alertMessage))
-    expect(wrapper.find('.k-alert-additional-text').html()).toEqual(expect.stringContaining(additionalAlertMessage))
+    expect(wrapper.find('.k-alert-additional-text').html()).toEqual(expect.stringContaining(description))
     expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -5,6 +5,7 @@ let rendersCorrectVariant = (variant) => {
   it(`Renders ${variant} variant`, () => {
     const wrapper = mount(KAlert, {
       propsData: {
+        'isShowing': true,
         'appearance': `${variant}`,
         'message': `I am ${variant}`
       }
@@ -21,6 +22,7 @@ describe('KAlert', () => {
   it('renders info variant when no appearance prop', () => {
     const wrapper = mount(KAlert, {
       propsData: {
+        'isShowing': true,
         'message': 'I should be info!'
       }
     })
@@ -41,24 +43,28 @@ describe('KAlert', () => {
   it('renders borders on the expected sides', () => {
     const wrapperBorderLeft = mount(KAlert, {
       propsData: {
+        'isShowing': true,
         message: 'Hello world',
         hasLeftBorder: true
       }
     })
     const wrapperBorderRight = mount(KAlert, {
       propsData: {
+        'isShowing': true,
         message: 'Hello world',
         hasRightBorder: true
       }
     })
     const wrapperBorderBottom = mount(KAlert, {
       propsData: {
+        'isShowing': true,
         message: 'Hello world',
         hasBottomBorder: true
       }
     })
     const wrapperBorderTop = mount(KAlert, {
       propsData: {
+        'isShowing': true,
         message: 'Hello world',
         hasTopBorder: true
       }

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -75,4 +75,28 @@ describe('KAlert', () => {
     expect(wrapperBorderBottom.attributes('class')).toContain('hasBottomBorder')
     expect(wrapperBorderTop.attributes('class')).toContain('hasTopBorder')
   })
+
+  it('show alert with white background and button(s)', () => {
+    const wrapper = mount(KAlert, {
+      propsData: {
+        'hasButton': true,
+        message: 'Hello world'
+      }
+    })
+
+    expect(wrapper.find('.k-alert').classes()).toContain('hasButton')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('show alert/banner with isWideBanner class styles for white background, buttons and notification icon', () => {
+    const wrapper = mount(KAlert, {
+      propsData: {
+        'isWideBanner': true,
+        message: 'Hello world'
+      }
+    })
+
+    expect(wrapper.find('.k-alert').classes()).toContain('isWideBanner')
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -101,7 +101,7 @@ describe('KAlert', () => {
 
     expect(wrapper.find('.k-alert-action').html()).toEqual(expect.stringContaining(actionButtons))
     expect(wrapper.find('.k-alert-msg').html()).toEqual(expect.stringContaining(alertMessage))
-    expect(wrapper.find('.k-alert-additional-text').html()).toEqual(expect.stringContaining(description))
+    expect(wrapper.find('.k-alert-description-text').html()).toEqual(expect.stringContaining(description))
     expect(wrapper.html()).toMatchSnapshot()
   })
 })

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -81,26 +81,27 @@ describe('KAlert', () => {
     expect(wrapperLargeAlert.attributes('class')).toContain('isLarge')
   })
 
-  // it('renders slots when passed', () => {
-  //   const alertButtons = 'Extra button'
-  //   const alertMessage = 'Hello World'
-  //   const additionalAlertMessage = 'I am an alert'
-  //   const wrapper = mount(KAlert, {
-  //     propsData: {
-  //       dismissType: 'button',
-  //       isLarge: true,
-  //       hasExtraButtons:
-  //     },
-  //     slots: {
-  //       'alertButtons': `<span>${alertButtons}</span>`,
-  //       'alertMessage': `<span>${alertMessage}</span>`,
-  //       'additionalAlertMessage': `<span>${additionalAlertMessage}</span>`
-  //     }
-  //   })
+  it('renders slots when passed', () => {
+    const extraButtons = 'Extra button'
+    const alertMessage = 'Hello World'
+    const additionalAlertMessage = 'I am an alert'
+    const wrapper = mount(KAlert, {
+      propsData: {
+        dismissType: 'button',
+        isLarge: true,
+        hasExtraButtons: true,
+        type: 'banner'
+      },
+      slots: {
+        'extraButtons': `<span>${extraButtons}</span>`,
+        'alertMessage': `<span>${alertMessage}</span>`,
+        'additionalAlertMessage': `<span>${additionalAlertMessage}</span>`
+      }
+    })
 
-  //   expect(wrapper.find('.k-alert div.alert-action').html()).toEqual(expect.stringContaining(alertButtons))
-  //   expect(wrapper.find('.alert-msg').html()).toEqual(expect.stringContaining(alertMessage))
-  //   expect(wrapper.find('.additionalAlertMessage').html()).toEqual(expect.stringContaining(additionalAlertMessage))
-  //   expect(wrapper.html()).toMatchSnapshot()
-  // })
+    expect(wrapper.find('.k-alert-action').html()).toEqual(expect.stringContaining(extraButtons))
+    expect(wrapper.find('.k-alert-msg').html()).toEqual(expect.stringContaining(alertMessage))
+    expect(wrapper.find('.k-alert-additional-text').html()).toEqual(expect.stringContaining(additionalAlertMessage))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
 })

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -5,7 +5,6 @@ let rendersCorrectVariant = (variant) => {
   it(`Renders ${variant} variant`, () => {
     const wrapper = mount(KAlert, {
       propsData: {
-        'isShowing': true,
         'appearance': `${variant}`,
         'message': `I am ${variant}`
       }
@@ -22,7 +21,6 @@ describe('KAlert', () => {
   it('renders info variant when no appearance prop', () => {
     const wrapper = mount(KAlert, {
       propsData: {
-        'isShowing': true,
         'message': 'I should be info!'
       }
     })
@@ -43,28 +41,24 @@ describe('KAlert', () => {
   it('renders borders on the expected sides', () => {
     const wrapperBorderLeft = mount(KAlert, {
       propsData: {
-        'isShowing': true,
         message: 'Hello world',
         hasLeftBorder: true
       }
     })
     const wrapperBorderRight = mount(KAlert, {
       propsData: {
-        'isShowing': true,
         message: 'Hello world',
         hasRightBorder: true
       }
     })
     const wrapperBorderBottom = mount(KAlert, {
       propsData: {
-        'isShowing': true,
         message: 'Hello world',
         hasBottomBorder: true
       }
     })
     const wrapperBorderTop = mount(KAlert, {
       propsData: {
-        'isShowing': true,
         message: 'Hello world',
         hasTopBorder: true
       }

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -229,7 +229,7 @@ export default {
   font-size: 16px;
   line-height: 16px;
   font-family: inherit;
-  border-radius: 3px;
+  border-radius: 4px;
   overflow-wrap: anywhere;
   margin-bottom: 1rem;
   a {
@@ -314,7 +314,7 @@ export default {
     width: 1220px;
     height: 80px;
     padding: 0;
-    border-radius: 4px;
+    border-radius: 2px;
     background-color: #fff;
     margin-bottom: 1rem;
     color: var(--black-500);

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -100,13 +100,6 @@ export default {
       default: ''
     },
     /**
-     * Set if close button is visible
-     */
-    isDismissible: {
-      type: Boolean,
-      default: false
-    },
-    /**
      * Set whether or not the alert box is shown.
      */
     isShowing: {
@@ -163,6 +156,48 @@ export default {
       default: false
     },
     /**
+     * Set alert box icon size
+     */
+    iconSize: {
+      type: String,
+      default: '32'
+    },
+    /**
+     * Set alert box type of icon
+     */
+    icon: {
+      type: String,
+      default: ''
+    },
+    /**
+     * Set alert box icon color
+     */
+    iconColor: {
+      type: String,
+      default: 'var(--red-500)'
+    },
+    /**
+     * Set whether alert box has icon on left, is of type banner
+     */
+    isLarge: {
+      type: Boolean,
+      default: false
+    },
+    /**
+    * Additional Alert Message
+    */
+    additionalAlertMessage: {
+      type: String,
+      default: ''
+    },
+    /**
+    * Set text for extra buttons
+    */
+    buttonText: {
+      type: String,
+      default: ''
+    },
+    /**
       * Base styling of the button<br>
       * One of ['primary, danger, warning, success ]
       */
@@ -186,6 +221,9 @@ export default {
         ].indexOf(value) !== -1
       }
     },
+    /**
+     * Set whether alert box has icon/button to dismiss or none
+     */
     dismissType: {
       type: String,
       default: 'none',
@@ -197,6 +235,9 @@ export default {
         ].indexOf(value) !== -1
       }
     },
+    /**
+     * Set whether alert box is alert or banner
+     */
     type: {
       type: String,
       default: 'alert',
@@ -206,33 +247,6 @@ export default {
           'banner'
         ].indexOf(value) !== -1
       }
-    },
-    iconSize: {
-      type: String,
-      default: '32'
-    },
-    icon: {
-      type: String,
-      default: ''
-    },
-    iconColor: {
-      type: String,
-      default: 'var(--red-500)'
-    },
-    isLarge: {
-      type: Boolean,
-      default: false
-    },
-    /**
-    * Additional Alert Message
-    */
-    additionalAlertMessage: {
-      type: String,
-      default: ''
-    },
-    buttonText: {
-      type: String,
-      default: ''
     }
   },
   computed: {

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -101,7 +101,7 @@ export default {
      */
     isShowing: {
       type: Boolean,
-      default: false
+      default: true
     },
     /**
      * Set whether or not the alert box shown has button.

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -1,62 +1,60 @@
 <template>
-  <div>
-    <div
-      v-if="isShowing || hasButton || isWideBanner"
-      :class="[
-        appearance,
-        size,
-        {'isBordered':isBordered},
-        {'hasLeftBorder':hasLeftBorder},
-        {'hasRightBorder':hasRightBorder},
-        {'hasTopBorder':hasTopBorder},
-        {'hasBottomBorder':hasBottomBorder},
-        {'isCentered': isCentered},
-        {'isFixed': isFixed},
-        {'hasButton': hasButton},
-        {'isWideBanner': isWideBanner}
-      ]"
-      class="k-alert"
-      role="alert">
-      <button
-        v-if="isDismissible"
-        type="button"
-        aria-label="Close"
-        class="close"
-        @click="dismissAlert()">
-        <KIcon
-          :color="appearance"
-          :class="appearance"
-          icon="close"
-          size="14" />
-      </button>
-      <span
-        v-if="hasRedIcon"
-        class="alert-red">
-        <slot name="alertRedIcon"/>
-      </span>
-      <span
-        v-if="hasIcon"
-        class="alert-icon">
-        <slot name="alertIcon"/>
-      </span>
-      <span
-        v-if="hasEllipse"
+  <div
+    v-if="isShowing || hasButton || isWideBanner"
+    :class="[
+      appearance,
+      size,
+      {'isBordered':isBordered},
+      {'hasLeftBorder':hasLeftBorder},
+      {'hasRightBorder':hasRightBorder},
+      {'hasTopBorder':hasTopBorder},
+      {'hasBottomBorder':hasBottomBorder},
+      {'isCentered': isCentered},
+      {'isFixed': isFixed},
+      {'hasButton': hasButton},
+      {'isWideBanner': isWideBanner}
+    ]"
+    class="k-alert"
+    role="alert">
+    <button
+      v-if="isDismissible"
+      type="button"
+      aria-label="Close"
+      class="close"
+      @click="dismissAlert()">
+      <KIcon
+        :color="appearance"
         :class="appearance"
-        class="dot"/>
-      <span>
-        <slot name="alertMessage">{{ alertMessage }}</slot>
-      </span>
-      <div>
-        <span class="longSpan"><slot name="mainMessageText">{{ mainMessageText }}</slot></span>
-        <span class="smallSpan"><slot name="secMessageText">{{ secMessageText }}</slot></span>
-      </div>
-      <span
-        v-if="hasActionButtons"
-        :class="appearance"
-        class="alert-action">
-        <slot name="actionButtons"/>
-      </span>
+        icon="close"
+        size="14" />
+    </button>
+    <span
+      v-if="hasRedIcon"
+      class="alert-red">
+      <slot name="alertRedIcon"/>
+    </span>
+    <span
+      v-if="hasIcon"
+      class="alert-icon">
+      <slot name="alertIcon"/>
+    </span>
+    <span
+      v-if="hasEllipse"
+      :class="appearance"
+      class="dot"/>
+    <span>
+      <slot name="alertMessage">{{ alertMessage }}</slot>
+    </span>
+    <div v-if="isWideBanner">
+      <span class="longSpan"><slot name="mainMessageText">{{ mainMessageText }}</slot></span>
+      <span class="smallSpan"><slot name="secMessageText">{{ secMessageText }}</slot></span>
     </div>
+    <span
+      v-if="hasActionButtons"
+      :class="appearance"
+      class="alert-action">
+      <slot name="actionButtons"/>
+    </span>
   </div>
 </template>
 

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -28,10 +28,18 @@
         icon="close"
         size="14" />
     </button>
-    <span
+    <!-- <span
       v-if="hasIcon"
       class="alert-icon">
       <slot name="alertIcon"/>
+    </span> -->
+    <span
+      v-if="hasIcon">
+      <KIcon
+        class="alert-icon"
+        color="var(--red-500)"
+        icon="notificationInbox"
+        size="32" />
     </span>
     <span
       v-if="hasEllipse"
@@ -196,13 +204,18 @@ export default {
           'small'
         ].indexOf(value) !== -1
       }
+    },
+
+    hasIcon: {
+      type: Boolean,
+      default: false
     }
   },
 
   computed: {
-    hasIcon () {
-      return !!this.$slots.alertIcon
-    },
+    // hasIcon () {
+    //   return !!this.$slots.alertIcon
+    // },
     hasActionButtons () {
       return !!this.$slots.actionButtons
     }
@@ -223,8 +236,8 @@ export default {
   position: relative;
   display: flex;
   align-items: center;
-  width: 830px;
-  font-style: normal;
+  // width: 830px;
+  // font-style: normal;
   font-weight: 300;
   font-size: 16px;
   line-height: 16px;
@@ -314,17 +327,17 @@ export default {
     height: 80px;
     // padding: 0;
     border-radius: 2px;
-    background-color: #fff;
+    background-color: var(--white);
     margin-bottom: 1rem;
     color: var(--black-500);
   }
 
   &.hasButton {
-    width: 763px;
-    height: 56px;
+    // width: 763px;
+    // height: 56px;
     // padding: 0;
     border-radius: 4px;
-    background-color: #fff;
+    background-color: var(--white);
     margin-bottom: 1rem;
     color: var(--black-500);
     & > .alert-ellipse {
@@ -375,8 +388,8 @@ button.close > svg {
 
 .alert-icon {
   padding: 23px 0 25px 21px;
-  width: 32px;
-  height: 32px;
+  // width: 32px;
+  // height: 32px;
   margin-right: -8px
 }
 

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -34,7 +34,7 @@
       class="k-alert-action ml-3">
       <!-- @slot Use this slot to pass extra buttons other than Dismiss  -->
       <slot
-        v-if="hasActionButtons && (dismissType === 'button' || dismissType ==='none')"
+        v-if="hasActionButtons"
         name="actionButtons">
         <KButton
           size="small"
@@ -61,7 +61,7 @@
     </span>
     <div class="k-alert-msg-text">
       <span
-        :class="type === 'banner' && (size === 'large') ? 'k-alert-text' : ''"
+        :class="type === 'banner' && size === 'large' ? 'k-alert-text' : ''"
         class="k-alert-msg">
         <!-- @slot Use this slot to pass default alert message  -->
         <slot name="alertMessage">{{ alertMessage }}

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -12,8 +12,7 @@
       {'hasTopBorder':hasTopBorder},
       {'hasBottomBorder':hasBottomBorder},
       {'isCentered': isCentered},
-      {'isFixed': isFixed},
-      {'isLarge': isLarge}
+      {'isFixed': isFixed}
     ]"
     class="k-alert"
     role="alert"
@@ -35,14 +34,12 @@
       class="k-alert-action ml-3">
       <!-- @slot Use this slot to pass extra buttons other than Dismiss  -->
       <slot
-        v-if="hasExtraButtons && dismissType === 'button'"
-        name="extraButtons">
+        v-if="hasActionButtons && (dismissType === 'button' || dismissType ==='none')"
+        name="actionButtons">
         <KButton
           size="small"
           @click="proceed"
-          @keyup.enter="proceed">
-          {{ buttonText }}
-        </KButton>
+          @keyup.enter="proceed"/>
       </slot>
       <KButton
         v-if="dismissType === 'button'"
@@ -52,10 +49,10 @@
       </KButton>
     </div>
     <span
-      v-if="type === 'banner' && !isLarge"
+      v-if="(type === 'banner' && (size !== 'large'))"
       :class="appearance"
       class="k-alert-ellipse"/>
-    <span v-if="isLarge">
+    <span v-if="size === 'large'">
       <KIcon
         :size="iconSize"
         :color="iconColor"
@@ -64,17 +61,17 @@
     </span>
     <div class="k-alert-msg-text">
       <span
-        :class="type === 'banner' && isLarge ? 'k-alert-text' : ''"
+        :class="type === 'banner' && (size === 'large') ? 'k-alert-text' : ''"
         class="k-alert-msg">
         <!-- @slot Use this slot to pass default alert message  -->
         <slot name="alertMessage">{{ alertMessage }}
         </slot>
       </span>
       <span
-        v-if="type === 'banner' && isLarge && hasAdditionalTextMsg"
+        v-if="type === 'banner' && (size === 'large') && hasAlertDescription"
         class="k-alert-additional-text">
         <!-- @slot Use this slot to pass additional alert message for wide alert  -->
-        <slot name="additionalAlertMessage">{{ additionalAlertMessage }}
+        <slot name="description">{{ description }}
         </slot>
       </span>
     </div>
@@ -95,13 +92,6 @@ export default {
   name: 'KAlert',
   components: { KIcon, KButton },
   props: {
-    /**
-     * Title string if slot not used, also used for aria-label
-     */
-    title: {
-      type: String,
-      default: ''
-    },
     /**
     * Message to show in alert
     */
@@ -187,23 +177,9 @@ export default {
       default: 'var(--red-500)'
     },
     /**
-     * Set large alert box with icon/ellipse on left, alertMessage(default/additional) and buttons on right based on other passed props
-     */
-    isLarge: {
-      type: Boolean,
-      default: false
-    },
-    /**
     * Additional alert message
     */
-    additionalAlertMessage: {
-      type: String,
-      default: ''
-    },
-    /**
-    * Set text for extra buttons
-    */
-    buttonText: {
+    description: {
       type: String,
       default: ''
     },
@@ -227,7 +203,8 @@ export default {
       validator: (value) => {
         return [
           '',
-          'small'
+          'small',
+          'large'
         ].indexOf(value) !== -1
       }
     },
@@ -261,10 +238,10 @@ export default {
   },
 
   computed: {
-    hasExtraButtons () {
-      return !!this.$slots.extraButtons
+    hasActionButtons () {
+      return !!this.$slots.actionButtons
     },
-    hasAdditionalTextMsg () {
+    hasAlertDescription () {
       return !!this.$slots.alertMessage
     }
   },
@@ -344,7 +321,7 @@ export default {
     font-size: var(--type-sm, type(sm));
     padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
   }
-  &.isLarge {
+  &.large {
     min-height: 80px;
   }
   // Appearances

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -258,20 +258,7 @@ export default {
         ].indexOf(value) !== -1
       }
     }
-    /**
-     * Test mode - for testing only, strips out generated ids
-     */
-    // testMode: {
-    //   type: Boolean,
-    //   default: false
-    // }
   },
-
-  // data () {
-  //   return {
-  //     titleId: !this.testMode ? uuid.v1() : 'test-title-id-1234'
-  //   }
-  // },
 
   computed: {
     hasExtraButtons () {
@@ -299,7 +286,6 @@ export default {
   position: relative;
   display: flex;
   align-items: center;
-  // padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
   padding: 14px;
   font-family: inherit;
   font-size: 1rem;
@@ -411,7 +397,7 @@ button.close > svg {
   width: 6px;
   border-radius: 50%;
   display: inline-block;
-  margin: 24px 8px 26px 24px;
+  margin: 24px 8px 26px 22px;
 
   &.info {
     background-color: var(--blue-400);
@@ -431,26 +417,17 @@ button.close > svg {
   padding: 23px 5px 25px 21px;
 }
 
-.k-alert.banner.none > div .k-alert-msg {
-  // padding: 12px 16px;
-  font-weight: 400;
-  font-size: 15px;
-  line-height: 20px;
-  padding: 2px 0;
-}
-
 .k-alert > div .k-alert-msg {
-font-weight: 400;
-font-size: 16px;
-line-height: 16px;
-padding: 2px 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 16px;
+  padding: 2px 0;
+  margin-left: 2px;
 }
 
-.k-alert.banner.button > div .k-alert-msg {
-  font-weight: 400;
-  font-size: 15px;
-  line-height: 20px;
-  padding: 2px 0;
+.toaster-item .k-alert .k-alert-msg {
+  padding: 0;
+  margin: 0;
 }
 
 .k-alert-action {

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -476,7 +476,7 @@ button.close > svg {
   }
 }
 
-.k-alert-additional-text {
+.k-alert-description-text {
   display: block;
   padding-top: 4px;
   font-weight: 400;

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -266,7 +266,7 @@ export default {
   padding: 14px;
   font-family: inherit;
   font-size: 1rem;
-  border-radius: 3px;
+  border-radius: 4px;
   overflow-wrap: anywhere;
   a {
     text-decoration: underline;
@@ -275,7 +275,7 @@ export default {
   .close {
     position: absolute;
     top: 0;
-    right: 18px;
+    right: 8px;
     bottom: 0;
     border: 0;
     background-color: transparent;
@@ -323,6 +323,7 @@ export default {
   }
   &.large {
     min-height: 80px;
+    border-radius: 2px;
   }
   // Appearances
   &.info {
@@ -350,13 +351,12 @@ export default {
 div.k-alert.banner {
   background-color: var(--white);
   color: var(--grey-600);
-  position: relative;
   padding: 0;
 }
 
 button.close > svg {
   &.info {
-    stroke: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
+    stroke: var(--KAlertInfoColor, var(--blue-500, color(blue-500)));
   }
   &.success {
     stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
@@ -396,8 +396,8 @@ button.close > svg {
 
 .k-alert > div .k-alert-msg {
   font-weight: 400;
-  font-size: 16px;
-  line-height: 16px;
+  font-size: var(--type-md, type(md));
+  line-height: var(--type-md, type(md));
   padding: 2px 0;
   margin-left: 2px;
 }
@@ -417,8 +417,6 @@ button.close > svg {
     font-weight: 400;
     font-size: 13px;
     line-height: 13px;
-    position: relative;
-    cursor: pointer;
   }
 
   &.info button.primary {
@@ -429,9 +427,9 @@ button.close > svg {
   }
   &.info button.outline {
     color: var(--blue-500);
-    border: 1px solid var(--blue-200);
+    border: 1px solid var(--blue-400);
     --KButtonOutlineBorder: var(--blue-500);
-    --KButtonOutlineHoverBorder: var(--blue-500);
+    --KButtonOutlineHoverBorder: var(--blue-600);
      --KButtonOutlineActive: var(--blue-100);
     --KButtonOutlineActiveBorder: var(--blue-500);
   }
@@ -460,7 +458,7 @@ button.close > svg {
     border: 1px solid var(--green-400);
     --KButtonOutlineBorder: var(--green-600);
     --KButtonOutlineHoverBorder: var(--green-600);
-     --KButtonOutlineActive: var(--green-100);
+    --KButtonOutlineActive: var(--green-100);
     --KButtonOutlineActiveBorder: var(--green-600);
   }
   &.danger button.primary {
@@ -490,7 +488,7 @@ button.close > svg {
 
 .k-alert.banner.button > div .k-alert-msg.k-alert-text {
   padding-left: 0;
-  font-size: 16px;
+  font-size: var(--type-md, type(md));
   line-height: 24px;
 }
 

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -26,13 +26,8 @@
         :color="appearance"
         :class="appearance"
         icon="close"
-        size="14" />
+        size="20" />
     </button>
-    <span
-      v-if="hasRedIcon"
-      class="alert-red">
-      <slot name="alertRedIcon"/>
-    </span>
     <span
       v-if="hasIcon"
       class="alert-icon">
@@ -41,26 +36,26 @@
     <span
       v-if="hasEllipse"
       :class="appearance"
-      class="dot"/>
-    <span>
+      class="ellipse"/>
+    <span class="alert-msg">
       <slot name="alertMessage">{{ alertMessage }}</slot>
     </span>
     <div v-if="isWideBanner">
-      <span class="longSpan"><slot name="mainMessageText">{{ mainMessageText }}</slot></span>
-      <span class="smallSpan"><slot name="secMessageText">{{ secMessageText }}</slot></span>
+      <span class="mainMessageText"><slot name="mainMessageText">{{ mainMessageText }}</slot></span>
+      <span class="secMessageText"><slot name="secMessageText">{{ secMessageText }}</slot></span>
     </div>
     <span
       v-if="hasActionButtons"
       :class="appearance"
       class="alert-action">
-      <slot name="actionButtons"/>
+      <slot
+        name="actionButtons"/>
     </span>
   </div>
 </template>
 
 <script>
 import KIcon from '@kongponents/kicon/KIcon.vue'
-import KButton from '@kongponents/kbutton/KButton.vue'
 
 export const appearances = {
   info: 'info',
@@ -71,7 +66,7 @@ export const appearances = {
 
 export default {
   name: 'KAlert',
-  components: { KIcon, KButton },
+  components: { KIcon },
   props: {
     /**
     * Message to show in alert
@@ -205,9 +200,6 @@ export default {
   },
 
   computed: {
-    hasRedIcon () {
-      return !!this.$slots.alertRedIcon
-    },
     hasIcon () {
       return !!this.$slots.alertIcon
     },
@@ -231,30 +223,19 @@ export default {
   position: relative;
   display: flex;
   align-items: center;
-  // padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
   width: 806px;
   padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
   font-style: normal;
   font-weight: 300;
   font-size: 16px;
   line-height: 16px;
-
   font-family: inherit;
-  // font-size: 1rem;
   border-radius: 3px;
   overflow-wrap: anywhere;
+  margin-bottom: 1rem;
   a {
     text-decoration: underline;
     color: var(--blue-600, color(blue-600));
-  }
-
-  .alert-icon {
-    margin-right: var(--spacing-xs, spacing(xs));
-    max-height: 1rem;
-    svg,
-    img {
-      max-height: 1rem;
-    }
   }
 
   .close {
@@ -329,22 +310,70 @@ export default {
     border-color: var(--KAlertWarningBorder, var(--yellow-200, color(yellow-200)));
     background-color: var(--KAlertWarningBackground, var(--yellow-100, color(yellow-100)));
   }
+
+  &.isWideBanner {
+    width: 1220px;
+    height: 80px;
+    padding: 0;
+    border-radius: 4px;
+    background-color: #fff;
+    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+    margin-bottom: 1rem;
+    color: var(--black-500);
+  }
+
+  &.hasButton {
+    width: 763px;
+    height: 56px;
+    padding: 0;
+    border-radius: 4px;
+    background-color: white;
+    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+    margin-bottom: 1rem;
+    color: var(--black-500);
+
+    & > .ellipse {
+      &.info {
+        background-color: var(--blue-500);
+      }
+
+      &.success {
+        background-color: var(--green-400);
+      }
+
+      &.warning {
+        background-color: var(--yellow-400);
+      }
+
+      &.danger {
+        background-color: var(--red-400);
+      }
+    }
+  }
+    & .alert-msg {
+      padding: 8px 0;
+      font-weight: 500;
+      font-size: 15px;
+      line-height: 20px;
+    }
 }
 
-button.close > svg.info {
-  stroke: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
-}
+button.close > svg {
+  &.info {
+    stroke: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
+  }
 
-button.close > svg.success {
-  stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
-}
+  &.success {
+    stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
+  }
 
-button.close > svg.danger {
-  stroke: var(--KAlertDangerColor, var(--red-700, color(red-700)));
-}
+  &.danger {
+    stroke: var(--KAlertDangerColor, var(--red-700, color(red-700)));
+  }
 
-button.close > svg.warning {
-  stroke: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
+  &.warning {
+    stroke: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
+  }
 }
 
 .button-right {
@@ -355,143 +384,114 @@ button.close > svg.warning {
   cursor: pointer;
 }
 
-.alert-red {
-  padding: 23px 19.93px 25px 21px;
+.alert-icon {
+  padding: 23px 20px 25px 21px;
   width: 32px;
   height: 32px;
 }
 
-.dot {
+.ellipse {
   height: 6px;
   width: 6px;
-  background-color: #d44324;
+  background-color: var(--red-500);
   border-radius: 50%;
   display: inline-block;
-  margin: 24px 26px 26px;
-}
-
-.k-alert {
-  margin-bottom: 1rem;
-}
-
-.k-alert.hasButton {
-  width: 763px;
-  height: 56px;
-  padding: 0;
-  border-radius: 4px;
-  background-color: white;
-  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
-  margin-bottom: 1rem;
-  color: var(--black-500);
-}
-
-// .k-alert.hasButton > button.info {
-//   color: var(--blue-500);
-//   background-color: var(--blue-100);
-// }
-
-// .k-alert.hasButton > button.success {
-//   color: var(--green-600);
-//   background-color: var(--green-100);
-// }
-
-// .k-alert.hasButton > button.warning {
-//   color: var(--yellow-500);
-//   background-color: var(--yellow-100);
-// }
-
-// .k-alert.hasButton > button.danger {
-//   color: var(--red-700);
-//   background-color: var(--red-100);
-// }
-
-.k-alert.hasButton > .dot.info {
-  background-color: var(--blue-500);
-}
-
-.k-alert.hasButton > .dot.success {
-  background-color: var(--green-400);
-}
-
-.k-alert.hasButton > .dot.warning {
-  background-color: var(--yellow-400);
-}
-
-.k-alert.hasButton > .dot.danger {
-  background-color: var(--red-400);
+  margin: 24px 24px 26px;
 }
 
 .alert-action {
   display: inline-flex;
   margin-left: auto;
-  margin-right: 14px;
-}
 
-.alert-action button {
-  height: 30px;
-  margin-right: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 13px;
-  position: relative;
-  font-family: var(--font-family-sans, font(sans));
-  border: 1px solid transparent;
-  cursor: pointer;
-}
+  &.info button {
+    color: var(--blue-500);
+    background-color: var(--blue-100);
+    border: var(--blue-100);
+  }
 
-.alert-action.info button {
-  color: var(--blue-500);
-  background-color: var(--blue-100);
-  border: var(--blue-100);
-}
+  &.success button {
+    color: var(--green-600);
+    background-color: var(--green-100);
+    border: var(--green-100);
+  }
 
-.alert-action.success button {
-  color: var(--green-600);
-  background-color: var(--green-100);
-  border: var(--green-100);
-}
+  &.warning button {
+    color: var(--yellow-500);
+    background-color: var(--yellow-100);
+    border: var(--yellow-100);
+    &:hover:not(:disabled) {
+      background-color: var(--yellow-400);
+      border-color: var(--yellow-400);
+    }
+  }
 
-.alert-action.warning button {
-  color: var(--yellow-500);
-  background-color: var(--yellow-100);
-  border: var(--yellow-100);
-}
+  &.danger button {
+    color: var(--red-700);
+    background-color: var(--red-100);
+    border: var(--red-100);
+  }
 
-.alert-action.danger button {
-  color: var(--red-700);
-  background-color: var(--red-100);
-  border: var(--red-100);
-}
-
-.k-alert.isWideBanner {
-  width: 1220px;
-  height: 80px;
-  padding: 0;
-  border-radius: 4px;
-  // background-color: white;
-  background-color: white;
-  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
-  margin-bottom: 1rem;
-  color: var(--black-500);
-}
-
-.longSpan {
-  display: block;
-    font-family: Maison Neue;
+  & button {
+    height: 30px;
+    margin-right: 13px;
     font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 13px;
+    position: relative;
+    cursor: pointer;
+  }
+}
+
+.alert-action.info button.outline {
+  color: var(--KButtonOutlineColor, var(--blue-500));
+  border: 1px solid var(--blue-500);
+  background-color: var(--white, #ffffff);
+}
+
+.alert-action.warning button.outline {
+  color: var(--KButtonOutlineColor, var(--yellow-500));
+  border: 1px solid var(--yellow-500);
+  background-color: var(--white, #ffffff);
+  --KButtonOutlineBorder: var(--yellow-500);
+}
+
+.alert-action.success button.outline {
+  color: var(--KButtonOutlineColor, var(--green-600));
+  border: 1px solid var(--green-600);
+  background-color: var(--white, #ffffff);
+  --KButtonOutlineBorder: var(--green-600);
+}
+.alert-action.danger button.outline {
+  color: var(--KButtonOutlineColor, var(--red-700));
+  border: 1px solid var(--red-700);
+  background-color: var(--white, #ffffff);
+  --KButtonOutlineBorder: var(--red-700);
+}
+
+.k-alert > .close + .alert-msg {
     font-weight: 400;
     font-size: 16px;
-    line-height: 24px;
+    line-height: 16px;
 }
 
-.smallSpan {
-    display: block;
-    font-family: Maison Neue;
-    font-style: normal;
-    font-weight: 400;
-    font-size: 13px;
-    line-height: 24px;
-    color: #6F7787;
+.mainMessageText {
+  display: block;
+  padding-top: 6px;
+  padding-bottom: 2px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.secMessageText {
+  display: block;
+  padding-top: 2px;
+  padding-bottom: 6px;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 24px;
+  color: #6F7787;
 }
 
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -1,44 +1,87 @@
 <template>
-  <div
-    v-if="isShowing"
-    :class="[
-      appearance,
-      size,
-      {'isBordered':isBordered},
-      {'hasLeftBorder':hasLeftBorder},
-      {'hasRightBorder':hasRightBorder},
-      {'hasTopBorder':hasTopBorder},
-      {'hasBottomBorder':hasBottomBorder},
-      {'isCentered': isCentered},
-      {'isFixed': isFixed}
-    ]"
-    class="k-alert"
-    role="alert">
-    <button
-      v-if="isDismissible"
-      type="button"
-      aria-label="Close"
-      class="close"
-      @click="dismissAlert()">
-      <KIcon
-        icon="close"
-        color="#000"
-        size="12"
-        view-box="0 0 12 12" />
-    </button>
-    <span
-      v-if="hasIcon"
-      class="alert-icon">
-      <slot name="alertIcon" />
-    </span>
-    <span>
-      <slot name="alertMessage">{{ alertMessage }}</slot>
-    </span>
+  <div>
+    <div
+      v-if="isShowing && !hasButton"
+      :class="[
+        appearance,
+        size,
+        {'isBordered':isBordered},
+        {'hasLeftBorder':hasLeftBorder},
+        {'hasRightBorder':hasRightBorder},
+        {'hasTopBorder':hasTopBorder},
+        {'hasBottomBorder':hasBottomBorder},
+        {'isCentered': isCentered},
+        {'isFixed': isFixed}
+      ]"
+      class="k-alert"
+      role="alert">
+      <button
+        v-if="isDismissible"
+        type="button"
+        aria-label="Close"
+        class="close"
+        @click="dismissAlert()">
+        <KIcon
+          :color="appearance"
+          :class="appearance"
+          icon="close"
+          size="14" />
+      </button>
+      <span
+        v-if="hasIcon"
+        class="alert-icon">
+        <slot name="alertIcon" />
+      </span>
+      <span>
+        <slot name="alertMessage">{{ alertMessage }}</slot>
+      </span>
+    </div>
+    <div
+      v-if="hasButton"
+      :class="[
+        appearance,
+        size,
+        {'isBordered':isBordered},
+        {'hasLeftBorder':hasLeftBorder},
+        {'hasRightBorder':hasRightBorder},
+        {'hasTopBorder':hasTopBorder},
+        {'hasBottomBorder':hasBottomBorder},
+        {'isCentered': isCentered},
+        {'isFixed': isFixed}
+      ]"
+      class="k-alert has-button"
+      role="alert">
+
+      <span
+        v-if="hasRedIcon"
+        class="alert-red">
+        <slot name="alertRedIcon"/>
+      </span>
+      <span
+        v-if="!hasRedIcon"
+        :class="appearance"
+        class="dot"/>
+      <span
+        v-if="hasIcon"
+        class="alert-icon">
+        <slot name="alertIcon" />
+      </span>
+      <span>
+        <slot name="alertMessage">{{ alertMessage }}</slot>
+      </span>
+      <span
+        v-if="hasActionButtons"
+        :class="appearance"
+        class="alert-action">
+        <slot name="actionButtons"/>
+      </span>
+    </div>
   </div>
 </template>
 
 <script>
 import KIcon from '@kongponents/kicon/KIcon.vue'
+import KButton from '@kongponents/kbutton/KButton.vue'
 
 export const appearances = {
   info: 'info',
@@ -49,7 +92,7 @@ export const appearances = {
 
 export default {
   name: 'KAlert',
-  components: { KIcon },
+  components: { KIcon, KButton },
   props: {
     /**
     * Message to show in alert
@@ -71,6 +114,13 @@ export default {
     isShowing: {
       type: Boolean,
       default: true
+    },
+    /**
+     * Set whether or not the alert box shown has button.
+     */
+    hasButton: {
+      type: Boolean,
+      default: false
     },
     /**
      * Fixes alert to top
@@ -148,8 +198,14 @@ export default {
   },
 
   computed: {
+    hasRedIcon () {
+      return !!this.$slots.alertRedIcon
+    },
     hasIcon () {
       return !!this.$slots.alertIcon
+    },
+    hasActionButtons () {
+      return !!this.$slots.actionButtons
     }
   },
 
@@ -168,9 +224,16 @@ export default {
   position: relative;
   display: flex;
   align-items: center;
+  // padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
+  width: 806px;
   padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
+  font-style: normal;
+  font-weight: 300;
+  font-size: 16px;
+  line-height: 16px;
+
   font-family: inherit;
-  font-size: 1rem;
+  // font-size: 1rem;
   border-radius: 3px;
   overflow-wrap: anywhere;
   a {
@@ -190,7 +253,7 @@ export default {
   .close {
     position: absolute;
     top: 0;
-    right: 18px;
+    right: 14.4px;
     bottom: 0;
     border: 0;
     background-color: transparent;
@@ -240,12 +303,12 @@ export default {
 
   // Appearances
   &.info {
-    color: var(--KAlertInfoColor, var(--blue-700, color(blue-700)));
+    color: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
     border-color: var(--KAlertInfoBorder, var(--blue-300, color(blue-300)));
     background-color: var(--KAlertInfoBackground, var(--blue-200, color(blue-200)));
   }
   &.success {
-    color: var(--KAlertSuccessColor, var(--green-500, color(green-500)));
+    color: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
     border-color: var(--KAlertSuccessBorder, var(--green-200, color(green-200)));
     background-color: var(--KAlertSuccessBackground, var(--green-100, color(green-100)));
   }
@@ -255,9 +318,138 @@ export default {
     background-color: var(--KAlertDangerBackground, var(--red-200, color(red-200)));
   }
   &.warning {
-    color: var(--KAlertWarningColor, var(--yellow-400, color(yellow-400)));
+    color: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
     border-color: var(--KAlertWarningBorder, var(--yellow-200, color(yellow-200)));
     background-color: var(--KAlertWarningBackground, var(--yellow-100, color(yellow-100)));
   }
 }
+
+button.close > svg.info {
+  stroke: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
+}
+
+button.close > svg.success {
+  stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
+}
+
+button.close > svg.danger {
+  stroke: var(--KAlertDangerColor, var(--red-700, color(red-700)));
+}
+
+button.close > svg.warning {
+  stroke: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
+}
+
+.button-right {
+  position: absolute;
+  right: 14.4px;
+  border: 0;
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+
+// .alert-red {
+//   padding: 23px 19.93px 25px 21px;
+//   width: 32px;
+//   height: 32px;
+// }
+
+.dot {
+  height: 6px;
+  width: 6px;
+  background-color: #d44324;
+  border-radius: 50%;
+  display: inline-block;
+  margin: 24px 26px 26px;
+}
+
+.k-alert.has-button {
+  width: 763px;
+  height: 56px;
+  padding: 0;
+  border-radius: 4px;
+  // background-color: white;
+  background-color: ghostwhite;
+  margin-bottom: 1rem;
+  color: var(--black-500);
+}
+
+// .k-alert.has-button > button.info {
+//   color: var(--blue-500);
+//   background-color: var(--blue-100);
+// }
+
+// .k-alert.has-button > button.success {
+//   color: var(--green-600);
+//   background-color: var(--green-100);
+// }
+
+// .k-alert.has-button > button.warning {
+//   color: var(--yellow-500);
+//   background-color: var(--yellow-100);
+// }
+
+// .k-alert.has-button > button.danger {
+//   color: var(--red-700);
+//   background-color: var(--red-100);
+// }
+
+.k-alert.has-button > .dot.info {
+  background-color: var(--blue-500);
+}
+
+.k-alert.has-button > .dot.success {
+  background-color: var(--green-400);
+}
+
+.k-alert.has-button > .dot.warning {
+  background-color: var(--yellow-400);
+}
+
+.k-alert.has-button > .dot.danger {
+  background-color: var(--red-400);
+}
+
+.alert-action {
+  display: inline-flex;
+  margin-left: auto;
+  margin-right: 14px;
+}
+
+.alert-action button {
+  height: 30px;
+  margin-right: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 13px;
+  position: relative;
+  font-family: var(--font-family-sans, font(sans));
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.alert-action.info button {
+  color: var(--blue-500);
+  background-color: var(--blue-100);
+  border: var(--blue-100);
+}
+
+.alert-action.success button {
+  color: var(--green-600);
+  background-color: var(--green-100);
+  border: var(--green-100);
+}
+
+.alert-action.warning button {
+  color: var(--yellow-500);
+  background-color: var(--yellow-100);
+  border: var(--yellow-100);
+}
+
+.alert-action.danger button {
+  color: var(--red-700);
+  background-color: var(--red-100);
+  border: var(--red-100);
+}
+
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -26,7 +26,7 @@
         :color="appearance"
         :class="appearance"
         icon="close"
-        size="16" />
+        size="14" />
     </button>
     <span
       v-if="hasIcon"
@@ -223,8 +223,7 @@ export default {
   position: relative;
   display: flex;
   align-items: center;
-  width: 806px;
-  padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
+  width: 830px;
   font-style: normal;
   font-weight: 300;
   font-size: 16px;
@@ -286,7 +285,7 @@ export default {
   }
   &.small {
     font-size: var(--type-sm, type(sm));
-    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
+    // padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
   }
 
   // Appearances
@@ -329,27 +328,24 @@ export default {
     background-color: white;
     margin-bottom: 1rem;
     color: var(--black-500);
-
     & > .alert-ellipse {
       &.info {
         background-color: var(--blue-400);
       }
-
       &.success {
         background-color: var(--green-400);
       }
-
       &.warning {
         background-color: var(--yellow-400);
       }
-
       &.danger {
         background-color: var(--red-400);
       }
     }
   }
     & .alert-msg {
-      padding: 8px 0;
+      // padding: 8px 0;
+        padding: 12px 16px;
       font-weight: 400;
       font-size: 15px;
       line-height: 20px;
@@ -360,15 +356,12 @@ button.close > svg {
   &.info {
     stroke: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
   }
-
   &.success {
     stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
   }
-
   &.danger {
     stroke: var(--KAlertDangerColor, var(--red-700, color(red-700)));
   }
-
   &.warning {
     stroke: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
   }
@@ -394,75 +387,12 @@ button.close > svg {
   background-color: var(--red-500);
   border-radius: 50%;
   display: inline-block;
-  margin: 24px 24px 26px;
+  margin: 24px 8px 24px 26px;
 }
 
 .alert-action {
   display: inline-flex;
   margin-left: auto;
-
-  &.info button.primary {
-    color: var(--blue-500);
-    background-color: var(--blue-100);
-    --KButtonPrimaryBase: var(--blue-300);
-    --KButtonPrimaryHover: var(--blue-300);
-  }
-
-  &.info button.outline {
-    color: var(--blue-400);
-    border: 1px solid var(--blue-400);
-    --KButtonOutlineBorder: var(--blue-300);
-    --KButtonOutlineHoverBorder: var(--blue-300);
-    --KButtonOutlineActiveBorder: var(--blue-300);
-  }
-
-  &.warning button.primary {
-    color: var(--yellow-500);
-    background-color: var(--yellow-100);
-    --KButtonPrimaryBase: var(--yellow-300);
-    --KButtonPrimaryHover: var(--yellow-300);
-  }
-
-  &.warning button.outline {
-    color: var(--yellow-400);
-    border: 1px solid var(--yellow-400);
-    --KButtonOutlineBorder: var(--yellow-300);
-    --KButtonOutlineHoverBorder: var(--yellow-300);
-    --KButtonOutlineActiveBorder: var(--yellow-300);
-  }
-
-  &.success button.primary {
-    color: var(--green-600);
-    background-color: var(--green-100);
-    border: var(--green-100);
-    --KButtonPrimaryBase: var(--green-300);
-    --KButtonPrimaryHover: var(--green-300);
-  }
-
-  &.success button.outline {
-    color: var(--green-500);
-    border: 1px solid var(--green-500);
-    --KButtonOutlineBorder: var(--green-400);
-    --KButtonOutlineHoverBorder: var(--green-400);
-    --KButtonOutlineActiveBorder: var(--green-400);
-  }
-
-  &.danger button.primary {
-    color: var(--red-700);
-    background-color: var(--red-100);
-    border: var(--red-100);
-    --KButtonPrimaryBase: var(--red-300);
-    --KButtonPrimaryHover: var(--red-300);
-  }
-
-  &.danger button.outline {
-    color: var(--red-600);
-    border: 1px solid var(--red-600);
-    --KButtonOutlineBorder: var(--red-500);
-    --KButtonOutlineHoverBorder: var(--red-500);
-    --KButtonOutlineActiveBorder: var(--red-500);
-  }
-
   & button {
     height: 30px;
     margin-right: 13px;
@@ -479,6 +409,7 @@ button.close > svg {
   font-weight: 400;
   font-size: 16px;
   line-height: 16px;
+  padding: 12px 16px;
 }
 
 .mainMessageText {

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -65,7 +65,7 @@
     <div class="k-alert-msg-text">
       <span
         :class="type === 'banner' && isLarge ? 'k-alert-text' : ''"
-        class="alert-msg">
+        class="k-alert-msg">
         <!-- @slot Use this slot to pass default alert message  -->
         <slot name="alertMessage">{{ alertMessage }}
         </slot>
@@ -431,7 +431,7 @@ button.close > svg {
   padding: 23px 5px 25px 21px;
 }
 
-.k-alert.banner.none > div .alert-msg {
+.k-alert.banner.none > div .k-alert-msg {
   // padding: 12px 16px;
   font-weight: 400;
   font-size: 15px;
@@ -439,14 +439,14 @@ button.close > svg {
   padding: 2px 0;
 }
 
-.k-alert > div .alert-msg {
+.k-alert > div .k-alert-msg {
 font-weight: 400;
 font-size: 16px;
 line-height: 16px;
 padding: 2px 0;
 }
 
-.k-alert.banner.button > div .alert-msg {
+.k-alert.banner.button > div .k-alert-msg {
   font-weight: 400;
   font-size: 15px;
   line-height: 20px;
@@ -534,7 +534,7 @@ padding: 2px 0;
   color: var(--grey-500);
 }
 
-.k-alert.banner.button > div .alert-msg.k-alert-text {
+.k-alert.banner.button > div .k-alert-msg.k-alert-text {
   padding-left: 0;
   font-size: 16px;
   line-height: 24px;

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -32,7 +32,8 @@
     </button>
     <div
       :class="appearance"
-      class="alert-action ml-3">
+      class="k-alert-action ml-3">
+      <!-- @slot Use this slot to pass extra buttons other than Dismiss  -->
       <slot
         v-if="hasExtraButtons && dismissType === 'button'"
         name="extraButtons">
@@ -53,24 +54,26 @@
     <span
       v-if="type === 'banner' && !isLarge"
       :class="appearance"
-      class="alert-ellipse"/>
+      class="k-alert-ellipse"/>
     <span v-if="isLarge">
       <KIcon
         :size="iconSize"
         :color="iconColor"
         :icon="icon ? icon : 'notificationInbox'"
-        class="alert-icon" />
+        class="k-alert-icon" />
     </span>
-    <div class="alert-msg-text">
+    <div class="k-alert-msg-text">
       <span
-        :class="type === 'banner' && isLarge ? 'mainMessageText' : ''"
+        :class="type === 'banner' && isLarge ? 'k-alert-text' : ''"
         class="alert-msg">
+        <!-- @slot Use this slot to pass default alert message  -->
         <slot name="alertMessage">{{ alertMessage }}
         </slot>
       </span>
       <span
-        v-if="type === 'banner' && isLarge"
-        class="additionalAlertMessage">
+        v-if="type === 'banner' && isLarge && hasAdditionalTextMsg"
+        class="k-alert-additional-text">
+        <!-- @slot Use this slot to pass additional alert message for wide alert  -->
         <slot name="additionalAlertMessage">{{ additionalAlertMessage }}
         </slot>
       </span>
@@ -92,6 +95,13 @@ export default {
   name: 'KAlert',
   components: { KIcon, KButton },
   props: {
+    /**
+     * Title string if slot not used, also used for aria-label
+     */
+    title: {
+      type: String,
+      default: ''
+    },
     /**
     * Message to show in alert
     */
@@ -177,14 +187,14 @@ export default {
       default: 'var(--red-500)'
     },
     /**
-     * Set whether alert box has icon on left, is of type banner
+     * Set large alert box with icon/ellipse on left, alertMessage(default/additional) and buttons on right based on other passed props
      */
     isLarge: {
       type: Boolean,
       default: false
     },
     /**
-    * Additional Alert Message
+    * Additional alert message
     */
     additionalAlertMessage: {
       type: String,
@@ -248,10 +258,27 @@ export default {
         ].indexOf(value) !== -1
       }
     }
+    /**
+     * Test mode - for testing only, strips out generated ids
+     */
+    // testMode: {
+    //   type: Boolean,
+    //   default: false
+    // }
   },
+
+  // data () {
+  //   return {
+  //     titleId: !this.testMode ? uuid.v1() : 'test-title-id-1234'
+  //   }
+  // },
+
   computed: {
     hasExtraButtons () {
       return !!this.$slots.extraButtons
+    },
+    hasAdditionalTextMsg () {
+      return !!this.$slots.alertMessage
     }
   },
 
@@ -358,8 +385,8 @@ export default {
 }
 
 div.k-alert.banner {
-  background-color: white;
-  color: black;
+  background-color: var(--white);
+  color: var(--grey-600);
   position: relative;
   padding: 0;
 }
@@ -379,7 +406,7 @@ button.close > svg {
   }
 }
 
-.alert-ellipse {
+.k-alert-ellipse {
   height: 6px;
   width: 6px;
   border-radius: 50%;
@@ -400,7 +427,7 @@ button.close > svg {
   }
 }
 
-.alert-icon {
+.k-alert-icon {
   padding: 23px 5px 25px 21px;
 }
 
@@ -426,7 +453,7 @@ padding: 2px 0;
   padding: 2px 0;
 }
 
-.alert-action {
+.k-alert-action {
   display: inline-flex;
   position: absolute;
   right: 13px;
@@ -498,7 +525,7 @@ padding: 2px 0;
   }
 }
 
-.additionalAlertMessage {
+.k-alert-additional-text {
   display: block;
   padding-top: 4px;
   font-weight: 400;
@@ -507,13 +534,13 @@ padding: 2px 0;
   color: var(--grey-500);
 }
 
-.k-alert.banner.button > div .alert-msg.mainMessageText {
+.k-alert.banner.button > div .alert-msg.k-alert-text {
   padding-left: 0;
   font-size: 16px;
   line-height: 24px;
 }
 
-.k-alert.banner > div.alert-msg-text {
+.k-alert.banner > div.k-alert-msg-text {
   padding: 12px 210px 12px 16px;
 }
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -26,7 +26,7 @@
         :color="appearance"
         :class="appearance"
         icon="close"
-        size="20" />
+        size="16" />
     </button>
     <span
       v-if="hasIcon"
@@ -36,7 +36,7 @@
     <span
       v-if="hasEllipse"
       :class="appearance"
-      class="ellipse"/>
+      class="alert-ellipse"/>
     <span class="alert-msg">
       <slot name="alertMessage">{{ alertMessage }}</slot>
     </span>
@@ -317,7 +317,6 @@ export default {
     padding: 0;
     border-radius: 4px;
     background-color: #fff;
-    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
     margin-bottom: 1rem;
     color: var(--black-500);
   }
@@ -328,13 +327,12 @@ export default {
     padding: 0;
     border-radius: 4px;
     background-color: white;
-    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
     margin-bottom: 1rem;
     color: var(--black-500);
 
-    & > .ellipse {
+    & > .alert-ellipse {
       &.info {
-        background-color: var(--blue-500);
+        background-color: var(--blue-400);
       }
 
       &.success {
@@ -352,7 +350,7 @@ export default {
   }
     & .alert-msg {
       padding: 8px 0;
-      font-weight: 500;
+      font-weight: 400;
       font-size: 15px;
       line-height: 20px;
     }
@@ -390,7 +388,7 @@ button.close > svg {
   height: 32px;
 }
 
-.ellipse {
+.alert-ellipse {
   height: 6px;
   width: 6px;
   background-color: var(--red-500);
@@ -403,39 +401,73 @@ button.close > svg {
   display: inline-flex;
   margin-left: auto;
 
-  &.info button {
+  &.info button.primary {
     color: var(--blue-500);
     background-color: var(--blue-100);
-    border: var(--blue-100);
+    --KButtonPrimaryBase: var(--blue-300);
+    --KButtonPrimaryHover: var(--blue-300);
   }
 
-  &.success button {
+  &.info button.outline {
+    color: var(--blue-400);
+    border: 1px solid var(--blue-400);
+    --KButtonOutlineBorder: var(--blue-300);
+    --KButtonOutlineHoverBorder: var(--blue-300);
+    --KButtonOutlineActiveBorder: var(--blue-300);
+  }
+
+  &.warning button.primary {
+    color: var(--yellow-500);
+    background-color: var(--yellow-100);
+    --KButtonPrimaryBase: var(--yellow-300);
+    --KButtonPrimaryHover: var(--yellow-300);
+  }
+
+  &.warning button.outline {
+    color: var(--yellow-400);
+    border: 1px solid var(--yellow-400);
+    --KButtonOutlineBorder: var(--yellow-300);
+    --KButtonOutlineHoverBorder: var(--yellow-300);
+    --KButtonOutlineActiveBorder: var(--yellow-300);
+  }
+
+  &.success button.primary {
     color: var(--green-600);
     background-color: var(--green-100);
     border: var(--green-100);
+    --KButtonPrimaryBase: var(--green-300);
+    --KButtonPrimaryHover: var(--green-300);
   }
 
-  &.warning button {
-    color: var(--yellow-500);
-    background-color: var(--yellow-100);
-    border: var(--yellow-100);
-    &:hover:not(:disabled) {
-      background-color: var(--yellow-400);
-      border-color: var(--yellow-400);
-    }
+  &.success button.outline {
+    color: var(--green-500);
+    border: 1px solid var(--green-500);
+    --KButtonOutlineBorder: var(--green-400);
+    --KButtonOutlineHoverBorder: var(--green-400);
+    --KButtonOutlineActiveBorder: var(--green-400);
   }
 
-  &.danger button {
+  &.danger button.primary {
     color: var(--red-700);
     background-color: var(--red-100);
     border: var(--red-100);
+    --KButtonPrimaryBase: var(--red-300);
+    --KButtonPrimaryHover: var(--red-300);
+  }
+
+  &.danger button.outline {
+    color: var(--red-600);
+    border: 1px solid var(--red-600);
+    --KButtonOutlineBorder: var(--red-500);
+    --KButtonOutlineHoverBorder: var(--red-500);
+    --KButtonOutlineActiveBorder: var(--red-500);
   }
 
   & button {
     height: 30px;
     margin-right: 13px;
     font-style: normal;
-    font-weight: 500;
+    font-weight: 400;
     font-size: 13px;
     line-height: 13px;
     position: relative;
@@ -443,41 +475,15 @@ button.close > svg {
   }
 }
 
-.alert-action.info button.outline {
-  color: var(--KButtonOutlineColor, var(--blue-500));
-  border: 1px solid var(--blue-500);
-  background-color: var(--white, #ffffff);
-}
-
-.alert-action.warning button.outline {
-  color: var(--KButtonOutlineColor, var(--yellow-500));
-  border: 1px solid var(--yellow-500);
-  background-color: var(--white, #ffffff);
-  --KButtonOutlineBorder: var(--yellow-500);
-}
-
-.alert-action.success button.outline {
-  color: var(--KButtonOutlineColor, var(--green-600));
-  border: 1px solid var(--green-600);
-  background-color: var(--white, #ffffff);
-  --KButtonOutlineBorder: var(--green-600);
-}
-.alert-action.danger button.outline {
-  color: var(--KButtonOutlineColor, var(--red-700));
-  border: 1px solid var(--red-700);
-  background-color: var(--white, #ffffff);
-  --KButtonOutlineBorder: var(--red-700);
-}
-
 .k-alert > .close + .alert-msg {
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 16px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 16px;
 }
 
 .mainMessageText {
   display: block;
-  padding-top: 6px;
+  padding-top: 14px;
   padding-bottom: 2px;
   font-weight: 400;
   font-size: 16px;
@@ -493,5 +499,4 @@ button.close > svg {
   line-height: 24px;
   color: #6F7787;
 }
-
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -69,8 +69,8 @@
       </span>
       <span
         v-if="type === 'banner' && (size === 'large') && hasAlertDescription"
-        class="k-alert-additional-text">
-        <!-- @slot Use this slot to pass additional alert message for wide alert  -->
+        class="k-alert-description-text">
+        <!-- @slot Use this slot to pass alert message description for large banner type alert  -->
         <slot name="description">{{ description }}
         </slot>
       </span>
@@ -177,7 +177,7 @@ export default {
       default: 'var(--red-500)'
     },
     /**
-    * Additional alert message
+    * Alert message description
     */
     description: {
       type: String,
@@ -346,6 +346,13 @@ export default {
     border-color: var(--KAlertWarningBorder, var(--yellow-200, color(yellow-200)));
     background-color: var(--KAlertWarningBackground, var(--yellow-100, color(yellow-100)));
   }
+  & > div .k-alert-msg {
+    font-weight: 400;
+    font-size: var(--type-md, type(md));
+    line-height: var(--type-md, type(md));
+    padding: 2px 0;
+    margin-left: 2px;
+  }
 }
 
 div.k-alert.banner {
@@ -392,14 +399,6 @@ button.close > svg {
 
 .k-alert-icon {
   padding: 23px 5px 25px 21px;
-}
-
-.k-alert > div .k-alert-msg {
-  font-weight: 400;
-  font-size: var(--type-md, type(md));
-  line-height: var(--type-md, type(md));
-  padding: 2px 0;
-  margin-left: 2px;
 }
 
 .toaster-item .k-alert .k-alert-msg {

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -12,16 +12,18 @@
       {'hasTopBorder':hasTopBorder},
       {'hasBottomBorder':hasBottomBorder},
       {'isCentered': isCentered},
-      {'isFixed': isFixed}
+      {'isFixed': isFixed},
+      {'isLarge': isLarge}
     ]"
     class="k-alert"
-    role="alert">
+    role="alert"
+    @click.stop>
     <button
       v-if="dismissType === 'icon'"
       type="button"
       aria-label="Close"
       class="close"
-      @click="dismissAlert()">
+      @click="dismissAlert">
       <KIcon
         :color="appearance"
         :class="appearance"
@@ -31,14 +33,22 @@
     <div
       :class="appearance"
       class="alert-action ml-3">
-      <slot>
+      <slot
+        v-if="hasExtraButtons && dismissType === 'button'"
+        name="extraButtons">
         <KButton
-          v-if="dismissType === 'button'"
           size="small"
-          @click="dismissAlert()">
-          Dismiss
+          @click="proceed"
+          @keyup.enter="proceed">
+          {{ buttonText }}
         </KButton>
       </slot>
+      <KButton
+        v-if="dismissType === 'button'"
+        size="small"
+        @click="dismissAlert">
+        Dismiss
+      </KButton>
     </div>
     <span
       v-if="type === 'banner' && !isLarge"
@@ -50,7 +60,6 @@
         :color="iconColor"
         :icon="icon ? icon : 'notificationInbox'"
         class="alert-icon" />
-
     </span>
     <div class="alert-msg-text">
       <span
@@ -70,7 +79,9 @@
 </template>
 
 <script>
+import KButton from '@kongponents/kbutton/KButton.vue'
 import KIcon from '@kongponents/kicon/KIcon.vue'
+
 export const appearances = {
   info: 'info',
   success: 'success',
@@ -79,7 +90,7 @@ export const appearances = {
 }
 export default {
   name: 'KAlert',
-  components: { KIcon },
+  components: { KIcon, KButton },
   props: {
     /**
     * Message to show in alert
@@ -213,24 +224,29 @@ export default {
       default: false
     },
     /**
-    * Short Message in the second line to show in alert
+    * Additional Alert Message
     */
     additionalAlertMessage: {
+      type: String,
+      default: ''
+    },
+    buttonText: {
       type: String,
       default: ''
     }
   },
   computed: {
-    hasIcon () {
-      return !!this.$slots.alertIcon
-    },
-    hasActionButtons () {
-      return !!this.$slots.actionButtons
+    hasExtraButtons () {
+      return !!this.$slots.extraButtons
     }
   },
+
   methods: {
     dismissAlert () {
       this.$emit('closed')
+    },
+    proceed () {
+      this.$emit('proceed')
     }
   }
 }
@@ -301,9 +317,9 @@ export default {
     font-size: var(--type-sm, type(sm));
     padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
   }
-  //  &.isLarge {
-  //   min-height: 80px;
-  // }
+  &.isLarge {
+    min-height: 80px;
+  }
   // Appearances
   &.info {
     color: var(--KAlertInfoColor, var(--blue-700, color(blue-700)));
@@ -485,6 +501,5 @@ padding: 2px 0;
 
 .k-alert.banner > div.alert-msg-text {
   padding: 12px 210px 12px 16px;
-  text-align: justify;
 }
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-if="isShowing && !hasButton && !isWideBanner"
+      v-if="isShowing || hasButton || isWideBanner"
       :class="[
         appearance,
         size,
@@ -11,7 +11,9 @@
         {'hasTopBorder':hasTopBorder},
         {'hasBottomBorder':hasBottomBorder},
         {'isCentered': isCentered},
-        {'isFixed': isFixed}
+        {'isFixed': isFixed},
+        {'hasButton': hasButton},
+        {'isWideBanner': isWideBanner}
       ]"
       class="k-alert"
       role="alert">
@@ -28,72 +30,25 @@
           size="14" />
       </button>
       <span
-        v-if="hasIcon"
-        class="alert-icon">
-        <slot name="alertIcon" />
-      </span>
-      <span>
-        <slot name="alertMessage">{{ alertMessage }}</slot>
-      </span>
-    </div>
-    <!-- White Background With Buttons -->
-    <div
-      v-if="hasButton"
-      :class="[
-        appearance,
-        size,
-        {'isBordered':isBordered},
-        {'hasLeftBorder':hasLeftBorder},
-        {'hasRightBorder':hasRightBorder},
-        {'hasTopBorder':hasTopBorder},
-        {'hasBottomBorder':hasBottomBorder},
-        {'isCentered': isCentered},
-        {'isFixed': isFixed}
-      ]"
-      class="k-alert has-button"
-      role="alert">
-
-      <!-- <span
-        v-if="hasEllipse"
-        class="alert-ellipse">
-        <slot name="alertEllipse"/>
-      </span> -->
-      <span
-        v-if="hasEllipse"
-        :class="appearance"
-        class="dot"/>
-      <span
-        v-if="hasIcon"
-        class="alert-icon">
-        <slot name="alertIcon" />
-      </span>
-      <span>
-        <slot name="alertMessage">{{ alertMessage }}</slot>
-      </span>
-      <span
-        v-if="hasActionButtons"
-        :class="appearance"
-        class="alert-action">
-        <slot name="actionButtons"/>
-      </span>
-    </div>
-    <!-- Wide Banner -->
-    <div
-      v-if="isWideBanner"
-      class="k-alert is-wide-banner"
-      role="alert">
-
-      <span
         v-if="hasRedIcon"
         class="alert-red">
         <slot name="alertRedIcon"/>
       </span>
+      <span
+        v-if="hasIcon"
+        class="alert-icon">
+        <slot name="alertIcon"/>
+      </span>
+      <span
+        v-if="hasEllipse"
+        :class="appearance"
+        class="dot"/>
       <span>
         <slot name="alertMessage">{{ alertMessage }}</slot>
       </span>
       <div>
-        <span class="longSpan"><slot name="alertLongMessageFirst">{{ alertLongMessageFirst }}</slot></span>
-        <span class="smallSpan"><slot name="alertLongMessageSec">{{ alertLongMessageSec }}</slot></span>
+        <span class="longSpan"><slot name="mainMessageText">{{ mainMessageText }}</slot></span>
+        <span class="smallSpan"><slot name="secMessageText">{{ secMessageText }}</slot></span>
       </div>
       <span
         v-if="hasActionButtons"
@@ -128,6 +83,20 @@ export default {
       default: ''
     },
     /**
+    * Long Message to show in the first line in alert
+    */
+    mainMessageText: {
+      type: String,
+      default: ''
+    },
+    /**
+    * Short Message in the second line to show in alert
+    */
+    secMessageText: {
+      type: String,
+      default: ''
+    },
+    /**
      * Set if close button is visible
      */
     isDismissible: {
@@ -139,7 +108,7 @@ export default {
      */
     isShowing: {
       type: Boolean,
-      default: true
+      default: false
     },
     /**
      * Set whether or not the alert box shown has button.
@@ -403,7 +372,11 @@ button.close > svg.warning {
   margin: 24px 26px 26px;
 }
 
-.k-alert.has-button {
+.k-alert {
+  margin-bottom: 1rem;
+}
+
+.k-alert.hasButton {
   width: 763px;
   height: 56px;
   padding: 0;
@@ -414,39 +387,39 @@ button.close > svg.warning {
   color: var(--black-500);
 }
 
-// .k-alert.has-button > button.info {
+// .k-alert.hasButton > button.info {
 //   color: var(--blue-500);
 //   background-color: var(--blue-100);
 // }
 
-// .k-alert.has-button > button.success {
+// .k-alert.hasButton > button.success {
 //   color: var(--green-600);
 //   background-color: var(--green-100);
 // }
 
-// .k-alert.has-button > button.warning {
+// .k-alert.hasButton > button.warning {
 //   color: var(--yellow-500);
 //   background-color: var(--yellow-100);
 // }
 
-// .k-alert.has-button > button.danger {
+// .k-alert.hasButton > button.danger {
 //   color: var(--red-700);
 //   background-color: var(--red-100);
 // }
 
-.k-alert.has-button > .dot.info {
+.k-alert.hasButton > .dot.info {
   background-color: var(--blue-500);
 }
 
-.k-alert.has-button > .dot.success {
+.k-alert.hasButton > .dot.success {
   background-color: var(--green-400);
 }
 
-.k-alert.has-button > .dot.warning {
+.k-alert.hasButton > .dot.warning {
   background-color: var(--yellow-400);
 }
 
-.k-alert.has-button > .dot.danger {
+.k-alert.hasButton > .dot.danger {
   background-color: var(--red-400);
 }
 
@@ -492,7 +465,7 @@ button.close > svg.warning {
   border: var(--red-100);
 }
 
-.k-alert.is-wide-banner {
+.k-alert.isWideBanner {
   width: 1220px;
   height: 80px;
   padding: 0;

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -285,7 +285,6 @@ export default {
   }
   &.small {
     font-size: var(--type-sm, type(sm));
-    // padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
   }
 
   // Appearances
@@ -313,7 +312,7 @@ export default {
   &.isWideBanner {
     width: 1220px;
     height: 80px;
-    padding: 0;
+    // padding: 0;
     border-radius: 2px;
     background-color: #fff;
     margin-bottom: 1rem;
@@ -323,9 +322,9 @@ export default {
   &.hasButton {
     width: 763px;
     height: 56px;
-    padding: 0;
+    // padding: 0;
     border-radius: 4px;
-    background-color: white;
+    background-color: #fff;
     margin-bottom: 1rem;
     color: var(--black-500);
     & > .alert-ellipse {
@@ -344,8 +343,7 @@ export default {
     }
   }
     & .alert-msg {
-      // padding: 8px 0;
-        padding: 12px 16px;
+      padding: 12px 16px;
       font-weight: 400;
       font-size: 15px;
       line-height: 20px;
@@ -376,9 +374,10 @@ button.close > svg {
 }
 
 .alert-icon {
-  padding: 23px 20px 25px 21px;
+  padding: 23px 0 25px 21px;
   width: 32px;
   height: 32px;
+  margin-right: -8px
 }
 
 .alert-ellipse {
@@ -387,7 +386,7 @@ button.close > svg {
   background-color: var(--red-500);
   border-radius: 50%;
   display: inline-block;
-  margin: 24px 8px 24px 26px;
+  margin: 24px 8px 26px 24px;
 }
 
 .alert-action {
@@ -396,7 +395,6 @@ button.close > svg {
   & button {
     height: 30px;
     margin-right: 13px;
-    font-style: normal;
     font-weight: 400;
     font-size: 13px;
     line-height: 13px;
@@ -409,7 +407,7 @@ button.close > svg {
   font-weight: 400;
   font-size: 16px;
   line-height: 16px;
-  padding: 12px 16px;
+  padding: var(--spacing-sm, spacing(sm)) var(--spacing-md, spacing(md));
 }
 
 .mainMessageText {
@@ -428,6 +426,6 @@ button.close > svg {
   font-weight: 400;
   font-size: 13px;
   line-height: 24px;
-  color: #6F7787;
+  color: var(--grey-500);
 }
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-if="isShowing && !hasButton"
+      v-if="isShowing && !hasButton && !isWideBanner"
       :class="[
         appearance,
         size,
@@ -36,6 +36,7 @@
         <slot name="alertMessage">{{ alertMessage }}</slot>
       </span>
     </div>
+    <!-- White Background With Buttons -->
     <div
       v-if="hasButton"
       :class="[
@@ -52,13 +53,13 @@
       class="k-alert has-button"
       role="alert">
 
+      <!-- <span
+        v-if="hasEllipse"
+        class="alert-ellipse">
+        <slot name="alertEllipse"/>
+      </span> -->
       <span
-        v-if="hasRedIcon"
-        class="alert-red">
-        <slot name="alertRedIcon"/>
-      </span>
-      <span
-        v-if="!hasRedIcon"
+        v-if="hasEllipse"
         :class="appearance"
         class="dot"/>
       <span
@@ -69,6 +70,31 @@
       <span>
         <slot name="alertMessage">{{ alertMessage }}</slot>
       </span>
+      <span
+        v-if="hasActionButtons"
+        :class="appearance"
+        class="alert-action">
+        <slot name="actionButtons"/>
+      </span>
+    </div>
+    <!-- Wide Banner -->
+    <div
+      v-if="isWideBanner"
+      class="k-alert is-wide-banner"
+      role="alert">
+
+      <span
+        v-if="hasRedIcon"
+        class="alert-red">
+        <slot name="alertRedIcon"/>
+      </span>
+      <span>
+        <slot name="alertMessage">{{ alertMessage }}</slot>
+      </span>
+      <div>
+        <span class="longSpan"><slot name="alertLongMessageFirst">{{ alertLongMessageFirst }}</slot></span>
+        <span class="smallSpan"><slot name="alertLongMessageSec">{{ alertLongMessageSec }}</slot></span>
+      </div>
       <span
         v-if="hasActionButtons"
         :class="appearance"
@@ -119,6 +145,20 @@ export default {
      * Set whether or not the alert box shown has button.
      */
     hasButton: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Set whether or not the alert box shown has ellipse.
+     */
+    hasEllipse: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Set whether or not the alert box shown is a banner.
+     */
+    isWideBanner: {
       type: Boolean,
       default: false
     },
@@ -348,11 +388,11 @@ button.close > svg.warning {
   cursor: pointer;
 }
 
-// .alert-red {
-//   padding: 23px 19.93px 25px 21px;
-//   width: 32px;
-//   height: 32px;
-// }
+.alert-red {
+  padding: 23px 19.93px 25px 21px;
+  width: 32px;
+  height: 32px;
+}
 
 .dot {
   height: 6px;
@@ -368,8 +408,8 @@ button.close > svg.warning {
   height: 56px;
   padding: 0;
   border-radius: 4px;
-  // background-color: white;
-  background-color: ghostwhite;
+  background-color: white;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
   margin-bottom: 1rem;
   color: var(--black-500);
 }
@@ -450,6 +490,37 @@ button.close > svg.warning {
   color: var(--red-700);
   background-color: var(--red-100);
   border: var(--red-100);
+}
+
+.k-alert.is-wide-banner {
+  width: 1220px;
+  height: 80px;
+  padding: 0;
+  border-radius: 4px;
+  // background-color: white;
+  background-color: white;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  margin-bottom: 1rem;
+  color: var(--black-500);
+}
+
+.longSpan {
+  display: block;
+    font-family: Maison Neue;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 24px;
+}
+
+.smallSpan {
+    display: block;
+    font-family: Maison Neue;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 13px;
+    line-height: 24px;
+    color: #6F7787;
 }
 
 </style>

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -71,6 +71,6 @@ exports[`KAlert renders slots when passed 1`] = `
       Dismiss
       <!----></button></div>
   <!----> <span><svg height="32" width="32" viewBox="0 0 32 32" role="img" class="kong-icon k-alert-icon kong-icon-notificationInbox"><title>Notifications</title>  <g><circle cx="16" cy="16" r="16" fill="var(--red-500)"></circle> <!----> <!----><!----> <!----> <path fill="var(--red-500)" d="M8 11h16.37v10.03H8z"></path><!----> <!----> <path type="secondary" fill="#fff" d="M16.17 21.03h-7.3c-.45 0-.74-.21-.84-.62a.8.8 0 0 1-.03-.23v-6.36c0-.06.03-.15.08-.2l2.52-2.44c.14-.14.3-.18.49-.18h10.18c.21 0 .38.07.54.22l2.46 2.4c.07.06.1.13.1.23v6.3c0 .57-.31.89-.9.89l-7.3-.01Zm-3-7.41v.1a1.98 1.98 0 0 0 1.8 1.96c.79.06 1.6.05 2.4 0 .89-.05 1.57-.7 1.77-1.56.04-.16.05-.33.08-.5h3.49l-.03-.05-1.6-1.56a.34.34 0 0 0-.17-.05h-9.45a.35.35 0 0 0-.2.08l-1.54 1.49a.88.88 0 0 0-.08.1l3.53-.01Z"></path></g></svg></span>
-  <div class="k-alert-msg-text"><span class="k-alert-msg k-alert-text"><span>Hello World</span></span> <span class="k-alert-additional-text"><span>I am an alert</span></span></div>
+  <div class="k-alert-msg-text"><span class="k-alert-msg k-alert-text"><span>Hello World</span></span> <span class="k-alert-description-text"><span>I am an alert</span></span></div>
 </div>
 `;

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -1,61 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KAlert Renders danger variant 1`] = `
-<div role="alert" class="k-alert danger" message="I am danger">
+<div role="alert" class="k-alert danger alert none" message="I am danger">
+  <!---->
+  <div class="alert-action ml-3 danger">
+    <!---->
+    <!---->
+  </div>
   <!---->
   <!---->
-  <!----> <span class="alert-msg"></span>
-  <!---->
-  <!---->
+  <div class="alert-msg-text"><span class="alert-msg">
+      </span>
+    <!---->
+  </div>
 </div>
 `;
 
 exports[`KAlert Renders info variant 1`] = `
-<div role="alert" class="k-alert info" message="I am info">
+<div role="alert" class="k-alert info alert none" message="I am info">
+  <!---->
+  <div class="alert-action ml-3 info">
+    <!---->
+    <!---->
+  </div>
   <!---->
   <!---->
-  <!----> <span class="alert-msg"></span>
-  <!---->
-  <!---->
+  <div class="alert-msg-text"><span class="alert-msg">
+      </span>
+    <!---->
+  </div>
 </div>
 `;
 
 exports[`KAlert Renders success variant 1`] = `
-<div role="alert" class="k-alert success" message="I am success">
+<div role="alert" class="k-alert success alert none" message="I am success">
+  <!---->
+  <div class="alert-action ml-3 success">
+    <!---->
+    <!---->
+  </div>
   <!---->
   <!---->
-  <!----> <span class="alert-msg"></span>
-  <!---->
-  <!---->
+  <div class="alert-msg-text"><span class="alert-msg">
+      </span>
+    <!---->
+  </div>
 </div>
 `;
 
 exports[`KAlert Renders warning variant 1`] = `
-<div role="alert" class="k-alert warning" message="I am warning">
+<div role="alert" class="k-alert warning alert none" message="I am warning">
+  <!---->
+  <div class="alert-action ml-3 warning">
+    <!---->
+    <!---->
+  </div>
   <!---->
   <!---->
-  <!----> <span class="alert-msg"></span>
-  <!---->
-  <!---->
-</div>
-`;
-
-exports[`KAlert show alert with white background and button(s) 1`] = `
-<div role="alert" class="k-alert info hasButton" message="Hello world">
-  <!---->
-  <!---->
-  <!----> <span class="alert-msg"></span>
-  <!---->
-  <!---->
-</div>
-`;
-
-exports[`KAlert show alert/banner with isWideBanner class styles for white background, buttons and notification icon 1`] = `
-<div role="alert" class="k-alert info isWideBanner" message="Hello world">
-  <!---->
-  <!---->
-  <!----> <span class="alert-msg"></span>
-  <div><span class="mainMessageText"></span> <span class="secMessageText"></span></div>
-  <!---->
+  <div class="alert-msg-text"><span class="alert-msg">
+      </span>
+    <!---->
+  </div>
 </div>
 `;

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -3,23 +3,43 @@
 exports[`KAlert Renders danger variant 1`] = `
 <div role="alert" class="k-alert danger" message="I am danger">
   <!---->
-  <!----> <span></span></div>
+  <!---->
+  <!---->
+  <!----> <span></span>
+  <!---->
+  <!---->
+</div>
 `;
 
 exports[`KAlert Renders info variant 1`] = `
 <div role="alert" class="k-alert info" message="I am info">
   <!---->
-  <!----> <span></span></div>
+  <!---->
+  <!---->
+  <!----> <span></span>
+  <!---->
+  <!---->
+</div>
 `;
 
 exports[`KAlert Renders success variant 1`] = `
 <div role="alert" class="k-alert success" message="I am success">
   <!---->
-  <!----> <span></span></div>
+  <!---->
+  <!---->
+  <!----> <span></span>
+  <!---->
+  <!---->
+</div>
 `;
 
 exports[`KAlert Renders warning variant 1`] = `
 <div role="alert" class="k-alert warning" message="I am warning">
   <!---->
-  <!----> <span></span></div>
+  <!---->
+  <!---->
+  <!----> <span></span>
+  <!---->
+  <!---->
+</div>
 `;

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -4,8 +4,7 @@ exports[`KAlert Renders danger variant 1`] = `
 <div role="alert" class="k-alert danger" message="I am danger">
   <!---->
   <!---->
-  <!---->
-  <!----> <span></span>
+  <!----> <span class="alert-msg"></span>
   <!---->
   <!---->
 </div>
@@ -15,8 +14,7 @@ exports[`KAlert Renders info variant 1`] = `
 <div role="alert" class="k-alert info" message="I am info">
   <!---->
   <!---->
-  <!---->
-  <!----> <span></span>
+  <!----> <span class="alert-msg"></span>
   <!---->
   <!---->
 </div>
@@ -26,8 +24,7 @@ exports[`KAlert Renders success variant 1`] = `
 <div role="alert" class="k-alert success" message="I am success">
   <!---->
   <!---->
-  <!---->
-  <!----> <span></span>
+  <!----> <span class="alert-msg"></span>
   <!---->
   <!---->
 </div>
@@ -37,8 +34,7 @@ exports[`KAlert Renders warning variant 1`] = `
 <div role="alert" class="k-alert warning" message="I am warning">
   <!---->
   <!---->
-  <!---->
-  <!----> <span></span>
+  <!----> <span class="alert-msg"></span>
   <!---->
   <!---->
 </div>
@@ -48,8 +44,7 @@ exports[`KAlert show alert with white background and button(s) 1`] = `
 <div role="alert" class="k-alert info hasButton" message="Hello world">
   <!---->
   <!---->
-  <!---->
-  <!----> <span></span>
+  <!----> <span class="alert-msg"></span>
   <!---->
   <!---->
 </div>
@@ -59,8 +54,7 @@ exports[`KAlert show alert/banner with isWideBanner class styles for white backg
 <div role="alert" class="k-alert info isWideBanner" message="Hello world">
   <!---->
   <!---->
-  <!---->
-  <!----> <span></span>
+  <!----> <span class="alert-msg"></span>
   <div><span class="mainMessageText"></span> <span class="secMessageText"></span></div>
   <!---->
 </div>

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -3,13 +3,13 @@
 exports[`KAlert Renders danger variant 1`] = `
 <div role="alert" class="k-alert danger alert none" message="I am danger">
   <!---->
-  <div class="alert-action ml-3 danger">
+  <div class="k-alert-action ml-3 danger">
     <!---->
     <!---->
   </div>
   <!---->
   <!---->
-  <div class="alert-msg-text"><span class="alert-msg">
+  <div class="k-alert-msg-text"><span class="k-alert-msg">
       </span>
     <!---->
   </div>
@@ -19,13 +19,13 @@ exports[`KAlert Renders danger variant 1`] = `
 exports[`KAlert Renders info variant 1`] = `
 <div role="alert" class="k-alert info alert none" message="I am info">
   <!---->
-  <div class="alert-action ml-3 info">
+  <div class="k-alert-action ml-3 info">
     <!---->
     <!---->
   </div>
   <!---->
   <!---->
-  <div class="alert-msg-text"><span class="alert-msg">
+  <div class="k-alert-msg-text"><span class="k-alert-msg">
       </span>
     <!---->
   </div>
@@ -35,13 +35,13 @@ exports[`KAlert Renders info variant 1`] = `
 exports[`KAlert Renders success variant 1`] = `
 <div role="alert" class="k-alert success alert none" message="I am success">
   <!---->
-  <div class="alert-action ml-3 success">
+  <div class="k-alert-action ml-3 success">
     <!---->
     <!---->
   </div>
   <!---->
   <!---->
-  <div class="alert-msg-text"><span class="alert-msg">
+  <div class="k-alert-msg-text"><span class="k-alert-msg">
       </span>
     <!---->
   </div>
@@ -51,15 +51,26 @@ exports[`KAlert Renders success variant 1`] = `
 exports[`KAlert Renders warning variant 1`] = `
 <div role="alert" class="k-alert warning alert none" message="I am warning">
   <!---->
-  <div class="alert-action ml-3 warning">
+  <div class="k-alert-action ml-3 warning">
     <!---->
     <!---->
   </div>
   <!---->
   <!---->
-  <div class="alert-msg-text"><span class="alert-msg">
+  <div class="k-alert-msg-text"><span class="k-alert-msg">
       </span>
     <!---->
   </div>
+</div>
+`;
+
+exports[`KAlert renders slots when passed 1`] = `
+<div role="alert" class="k-alert info banner button isLarge" hasextrabuttons="true">
+  <!---->
+  <div class="k-alert-action ml-3 info"><span>Extra button</span> <button type="button" class="k-button small rounded outline">
+      Dismiss
+      <!----></button></div>
+  <!----> <span><svg height="32" width="32" viewBox="0 0 32 32" role="img" class="kong-icon k-alert-icon kong-icon-notificationInbox"><title>Notifications</title>  <g><circle cx="16" cy="16" r="16" fill="var(--red-500)"></circle> <!----> <!----><!----> <!----> <path fill="var(--red-500)" d="M8 11h16.37v10.03H8z"></path><!----> <!----> <path type="secondary" fill="#fff" d="M16.17 21.03h-7.3c-.45 0-.74-.21-.84-.62a.8.8 0 0 1-.03-.23v-6.36c0-.06.03-.15.08-.2l2.52-2.44c.14-.14.3-.18.49-.18h10.18c.21 0 .38.07.54.22l2.46 2.4c.07.06.1.13.1.23v6.3c0 .57-.31.89-.9.89l-7.3-.01Zm-3-7.41v.1a1.98 1.98 0 0 0 1.8 1.96c.79.06 1.6.05 2.4 0 .89-.05 1.57-.7 1.77-1.56.04-.16.05-.33.08-.5h3.49l-.03-.05-1.6-1.56a.34.34 0 0 0-.17-.05h-9.45a.35.35 0 0 0-.2.08l-1.54 1.49a.88.88 0 0 0-.08.1l3.53-.01Z"></path></g></svg></span>
+  <div class="k-alert-msg-text"><span class="k-alert-msg k-alert-text"><span>Hello World</span></span> <span class="k-alert-additional-text"><span>I am an alert</span></span></div>
 </div>
 `;

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -43,3 +43,25 @@ exports[`KAlert Renders warning variant 1`] = `
   <!---->
 </div>
 `;
+
+exports[`KAlert show alert with white background and button(s) 1`] = `
+<div role="alert" class="k-alert info hasButton" message="Hello world">
+  <!---->
+  <!---->
+  <!---->
+  <!----> <span></span>
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`KAlert show alert/banner with isWideBanner class styles for white background, buttons and notification icon 1`] = `
+<div role="alert" class="k-alert info isWideBanner" message="Hello world">
+  <!---->
+  <!---->
+  <!---->
+  <!----> <span></span>
+  <div><span class="mainMessageText"></span> <span class="secMessageText"></span></div>
+  <!---->
+</div>
+`;

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -65,9 +65,9 @@ exports[`KAlert Renders warning variant 1`] = `
 `;
 
 exports[`KAlert renders slots when passed 1`] = `
-<div role="alert" class="k-alert info banner button isLarge" hasextrabuttons="true">
+<div role="alert" class="k-alert info large banner button" hasactionbuttons="true">
   <!---->
-  <div class="k-alert-action ml-3 info"><span>Extra button</span> <button type="button" class="k-button small rounded outline">
+  <div class="k-alert-action ml-3 info"><span>Action button</span> <button type="button" class="k-button small rounded outline">
       Dismiss
       <!----></button></div>
   <!----> <span><svg height="32" width="32" viewBox="0 0 32 32" role="img" class="kong-icon k-alert-icon kong-icon-notificationInbox"><title>Notifications</title>  <g><circle cx="16" cy="16" r="16" fill="var(--red-500)"></circle> <!----> <!----><!----> <!----> <path fill="var(--red-500)" d="M8 11h16.37v10.03H8z"></path><!----> <!----> <path type="secondary" fill="#fff" d="M16.17 21.03h-7.3c-.45 0-.74-.21-.84-.62a.8.8 0 0 1-.03-.23v-6.36c0-.06.03-.15.08-.2l2.52-2.44c.14-.14.3-.18.49-.18h10.18c.21 0 .38.07.54.22l2.46 2.4c.07.06.1.13.1.23v6.3c0 .57-.31.89-.9.89l-7.3-.01Zm-3-7.41v.1a1.98 1.98 0 0 0 1.8 1.96c.79.06 1.6.05 2.4 0 .89-.05 1.57-.7 1.77-1.56.04-.16.05-.33.08-.5h3.49l-.03-.05-1.6-1.56a.34.34 0 0 0-.17-.05h-9.45a.35.35 0 0 0-.2.08l-1.54 1.49a.88.88 0 0 0-.08.1l3.53-.01Z"></path></g></svg></span>

--- a/packages/KAlert/package.json
+++ b/packages/KAlert/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^5.0.7"
+    "@kongponents/kicon": "^5.0.5",
+    "@kongponents/kbutton": "^5.0.5"
   }
 }

--- a/packages/KToaster/KToaster.vue
+++ b/packages/KToaster/KToaster.vue
@@ -9,7 +9,7 @@
       class="toaster-item">
       <KAlert
         :appearance="toaster.appearance"
-        is-dismissible
+        dismiss-type = "icon"
         has-left-border
         @closed="$emit('close', toaster.key)">
         <template v-slot:alertMessage>

--- a/packages/KToaster/KToaster.vue
+++ b/packages/KToaster/KToaster.vue
@@ -95,6 +95,7 @@ $transition: all .3s;
     text-align: left;
     background-color: #fff;
     color: var(--black-70);
+    margin-bottom: 0;
   }
 
   .message {

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
 <!---->
 <!---->
 </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
+  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
         <title>close</title>
         <g>
           <!---->
@@ -22,7 +22,7 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
         <title>close</title>
         <g>
           <!---->
@@ -37,7 +37,7 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
         <title>close</title>
         <g>
           <!---->

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,40 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close"><title>Close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="#000" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <span><div class="message">hey toasty</div></span></div>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+<!---->
+<!---->
+</div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
-        <title>Close</title>
+  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
+        <title>close</title>
         <g>
           <!---->
           <!---->
-          <path d="M16 4 3 17m13 0L3 4" stroke="#000" stroke-width="2" stroke-linecap="round"></path>
+          <path d="M16 4 3 17m13 0L3 4" stroke="success" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
-    <!----> <span><div class="message">hey toasty</div></span></div>
+    <!---->
+    <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+    <!---->
+    <!---->
+  </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
-        <title>Close</title>
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+        <title>close</title>
         <g>
           <!---->
           <!---->
-          <path d="M16 4 3 17m13 0L3 4" stroke="#000" stroke-width="2" stroke-linecap="round"></path>
+          <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
-    <!----> <span><div class="message">hey toasty</div></span></div>
+    <!---->
+    <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+    <!---->
+    <!---->
+  </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="12" width="12" viewBox="0 0 12 12" role="img" class="kong-icon kong-icon-close">
-        <title>Close</title>
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+        <title>close</title>
         <g>
           <!---->
           <!---->
-          <path d="M16 4 3 17m13 0L3 4" stroke="#000" stroke-width="2" stroke-linecap="round"></path>
+          <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
-    <!----> <span><div class="message">hey toasty</div></span></div>
+    <!---->
+    <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+    <!---->
+    <!---->
+  </div>
 </div>
 </span>
 `;

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,67 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <div class="alert-action ml-3 info"><!----> <!----></div> <!----> <!----> <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>Close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <div class="k-alert-action ml-3 info"><!----> <!----></div> <!----> <!----> <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
 <!---->
 </div>
 </div>
 </div>
 <div class="toaster-item">
   <div role="alert" class="k-alert success alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
-        <title>close</title>
+        <title>Close</title>
         <g>
           <!---->
           <!---->
           <path d="M16 4 3 17m13 0L3 4" stroke="success" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
-    <div class="alert-action ml-3 success">
+    <div class="k-alert-action ml-3 success">
       <!---->
       <!---->
     </div>
     <!---->
     <!---->
-    <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
-      <!---->
-    </div>
-  </div>
-</div>
-<div class="toaster-item">
-  <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
-        <title>close</title>
-        <g>
-          <!---->
-          <!---->
-          <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
-        </g>
-      </svg></button>
-    <div class="alert-action ml-3 danger">
-      <!---->
-      <!---->
-    </div>
-    <!---->
-    <!---->
-    <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
+    <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
       <!---->
     </div>
   </div>
 </div>
 <div class="toaster-item">
   <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
-        <title>close</title>
+        <title>Close</title>
         <g>
           <!---->
           <!---->
           <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
-    <div class="alert-action ml-3 danger">
+    <div class="k-alert-action ml-3 danger">
       <!---->
       <!---->
     </div>
     <!---->
     <!---->
-    <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
+    <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
+      <!---->
+    </div>
+  </div>
+</div>
+<div class="toaster-item">
+  <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+        <title>Close</title>
+        <g>
+          <!---->
+          <!---->
+          <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
+        </g>
+      </svg></button>
+    <div class="k-alert-action ml-3 danger">
+      <!---->
+      <!---->
+    </div>
+    <!---->
+    <!---->
+    <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
       <!---->
     </div>
   </div>

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <div class="alert-action ml-3 info"><!----> <!----></div> <!----> <!----> <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
 <!---->
-<!---->
+</div>
 </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
+  <div role="alert" class="k-alert success alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
         <title>close</title>
         <g>
           <!---->
@@ -15,14 +15,19 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
           <path d="M16 4 3 17m13 0L3 4" stroke="success" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
+    <div class="alert-action ml-3 success">
+      <!---->
+      <!---->
+    </div>
     <!---->
-    <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
     <!---->
-    <!---->
+    <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
+      <!---->
+    </div>
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+  <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
         <title>close</title>
         <g>
           <!---->
@@ -30,14 +35,19 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
           <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
+    <div class="alert-action ml-3 danger">
+      <!---->
+      <!---->
+    </div>
     <!---->
-    <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
     <!---->
-    <!---->
+    <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
+      <!---->
+    </div>
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+  <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="14" width="14" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
         <title>close</title>
         <g>
           <!---->
@@ -45,10 +55,15 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
           <path d="M16 4 3 17m13 0L3 4" stroke="danger" stroke-width="2" stroke-linecap="round"></path>
         </g>
       </svg></button>
+    <div class="alert-action ml-3 danger">
+      <!---->
+      <!---->
+    </div>
     <!---->
-    <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
     <!---->
-    <!---->
+    <div class="alert-msg-text"><span class="alert-msg"><div class="message">hey toasty</div></span>
+      <!---->
+    </div>
   </div>
 </div>
 </span>

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close info"><title>close</title>  <g><!----> <!----> <path d="M16 4 3 17m13 0L3 4" stroke="info" stroke-width="2" stroke-linecap="round"></path></g></svg></button> <!----> <!----> <span class="alert-msg"><div class="message">hey toasty</div></span>
 <!---->
 <!---->
 </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
+  <div role="alert" class="k-alert success hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close success">
         <title>close</title>
         <g>
           <!---->
@@ -22,7 +22,7 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
         <title>close</title>
         <g>
           <!---->
@@ -37,7 +37,7 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="20" width="20" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
+  <div role="alert" class="k-alert danger hasLeftBorder"><button type="button" aria-label="Close" class="close"><svg height="16" width="16" viewBox="0 0 20 20" role="img" class="kong-icon kong-icon-close danger">
         <title>close</title>
         <g>
           <!---->


### PR DESCRIPTION
### Summary
KAlert was redesigned to allow for different dismiss types(none/icon/button), alert type(banner/alert), different size(small/large). 

#### Changes made:
* Add new props: type, dismissType, size(large)
* Add new icon/buttons
* Style icons/buttons based on appearance
* Update test snapshots

![Screen Shot 2021-11-01 at 1 16 23 PM](https://user-images.githubusercontent.com/87779967/139713647-c5ae796d-3886-49a9-bddd-18030dcb6087.png)
![Screen Shot 2021-11-01 at 1 16 51 PM](https://user-images.githubusercontent.com/87779967/139713654-9df7c21d-a20c-428b-adc1-a36d8a3c67fd.png)
![Screen Shot 2021-11-01 at 1 25 18 PM](https://user-images.githubusercontent.com/87779967/139713664-f9cbcabf-15a8-464b-b128-0e998f796ee5.png)



### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
