### PR TITLE
fix(*): kbutton and color fixes

### DIFF
--- a/packages/KBadge/KBadge.vue
+++ b/packages/KBadge/KBadge.vue
@@ -84,8 +84,8 @@ export default {
     background-color: var(--KBadgeDefaultBackground, var(--blue-100, color(blue-100)));
   }
   &.kbadge-success {
-    color: var(--KBadgeSuccessColor, var(--green-500, color(green-500)));
-    border-color: var(--KBadgeSuccessBorder, var(--green-500, color(green-500)));
+    color: var(--KBadgeSuccessColor, var(--green-700, color(green-700)));
+    border-color: var(--KBadgeSuccessBorder, var(--green-700, color(green-700)));
     background-color: var(--KBadgeSuccessBackground, var(--green-100, color(green-100)));
   }
   &.kbadge-danger {
@@ -99,8 +99,8 @@ export default {
     background-color: var(--KBadgeInfoBackground, var(--petrol-100, color(petrol-100)));
   }
   &.kbadge-warning {
-    color: var(--KBadgeWarningColor, var(--yellow-500, color(yellow-500)));
-    border-color: var(--KBadgeWarningBorder, var(--yellow-500, color(yellow-500)));
+    color: var(--KBadgeWarningColor, var(--yellow-600, color(yellow-600)));
+    border-color: var(--KBadgeWarningBorder, var(--yellow-600, color(yellow-600)));
     background-color: var(--KBadgeWarningBackground, var(--yellow-100, color(yellow-100)));
   }
 

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -144,7 +144,7 @@ export default {
   padding: var(--KButtonPaddingY, var(--spacing-sm, spacing(sm))) var(--KButtonPaddingX, var(--spacing-lg, spacing(lg)));
   font-family: var(--font-family-sans, font(sans));
   font-size: var(--type-md, type(md));
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.25;
   text-decoration: none;
   vertical-align: middle;

--- a/packages/styles/_variables.scss
+++ b/packages/styles/_variables.scss
@@ -38,6 +38,7 @@ $colors: (
   green-400: #42D782,
   green-500: #07A88D,
   green-600: #008871,
+  green-700: #13755E,
 
   teal-100: #CDF1FE,
   teal-200: #91E1FC,
@@ -50,6 +51,7 @@ $colors: (
   yellow-300: #FFD68C,
   yellow-400: #FABE5F,
   yellow-500: #C67C06,
+  yellow-600: #A05604,
 
   grey-100: #F8F8FA,
   grey-200: #F1F1F5,


### PR DESCRIPTION
### Summary
Fixes for UX-555.

#### Changes made:
* UX-595 - adjust KButton font-weight from 500 to 400
* UX-602 - add colors `green-700` and `yellow-600` and adjust KBadge `success` and `warning` colors for a11y

Before:

![image](https://user-images.githubusercontent.com/67973710/139092433-54077d52-b0e9-473a-bc3d-f9d0d1fbb7cb.png)

After:

![image](https://user-images.githubusercontent.com/67973710/139092353-990442fd-8f22-4021-8387-52c8ffd91103.png)

Before:

![image](https://user-images.githubusercontent.com/67973710/139092747-ed348afb-d1bd-48c4-9063-5196205046c9.png)

After:

![image](https://user-images.githubusercontent.com/67973710/139093086-02c7e4eb-78f0-405b-a217-b8a7d64514c3.png)

Colors:

![image](https://user-images.githubusercontent.com/67973710/139093164-8843b55e-d8b4-4dbc-893a-f765d7ecf0ae.png)

![image](https://user-images.githubusercontent.com/67973710/139093217-0c5c5e7f-fd06-4d16-a1c4-3c6a503c8bc0.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
