### PR TITLE
fix(kinputswitch): update style for switch-icon

### DIFF
--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -20,6 +20,7 @@
 
   <label
     v-else
+    :class="{ 'switch-with-icon' : enabledIcon }"
     class="k-switch">
     <input
       :checked="value"

--- a/packages/styles/forms/_switch.scss
+++ b/packages/styles/forms/_switch.scss
@@ -7,6 +7,17 @@ $transition: .2s linear;
   display: inline-flex;
   align-items: center;
   cursor: pointer;
+  &.switch-with-icon .switch-control {
+    width: 48px;
+  }
+  &.switch-with-icon svg {
+    height: 20px;
+    width: 22px;
+    left: 57px;
+  }
+  &.switch-with-icon input:checked + .switch-control:after {
+    left: 26px;
+  }
   .switch-control {
     position: relative;
     display: block;


### PR DESCRIPTION
### Summary
Fix the style for switch with icon in KInputSwitch 
[UX-565]
#### Changes made:
Before:
![Screen Shot 2021-10-21 at 11 53 29 AM](https://user-images.githubusercontent.com/87779967/138313544-0c7dd98a-0d8d-4097-b433-456fc66c7738.png)

After:
![Screen Shot 2021-10-21 at 11 53 37 AM](https://user-images.githubusercontent.com/87779967/138313556-a2c07ee1-b34c-455d-8a56-963719173096.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[UX-565]: https://konghq.atlassian.net/browse/UX-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ