### PR TITLE
feat(ktable/kcardcatalog): emit cta click events

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -254,6 +254,8 @@ Set the following properties to handle empty state:
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
 
+If using a CTA button, a `kcardcatalog-empty-state-cta-clicked` event is fired when clicked.
+
 <KCardCatalog
   title="Customized empty catalog"
   :items="getItems(0)"
@@ -318,6 +320,8 @@ Set the following properties to customize error state:
 - `errorStateIconSize` - Size for error state icon
 - `errorStateActionRoute` - Route for error state action
 - `errorStateActionMessage` - Button text for error state action
+
+If using a CTA button, a `kcardcatalog-error-cta-clicked` event is fired when clicked.
 
 <KCardCatalog
   title="Catalog with error"

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -675,6 +675,8 @@ Set the following properties to handle empty state:
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
 
+If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when clicked.
+
 #### Default Empty State Messaging
 
 <KCard class="my-2">
@@ -765,6 +767,8 @@ Set the following properties to handle error state:
 - `errorStateIconSize` - Size for error state icon
 - `errorStateActionRoute` - Route for error state action
 - `errorStateActionMessage` - Button text for error state action
+
+If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 #### Default Error State Messaging
 

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -42,8 +42,8 @@
       <template v-slot:message>{{ errorStateMessage }}</template>
       <template v-slot:cta>
         <KButton
-          v-if="errorStateActionMessage && errorStateActionRoute"
-          :to="errorStateActionRoute"
+          v-if="errorStateActionMessage"
+          :to="errorStateActionRoute ? errorStateActionRoute : null"
           appearance="primary"
           @click="$emit('kcardcatalog-error-cta-clicked')"
         >
@@ -62,8 +62,8 @@
       <template v-slot:message>{{ emptyStateMessage }}</template>
       <template v-slot:cta>
         <KButton
-          v-if="emptyStateActionMessage && emptyStateActionRoute"
-          :to="emptyStateActionRoute"
+          v-if="emptyStateActionMessage"
+          :to="emptyStateActionRoute ? emptyStateActionRoute : null"
           appearance="primary"
           @click="$emit('kcardcatalog-empty-state-cta-clicked')"
         >

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -45,6 +45,7 @@
           v-if="errorStateActionMessage && errorStateActionRoute"
           :to="errorStateActionRoute"
           appearance="primary"
+          @click="$emit('kcardcatalog-error-cta-clicked')"
         >
           {{ errorStateActionMessage }}
         </KButton>
@@ -64,6 +65,7 @@
           v-if="emptyStateActionMessage && emptyStateActionRoute"
           :to="emptyStateActionRoute"
           appearance="primary"
+          @click="$emit('kcardcatalog-empty-state-cta-clicked')"
         >
           {{ emptyStateActionMessage }}
         </KButton>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -16,9 +16,10 @@
     <template v-slot:message>{{ errorStateMessage }}</template>
     <template v-slot:cta>
       <KButton
-        v-if="errorStateActionMessage && errorStateActionRoute"
-        :to="errorStateActionRoute"
+        v-if="errorStateActionMessage"
+        :to="errorStateActionRoute ? errorStateActionRoute : null"
         appearance="primary"
+        @click="$emit('ktable-error-cta-clicked')"
       >
         {{ errorStateActionMessage }}
       </KButton>
@@ -35,9 +36,10 @@
     <template v-slot:message>{{ emptyStateMessage }}</template>
     <template v-slot:cta>
       <KButton
-        v-if="emptyStateActionMessage && emptyStateActionRoute"
-        :to="emptyStateActionRoute"
+        v-if="emptyStateActionMessage"
+        :to="emptyStateActionRoute ? emptyStateActionRoute : null"
         appearance="primary"
+        @click="$emit('ktable-empty-state-cta-clicked')"
       >
         {{ emptyStateActionMessage }}
       </KButton>


### PR DESCRIPTION
### Summary
Emit events when empty/error state CTA buttons are clicked to allow hooking up a callback.

#### Changes made:
* Emit events in both `KTable` and `KCardCatalog`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
