### PR TITLE
chore(ktable): add class to th when hiding label in header for a11y reasons

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -8,7 +8,7 @@
           <th
             v-for="(column, index) in options.headers"
             :key="index"
-            :class="{'sortable': !column.hideLabel && column.sortable, 'hidden-label': column.hideLabel, [sortOrder]: column.key === sortKey && !column.hideLabel}"
+            :class="{'sortable': !column.hideLabel && column.sortable, 'sr-only': column.hideLabel, [sortOrder]: column.key === sortKey && !column.hideLabel}"
             @click="column.sortable && $emit('sort', column.key, sortOrder)"
           >
             <slot
@@ -240,8 +240,16 @@ export default {
       font-size: var(--KTableHeaderSize, var(--type-sm, type(sm)));
       font-weight: 500;
 
-      &.hidden-label {
-        display: none;
+      &.sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border-width: 0;
       }
 
       &.sortable {

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -13,7 +13,7 @@ exports[`KTable default has hover class when passed 1`] = `
       <th class="">
         Enabled
       </th>
-      <th class="hidden-label">
+      <th class="sr-only">
         actions
       </th>
     </tr>
@@ -54,7 +54,7 @@ exports[`KTable default has small class when passed 1`] = `
       <th class="">
         Enabled
       </th>
-      <th class="hidden-label">
+      <th class="sr-only">
         actions
       </th>
     </tr>
@@ -95,7 +95,7 @@ exports[`KTable default renders link in action slot 1`] = `
       <th class="">
         Enabled
       </th>
-      <th class="hidden-label">
+      <th class="sr-only">
         actions
       </th>
     </tr>
@@ -136,7 +136,7 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
       <th class="">
         Enabled
       </th>
-      <th class="hidden-label">
+      <th class="sr-only">
         actions
       </th>
     </tr>


### PR DESCRIPTION
### Summary
Solves [this a11y issue](https://dequeuniversity.com/rules/axe/4.3/empty-table-header?application=AxeFirefox). Think this solution is more readable than `component :is`
#### Changes made:
* Render a empty `td` instead of a `th`
* Updated the spec to reflect this (tests are still passing)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
