### PR TITLE
Increase radio button stroke change

### DIFF
--- a/packages/styles/forms/_checkbox-radio.scss
+++ b/packages/styles/forms/_checkbox-radio.scss
@@ -87,6 +87,7 @@ input.form-control {
     height: 20px;
     width: 20px;
     color: $primaryRadioColor;
+    border: 2px solid $borderColor;
     border-radius: 100%;
     margin: 0 6px 0 0;
 
@@ -108,7 +109,7 @@ input.form-control {
 
     // IE11
     &:checked::-ms-check {
-      border: 1px solid currentColor;
+      border: 2px solid currentColor;
       color: currentColor;
     }
 


### PR DESCRIPTION
### Summary
Increase radio button stroke from 1px to 2px

#### Changes made:
* Increase radio button stroke from 1px to 2px

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
