### PR TITLE
chore(docs): nowrap whitespace on code inside table

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -18,8 +18,14 @@ table {
   }
 }
 
-.theme-default-content code {
-  color: var(--black-70);
+.theme-default-content {
+  code {
+    color: var(--black-70);
+  }
+
+  td code {
+    white-space: nowrap;
+  }
 }
 
 .theme-container .search-box {


### PR DESCRIPTION
### Summary

Add CSS rule to force nowrap whitespace on inline code placed inside of table cells.

![Screen Shot 2021-11-17 at 2 02 18 PM](https://user-images.githubusercontent.com/2229946/142271111-87b02b95-68a6-4daa-811f-8eb434906aae.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
