### PR TITLE
style(kinput): add error state

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -46,6 +46,14 @@ You also have the option of using the `.help` utility class. This is meant to be
 
 ### Error State
 
+- `hasError`
+
+Boolean value that is by default false.
+
+- `errorMessage`
+
+String to be displayed as error message.
+
 <KInput class="w-100" hasError errorMessage="Service name should not contain “_”"/>
 ```vue
 <KInput class="w-100" 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -2,7 +2,7 @@
 
 **KInput** provides a wrapper around general `text` input's and provides specific Kong styling and state treatments (error, focus, etc).
 
-<KInput class="w-100" hasError errorMessage="Service name should not contain “_”"/>
+<KInput class="w-100" />
 ```vue
 <KInput class="w-100"/>
 ```
@@ -11,9 +11,9 @@
 ### Size
 You can specify `small`, `medium` (default), or `large` for the size.
 
-<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
-<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
-<KInput label="Large" size="large" hasError errorMessage="Service name should not contain “_”" />
+<KInput label="Small" size="small" class="mb-2" />
+<KInput label="Medium" class="mb-2" />
+<KInput label="Large" size="large" />
 
 ```
 <KInput label="Small" size="small" class="mb-2" />

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -2,7 +2,7 @@
 
 **KInput** provides a wrapper around general `text` input's and provides specific Kong styling and state treatments (error, focus, etc).
 
-<KInput class="w-100"/>
+<KInput class="w-100" hasError errorMessage="Service name should not contain “_”"/>
 ```vue
 <KInput class="w-100"/>
 ```
@@ -11,9 +11,9 @@
 ### Size
 You can specify `small`, `medium` (default), or `large` for the size.
 
-<KInput label="Small" size="small" class="mb-2" />
-<KInput label="Medium" class="mb-2" />
-<KInput label="Large" size="large" />
+<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
+<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
+<KInput label="Large" size="large" hasError errorMessage="Service name should not contain “_”" />
 
 ```
 <KInput label="Small" size="small" class="mb-2" />
@@ -44,6 +44,34 @@ You also have the option of using the `.help` utility class. This is meant to be
 </template>
 ```
 
+### Error State
+
+<KInput class="w-100" hasError errorMessage="Service name should not contain “_”"/>
+```vue
+<KInput class="w-100" 
+  hasError errorMessage="Service name should not contain “_”"/>
+```
+
+<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
+<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
+<KInput label="Large" size="large" hasError errorMessage="Service name should not contain “_”" />
+
+```
+<KInput 
+  label="Small" size="small" class="mb-2" 
+  hasError 
+  errorMessage="Service name should not contain “_”" />
+<KInput 
+  label="Medium" 
+  class="mb-2" 
+  hasError 
+  errorMessage="Service name should not contain “_”" />
+<KInput 
+  label="Large" 
+  size="large" 
+  hasError 
+  errorMessage="Service name should not contain “_”" />
+```
 ### Label
 String to be used as the input label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element. 
 

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -7,6 +7,7 @@
       v-bind="attrs"
       :value="value"
       :class="`k-input-${size}`"
+      :aria-invalid="hasError ? hasError : null"
       class="form-control k-input"
       @input="e => {
         $emit('input', e.target.value)
@@ -28,6 +29,7 @@
           :id="inputId"
           :value="currValue ? currValue : value"
           :class="`k-input-${size}`"
+          :aria-invalid="hasError ? hasError : null"
           class="form-control k-input"
           @input="e => {
             $emit('input', e.target.value),

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="k-input-wrapper">
+  <div
+    :class="{'input-error' : hasError}"
+    class="k-input-wrapper">
     <input
       v-if="!label"
       v-bind="attrs"
@@ -18,7 +20,7 @@
       <div class="text-on-input">
         <label
           :for="inputId"
-          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled }">
+          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled, error: hasError }">
           <span>{{ label }}</span>
         </label>
         <input
@@ -38,11 +40,15 @@
           v-on="listeners">
       </div>
     </div>
-
     <p
       v-if="help"
       class="help">
       {{ help }}
+    </p>
+    <p
+      v-if="hasError"
+      class="has-error">
+      {{ errorMessage }}
     </p>
   </div>
 </template>
@@ -53,6 +59,14 @@ import { uuid } from 'vue-uuid'
 export default {
   name: 'KInput',
   props: {
+    hasError: {
+      type: Boolean,
+      default: false
+    },
+    errorMessage: {
+      type: String,
+      default: ''
+    },
     value: {
       type: String,
       default: ''
@@ -117,5 +131,46 @@ export default {
   margin: var(--spacing-xs, spacing(xs)) 0 0;
   font-size: var(--type-sm, type(sm));
   color: var(--black-45, color(black-45));
+}
+
+.has-error {
+  font-weight: 500;
+  color: var(--red-500);
+}
+
+.k-input-wrapper > .k-input-label-large + .has-error {
+  font-size: 12px;
+  line-height: 15px;
+  margin-top: 4px;
+}
+
+.k-input-wrapper > .k-input-label-medium + .has-error {
+  font-size: 10px;
+  line-height: 13px;
+  margin-top: 3px;
+}
+
+.k-input-wrapper > .k-input-label-small + .has-error {
+  font-size: 9px;
+  line-height: 11px;
+  margin-top: 2px;
+}
+
+.k-input-wrapper > .k-input-large + .has-error {
+  font-size: 12px;
+  line-height: 15px;
+  margin-top: 4px;
+}
+
+.k-input-wrapper > .k-input-medium + .has-error {
+  font-size: 10px;
+  line-height: 13px;
+  margin-top: 3px;
+}
+
+.k-input-wrapper > .k-input-small + .has-error {
+  font-size: 9px;
+  line-height: 11px;
+  margin-top: 2px;
 }
 </style>

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -138,39 +138,42 @@ export default {
   color: var(--red-500);
 }
 
-.k-input-wrapper > .k-input-label-large + .has-error {
-  font-size: 12px;
-  line-height: 15px;
-  margin-top: 4px;
+.k-input-wrapper {
+  & .k-input-label-large + .has-error {
+    font-size: 12px;
+    line-height: 15px;
+    margin-top: 4px;
+  }
+
+  & .k-input-label-medium + .has-error {
+    font-size: 10px;
+    line-height: 13px;
+    margin-top: 3px;
+  }
+
+  & .k-input-label-small + .has-error {
+    font-size: 9px;
+    line-height: 11px;
+    margin-top: 2px;
+  }
+
+  & .k-input-large + .has-error {
+    font-size: 12px;
+    line-height: 15px;
+    margin-top: 4px;
+  }
+
+  & .k-input-medium + .has-error {
+    font-size: 10px;
+    line-height: 13px;
+    margin-top: 3px;
+  }
+
+  & .k-input-small + .has-error {
+    font-size: 9px;
+    line-height: 11px;
+    margin-top: 2px;
+  }
 }
 
-.k-input-wrapper > .k-input-label-medium + .has-error {
-  font-size: 10px;
-  line-height: 13px;
-  margin-top: 3px;
-}
-
-.k-input-wrapper > .k-input-label-small + .has-error {
-  font-size: 9px;
-  line-height: 11px;
-  margin-top: 2px;
-}
-
-.k-input-wrapper > .k-input-large + .has-error {
-  font-size: 12px;
-  line-height: 15px;
-  margin-top: 4px;
-}
-
-.k-input-wrapper > .k-input-medium + .has-error {
-  font-size: 10px;
-  line-height: 13px;
-  margin-top: 3px;
-}
-
-.k-input-wrapper > .k-input-small + .has-error {
-  font-size: 9px;
-  line-height: 11px;
-  margin-top: 2px;
-}
 </style>

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -20,7 +20,7 @@
       <div class="text-on-input">
         <label
           :for="inputId"
-          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled, error: hasError }">
+          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled }">
           <span>{{ label }}</span>
         </label>
         <input

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -59,14 +59,6 @@ import { uuid } from 'vue-uuid'
 export default {
   name: 'KInput',
   props: {
-    hasError: {
-      type: Boolean,
-      default: false
-    },
-    errorMessage: {
-      type: String,
-      default: ''
-    },
     value: {
       type: String,
       default: ''
@@ -82,6 +74,14 @@ export default {
     size: {
       type: String,
       default: 'medium'
+    },
+    hasError: {
+      type: Boolean,
+      default: false
+    },
+    errorMessage: {
+      type: String,
+      default: ''
     },
     /**
      * Test mode - for testing only, strips out generated ids

--- a/packages/KInput/__snapshots__/KInput.spec.js.snap
+++ b/packages/KInput/__snapshots__/KInput.spec.js.snap
@@ -3,5 +3,6 @@
 exports[`KInput matches snapshot 1`] = `
 <div class="k-input-wrapper" placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input k-input-medium">
   <!---->
+  <!---->
 </div>
 `;

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -10,6 +10,7 @@ exports[`KSelect matches snapshot 1`] = `
         <!---->
         <div class="k-input-wrapper k-select-input" id="test-select-text-id-1234" placeholder="Filter..."><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->
+          <!---->
         </div>
       </div>
       <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="width: 170px; display: none;" name="fade">
@@ -39,6 +40,7 @@ exports[`KSelect renders props when passed 1`] = `
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
         <div class="k-input-wrapper k-select-input" id="test-select-text-id-1234" placeholder="Filter..." is-open="true"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium" is-open="true">
+          <!---->
           <!---->
         </div>
       </div>
@@ -87,6 +89,7 @@ exports[`KSelect renders with selected item 1`] = `
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
         <div class="k-input-wrapper k-select-input" id="test-select-text-id-1234" placeholder="Filter..."><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
+          <!---->
           <!---->
         </div>
       </div>


### PR DESCRIPTION
### Summary
Fix for UX-555.
#### Changes made:
UX-601 - add 2 new props `hasError`, `errorMessage` and error styling for error state in KInput.

![Screen Shot 2021-11-02 at 2 17 44 PM](https://user-images.githubusercontent.com/87779967/139922427-4d13125f-4865-41c5-8b6c-eff93c1f2ac1.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
