### PR TITLE
fix(kclipboard): update notification to toaster

### DIFF
--- a/docs/components/renderless/kclipboard.md
+++ b/docs/components/renderless/kclipboard.md
@@ -7,7 +7,7 @@
     <KInput :value="dataToCopy1" @input="dataToCopy1 = $event.target.value" type="text" class="mb-2 w-100" />
     <KClipboardProvider v-slot="{ copyToClipboard }">
       <KButton
-        @click="() => { if(copyToClipboard(dataToCopy1)){ alert(`copied to the clipboard: '${dataToCopy1}'`) } }">
+        @click="$toaster.open(`${dataToCopy1}`)">
         copy to clipboard
       </KButton>
     </KClipboardProvider>


### PR DESCRIPTION
### Summary
Update the notification for kclipboard from default browser confirmation to toaster
`UX-567`
#### Changes made:
Before:
![Screen Shot 2021-10-26 at 6 18 59 PM](https://user-images.githubusercontent.com/87779967/138971412-66a94e27-33e9-43e8-b43b-e38167b2bd5c.png)

After:
![Screen Shot 2021-10-26 at 6 20 02 PM](https://user-images.githubusercontent.com/87779967/138971424-af87218f-c36a-4a70-a5f9-dbfdc1625d22.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
