### PR TITLE
fix(ktextarea): limit exceeded event

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -93,6 +93,7 @@ KTextArea has a couple of natural event bindings.
 
 - `ktextarea` - Fired on change, returns the content of the textarea
 - `char-limit-exceeded` - Fired when the text starts or stops exceeding the limit, returns an object:
+
     ```json
     {
         value,          // current value

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -91,10 +91,16 @@ KTextArea works as regular texarea do using v-model for data binding:
 
 KTextArea has a couple of natural event bindings.
 
-| Event     | returns             |
-| :-------- | :------------------ |
-| `ktextarea` | The content of the textarea when it is changed |
-| `char-limit-exceeded` | A warning message if the character limit is exceeded when it's enabled |
+- `ktextarea` - Fired on change, returns the content of the textarea
+- `char-limit-exceeded` - Fired when the text starts or stops exceeding the limit, returns an object:
+    ```json
+    {
+        value,          // current value
+        length,         // length of current value
+        characterLimit, // character limit
+        limitExceeded   // whether or not the limit has been exceeded
+    }
+    ```
 
 KTextArea also transparently binds to events:
 

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -117,7 +117,7 @@ export default {
   watch: {
     charLimitExceeded (newval, oldval) {
       if (newval !== oldval) {
-        this.$emit('char-limit-exceed', {
+        this.$emit('char-limit-exceeded', {
           value: this.currValue,
           length: this.currValue.length,
           characterLimit: this.characterLimit,

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -10,10 +10,6 @@
       @input="e => {
         $emit('textarea', e.target.value),
         currValue = e.target.value
-
-        if (!disableCharacterLimit && currValue.length > characterLimit) {
-          $emit('char-limit-exceed', `Character limit of ${characterLimit} execeeded by ${currValue.length - characterLimit} characters`)
-        }
       }"
       v-on="listeners"
     />
@@ -37,10 +33,6 @@
           @input="e => {
             $emit('textarea', e.target.value),
             currValue = e.target.value
-
-            if (!disableCharacterLimit && currValue.length > characterLimit) {
-              $emit('char-limit-exceed', `Character limit of ${characterLimit} execeeded by ${currValue.length - characterLimit} characters`)
-            }
           }"
           @mouseenter="() => isHovered = true"
           @mouseleave="() => isHovered = false"
@@ -117,6 +109,21 @@ export default {
       delete listeners['input']
 
       return listeners
+    },
+    charLimitExceeded () {
+      return !this.disableCharacterLimit && this.currValue.length > this.characterLimit
+    }
+  },
+  watch: {
+    charLimitExceeded (newval, oldval) {
+      if (newval !== oldval) {
+        this.$emit('char-limit-exceed', {
+          value: this.currValue,
+          length: this.currValue.length,
+          characterLimit: this.characterLimit,
+          limitExceeded: newval
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary

#### Changes made:
* Update `char-limit-exceeded` event to only fire if switching between exceeding and not exceeding
* Return more data on the event

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
