### PR TITLE
chore(*): fix KBadge KButton and KCheckbox ux bugs

### DIFF
--- a/docs/components/input-checkbox.md
+++ b/docs/components/input-checkbox.md
@@ -18,7 +18,7 @@
 export default {
   data() {
     return {
-      checked: false
+      checked: true
     }
   },
   methods: {
@@ -44,6 +44,7 @@ state of the input. You can read more about passing values via `v-model`
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/v2/api/#vm-attrs).
 
+
 ```vue
 <KCheckbox
   v-model="checked"
@@ -52,7 +53,8 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 <KCard>
   <template v-slot:body>
-    <KCheckbox v-model="defaultChecked" disabled />
+    <KCheckbox v-model="checked" disabled />
+    <KCheckbox v-model="disabledChecked" disabled />
   </template>
 </KCard>
 
@@ -89,6 +91,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 |:-------- |:-------
 | `--KCheckboxPrimary `| KCheckbox checked background color
 | `--KCheckboxDisabled `| KCheckbox disabled background color
+| `--KCheckboxDisabledChecked `| KCheckbox disabled checked background color
 
 
 An Example of changing the background color of KCheckbox to `blueviolet` might look 
@@ -128,6 +131,7 @@ export default {
       labelPropChecked2: false,
       labelPropChecked3: false,
       defaultChecked: false,
+      disabledChecked: true,
       themeChecked: true,
       slots1: true,
       slots2: false

--- a/packages/KBadge/KBadge.vue
+++ b/packages/KBadge/KBadge.vue
@@ -68,7 +68,6 @@ export default {
 .k-badge {
   display: inline-block;
   font-weight: 300;
-  vertical-align: top;
   font-size: var(--KBadgeFontSize, 11px);
   line-height: var(--KBadgeLineHeight, var(--type-md, type(md)));
   height: auto;

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -7,6 +7,12 @@
     class="k-button"
     v-on="listeners">
     <slot name="icon" /><slot/>
+    <KIcon
+      v-if="isOpen !== undefined"
+      :class="[caretClasses]"
+      color="white"
+      view-box="2 2 15 15"
+      icon="chevronDown"/>
   </a>
   <component
     v-else
@@ -17,10 +23,18 @@
     class="k-button"
     v-on="listeners">
     <slot name="icon" /><slot/>
+    <KIcon
+      v-if="isOpen !== undefined"
+      :class="['caret', caretClasses]"
+      color="white"
+      view-box="2 2 15 15"
+      icon="chevronDown"/>
   </component>
 </template>
 
 <script>
+import KIcon from '@kongponents/kicon/KIcon.vue'
+
 export const appearances = {
   primary: 'primary',
   secondary: 'secondary',
@@ -38,6 +52,7 @@ export const sizes = {
 
 export default {
   name: 'KButton',
+  components: { KIcon },
   props: {
     /**
       * Base styling of the button
@@ -192,20 +207,13 @@ export default {
   }
 
   /* class to add for dropdown caret */
-  &.has-caret {
-    &:after {
-      display: inline-block;
-      width: 0;
-      height: 0;
-      margin-left: var(--spacing-xs,8px);
-      vertical-align: middle;
-      content: "";
-      border-top: .325em solid;
-      border-right: .325em solid transparent;
-      border-left: .325em solid transparent;
-      transition: 250ms ease;
-    }
-    &.is-active:after {
+  & .caret {
+    margin-left: 15px;
+    padding: 0;
+    display: inline-block;
+    transition: 250ms ease;
+
+    &.is-active {
       transform: rotate(-180deg);
       transition: 250ms ease;
     }

--- a/packages/KButton/__snapshots__/KButton.spec.js.snap
+++ b/packages/KButton/__snapshots__/KButton.spec.js.snap
@@ -1,19 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KButton renders a native link with KButton styles 1`] = `<a type="button" href="https://google.com" class="k-button medium rounded secondary">I'm a native link</a>`;
+exports[`KButton renders a native link with KButton styles 1`] = `
+<a type="button" href="https://google.com" class="k-button medium rounded secondary">I'm a native link
+  <!----></a>
+`;
 
-exports[`KButton renders a router link with KButton styles 1`] = `<a href="/services" class="k-button medium rounded primary" type="button">I'm a router link</a>`;
+exports[`KButton renders a router link with KButton styles 1`] = `
+<a href="/services" class="k-button medium rounded primary" type="button">I'm a router link
+  <!----></a>
+`;
 
-exports[`KButton renders kbutton with the btn-link appearance 1`] = `<button type="button" class="k-button medium rounded btn-link">btn-link</button>`;
+exports[`KButton renders kbutton with the btn-link appearance 1`] = `
+<button type="button" class="k-button medium rounded btn-link">btn-link
+  <!----></button>
+`;
 
-exports[`KButton renders kbutton with the creation appearance 1`] = `<button type="button" class="k-button medium rounded creation">creation</button>`;
+exports[`KButton renders kbutton with the creation appearance 1`] = `
+<button type="button" class="k-button medium rounded creation">creation
+  <!----></button>
+`;
 
-exports[`KButton renders kbutton with the danger appearance 1`] = `<button type="button" class="k-button medium rounded danger">danger</button>`;
+exports[`KButton renders kbutton with the danger appearance 1`] = `
+<button type="button" class="k-button medium rounded danger">danger
+  <!----></button>
+`;
 
-exports[`KButton renders kbutton with the outline appearance 1`] = `<button type="button" class="k-button medium rounded outline">outline</button>`;
+exports[`KButton renders kbutton with the outline appearance 1`] = `
+<button type="button" class="k-button medium rounded outline">outline
+  <!----></button>
+`;
 
-exports[`KButton renders kbutton with the primary appearance 1`] = `<button type="button" class="k-button medium rounded primary">primary</button>`;
+exports[`KButton renders kbutton with the primary appearance 1`] = `
+<button type="button" class="k-button medium rounded primary">primary
+  <!----></button>
+`;
 
-exports[`KButton renders kbutton with the secondary appearance 1`] = `<button type="button" class="k-button medium rounded secondary">secondary</button>`;
+exports[`KButton renders kbutton with the secondary appearance 1`] = `
+<button type="button" class="k-button medium rounded secondary">secondary
+  <!----></button>
+`;
 
-exports[`KButton sets small class when size passed 1`] = `<button type="button" class="k-button small rounded outline">Small Button</button>`;
+exports[`KButton sets small class when size passed 1`] = `
+<button type="button" class="k-button small rounded outline">Small Button
+  <!----></button>
+`;

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kicon": "^5.0.5"
   }
 }

--- a/packages/KEmptyState/__snapshots__/KEmptyState.spec.js.snap
+++ b/packages/KEmptyState/__snapshots__/KEmptyState.spec.js.snap
@@ -10,7 +10,7 @@ exports[`KEmptyState matches snapshot 1`] = `
     <div class="k-empty-state-message"></div>
     <div class="k-empty-state-cta"><button type="button" class="k-button small rounded primary">
 
-      </button></div>
+        <!----></button></div>
   </div>
 </section>
 `;
@@ -81,7 +81,7 @@ exports[`KEmptyState renders slots when passed 1`] = `
     </div>
     <div class="k-empty-state-cta"><button type="button" class="k-button small rounded primary">
         Click Me!
-      </button></div>
+        <!----></button></div>
   </div>
 </section>
 `;

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -9,10 +9,10 @@ exports[`KModal hides the title when using hideTitle prop 1`] = `
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
-          </button>
+            <!----></button>
           <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
               Submit
-            </button></div>
+              <!----></button></div>
         </div>
       </div>
     </div>
@@ -31,10 +31,10 @@ exports[`KModal renders custom button text & appearance 1`] = `
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
-          </button>
+            <!----></button>
           <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded outline">
               click to continue
-            </button></div>
+              <!----></button></div>
         </div>
       </div>
     </div>
@@ -51,7 +51,7 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
-          </button>
+            <!----></button>
           <div class="k-modal-action-buttons">
             <div>This is some action buttons text</div>
           </div>
@@ -71,10 +71,10 @@ exports[`KModal renders proper content when using props 1`] = `
         <div class="k-modal-body modal-body">Sweet prop content</div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
-          </button>
+            <!----></button>
           <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
               Submit
-            </button></div>
+              <!----></button></div>
         </div>
       </div>
     </div>

--- a/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
+++ b/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
@@ -3,7 +3,14 @@
 exports[`KMultiselect matches snapshot 1`] = `
 <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><button type="button" class="k-button k-multiselect-trigger has-caret medium rounded secondary has-caret">
 
-  </button>
+    <svg height="24" width="24" viewBox="2 2 15 15" role="img" class="kong-icon kong-icon-chevronDown caret has-caret">
+      <title>Expand</title>
+      <g>
+        <!---->
+        <!---->
+        <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+      </g>
+    </svg></button>
   <div id="test-popover-id-1234" role="region" class="k-popover k-multiselect mt-0 mb-0 hide-caret" style="width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
@@ -19,7 +26,8 @@ exports[`KMultiselect matches snapshot 1`] = `
               Item 2
             </li>
           </ul>
-          <div class="k-multiselect-footer"><button type="button" class="k-button k-multiselect-apply small rounded secondary" disabled="disabled">Apply</button></div>
+          <div class="k-multiselect-footer"><button type="button" class="k-button k-multiselect-apply small rounded secondary" disabled="disabled">Apply
+              <!----></button></div>
         </div>
       </div>
     </div>

--- a/packages/KPop/__snapshots__/KPop.spec.js.snap
+++ b/packages/KPop/__snapshots__/KPop.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`KPop renders props when passed 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     Click Me!
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover" style="width: 200px; display: none;" name="fade">
     <div class="k-popover-header d-flex">
       <div class="k-popover-title">Cool Beans!</div>
@@ -18,7 +18,7 @@ exports[`KPop renders props when passed 1`] = `
 exports[`KPop renders slots when passed 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     OK
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover pb-0" style="width: 200px; display: none;" name="fade">
     <div class="k-popover-header d-flex">
       <div class="k-popover-title"><span>Look Mah!</span></div>

--- a/packages/KSegmentedControl/__snapshots__/KSegmentedControl.spec.js.snap
+++ b/packages/KSegmentedControl/__snapshots__/KSegmentedControl.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`KSegmentedControl matches snapshot 1`] = `
 <div class="segmented-control d-flex"><button type="button" class="k-button justify-content-center small rounded primary" name="1">
     1
-  </button><button type="button" class="k-button justify-content-center small rounded outline" name="2">
+    <!----></button><button type="button" class="k-button justify-content-center small rounded outline" name="2">
     2
-  </button></div>
+    <!----></button></div>
 `;

--- a/packages/KViewSwitcher/__snapshots__/KViewSwitcher.spec.js.snap
+++ b/packages/KViewSwitcher/__snapshots__/KViewSwitcher.spec.js.snap
@@ -6,5 +6,6 @@ exports[`KViewSwitcher matches snapshot 1`] = `
     <div class="dots"><i></i><i></i><i></i><i></i></div>
     <div class="lines"><i></i><i></i><i></i><i></i></div>
   </div>
+  <!---->
 </button>
 `;

--- a/packages/KoolTip/__snapshots__/KoolTip.spec.js.snap
+++ b/packages/KoolTip/__snapshots__/KoolTip.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`KoolTip matches snapshot 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     OK
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
@@ -17,7 +17,7 @@ exports[`KoolTip matches snapshot 1`] = `
 exports[`KoolTip renders tooltip to the bottom side 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     OK
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
@@ -31,7 +31,7 @@ exports[`KoolTip renders tooltip to the bottom side 1`] = `
 exports[`KoolTip renders tooltip to the left side 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     OK
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover kooltip mr-2  hide-caret" style="width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
@@ -45,7 +45,7 @@ exports[`KoolTip renders tooltip to the left side 1`] = `
 exports[`KoolTip renders tooltip to the right side 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     OK
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover kooltip ml-2  hide-caret" style="width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
@@ -59,7 +59,7 @@ exports[`KoolTip renders tooltip to the right side 1`] = `
 exports[`KoolTip renders tooltip to the top side 1`] = `
 <div><button type="button" class="k-button medium rounded outline" id="test-target-id-1234" aria-controls="test-popover-id-1234" data-testid="kpop-button">
     OK
-  </button>
+    <!----></button>
   <div id="test-popover-id-1234" role="region" class="k-popover kooltip mb-2  hide-caret" style="width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">

--- a/packages/styles/forms/_checkbox-radio.scss
+++ b/packages/styles/forms/_checkbox-radio.scss
@@ -36,8 +36,14 @@ input.form-control {
     height: 20px;
     width: 20px;
     color: $primaryCheckboxColor;
+    border: none;
     border-radius: 3px;
     margin: 0 6px 0 0;
+    outline: none;
+
+    &:not(:checked) {
+      border: 1px solid $primaryCheckboxColor;
+    }
 
     &:checked {
       background-image: url("data:image/svg+xml,%3Csvg width='13' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10.633 0L12 1.397 3.583 10 0 6.337 1.367 4.94l2.216 2.265z' fill='%23FFF' fill-rule='nonzero'/%3E%3C/svg%3E");
@@ -63,9 +69,14 @@ input.form-control {
       border-color: $primaryCheckboxColor;
     }
 
-    &:disabled {
-      background-color: var(--KInputCheckboxDisabled, var(--grey-200, color(grey-200)));
-      border: none;
+    &:disabled:not(:checked) {
+      background-color: var(--KInputCheckboxDisabled, var(--grey-100, color(grey-100)));
+      border: 1px solid var(--KCheckboxDisabledChecked, var(--grey-400, color(grey-400)));
+      border-radius: 2px;
+    }
+    &:disabled:checked {
+      background-color: var(--KCheckboxDisabledChecked, var(--grey-400, color(grey-400)));
+      // border: 1px solid var(--KCheckboxDisabledChecked, var(--grey-400, color(grey-400)));;
     }
   }
 


### PR DESCRIPTION
### Summary
This PR changes various visual bugs that got caught during the redesign review by the UX team.

#### Changes made:
* Vertically align KBadge
* Replace icon in KButton Caret
* Update styles of KCheckbox with a disabled attribute

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
