### PR TITLE
fix(*): fix deps and build process

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -1,5 +1,14 @@
 # Card Catalog
 
+:::tip Note
+The `KCardCatalog` component requires the [`@vue/composition-api`](https://github.com/vuejs/composition-api) package as a `peerDependency`. You must **manually** add the package to your host project by running the following
+
+``` shell
+yarn add @vue/composition-api
+```
+
+:::
+
 **KCardCatalog** - A grid view of KCards
 
 <KCardCatalog :items="getItems(5)" />
@@ -88,7 +97,7 @@ See [the State section](#loading) about `isLoading`
 ### fetcher
 
 Use a custom fetcher function to fetch card catalog items and leverage server-side pagination.
-::: tip Note:
+::: tip Note
 All fetcher functions should take a single param. This parameter is a JSON
 object supporting the following properties:
 
@@ -97,7 +106,7 @@ object supporting the following properties:
   - `pageSize`: the number of items to display per page
 :::
 
-::: tip Note:
+::: tip Note
 All fetcher functions should return a JSON object. This JSON object should contain the following properties:
 
 - `total` - the total count of catalog items (if using pagination)
@@ -175,7 +184,7 @@ Set this to `true` to limit pagination navigation to `previous` / `next` page on
 ```vue
 <template>
   <KCardCatalog
-    :fetcher="fetcher" 
+    :fetcher="fetcher"
     :disablePaginationPageJump="true" />
 </template>
 ```

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -3,6 +3,15 @@ pageClass: table-docs
 ---
 # Table
 
+:::tip Note
+The `KTable` component requires the [`@vue/composition-api`](https://github.com/vuejs/composition-api) package as a `peerDependency`. You must **manually** add the package to your host project by running the following
+
+``` shell
+yarn add @vue/composition-api
+```
+
+:::
+
 Pass a fetcher function to build a slot-able table.
 
 ```vue
@@ -93,7 +102,7 @@ This functionality may be flaky.
 
 Use a custom fetcher function to fetch table data and leverage server-side search, sort and pagination.
 
-::: tip Note:
+::: tip Note
 All fetcher functions should take a single param. This parameter is a JSON
 object supporting the following properties:
 
@@ -107,7 +116,7 @@ object supporting the following properties:
   - `query`: a text string to filter table data on
 :::
 
-::: tip Note:
+::: tip Note
 All fetcher functions should return a JSON object. This JSON object should contain the following properties:
 
 - `total` - the total count of items (if using pagination)
@@ -211,8 +220,8 @@ object these features should be explicitly disabled.
       }
     }"
     :headers="[
-      { label: 'Title', key: 'title', sortable: true },
-      { label: 'Description', key: 'description', sortable: true },
+      { label: 'Name', key: 'name', sortable: true },
+      { label: 'Id', key: 'id', sortable: true },
       { label: 'Enabled', key: 'enabled', sortable: false }
     ]"
     disablePagination

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   "scripts": {
     "build": "yarn build:styles && yarn build:utils && yarn docs:build && yarn build:cli",
     "build:postcss": "postcss packages/styles/styles.css --dir packages/styles",
-    "build:cli": "lerna exec --ignore @kongponents/styles --ignore @kongponents/utils \"ln -f ../../vue.config.js ./vue.config.js && ln -f ../../postcss-custom-properties.config.js ./postcss.config.js && yarn vue-cli-service build --target lib ./\\$(cat package.json | jq -r .source) --name \\$(cat package.json | jq -r .componentName) --dest dist && rm ./vue.config.js ./postcss.config.js\"",
+    "build:cli": "yarn create:package-configs && lerna exec --ignore @kongponents/styles --ignore @kongponents/utils \"yarn vue-cli-service build --target lib ./\\$(cat package.json | jq -r .source) --name \\$(cat package.json | jq -r .componentName) --dest ./dist\" && yarn delete:package-configs",
     "build:styles": "yarn node-sass packages/styles/styles.scss -o packages/styles && yarn build:postcss",
     "build:utils": "yarn vue-cli-service build --target lib --name utils --entry ./packages/utils/utils.js --dest ./packages/utils/dist && rm ./packages/utils/dist/demo.html",
+    "create:package-configs": "lerna exec --ignore @kongponents/styles --ignore @kongponents/utils \"ln -f ../../vue.config.js ./vue.config.js && ln -f ../../postcss-custom-properties.config.js ./postcss.config.js && ln -f ../../tailwind-custom-properties.config.js ./tailwind.config.js\"",
+    "delete:package-configs": "lerna exec --ignore @kongponents/styles --ignore @kongponents/utils \"rm -f ./vue.config.js ./postcss.config.js ./tailwind.config.js\"",
     "docs:dev": "yarn build:styles && vuepress dev docs",
     "docs:build": "vuepress build docs",
     "publish:ci": "lerna publish --conventional-commits --yes --force-publish",

--- a/packages/KCardCatalog/package.json
+++ b/packages/KCardCatalog/package.json
@@ -30,7 +30,9 @@
     "@kongponents/kpagination": "^6.1.16",
     "@kongponents/kskeleton": "^6.1.16",
     "@kongponents/utils": "^6.1.16",
-    "@vue/composition-api": "^1.2.4",
     "vue": "2.6.10"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.2.4"
   }
 }

--- a/packages/KCardCatalog/package.json
+++ b/packages/KCardCatalog/package.json
@@ -29,8 +29,7 @@
     "@kongponents/kemptystate": "^6.1.16",
     "@kongponents/kpagination": "^6.1.16",
     "@kongponents/kskeleton": "^6.1.16",
-    "@kongponents/utils": "^6.1.16",
-    "vue": "2.6.10"
+    "@kongponents/utils": "^6.1.16"
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.2.4"

--- a/packages/KTable/package.json
+++ b/packages/KTable/package.json
@@ -29,7 +29,6 @@
     "@kongponents/kpagination": "^6.1.16",
     "@kongponents/kskeleton": "^6.1.16",
     "@kongponents/utils": "^6.1.16",
-    "vue": "2.6.10",
     "vue-uuid": "^2.0.2"
   },
   "peerDependencies": {

--- a/packages/KTable/package.json
+++ b/packages/KTable/package.json
@@ -29,8 +29,10 @@
     "@kongponents/kpagination": "^6.1.16",
     "@kongponents/kskeleton": "^6.1.16",
     "@kongponents/utils": "^6.1.16",
-    "@vue/composition-api": "^1.2.4",
     "vue": "2.6.10",
     "vue-uuid": "^2.0.2"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.2.4"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,8 +17,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@vue/composition-api": "^1.2.4",
     "swrv": "0.9.4",
     "vue": "2.6.10"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.2.4"
   }
 }

--- a/tailwind-custom-properties.config.js
+++ b/tailwind-custom-properties.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  purge: [
+    './**/*.vue'
+  ],
+  theme: {
+    extend: {
+      screens: {
+        '2xl': '1390px'
+      },
+      maxWidth: {
+        'screen-2xl': '1390px'
+      }
+    }
+  },
+  variants: {},
+  plugins: []
+}


### PR DESCRIPTION
### Summary

#### Vue Composition API

When utilizing the `@vue/composition-api` inside of a Kongponent package, the `@vue/composition-api` needs to be added as a `peerDependency` to the component package rather than a `dependency`.

> Currently, installing with yarn with the peer flag `yarn add {package-name} --peer` [is broken](https://github.com/yarnpkg/yarn/issues/5287)

You will need to manually add the `peerDependencies` entry inside the individual component's `package.json`. For example, inside `./packages/KTable/package.json` this is what was added

``` json
{
  "peerDependencies": {
    "@vue/composition-api": "^1.2.4"
  }
}
```

The **_parent application_** must then manually add `@vue/composition-api` to it's `package.json` as a dependency if utilizing any of the components depending on the package (this is now outlined in the docs for each corresponding component, currently `KTable` and `KCardCatalog`).

This is required as the component _must_ use the same instance of the plugin as the parent application, meaning that the plugin has to be added to the parent application's dependencies. [This is further outlined in an issue on the composition api repo](https://github.com/vuejs/composition-api/issues/792).

> Once Vue 2.7 is released, `@vue/composition-api` will be directly shipped with it, so this extra step will no longer be needed.

The quote above, taken from the issue, means that we should plan to upgrade Konponents (and any parent Kong-owned applications, such as `khcp`, `kong-admin`, etc.) to `2.7` when released, which will make utilizing the library easier on the user.

#### Build Process

Update the build process to copy necessary config files in a separate step, leaving them in place until `yarn build:cli` finishes, then remove from the individual `/package/*` directories, as other steps in the build process will fail if `postcss.config.js` files are not left in place (e.g. in `KIcon` package) until the completion of all package builds.

#### Docs

Update docs for `KTable` and `KCardCatalog` for usage with Composition API.

### PR Checklist
- [ ] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
