### PR TITLE
chore: move sr-only class to span inside th instead for KTable

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -8,13 +8,17 @@
           <th
             v-for="(column, index) in options.headers"
             :key="index"
-            :class="{'sortable': !column.hideLabel && column.sortable, 'sr-only': column.hideLabel, [sortOrder]: column.key === sortKey && !column.hideLabel}"
+            :class="{'sortable': !column.hideLabel && column.sortable, [sortOrder]: column.key === sortKey && !column.hideLabel}"
             @click="column.sortable && $emit('sort', column.key, sortOrder)"
           >
             <slot
               :name="`column-${column.key}`"
               :column="column">
-              {{ column.label ? column.label : column.key }}
+              <span
+                :class="{'sr-only': column.hideLabel}"
+              >
+                {{ column.label ? column.label : column.key }}
+              </span>
             </slot>
           </th>
         </template>
@@ -240,7 +244,7 @@ export default {
       font-size: var(--KTableHeaderSize, var(--type-sm, type(sm)));
       font-weight: 500;
 
-      &.sr-only {
+      .sr-only {
         position: absolute;
         width: 1px;
         height: 1px;

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -4,18 +4,18 @@ exports[`KTable default has hover class when passed 1`] = `
 <table class="k-table has-hover side-border">
   <thead>
     <tr>
-      <th class="sortable">
-        Name
-      </th>
-      <th class="">
-        ID
-      </th>
-      <th class="">
-        Enabled
-      </th>
-      <th class="sr-only">
-        actions
-      </th>
+      <th class="sortable"><span class="">
+              Name
+            </span></th>
+      <th class=""><span class="">
+              ID
+            </span></th>
+      <th class=""><span class="">
+              Enabled
+            </span></th>
+      <th class=""><span class="sr-only">
+              actions
+            </span></th>
     </tr>
   </thead>
   <tbody>
@@ -45,18 +45,18 @@ exports[`KTable default has small class when passed 1`] = `
 <table class="k-table has-hover is-small side-border">
   <thead>
     <tr>
-      <th class="sortable">
-        Name
-      </th>
-      <th class="">
-        ID
-      </th>
-      <th class="">
-        Enabled
-      </th>
-      <th class="sr-only">
-        actions
-      </th>
+      <th class="sortable"><span class="">
+              Name
+            </span></th>
+      <th class=""><span class="">
+              ID
+            </span></th>
+      <th class=""><span class="">
+              Enabled
+            </span></th>
+      <th class=""><span class="sr-only">
+              actions
+            </span></th>
     </tr>
   </thead>
   <tbody>
@@ -86,18 +86,18 @@ exports[`KTable default renders link in action slot 1`] = `
 <table class="k-table has-hover side-border">
   <thead>
     <tr>
-      <th class="sortable">
-        Name
-      </th>
-      <th class="">
-        ID
-      </th>
-      <th class="">
-        Enabled
-      </th>
-      <th class="sr-only">
-        actions
-      </th>
+      <th class="sortable"><span class="">
+              Name
+            </span></th>
+      <th class=""><span class="">
+              ID
+            </span></th>
+      <th class=""><span class="">
+              Enabled
+            </span></th>
+      <th class=""><span class="sr-only">
+              actions
+            </span></th>
     </tr>
   </thead>
   <tbody>
@@ -127,18 +127,18 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
 <table class="k-table has-hover side-border">
   <thead>
     <tr>
-      <th class="sortable">
-        Name
-      </th>
-      <th class="">
-        ID
-      </th>
-      <th class="">
-        Enabled
-      </th>
-      <th class="sr-only">
-        actions
-      </th>
+      <th class="sortable"><span class="">
+              Name
+            </span></th>
+      <th class=""><span class="">
+              ID
+            </span></th>
+      <th class=""><span class="">
+              Enabled
+            </span></th>
+      <th class=""><span class="sr-only">
+              actions
+            </span></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
### Summary
Move `sr-only` class to a span inside of th, so it doesn't affect any borders that are currently being applied to a `th`, and thus breaking the styling.

#### Changes made:
* Move `sr-only` class

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
