### PR TITLE
fix(attrs): apply attributes to child elements [KHCP-2173]

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -2,7 +2,7 @@
 
 **KInput** provides a wrapper around general `text` input's and provides specific Kong styling and state treatments (error, focus, etc).
 
-<KInput class="w-100" />
+<KInput class="w-100"/>
 ```vue
 <KInput class="w-100"/>
 ```
@@ -32,7 +32,7 @@ String to be displayed as help text.
 <KInput help="I can help with that" placeholder="Need help?" />
 ```
 
-You also have the option of using the `.help` utility class. This is meant to be used after **KInput** and will be styled appropriately. 
+You also have the option of using the `.help` utility class. This is meant to be used after **KInput** and will be styled appropriately.
 
 <KInput type="text" placeholder="Need help?" />
 <p class="help">I can help with that</p>
@@ -56,7 +56,7 @@ String to be displayed as error message.
 
 <KInput class="w-100" hasError errorMessage="Service name should not contain “_”"/>
 ```vue
-<KInput class="w-100" 
+<KInput class="w-100"
   hasError errorMessage="Service name should not contain “_”"/>
 ```
 
@@ -65,27 +65,27 @@ String to be displayed as error message.
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain “_”" />
 
 ```
-<KInput 
-  label="Small" size="small" class="mb-2" 
-  hasError 
+<KInput
+  label="Small" size="small" class="mb-2"
+  hasError
   errorMessage="Service name should not contain “_”" />
-<KInput 
-  label="Medium" 
-  class="mb-2" 
-  hasError 
+<KInput
+  label="Medium"
+  class="mb-2"
+  hasError
   errorMessage="Service name should not contain “_”" />
-<KInput 
-  label="Large" 
-  size="large" 
-  hasError 
+<KInput
+  label="Large"
+  size="large"
+  hasError
   errorMessage="Service name should not contain “_”" />
 ```
 ### Label
-String to be used as the input label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element. 
+String to be used as the input label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
 
 - `label`
 
-<KInput label="Name" placeholder="I'm labelled!" />
+<KInput label="Name" placeholder="I'm labelled!"/>
 <KInput label="Error" class="input-error" placeholder="I'm erroneous!" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" />
 
@@ -95,7 +95,7 @@ String to be used as the input label. Make sure that if you are using the built 
 <KInput label="Disabled" disabled placeholder="I'm disabled!" />
 ```
 
-If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KInput** and will be styled appropriately. 
+If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KInput** and will be styled appropriately.
 
 <KLabel for="my-input">Label</KLabel>
 <KInput id="my-input" type="text" placeholder="I have a label" />
@@ -139,7 +139,7 @@ KInput works as regular inputs do using v-model for data binding:
 <Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
   <div>
     {{ data.myInput }}
-    <KInput 
+    <KInput
       v-model="data.myInput"
       @blur="e => (data.myInput = 'blurred')" />
   </div>

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -1,23 +1,23 @@
 # TextArea
 
 **KTextArea** - Text areas are primarily used in modal views (wizards).
-<KTextArea />
+<KTextArea/>
 ```vue
 <KTextArea />
 ```
 
 ### Label
-String to be used as the textarea label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the textarea element. 
+String to be used as the textarea label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the textarea element.
 
 - `label` (**Note**: this field is required for accessibility reasons)
 
-<KTextArea label="Name" placeholder="I'm labelled!" />
+<KTextArea label="Name" placeholder="I'm labelled!" id="adam"/>
 
 ```vue
 <KTextArea label="Name" placeholder="I'm labelled!" />
 ```
 
-If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KTextArea** will be styled appropriately. 
+If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KTextArea** will be styled appropriately.
 
 <KLabel>Label</KLabel>
 <KTextArea placeholder="I have a label" />
@@ -55,7 +55,7 @@ KTextArea works as regular texarea do using v-model for data binding:
 <Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
   <div>
     {{ data.myInput }}
-    <KTextArea 
+    <KTextArea
       v-model="data.myInput"
       @blur="e => (data.myInput = 'blurred')" />
   </div>

--- a/packages/KCheckbox/KCheckbox.vue
+++ b/packages/KCheckbox/KCheckbox.vue
@@ -13,6 +13,7 @@
 <script>
 export default {
   name: 'KCheckbox',
+  inheritAttrs: false,
   props: {
     /**
      * Sets whether or not checkbox is checked

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -60,6 +60,7 @@ import { uuid } from 'vue-uuid'
 
 export default {
   name: 'KInput',
+  inheritAttrs: false,
   props: {
     value: {
       type: String,

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -4,7 +4,7 @@
     class="k-input-wrapper">
     <input
       v-if="!label"
-      v-bind="attrs"
+      v-bind="$attrs"
       :value="value"
       :class="`k-input-${size}`"
       :aria-invalid="hasError ? hasError : null"
@@ -25,7 +25,7 @@
           <span>{{ label }}</span>
         </label>
         <input
-          v-bind="attrs"
+          v-bind="$attrs"
           :id="inputId"
           :value="currValue ? currValue : value"
           :class="`k-input-${size}`"
@@ -98,13 +98,12 @@ export default {
     return {
       currValue: '', // We need this so that we don't lose the updated value on hover/blur event with label
       isFocused: false,
-      isHovered: false,
-      inputId: !this.testMode ? uuid.v1() : 'test-input-id-1234'
+      isHovered: false
     }
   },
   computed: {
-    attrs () {
-      return this.$attrs
+    inputId () {
+      return this.$attrs.id ? this.$attrs.id : !this.testMode ? uuid.v1() : 'test-input-id-1234'
     },
     isDisabled () {
       return this.$attrs.hasOwnProperty('disabled')

--- a/packages/KInput/__snapshots__/KInput.spec.js.snap
+++ b/packages/KInput/__snapshots__/KInput.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KInput matches snapshot 1`] = `
-<div class="k-input-wrapper" placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input k-input-medium">
+<div class="k-input-wrapper"><input placeholder="I am a placeholder" name="custom-input-name" id="custom-input-id" data-testid="custom-input" class="form-control k-input k-input-medium">
   <!---->
   <!---->
 </div>

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -4,7 +4,8 @@
     :label="disabledTooltipText"
   >
     <label
-      v-bind="$attrs"
+      :for="$attrs.id ? $attrs.id : null"
+      :disabled="$attrs.disabled"
       class="k-switch">
       <input
         :checked="value"
@@ -20,6 +21,8 @@
 
   <label
     v-else
+    :for="$attrs.id ? $attrs.id : null"
+    :disabled="$attrs.disabled"
     :class="{ 'switch-with-icon' : enabledIcon }"
     class="k-switch">
     <input
@@ -45,6 +48,7 @@ import KIcon from '@kongponents/kicon/KIcon.vue'
 export default {
   name: 'KInputSwitch',
   components: { KoolTip, KIcon },
+  inheritAttrs: false,
   props: {
     /**
      * Sets whether or not toggle is checked

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -1,6 +1,5 @@
 <template>
   <label
-    v-bind="$attrs"
     class="k-input-label">
     <KoolTip
       v-if="help"

--- a/packages/KLabel/__snapshots__/KLabel.spec.js.snap
+++ b/packages/KLabel/__snapshots__/KLabel.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KLabel passes the \`for\` attribute to label when \`for\` is provided 1`] = `<label for="test-id" class="k-input-label">Full Name</label>`;
+exports[`KLabel passes the \`for\` attribute to label when \`for\` is provided 1`] = `<label class="k-input-label" for="test-id">Full Name</label>`;
 
 exports[`KLabel renders a tooltip when \`help\` is provided 1`] = `
 <label class="k-input-label">

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -14,6 +14,8 @@
 export default {
   name: 'KRadio',
 
+  inheritAttrs: false,
+
   model: {
     prop: 'model',
     event: 'change'

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -60,7 +60,7 @@
               :id="selectTextId"
               :is-open="isToggled"
               :is-rounded="false"
-              v-bind="attrs"
+              v-bind="$attrs"
               appearance="btn-link"
               @keyup="triggerFocus(isToggled)">{{ selectButtonText }}</KButton>
           </div>
@@ -79,7 +79,7 @@
             <KInput
               :is-open="isToggled"
               :id="selectTextId"
-              v-bind="attrs"
+              v-bind="$attrs"
               v-model="filterStr"
               :placeholder="placeholderText"
               class="k-select-input"
@@ -219,9 +219,6 @@ export default {
         disabled: this.$attrs.disabled
       }
     },
-    attrs () {
-      return this.$attrs
-    },
     listeners () {
       return this.$listeners
     },
@@ -250,8 +247,8 @@ export default {
     placeholderText () {
       if (this.placeholder) {
         return this.placeholder
-      } else if (this.attrs.placeholder) {
-        return this.attrs.placeholder
+      } else if (this.$attrs.placeholder) {
+        return this.$attrs.placeholder
       }
 
       if (this.appearance === 'button') {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -135,6 +135,7 @@ const defaultKPopAttributes = {
 export default {
   name: 'KSelect',
   components: { KButton, KIcon, KInput, KLabel, KPop, KSelectItem, KToggle },
+  inheritAttrs: false,
   props: {
     kpopAttributes: {
       type: Object,

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -8,7 +8,7 @@ exports[`KSelect matches snapshot 1`] = `
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
-        <div class="k-input-wrapper k-select-input" id="test-select-text-id-1234" placeholder="Filter..."><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
+        <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->
           <!---->
         </div>
@@ -39,7 +39,7 @@ exports[`KSelect renders props when passed 1`] = `
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" aria-expanded="true">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
-        <div class="k-input-wrapper k-select-input" id="test-select-text-id-1234" placeholder="Filter..." is-open="true"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium" is-open="true">
+        <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium" is-open="true">
           <!---->
           <!---->
         </div>
@@ -88,7 +88,7 @@ exports[`KSelect renders with selected item 1`] = `
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
-        <div class="k-input-wrapper k-select-input" id="test-select-text-id-1234" placeholder="Filter..."><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
+        <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->
           <!---->
         </div>

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -3,7 +3,7 @@
     <textarea
       v-if="!label"
       :required="required"
-      v-bind="attrs"
+      v-bind="$attrs"
       :value="currValue ? currValue : value"
       :rows="rows"
       :cols="cols"
@@ -25,7 +25,7 @@
           <span>{{ label }}</span>
         </label>
         <textarea
-          v-bind="attrs"
+          v-bind="$attrs"
           :id="textAreaId"
           :value="currValue ? currValue : value"
           :rows="rows"
@@ -95,13 +95,12 @@ export default {
     return {
       currValue: '', // We need this so that we don't lose the updated value on hover/blur event with label
       isFocused: false,
-      isHovered: false,
-      textAreaId: !this.testMode ? uuid.v1() : 'test-textArea-id-1234'
+      isHovered: false
     }
   },
   computed: {
-    attrs () {
-      return this.$attrs
+    textAreaId () {
+      return this.$attrs.id ? this.$attrs.id : !this.testMode ? uuid.v1() : 'test-textArea-id-1234'
     },
     listeners () {
       const listeners = { ...this.$listeners }

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -25,7 +25,7 @@
           <span>{{ label }}</span>
         </label>
         <textarea
-          v-bind="attrs"
+          v-bind="$attrs"
           :id="textAreaId"
           :value="currValue ? currValue : value"
           :rows="rows"
@@ -57,6 +57,7 @@ const CHARACTER_LIMIT = 2048
 
 export default {
   name: 'KTextArea',
+  inheritAttrs: false,
   props: {
     value: {
       type: String,

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -25,7 +25,7 @@
           <span>{{ label }}</span>
         </label>
         <textarea
-          v-bind="$attrs"
+          v-bind="attrs"
           :id="textAreaId"
           :value="currValue ? currValue : value"
           :rows="rows"

--- a/packages/KTextArea/__snapshots__/KTextArea.spec.js.snap
+++ b/packages/KTextArea/__snapshots__/KTextArea.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KTextArea matches snapshot 1`] = `
-<div class="k-input-wrapper" placeholder="I am a placeholder" name="custom-textArea-name" id="custom-textArea-id" data-testid="custom-textArea"><textarea rows="5" cols="52" placeholder="I am a placeholder" name="custom-textArea-name" id="custom-textArea-id" data-testid="custom-textArea" class="form-control k-input style-body-lg"></textarea>
+<div class="k-input-wrapper"><textarea rows="5" cols="52" placeholder="I am a placeholder" name="custom-textArea-name" id="custom-textArea-id" data-testid="custom-textArea" class="form-control k-input style-body-lg"></textarea>
   <div class="type-sm color-black-45 float-right">
     9 / 2048
   </div>

--- a/packages/Krumbs/Krumbs.vue
+++ b/packages/Krumbs/Krumbs.vue
@@ -1,6 +1,5 @@
 <template>
   <ul
-    v-bind="$attrs"
     class="krumbs style-body-bc"
     v-on="$listeners"
   >


### PR DESCRIPTION
Apply attributes (`$attrs` or computed variable in component, `attrs`) to child elements within applicable components.

### Summary

#### Changes made:
* Add `inheritAttrs: false` to component definitions, where applicable.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
