### PR TITLE
fix(css): box-shadow does not render on ios

### DIFF
--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -141,6 +141,11 @@ export default {
 }
 
 .k-input-wrapper {
+
+  input.k-input {
+    -webkit-appearance: none;
+  }
+
   & .k-input-label-large + .has-error {
     font-size: 12px;
     line-height: 15px;

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -137,6 +137,10 @@ export default {
   width: fit-content;
   display: grid;
 
+  textarea.k-input {
+    -webkit-appearance: none;
+  }
+
   textarea.form-control {
     font-family: var(--font-family-sans);
     resize: none;


### PR DESCRIPTION
`box-shadow` CSS attribute does not display properly in iOS, meaning `KInput`, `KTextArea`, and `KSelect` components appear with no borders on iOS browsers.

### Summary

#### Changes made:
* Add `-webkit-appearance: none` to `KInput` and `KTextArea` native input components (`input` and `textarea`).

![box-shadow-fix](https://user-images.githubusercontent.com/2229946/142298167-8d1e0d8c-0efc-42f5-94a2-333d692c841a.jpg)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
