### PR TITLE
fix(kinput): apply attributes to input [KHCP-2108]

### DIFF
--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -3,7 +3,7 @@
     <input
       v-if="!label"
       :value="value"
-      v-bind="attrs"
+      v-bind="$attrs"
       class="form-control k-input"
       @input="e => $emit('input', e.target.value)"
       v-on="listeners">
@@ -12,12 +12,14 @@
       v-else
       class="col-md-4 mt-5">
       <div class="text-on-input">
-        <label :class="{ focused: isFocused }">
+        <label
+          :for="$attrs.id ? $attrs.id : null"
+          :class="{ focused: isFocused }">
           {{ label }}
         </label>
         <input
           :value="value"
-          v-bind="attrs"
+          v-bind="$attrs"
           class="form-control k-input"
           @input="e => $emit('input', e.target.value)"
           @focus="() => isFocused = true"
@@ -58,9 +60,6 @@ export default {
     }
   },
   computed: {
-    attrs () {
-      return this.$attrs
-    },
     listeners () {
       const listeners = { ...this.$listeners }
 

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -17,7 +17,7 @@
         </label>
         <input
           :value="value"
-          v-bind="attrs"
+          v-bind="$attrs"
           class="form-control k-input"
           @input="e => $emit('input', e.target.value)"
           @focus="() => isFocused = true"
@@ -37,6 +37,7 @@
 <script>
 export default {
   name: 'KInput',
+  inheritAttrs: false,
   props: {
     value: {
       type: String,

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -17,7 +17,7 @@
         </label>
         <input
           :value="value"
-          v-bind="$attrs"
+          v-bind="attrs"
           class="form-control k-input"
           @input="e => $emit('input', e.target.value)"
           @focus="() => isFocused = true"

--- a/packages/KInput/__snapshots__/KInput.spec.js.snap
+++ b/packages/KInput/__snapshots__/KInput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KInput matches snapshot 1`] = `
-<div class="k-input-wrapper" placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input">
+<div class="k-input-wrapper"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input">
   <!---->
 </div>
 `;


### PR DESCRIPTION
### Summary

Apply attributes to the child input element rather than the wrapper to avoid duplicate elements with the same id.

#### Changes made:
* Add `inheritAttrs` property to component definition to disable attribute inheritance on the wrapper element.
* Alter `v-bind` to use `$attrs` instead of `attrs` (to spec).

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
