### PR TITLE
feat(kpagination): fixes for ktable

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -78,6 +78,49 @@ A number that sets the neighboring pages visible to the left and right of the ce
 <KPagination :totalCount="1000" :pageSize="15" neighbors="2"/>
 ```
 
+### currentPage
+Manually control the current page instead of using native handling.
+
+<Komponent :data="{ letters: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], visibleLetters: ['a', 'b', 'c'], currPage: 2}" v-slot="{ data }">
+  <div>
+    <span><b>Visible letters: </b></span>
+    <span v-for="number in data.visibleLetters">{{ number }} </span>
+    <KPagination 
+      :items="data.letters"
+      :totalCount="data.letters.length" 
+      :pageSizes="[3]" 
+      :currentPage="data.currPage"
+      @pageChanged="({visibleItems, page}) => { data.visibleLetters = visibleItems, data.currPage = page }"/>
+  </div>
+</Komponent>
+
+```vue
+<template>
+  <div>
+    <span><b>Visible letters: </b></span>
+    <span v-for="number in data.visibleLetters">{{ number }} </span>
+    <KPagination 
+      :items="data.letters"
+      :totalCount="data.letters.length" 
+      :pageSizes="[3]" 
+      :currentPage="currPage"
+      @pageChanged="({visibleItems, page}) => { 
+        data.visibleLetters = visibleItems, 
+        currPage = page 
+      }"/>
+  </div>
+</template>
+
+export default {
+  data () {
+    return {
+      currPage: 2
+    }
+  }
+}
+</script>
+```
+
 ## Usage
 
 ### Events
@@ -149,7 +192,8 @@ export default {
     return {
       names
       visibleNames: names.slice(0,3);
-      page: 1
+      page: 1,
+      currPage: 2
     }
   }
 }

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -81,7 +81,7 @@ A number that sets the neighboring pages visible to the left and right of the ce
 ### currentPage
 Manually control the current page instead of using native handling.
 
-<Komponent :data="{ letters: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], visibleLetters: ['a', 'b', 'c'], currPage: 2}" v-slot="{ data }">
+<Komponent :data="{ letters: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], visibleLetters: ['d', 'e', 'f'], currPage: 2}" v-slot="{ data }">
   <div>
     <span><b>Visible letters: </b></span>
     <span v-for="number in data.visibleLetters">{{ number }} </span>
@@ -90,7 +90,7 @@ Manually control the current page instead of using native handling.
       :totalCount="data.letters.length" 
       :pageSizes="[3]" 
       :currentPage="data.currPage"
-      @pageChanged="({visibleItems, page}) => { data.visibleLetters = visibleItems, data.currPage = page }"/>
+      @pageChanged="({visibleItems, page}) => { data.visibleLetters = visibleItems; data.currPage = page }"/>
   </div>
 </Komponent>
 
@@ -105,7 +105,7 @@ Manually control the current page instead of using native handling.
       :pageSizes="[3]" 
       :currentPage="currPage"
       @pageChanged="({visibleItems, page}) => { 
-        data.visibleLetters = visibleItems, 
+        data.visibleLetters = visibleItems 
         currPage = page 
       }"/>
   </div>
@@ -192,8 +192,7 @@ export default {
     return {
       names
       visibleNames: names.slice(0,3);
-      page: 1,
-      currPage: 2
+      page: 1
     }
   }
 }

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -78,8 +78,9 @@ A number that sets the neighboring pages visible to the left and right of the ce
 <KPagination :totalCount="1000" :pageSize="15" neighbors="2"/>
 ```
 
-### currentPage
-Manually control the current page instead of using native handling.
+### Current Page
+Manually control the current page instead of using native handling. If using this prop you MUST keep it up-to-date using
+the `@pageChanged` event in order to remain reactive to clicking the prev, next, and specific page buttons.
 
 <Komponent :data="{ letters: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], visibleLetters: ['d', 'e', 'f'], currPage: 2}" v-slot="{ data }">
   <div>

--- a/packages/KPagination/KPagination.spec.js
+++ b/packages/KPagination/KPagination.spec.js
@@ -1,12 +1,98 @@
 import { mount } from '@vue/test-utils'
 import KPagination from '@/KPagination/KPagination'
 
+/**
+ * ALL TESTS MUST USE testMode: true
+ * We generate unique IDs for reference by aria properties. Test mode strips these out
+ * allowing for successful snapshot verification.
+ * propsData: {
+ *   testMode: true
+ * }
+ */
 describe('KPagination', () => {
+  const myItems = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+  const pageSizes = [2, 4, 6]
+
+  it('correctly renders props', () => {
+    const currPage = 2
+    const wrapper = mount(KPagination, {
+      propsData: {
+        totalCount: 9,
+        pageSizes: pageSizes,
+        currentPage: currPage,
+        items: myItems,
+        testMode: true
+      }
+    })
+
+    expect(wrapper.find('[data-testid="visible-items"]').html()).toEqual(expect.stringContaining('3 to 4'))
+    expect(wrapper.find('[data-testid="visible-items"]').html()).toEqual(expect.stringContaining('of 9'))
+    expect(wrapper.find('.pagination-button.active a').html()).toEqual(expect.stringContaining(currPage + ''))
+
+    for (let i = 0; i < pageSizes.length; i++) {
+      expect(wrapper.find(`[data-testid="k-select-item-${pageSizes[i]}"]`).exists()).toBe(true)
+    }
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('goes to first page', () => {
+    const wrapper = mount(KPagination, {
+      propsData: {
+        totalCount: 9,
+        pageSizes: [2, 4, 6],
+        items: myItems,
+        testMode: true
+      }
+    })
+
+    expect(wrapper.find('.pagination-button.active').html()).toEqual(expect.stringContaining(1 + ''))
+    wrapper.find('[data-testid="next-btn"] a').trigger('click')
+    wrapper.find('[data-testid="next-btn"] a').trigger('click')
+    expect(wrapper.find('.pagination-button.active').html()).toEqual(expect.stringContaining(3 + ''))
+    wrapper.find('[data-testid="page-1-btn"] a').trigger('click')
+    expect(wrapper.find('.pagination-button.active').html()).toEqual(expect.stringContaining(1 + ''))
+  })
+
+  it('goes to previous page', () => {
+    const wrapper = mount(KPagination, {
+      propsData: {
+        totalCount: 9,
+        pageSizes: [2, 4, 6],
+        items: myItems,
+        testMode: true
+      }
+    })
+
+    expect(wrapper.find('.pagination-button.active').html()).toEqual(expect.stringContaining(1 + ''))
+    wrapper.find('[data-testid="next-btn"] a').trigger('click')
+    expect(wrapper.find('.pagination-button.active').html()).toEqual(expect.stringContaining(2 + ''))
+    wrapper.find('[data-testid="prev-btn"] a').trigger('click')
+    expect(wrapper.find('.pagination-button.active').html()).toEqual(expect.stringContaining(1 + ''))
+  })
+
+  it('can change page size', () => {
+    const wrapper = mount(KPagination, {
+      propsData: {
+        totalCount: 9,
+        pageSizes: [2, 4, 6],
+        items: myItems,
+        testMode: true
+      }
+    })
+
+    expect(wrapper.find('[data-testid="k-select-input"] .k-button').html()).toEqual(expect.stringContaining('2 items per page'))
+    wrapper.find('[data-testid="k-select-input"] button').trigger('click')
+    wrapper.find('[data-testid="k-select-item-4"] button').trigger('click')
+    expect(wrapper.find('[data-testid="k-select-input"] .k-button').html()).toEqual(expect.stringContaining('4 items per page'))
+  })
+
   it('matches snapshot', () => {
     const wrapper = mount(KPagination, {
       propsData: {
         totalCount: 100,
         pageSizes: [10, 20, 30],
+        neighbors: 2,
         testMode: true
       }
     })

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -1,16 +1,21 @@
 <template>
-  <nav aria-label="Pagination Navigation">
+  <nav
+    aria-label="Pagination Navigation"
+    data-testid="k-pagination-container">
     <div
       v-if="totalCount > currentPageSize"
       class="card-pagination-bar">
-      <span class="pagination-text">
+      <span
+        class="pagination-text"
+        data-testid="visible-items">
         <span class="pagination-text-pages">{{ pagesString }}</span>
         {{ pageCountString }}
       </span>
       <ul class="pagination-button-container">
         <li
           :class="{ disabled: backDisabled }"
-          class="pagination-button square">
+          class="pagination-button square"
+          data-testid="prev-btn">
           <a
             href="#"
             aria-label="Go to the previous page"
@@ -26,7 +31,8 @@
         </li>
         <li
           v-if="firstDetached"
-          class="pagination-button">
+          class="pagination-button"
+          data-testid="page-1-btn">
           <a
             href="#"
             aria-label="Go to the first page"
@@ -43,6 +49,7 @@
           v-for="page in pagesVisible"
           :key="page"
           :class="{ active: page == currentlySelectedPage }"
+          :data-testid="`page-${page}-btn`"
           class="pagination-button">
           <a
             :aria-label="`Go to page ${page}`"
@@ -63,13 +70,15 @@
           <a
             href="#"
             aria-label="Go to the last page"
+            data-testid="last-btn"
             @click="changePage(pageCount)">
             {{ pageCount }}
           </a>
         </li>
         <li
           :class="{ disabled: forwardDisabled }"
-          class="pagination-button square">
+          class="pagination-button square"
+          data-testid="next-btn">
           <a
             href="#"
             aria-label="Go to the next page"
@@ -84,7 +93,9 @@
           </a>
         </li>
       </ul>
-      <span class="page-size-select">
+      <span
+        class="page-size-select"
+        data-testid="page-size-dropdown">
         <KSelect
           :placeholder="`${currentPageSize} items per page`"
           :items="pageSizeOptions"

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -42,11 +42,11 @@
         <li
           v-for="page in pagesVisible"
           :key="page"
-          :class="{ active: page == currentPage }"
+          :class="{ active: page == currentlySelectedPage }"
           class="pagination-button">
           <a
             :aria-label="`Go to page ${page}`"
-            :aria-current="page == currentPage && 'page'"
+            :aria-current="page == currentlySelectedPage && 'page'"
             href="#"
             @click="changePage(page)">
             {{ page }}
@@ -90,6 +90,7 @@
           :items="pageSizeOptions"
           :test-mode="testMode"
           :button-text="pageSizeText"
+          :kpop-attributes="kpopAttrs"
           appearance="button"
           @selected="updatePageSize"
         />
@@ -129,6 +130,10 @@ export default {
       type: Boolean,
       default: false
     },
+    currentPage: {
+      type: Number,
+      default: null
+    },
     /**
      * Test mode - for testing only, strips out generated ids
      */
@@ -138,7 +143,7 @@ export default {
     }
   },
   data () {
-    const currentPage = 1
+    const currPage = this.currentPage ? this.currentPage : 1
     const currentPageSize = this.pageSizes[0]
     const pageCount = Math.ceil(this.totalCount / currentPageSize)
 
@@ -149,7 +154,10 @@ export default {
     }))
 
     return {
-      currentPage,
+      kpopAttrs: {
+        placement: 'top'
+      },
+      currPage,
       currentPageSize,
       pageCount,
       pageSizeOptions,
@@ -157,7 +165,7 @@ export default {
       forwardDisabled: this.totalCount === 1,
       pageSizeText: '',
       pagesVisible: this.getVisiblePages(
-        currentPage,
+        currPage,
         pageCount,
         false,
         pageCount > 5 + 2 * this.neighbors
@@ -168,7 +176,7 @@ export default {
   },
   computed: {
     startCount () {
-      return (this.currentPage - 1) * this.currentPageSize + 1
+      return (this.currPage - 1) * this.currentPageSize + 1
     },
     endCount () {
       let calculatedEndCount = this.startCount - 1 + this.currentPageSize
@@ -182,6 +190,13 @@ export default {
     },
     pageCountString () {
       return ` of ${this.totalCount}`
+    },
+    currentlySelectedPage () {
+      if (this.currentPage) {
+        return this.currentPage
+      } else {
+        return this.currPage
+      }
     }
   },
   watch: {
@@ -197,7 +212,7 @@ export default {
         return
       }
 
-      this.currentPage++
+      this.currPage++
       this.updatePage()
     },
     pageBack () {
@@ -205,19 +220,19 @@ export default {
         return
       }
 
-      this.currentPage--
+      this.currPage--
       this.updatePage()
     },
     changePage (page) {
-      this.currentPage = page
+      this.currPage = page
       this.updatePage()
     },
     updatePage () {
       const lastEntry =
-        (this.currentPage - 1) * this.currentPageSize + this.currentPageSize
+        (this.currPage - 1) * this.currentPageSize + this.currentPageSize
 
       this.forwardDisabled = lastEntry >= this.totalCount
-      this.backDisabled = this.currentPage === 1
+      this.backDisabled = this.currPage === 1
 
       // The view will hold
       // Selected page, first page, last page, 2 placeholders and 2 * neighbors
@@ -228,15 +243,15 @@ export default {
         this.firstDetached = false
         this.lastDetached = false
       } else {
-        this.firstDetached = this.currentPage >= this.neighbors + 4
+        this.firstDetached = this.currPage >= this.neighbors + 4
         this.lastDetached =
-          this.currentPage <= this.pageCount - this.neighbors - 3
+          this.currPage <= this.pageCount - this.neighbors - 3
       }
 
       this.pagesVisible = this.getVisiblePages()
 
       this.$emit('pageChanged', {
-        page: this.currentPage,
+        page: this.currPage,
         pageCount: this.pageCount,
         firstItem: this.startCount,
         lastItem: this.endCount,
@@ -256,7 +271,7 @@ export default {
       this.changePage(1)
     },
     getVisiblePages (
-      currentPage = this.currentPage,
+      currPage = this.currPage,
       pageCount = this.pageCount,
       firstDetached = this.firstDetached,
       lastDetached = this.lastDetached
@@ -276,8 +291,8 @@ export default {
         // Middle pages (if they do not fit on one screen)
         pages = pages.filter(
           (n) =>
-            n > currentPage - this.neighbors - 1 &&
-            n < currentPage + this.neighbors + 1
+            n > currPage - this.neighbors - 1 &&
+            n < currPage + this.neighbors + 1
         )
       } else if (firstDetached && !lastDetached) {
         // Last pages
@@ -320,6 +335,7 @@ export default {
   a {
     text-decoration: none !important;
     font-weight: initial;
+    display: block;
   }
 
   .pagination-button {
@@ -363,6 +379,14 @@ export default {
       border-radius: 4px;
       background-color: var(--blue-100);
     }
+  }
+}
+</style>
+
+<style lang="scss">
+.page-size-select {
+  .k-select-pop-button[x-placement^="top"] {
+    margin-bottom: 2px;
   }
 }
 </style>

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -161,11 +161,11 @@ export default {
       currentPageSize,
       pageCount,
       pageSizeOptions,
-      backDisabled: true,
+      backDisabled: currPage === 1,
       forwardDisabled: this.totalCount === 1,
       pageSizeText: '',
       pagesVisible: this.getVisiblePages(
-        currPage,
+        this.currentlySelectedPage,
         pageCount,
         false,
         pageCount > 5 + 2 * this.neighbors

--- a/packages/KPagination/__snapshots__/KPagination.spec.js.snap
+++ b/packages/KPagination/__snapshots__/KPagination.spec.js.snap
@@ -1,12 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KPagination correctly renders props 1`] = `
+<nav aria-label="Pagination Navigation" data-testid="k-pagination-container">
+  <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">3 to 4</span>
+    of 9
+    </span>
+    <ul class="pagination-button-container">
+      <li data-testid="prev-btn" class="pagination-button square"><a href="#" aria-label="Go to the previous page"><svg height="24" width="16px" viewBox="0 0 16 14" role="img" class="kong-icon kong-icon-arrowLeft" heigth="16px">
+            <title>Back</title>
+            <g>
+              <!---->
+              <!---->
+              <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
+            </g>
+          </svg></a></li>
+      <!---->
+      <!---->
+      <li data-testid="page-1-btn" class="pagination-button"><a aria-label="Go to page 1" href="#">
+          1
+        </a></li>
+      <li data-testid="page-2-btn" class="pagination-button active"><a aria-label="Go to page 2" aria-current="page" href="#">
+          2
+        </a></li>
+      <li data-testid="page-3-btn" class="pagination-button"><a aria-label="Go to page 3" href="#">
+          3
+        </a></li>
+      <li data-testid="page-4-btn" class="pagination-button"><a aria-label="Go to page 4" href="#">
+          4
+        </a></li>
+      <li data-testid="page-5-btn" class="pagination-button"><a aria-label="Go to page 5" href="#">
+          5
+        </a></li>
+      <!---->
+      <!---->
+      <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><svg height="24" width="16px" viewBox="0 0 16 14" role="img" class="kong-icon kong-icon-arrowRight" heigth="16px">
+            <title>Forward</title>
+            <g>
+              <!---->
+              <!---->
+              <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
+            </g>
+          </svg></a></li>
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;">2 items per page <svg height="24" width="24" viewBox="2 2 15 15" role="img" class="kong-icon kong-icon-chevronDown caret has-caret"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></button></div> <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade"><!----> <div class="k-popover-content"><ul class="k-select-list ma-0 pa-0"><div><div data-testid="k-select-item-2" class="k-select-item"><li role="option" class="d-block"><button value="2" class=""><span class="k-select-item-label mr-2">2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+  </div>
+  <div data-testid="k-select-item-4" class="k-select-item">
+    <li role="option" class="d-block"><button value="4" class=""><span class="k-select-item-label mr-2">4</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+  </div>
+  <div data-testid="k-select-item-6" class="k-select-item">
+    <li role="option" class="d-block"><button value="6" class=""><span class="k-select-item-label mr-2">6</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+  </div>
+  </div>
+  </ul>
+  </div>
+  <!---->
+  </div>
+  </div>
+  </div>
+  </div></span></div>
+</nav>
+`;
+
 exports[`KPagination matches snapshot 1`] = `
-<nav aria-label="Pagination Navigation">
-  <div class="card-pagination-bar"><span class="pagination-text"><span class="pagination-text-pages">1 to 10</span>
+<nav aria-label="Pagination Navigation" data-testid="k-pagination-container">
+  <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 10</span>
     of 100
     </span>
     <ul class="pagination-button-container">
-      <li class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><svg height="24" width="16px" viewBox="0 0 16 14" role="img" class="kong-icon kong-icon-arrowLeft" heigth="16px">
+      <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><svg height="24" width="16px" viewBox="0 0 16 14" role="img" class="kong-icon kong-icon-arrowLeft" heigth="16px">
             <title>Back</title>
             <g>
               <!---->
@@ -16,28 +76,34 @@ exports[`KPagination matches snapshot 1`] = `
           </svg></a></li>
       <!---->
       <!---->
-      <li class="pagination-button active"><a aria-label="Go to page 1" aria-current="page" href="#">
+      <li data-testid="page-1-btn" class="pagination-button active"><a aria-label="Go to page 1" aria-current="page" href="#">
           1
         </a></li>
-      <li class="pagination-button"><a aria-label="Go to page 2" href="#">
+      <li data-testid="page-2-btn" class="pagination-button"><a aria-label="Go to page 2" href="#">
           2
         </a></li>
-      <li class="pagination-button"><a aria-label="Go to page 3" href="#">
+      <li data-testid="page-3-btn" class="pagination-button"><a aria-label="Go to page 3" href="#">
           3
         </a></li>
-      <li class="pagination-button"><a aria-label="Go to page 4" href="#">
+      <li data-testid="page-4-btn" class="pagination-button"><a aria-label="Go to page 4" href="#">
           4
         </a></li>
-      <li class="pagination-button"><a aria-label="Go to page 5" href="#">
+      <li data-testid="page-5-btn" class="pagination-button"><a aria-label="Go to page 5" href="#">
           5
+        </a></li>
+      <li data-testid="page-6-btn" class="pagination-button"><a aria-label="Go to page 6" href="#">
+          6
+        </a></li>
+      <li data-testid="page-7-btn" class="pagination-button"><a aria-label="Go to page 7" href="#">
+          7
         </a></li>
       <li class="pagination-button placeholder">
         ...
       </li>
-      <li class="pagination-button"><a href="#" aria-label="Go to the last page">
+      <li class="pagination-button"><a href="#" aria-label="Go to the last page" data-testid="last-btn">
           10
         </a></li>
-      <li class="pagination-button square"><a href="#" aria-label="Go to the next page"><svg height="24" width="16px" viewBox="0 0 16 14" role="img" class="kong-icon kong-icon-arrowRight" heigth="16px">
+      <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><svg height="24" width="16px" viewBox="0 0 16 14" role="img" class="kong-icon kong-icon-arrowRight" heigth="16px">
             <title>Forward</title>
             <g>
               <!---->
@@ -45,7 +111,7 @@ exports[`KPagination matches snapshot 1`] = `
               <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
             </g>
           </svg></a></li>
-    </ul> <span class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;">10 items per page <svg height="24" width="24" viewBox="2 2 15 15" role="img" class="kong-icon kong-icon-chevronDown caret has-caret"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></button></div> <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade"><!----> <div class="k-popover-content"><ul class="k-select-list ma-0 pa-0"><div><div data-testid="k-select-item-10" class="k-select-item"><li role="option" class="d-block"><button value="10" class=""><span class="k-select-item-label mr-2">10</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;">10 items per page <svg height="24" width="24" viewBox="2 2 15 15" role="img" class="kong-icon kong-icon-chevronDown caret has-caret"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></button></div> <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade"><!----> <div class="k-popover-content"><ul class="k-select-list ma-0 pa-0"><div><div data-testid="k-select-item-10" class="k-select-item"><li role="option" class="d-block"><button value="10" class=""><span class="k-select-item-label mr-2">10</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
   </div>
   <div data-testid="k-select-item-20" class="k-select-item">
     <li role="option" class="d-block"><button value="20" class=""><span class="k-select-item-label mr-2">20</span> <span class="k-select-selected-icon-container"><!----></span></button></li>

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -62,7 +62,6 @@
               :is-rounded="false"
               v-bind="attrs"
               appearance="btn-link"
-              v-on="listeners"
               @keyup="triggerFocus(isToggled)">{{ selectButtonText }}</KButton>
           </div>
           <div
@@ -130,7 +129,7 @@ const defaultKPopAttributes = {
   hideCaret: true,
   popoverClasses: 'k-select-popover mt-0',
   popoverTimeout: 0,
-  placement: 'bottomLeft'
+  placement: 'bottomStart'
 }
 
 export default {
@@ -139,7 +138,9 @@ export default {
   props: {
     kpopAttributes: {
       type: Object,
-      default: () => ({})
+      default: () => ({
+        popoverClasses: ''
+      })
     },
     label: {
       type: String,

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -35,7 +35,6 @@
           }"
           :test-mode="testMode"
           :target="`[id='${selectInputId}']`"
-          placement="bottomStart"
           @opened="() => {
             filterStr = ''
             toggle()
@@ -214,7 +213,6 @@ export default {
         ...defaultKPopAttributes,
         ...this.kpopAttributes,
         popoverClasses: `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses} k-select-pop-${this.appearance}`,
-        placement: this.placement,
         width: this.width,
         disabled: this.$attrs.disabled
       }

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -13,7 +13,7 @@ exports[`KSelect matches snapshot 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -44,7 +44,7 @@ exports[`KSelect renders props when passed 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -93,7 +93,7 @@ exports[`KSelect renders with selected item 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">


### PR DESCRIPTION
### Summary
Fixes for KTable.

#### Changes made:
* Have the page size dropdown open upward
* Add `currentPage` prop
* Make full page selection button clickable, not just the number
* Update docs and snaps

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
