### PR TITLE
feat(kselect): add `button` appearance

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -87,7 +87,7 @@ The label for the select.
 ```
 
 ### appearance
-There are two styles of selects, `select` and `dropdown` (default).
+There are three styles of selects, `select` and `dropdown` (default) which are filterable, and lastly `button` which is not.
 
 The `dropdown` appearance style has a selected item object. You can deselect the item by clicking
 the Clear icon.
@@ -139,6 +139,28 @@ way to clear the selection once it is made.
 />
 ```
 
+The `button` style triggers the dropdown on click and you cannot filter the entries.
+
+<KSelect appearance='button' width="250" :items="[{ 
+    label: 'Show 25 per page', 
+    value: '25'
+  }, { 
+    label: 'Show 50 per page', 
+    value: '50'
+  }]" 
+/>
+
+```vue
+<KSelect appearance='button' width="250" :items="[{ 
+    label: 'Show 25 per page', 
+    value: '25'
+  }, { 
+    label: 'Show 50 per page', 
+    value: '50'
+  }]" 
+/>
+```
+
 ### width
 You can pass a `width` string for dropdown. By default the `width` is `170px`. This is the width
 of the input, dropdown, and selected item.
@@ -173,3 +195,9 @@ You can pass any input attribute and it will get properly bound to the element.
 ```vue
 <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
 ```
+
+## Events
+
+| Event     | returns             |
+| :-------- | :------------------ |
+| `selected` | `selectedItem` Object |

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -141,7 +141,7 @@ way to clear the selection once it is made.
 
 The `button` style triggers the dropdown on click and you cannot filter the entries.
 
-<KSelect appearance='button' width="250" :items="[{ 
+<KSelect appearance='button' :items="[{ 
     label: 'test', 
     value: 'test'
   }, { 
@@ -151,7 +151,7 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 />
 
 ```vue
-<KSelect appearance='button' width="250" :items="[{ 
+<KSelect appearance='button' :items="[{ 
     label: 'test', 
     value: 'test'
   }, { 
@@ -164,7 +164,7 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 ### buttonText
 You can configure the button text when an item is selected, if `appearance` is type `button`.
 
-<KSelect appearance='button' width="250" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
+<KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
 
 <script>
 export default {
@@ -191,7 +191,7 @@ export default {
 ```vue
 <KSelect 
   appearance='button' 
-  width="250" 
+  width="225" 
   @selected="item => handleItemSelect(item)" 
   :buttonText="`Show ${mySelect} per page`" 
   :items="items" 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -142,23 +142,82 @@ way to clear the selection once it is made.
 The `button` style triggers the dropdown on click and you cannot filter the entries.
 
 <KSelect appearance='button' width="250" :items="[{ 
-    label: 'Show 25 per page', 
-    value: '25'
+    label: 'test', 
+    value: 'test'
   }, { 
-    label: 'Show 50 per page', 
-    value: '50'
+    label: 'Test 1', 
+    value: 'test1'
   }]" 
 />
 
 ```vue
 <KSelect appearance='button' width="250" :items="[{ 
-    label: 'Show 25 per page', 
-    value: '25'
+    label: 'test', 
+    value: 'test'
   }, { 
-    label: 'Show 50 per page', 
-    value: '50'
+    label: 'Test 1', 
+    value: 'test1'
   }]" 
 />
+```
+
+### buttonText
+You can configure the button text when an item is selected, if `appearance` is type `button`.
+
+<KSelect appearance='button' width="250" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
+
+<script>
+export default {
+  data() {
+    return {
+      mySelect: '',
+      items: [{ 
+        label: '25', 
+        value: '25'
+      }, { 
+        label: '50', 
+        value: '50'
+      }]
+    }
+  },
+  methods: {
+    handleItemSelect (item) {
+      this.mySelect = item.label
+    }
+  }
+}
+</script>
+
+```vue
+<KSelect 
+  appearance='button' 
+  width="250" 
+  @selected="item => handleItemSelect(item)" 
+  :buttonText="`Show ${mySelect} per page`" 
+  :items="items" 
+/>
+
+<script>
+export default {
+  data() {
+    return {
+      mySelect: '',
+      items: [{ 
+        label: '25', 
+        value: '25'
+      }, { 
+        label: '50', 
+        value: '50'
+      }]
+    }
+  },
+  methods: {
+    handleItemSelect (item) {
+      this.mySelect = item.label
+    }
+  }
+}
+</script>
 ```
 
 ### width

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -316,7 +316,7 @@ export default {
 </style>
 
 <style lang="scss">
-.k-button.btn-link.has-caret .caret path {
+.k-button.btn-link.has-caret .caret.has-caret path {
   stroke: var(--KButtonBtnLink, var(--blue-500, color(blue-500)));
 }
 </style>

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -26,7 +26,7 @@
     <KIcon
       v-if="isOpen !== undefined"
       :class="['caret', caretClasses]"
-      color="white"
+      :color="appearance !== 'btn-link' ? 'white' : null"
       view-box="2 2 15 15"
       icon="chevronDown"/>
   </component>
@@ -313,5 +313,10 @@ export default {
     border-radius: 100px;
   }
 }
+</style>
 
+<style lang="scss">
+.k-button.btn-link.has-caret .caret path {
+  stroke: var(--KButtonBtnLink, var(--blue-500, color(blue-500)));
+}
 </style>

--- a/packages/KSelect/KSelect.spec.js
+++ b/packages/KSelect/KSelect.spec.js
@@ -92,7 +92,7 @@ describe('KSelect', () => {
     expect(selectLabel.text()).toEqual('Cool Beans!')
   })
 
-  it('renders with correct appearance', () => {
+  it('renders with correct appearance - select', () => {
     const wrapper = mount(KSelect, {
       propsData: {
         testMode: true,
@@ -105,6 +105,21 @@ describe('KSelect', () => {
     })
 
     expect(wrapper.find('.k-select-pop-select').exists()).toBe(true)
+  })
+
+  it('renders with correct appearance - button', () => {
+    const wrapper = mount(KSelect, {
+      propsData: {
+        testMode: true,
+        appearance: 'button',
+        items: [{
+          label: 'Label 1',
+          value: 'label1'
+        }]
+      }
+    })
+
+    expect(wrapper.find('.k-select-button').exists()).toBe(true)
   })
 
   it('reacts to text change and select', () => {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -57,10 +57,13 @@
             style="position: relative;"
             role="listbox">
             <KButton
+              :id="selectTextId"
               :is-open="isToggled"
               :placeholder="placeholderText"
+              :is-rounded="false"
               appearance="btn-link"
-              v-on="listeners">{{ selectedItem ? selectedItem.label : placeholderText }}</KButton>
+              v-on="listeners"
+              @keyup="triggerFocus(isToggled)">{{ selectedItem ? selectedItem.label : placeholderText }}</KButton>
           </div>
           <div
             v-else

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -115,6 +115,7 @@
 
 <script>
 import { uuid } from 'vue-uuid'
+import KButton from '@kongponents/kbutton/KButton.vue'
 import KIcon from '@kongponents/kicon/KIcon.vue'
 import KInput from '@kongponents/kinput/KInput.vue'
 import KLabel from '@kongponents/klabel/KLabel.vue'
@@ -131,7 +132,7 @@ const defaultKPopAttributes = {
 
 export default {
   name: 'KSelect',
-  components: { KIcon, KInput, KLabel, KPop, KSelectItem, KToggle },
+  components: { KButton, KIcon, KInput, KLabel, KPop, KSelectItem, KToggle },
   props: {
     kpopAttributes: {
       type: Object,

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -59,11 +59,11 @@
             <KButton
               :id="selectTextId"
               :is-open="isToggled"
-              :placeholder="placeholderText"
               :is-rounded="false"
+              v-bind="attrs"
               appearance="btn-link"
               v-on="listeners"
-              @keyup="triggerFocus(isToggled)">{{ selectedItem ? selectedItem.label : placeholderText }}</KButton>
+              @keyup="triggerFocus(isToggled)">{{ selectButtonText }}</KButton>
           </div>
           <div
             v-else
@@ -157,7 +157,7 @@ export default {
       default: ''
     },
     /**
-     * The display style, can be either dropdown or select
+     * The display style, can be either dropdown, select, or button
      */
     appearance: {
       type: String,
@@ -165,6 +165,14 @@ export default {
       validator: function (value) {
         return ['dropdown', 'select', 'button'].indexOf(value) !== -1
       }
+    },
+    /**
+     * Override the text displayed on the button if `appearance` is `button` after an item
+     * has been selected. By default display the selected item's label
+     */
+    buttonText: {
+      type: String,
+      default: ''
     },
     /**
      * Items are JSON objects with required 'label' and 'value'
@@ -236,6 +244,15 @@ export default {
       }
 
       return 'Filter...'
+    },
+    selectButtonText () {
+      if (this.buttonText && this.selectedItem) {
+        return this.buttonText
+      } else if (this.selectedItem) {
+        return this.selectedItem.label
+      }
+
+      return this.placeholderText
     }
   },
   beforeMount () {
@@ -360,6 +377,13 @@ export default {
     box-sizing: border-box;
     width: 100%;
     border-radius: 0 0 4px 4px;
+
+    &.k-select-pop-button {
+      --KPopPaddingY: var(--spacing-md);
+      --KPopPaddingX: var(--spacing-xxs);
+      border-radius: 4px;
+      border: 1px solid var(--blue-200);
+    }
 
     &.k-select-pop-dropdown {
       --KPopPaddingY: var(--spacing-md);

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -57,6 +57,7 @@
             style="position: relative;"
             role="listbox">
             <KButton
+              :style="widthStyle"
               :id="selectTextId"
               :is-open="isToggled"
               :is-rounded="false"
@@ -150,7 +151,7 @@ export default {
      */
     width: {
       type: String,
-      default: '170'
+      default: ''
     },
     placeholder: {
       type: String,
@@ -224,9 +225,23 @@ export default {
     listeners () {
       return this.$listeners
     },
+    widthValue: function () {
+      let w
+
+      if (!this.width) {
+        w = 170
+        if (this.appearance === 'button') {
+          w = 200
+        }
+      } else {
+        w = this.width
+      }
+
+      return w === 'auto' ? w : w + 'px'
+    },
     widthStyle: function () {
       return {
-        width: this.width === 'auto' ? this.width : this.width + 'px'
+        width: this.widthValue
       }
     },
     filteredItems: function () {
@@ -355,6 +370,10 @@ export default {
     .kong-icon-chevronDown {
       top: 10px;
     }
+  }
+
+  .k-select-button .has-caret svg {
+    margin-left: auto;
   }
 
   .k-input {      // need this so input takes the

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -44,10 +44,26 @@
             if (selectedItem && appearance === 'select') {
               filterStr = selectedItem.label
             }
-            toggle()
+            if (isToggled) {
+              toggle()
+            }
           }"
         >
           <div
+            v-if="appearance === 'button'"
+            :id="selectInputId"
+            class="k-select-button"
+            data-testid="k-select-input"
+            style="position: relative;"
+            role="listbox">
+            <KButton
+              :is-open="isToggled"
+              :placeholder="placeholderText"
+              appearance="btn-link"
+              v-on="listeners">{{ selectedItem ? selectedItem.label : placeholderText }}</KButton>
+          </div>
+          <div
+            v-else
             :id="selectInputId"
             :class="{ 'k-select-input': appearance === 'select'}"
             data-testid="k-select-input"
@@ -63,7 +79,7 @@
               :id="selectTextId"
               v-bind="attrs"
               v-model="filterStr"
-              :placeholder="placeholder || attrs.placeholder"
+              :placeholder="placeholderText"
               class="k-select-input"
               v-on="listeners"
               @keyup="triggerFocus(isToggled)" />
@@ -134,7 +150,7 @@ export default {
     },
     placeholder: {
       type: String,
-      default: 'Filter...'
+      default: ''
     },
     /**
      * The display style, can be either dropdown or select
@@ -143,7 +159,7 @@ export default {
       type: String,
       default: 'dropdown',
       validator: function (value) {
-        return ['dropdown', 'select'].indexOf(value) !== -1
+        return ['dropdown', 'select', 'button'].indexOf(value) !== -1
       }
     },
     /**
@@ -203,6 +219,19 @@ export default {
     },
     filteredItems: function () {
       return this.items.filter(item => item.label.toLowerCase().includes(this.filterStr.toLowerCase()))
+    },
+    placeholderText () {
+      if (this.placeholder) {
+        return this.placeholder
+      } else if (this.attrs.placeholder) {
+        return this.attrs.placeholder
+      }
+
+      if (this.appearance === 'button') {
+        return 'Select an item'
+      }
+
+      return 'Filter...'
     }
   },
   beforeMount () {
@@ -232,6 +261,7 @@ export default {
         }
       })
       this.filterStr = this.appearance === 'dropdown' ? '' : item.label
+      this.$emit('selected', item)
     },
     clearSelection () {
       this.items.forEach(anItem => {

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -12,7 +12,7 @@ exports[`KSelect matches snapshot 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="width: 170px; display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -42,7 +42,7 @@ exports[`KSelect renders props when passed 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="width: 170px;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -90,7 +90,7 @@ exports[`KSelect renders with selected item 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="width: 170px; display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">

--- a/packages/KSelect/package.json
+++ b/packages/KSelect/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@kongponents/kbutton": "^5.0.4",
     "@kongponents/kicon": "^5.0.4",
     "@kongponents/kinput": "^5.0.4",
     "@kongponents/klabel": "^5.0.4",


### PR DESCRIPTION
### Summary

#### Changes made:
* Add `button` style `appearance` for pagination page size dropdown style
* Add `buttonText` prop that allows customizing the text if the appearance is `button`
* Emit `selected` event when an item is selected
* Update docs

![image](https://user-images.githubusercontent.com/67973710/139692579-d43fb2bf-da7c-4400-9503-400f02a5b136.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
