### PR TITLE
fix(ktable): add missing style

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -639,6 +639,7 @@ export default defineComponent({
   width: 100%;
   max-width: 100%;
   margin-top: 0;
+  border-collapse: collapse;
 
   th,
   td {


### PR DESCRIPTION
### Summary

#### Changes made:
* Add missing `border-collapse` style to KTable

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
