### PR TITLE
feat(ktable/kcardcatalog): make states slottable

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -464,7 +464,7 @@ This should be used instead of the `items` property.
 </KCardCatalog>
 ```
 
-KCardCatalog has built in state management for loading, empty, and error states. You can either use the props described in
+KCardCatalog has built-in state management for loading, empty, and error states. You can either use the props described in
 the section above or completely slot in your own content.
 
 - `empty-state` - Slot content to be displayed when empty

--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -464,6 +464,50 @@ This should be used instead of the `items` property.
 </KCardCatalog>
 ```
 
+KCardCatalog has built in state management for loading, empty, and error states. You can either use the props described in
+the section above or completely slot in your own content.
+
+- `empty-state` - Slot content to be displayed when empty
+- `error-state` - Slot content to be displayed when in an error state
+
+<KCard>
+  <template v-slot:body>
+    <KCardCatalog
+      :fetcher="emptyFetcher"
+      :headers="headers"
+    >
+      <template v-slot:empty-state>
+        <div class="w-100" style="text-align: center;">
+          <KIcon icon="warning" />
+          <div>No Content!!!</div>
+        </div>
+      </template>
+      <template v-slot:error-state>
+        <KIcon icon="error" />
+        Something went wrong
+      </template>
+    </KCardCatalog>
+  </template>
+</KCard>
+
+```vue
+<template>
+  <KCardCatalog
+    :fetcher="() => { return { data: [] } }"
+    :headers="headers"
+  >
+    <template v-slot:empty-state>
+      <KIcon icon="warning" />
+      No Content!!!
+    </template>
+    <template v-slot:error-state>
+      <KIcon icon="error" />
+      Something went wrong
+    </template>
+  </KCardCatalog>
+</template>
+```
+
 ## Server-side functions
 
 Pass a fetcher function to enable server-side pagination.

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -676,7 +676,7 @@ export default {
 
 ### State Slots
 
-KTable has built in state management for loading, empty, and error states. You can either use the props described in
+KTable has built-in state management for loading, empty, and error states. You can either use the props described in
 the section below or completely slot in your own content.
 
 - `empty-state` - Slot content to be displayed when empty

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -661,6 +661,52 @@ export default {
 </script>
 ```
 
+### State Slots
+
+KTable has built in state management for loading, empty, and error states. You can either use the props described in
+the section below or completely slot in your own content.
+
+- `empty-state` - Slot content to be displayed when empty
+- `error-state` - Slot content to be displayed when in an error state
+
+<KCard>
+  <template v-slot:body>
+    <KTable
+      :fetcher="emptyFetcher"
+      :headers="headers"
+    >
+      <template v-slot:empty-state>
+        <div class="w-100" style="text-align: center;">
+          <KIcon icon="warning" />
+          <div>No Content!!!</div>
+        </div>
+      </template>
+      <template v-slot:error-state>
+        <KIcon icon="error" />
+        Something went wrong
+      </template>
+    </KTable>
+  </template>
+</KCard>
+
+```vue
+<template>
+  <KTable
+    :fetcher="() => { return { data: [] } }"
+    :headers="headers"
+  >
+    <template v-slot:empty-state>
+      <KIcon icon="warning" />
+      No Content!!!
+    </template>
+    <template v-slot:error-state>
+      <KIcon icon="error" />
+      Something went wrong
+    </template>
+  </KTable>
+</template>
+```
+
 ## States
 
 ### Empty
@@ -1078,6 +1124,10 @@ for (let i = ((page-1)* pageSize); i < limit; i++) {
           }
         ]
       }
+    },
+
+    emptyFetcher () {
+      return { data: [] }
     },
 
     tableOptionsLinkFetcher () {

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -246,6 +246,19 @@ Pass in an array of header objects for the table.
 | `sortable` | boolean | Enables or disables server-side sorting for the column (`false` by default)
 | `hideLabel`| boolean | Hides or displays the column label (useful for actions columns)
 
+:::tip Note
+`sortable` columns emit a `sort` event when clicked, returns:
+
+  ```json
+  {
+    prevKey,        // the previously sorted column
+    sortColumnKey,  // the column being sorted now
+    sortColumnOrder // the sort direction (asc/desc)
+  }
+  ```
+
+:::
+
 Example headers array:
 
 ```vue

--- a/packages/KCardCatalog/KCardCatalog.spec.js
+++ b/packages/KCardCatalog/KCardCatalog.spec.js
@@ -112,6 +112,43 @@ describe('KCardCatalog', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
 
+    it('renders slots when passed (with empty)', async () => {
+      const emptySlotContent = 'Look mah! I am empty! (except testMode)'
+
+      const wrapper = mount(KCardCatalog, {
+        propsData: {
+          testMode: true,
+          isLoading: false,
+          fetcher: () => { return { data: [] } }
+        },
+        scopedSlots: {
+          'empty-state': `<span>${emptySlotContent}</span>`
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+
+      expect(wrapper.find('[data-testid="k-card-catalog-empty-state"]').html()).toEqual(expect.stringContaining(emptySlotContent))
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('renders slots when passed (with error)', () => {
+      const errorSlotContent = 'Look mah! I am erroneous! (except testMode)'
+
+      const wrapper = mount(KCardCatalog, {
+        propsData: {
+          testMode: true,
+          hasError: true
+        },
+        scopedSlots: {
+          'error-state': `<span>${errorSlotContent}</span>`
+        }
+      })
+
+      expect(wrapper.find('[data-testid="k-card-catalog-error-state"]').html()).toEqual(expect.stringContaining(errorSlotContent))
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
     it('can change card sizes - small', () => {
       const wrapper = mount(KCardCatalog, {
         propsData: {

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -30,47 +30,60 @@
         </div>
       </template>
     </KSkeleton>
-    <KEmptyState
+
+    <div
       v-else-if="hasError"
-      :cta-is-hidden="!errorStateActionMessage || !errorStateActionRoute"
-      :icon="errorStateIcon || ''"
-      :is-error="true"
-      :icon-color="errorStateIconColor"
-      :icon-size="errorStateIconSize"
-    >
-      <template v-slot:title>{{ errorStateTitle }}</template>
-      <template v-slot:message>{{ errorStateMessage }}</template>
-      <template v-slot:cta>
-        <KButton
-          v-if="errorStateActionMessage"
-          :to="errorStateActionRoute ? errorStateActionRoute : null"
-          appearance="primary"
-          @click="$emit('kcardcatalog-error-cta-clicked')"
+      data-testid="k-card-catalog-error-state">
+      <slot name="error-state">
+        <KEmptyState
+          :cta-is-hidden="!errorStateActionMessage || !errorStateActionRoute"
+          :icon="errorStateIcon || ''"
+          :is-error="true"
+          :icon-color="errorStateIconColor"
+          :icon-size="errorStateIconSize"
         >
-          {{ errorStateActionMessage }}
-        </KButton>
-      </template>
-    </KEmptyState>
-    <KEmptyState
+          <template v-slot:title>{{ errorStateTitle }}</template>
+          <template v-slot:message>{{ errorStateMessage }}</template>
+          <template v-slot:cta>
+            <KButton
+              v-if="errorStateActionMessage"
+              :to="errorStateActionRoute ? errorStateActionRoute : null"
+              appearance="primary"
+              @click="$emit('kcardcatalog-error-cta-clicked')"
+            >
+              {{ errorStateActionMessage }}
+            </KButton>
+          </template>
+        </KEmptyState>
+      </slot>
+    </div>
+
+    <div
       v-else-if="!$scopedSlots.body && !hasError && (!isCardLoading && !isLoading) && (data && !data.length)"
-      :cta-is-hidden="!emptyStateActionMessage || !emptyStateActionRoute"
-      :icon="emptyStateIcon || ''"
-      :icon-color="emptyStateIconColor"
-      :icon-size="emptyStateIconSize"
-    >
-      <template v-slot:title>{{ emptyStateTitle }}</template>
-      <template v-slot:message>{{ emptyStateMessage }}</template>
-      <template v-slot:cta>
-        <KButton
-          v-if="emptyStateActionMessage"
-          :to="emptyStateActionRoute ? emptyStateActionRoute : null"
-          appearance="primary"
-          @click="$emit('kcardcatalog-empty-state-cta-clicked')"
+      data-testid="k-card-catalog-empty-state">
+      <slot name="empty-state">
+        <KEmptyState
+          :cta-is-hidden="!emptyStateActionMessage || !emptyStateActionRoute"
+          :icon="emptyStateIcon || ''"
+          :icon-color="emptyStateIconColor"
+          :icon-size="emptyStateIconSize"
         >
-          {{ emptyStateActionMessage }}
-        </KButton>
-      </template>
-    </KEmptyState>
+          <template v-slot:title>{{ emptyStateTitle }}</template>
+          <template v-slot:message>{{ emptyStateMessage }}</template>
+          <template v-slot:cta>
+            <KButton
+              v-if="emptyStateActionMessage"
+              :to="emptyStateActionRoute ? emptyStateActionRoute : null"
+              appearance="primary"
+              @click="$emit('kcardcatalog-empty-state-cta-clicked')"
+            >
+              {{ emptyStateActionMessage }}
+            </KButton>
+          </template>
+        </KEmptyState>
+      </slot>
+    </div>
+
     <div
       v-else
       :class="`k-card-${cardSize}`"

--- a/packages/KCardCatalog/__snapshots__/KCardCatalog.spec.js.snap
+++ b/packages/KCardCatalog/__snapshots__/KCardCatalog.spec.js.snap
@@ -56,6 +56,20 @@ exports[`KCardCatalog general renders proper cards when using props 1`] = `
 </div>
 `;
 
+exports[`KCardCatalog general renders slots when passed (with empty) 1`] = `
+<div class="k-card-catalog">
+  <!---->
+  <div class="" data-testid="k-card-catalog-empty-state"><span>Look mah! I am empty! (except testMode)</span></div>
+</div>
+`;
+
+exports[`KCardCatalog general renders slots when passed (with error) 1`] = `
+<div class="k-card-catalog">
+  <!---->
+  <div data-testid="k-card-catalog-error-state"><span>Look mah! I am erroneous! (except testMode)</span></div>
+</div>
+`;
+
 exports[`KCardCatalog general renders slots when passed 1`] = `
 <div class="k-card-catalog">
   <!---->
@@ -77,17 +91,19 @@ exports[`KCardCatalog states displays a loading skeletion when the "isLoading" p
 exports[`KCardCatalog states displays an error state when the "hasError" prop is set to true" 1`] = `
 <div class="k-card-catalog" options="">
   <!---->
-  <section class="empty-state-wrapper is-error">
-    <div class="empty-state-title">
-      <div class="k-empty-state-icon card-icon mb-4 warning-icon"><span class="kong-icon kong-icon-warning"><!----></span></div>
-      <div class="k-empty-state-title-header">An error occurred</div>
-    </div>
-    <div class="empty-state-content">
-      <div class="k-empty-state-message">Data cannot be displayed due to an error.</div>
-      <div class="k-empty-state-cta">
-        <!---->
+  <div data-testid="k-card-catalog-error-state">
+    <section class="empty-state-wrapper is-error">
+      <div class="empty-state-title">
+        <div class="k-empty-state-icon card-icon mb-4 warning-icon"><span class="kong-icon kong-icon-warning"><!----></span></div>
+        <div class="k-empty-state-title-header">An error occurred</div>
       </div>
-    </div>
-  </section>
+      <div class="empty-state-content">
+        <div class="k-empty-state-message">Data cannot be displayed due to an error.</div>
+        <div class="k-empty-state-cta">
+          <!---->
+        </div>
+      </div>
+    </section>
+  </div>
 </div>
 `;

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -253,6 +253,27 @@ describe('KTable', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
 
+    it('displays an empty state when no data is available (slot)', async () => {
+      const emptySlotContent = 'Look mah! I am empty! (except testMode)'
+      const fetcher = () => new Promise(resolve => resolve({ data: [] }))
+      const wrapper = mount(KTable, {
+        propsData: {
+          testMode: 'true',
+          fetcher: fetcher,
+          headers: options.headers,
+          pageSize: 4
+        },
+        scopedSlots: {
+          'empty-state': `<span>${emptySlotContent}</span>`
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+
+      expect(wrapper.find('[data-testid="k-table-empty-state"]').html()).toEqual(expect.stringContaining(emptySlotContent))
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
     it('displays a loading skeletion when the "isLoading" prop is set to true"', () => {
       const wrapper = mount(KTable, {
         propsData: {
@@ -275,6 +296,25 @@ describe('KTable', () => {
 
       expect(wrapper.html()).toContain('empty-state-wrapper')
       expect(wrapper.html()).toContain('is-error')
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('displays an error state (slot)', async () => {
+      const errorSlotContent = 'Look mah! I am erroneous! (except testMode)'
+      const wrapper = mount(KTable, {
+        propsData: {
+          testMode: 'true',
+          hasError: true
+        },
+        scopedSlots: {
+          'error-state': `<span>${errorSlotContent}</span>`
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+      console.log(wrapper.html())
+
+      expect(wrapper.find('[data-testid="k-table-error-state"]').html()).toEqual(expect.stringContaining(errorSlotContent))
       expect(wrapper.html()).toMatchSnapshot()
     })
 

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -80,7 +80,16 @@
                   [sortColumnOrder]: !disableSorting && column.key === sortColumnKey && !column.hideLabel,
                   'is-scrolled': isScrolled
                 }"
-                @click="!disableSorting && column.sortable && sortClickHandler(column.key)"
+                @click="() => {
+                  if (!disableSorting && column.sortable) {
+                    $emit('sort', {
+                      prevKey: sortColumnKey,
+                      sortColumnKey: column.key,
+                      sortColumnOrder: sortColumnOrder === 'desc' ? 'asc' : 'desc' // display opposite because sortColumnOrder outdated
+                    })
+                    sortClickHandler(column.key)
+                  }
+                }"
               >
                 <span class="d-flex align-items-center">
                   <slot
@@ -447,7 +456,7 @@ export default defineComponent({
       page: 1,
       query: '',
       sortColumnKey: '',
-      sortColumnOrder: ''
+      sortColumnOrder: 'desc'
     }
 
     const data = ref([])

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -1,398 +1,428 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KTable default has hover class when passed 1`] = `
-<section class="k-table-wrapper">
-  <table data-tableid="test-table-id-1234" class="k-table has-hover">
-    <thead class="">
-      <tr class="">
-        <th class="sortable"><span class="d-flex align-items-center"><span class="">
-                  Name
-                </span> <span class="kong-icon caret ml-2 kong-icon-chevronDown"><svg height="12" width="12" viewBox="0 0 20 20" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KTableColor, var(--black-70, color(black-70)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  ID
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  Enabled
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="sr-only">
-                  actions
-                </span>
-          <!----></span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Basic Auth</td>
-        <td>517526354743085</td>
-        <td>true</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Website Desktop</td>
-        <td>328027447731198</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Android App</td>
-        <td>405383051040955</td>
-        <td>true</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <nav aria-label="Pagination Navigation" data-testid="k-pagination-container" class="pa-1">
-    <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 3</span>
-      of 3
-      </span>
-      <ul class="pagination-button-container">
-        <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><span class="kong-icon kong-icon-arrowLeft"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Back</title>  <g><!----> <!----> <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
-        <!---->
-        <!---->
-        <!---->
-        <!---->
-        <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Forward</title>  <g><!----> <!----> <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
-      </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg height="16" width="16" viewBox="2 2 15 15" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></button>
-    </div>
-    <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
-      <!---->
-      <div class="k-popover-content">
-        <ul class="k-select-list ma-0 pa-0">
-          <div>
-            <div data-testid="k-select-item-15" class="k-select-item">
-              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-25" class="k-select-item">
-              <li role="option" class="d-block"><button value="25" class=""><span class="k-select-item-label mr-2">25</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-50" class="k-select-item">
-              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-75" class="k-select-item">
-              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-100" class="k-select-item">
-              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-          </div>
-        </ul>
+<div>
+  <section class="k-table-wrapper">
+    <table data-tableid="test-table-id-1234" class="k-table has-hover">
+      <thead class="">
+        <tr class="">
+          <th class="sortable"><span class="d-flex align-items-center"><span class="">
+                    Name
+                  </span> <span class="kong-icon caret ml-2 kong-icon-chevronDown"><svg height="12" width="12" viewBox="0 0 20 20" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KTableColor, var(--black-70, color(black-70)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    ID
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    Enabled
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="sr-only">
+                    actions
+                  </span>
+            <!----></span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Basic Auth</td>
+          <td>517526354743085</td>
+          <td>true</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Website Desktop</td>
+          <td>328027447731198</td>
+          <td>false</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Android App</td>
+          <td>405383051040955</td>
+          <td>true</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <nav aria-label="Pagination Navigation" data-testid="k-pagination-container" class="pa-1">
+      <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 3</span>
+        of 3
+        </span>
+        <ul class="pagination-button-container">
+          <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><span class="kong-icon kong-icon-arrowLeft"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Back</title>  <g><!----> <!----> <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
+          <!---->
+          <!---->
+          <!---->
+          <!---->
+          <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Forward</title>  <g><!----> <!----> <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
+        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg height="16" width="16" viewBox="2 2 15 15" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></button>
       </div>
-      <!---->
-    </div>
-    </div>
-    </div>
-    </div></span></div>
-  </nav>
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+        <!---->
+        <div class="k-popover-content">
+          <ul class="k-select-list ma-0 pa-0">
+            <div>
+              <div data-testid="k-select-item-15" class="k-select-item">
+                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-25" class="k-select-item">
+                <li role="option" class="d-block"><button value="25" class=""><span class="k-select-item-label mr-2">25</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-50" class="k-select-item">
+                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-75" class="k-select-item">
+                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-100" class="k-select-item">
+                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+            </div>
+          </ul>
+        </div>
+        <!---->
+      </div>
+</div>
+</div>
+</div></span></div>
+</nav>
 </section>
+</div>
 `;
 
 exports[`KTable default renders link in action slot 1`] = `
-<section class="k-table-wrapper">
-  <table data-tableid="test-table-id-1234" class="k-table has-hover">
-    <thead class="">
-      <tr class="">
-        <th class="sortable"><span class="d-flex align-items-center"><span class="">
-                  Name
-                </span> <span class="kong-icon caret ml-2 kong-icon-chevronDown"><svg height="12" width="12" viewBox="0 0 20 20" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KTableColor, var(--black-70, color(black-70)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  ID
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  Enabled
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="sr-only">
-                  actions
-                </span>
-          <!----></span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Basic Auth</td>
-        <td>517526354743085</td>
-        <td>true</td>
-        <td><a href="#">Link</a></td>
-      </tr>
-      <tr>
-        <td>Website Desktop</td>
-        <td>328027447731198</td>
-        <td>false</td>
-        <td><a href="#">Link</a></td>
-      </tr>
-      <tr>
-        <td>Android App</td>
-        <td>405383051040955</td>
-        <td>true</td>
-        <td><a href="#">Link</a></td>
-      </tr>
-    </tbody>
-  </table>
-  <!---->
-</section>
+<div>
+  <section class="k-table-wrapper">
+    <table data-tableid="test-table-id-1234" class="k-table has-hover">
+      <thead class="">
+        <tr class="">
+          <th class="sortable"><span class="d-flex align-items-center"><span class="">
+                    Name
+                  </span> <span class="kong-icon caret ml-2 kong-icon-chevronDown"><svg height="12" width="12" viewBox="0 0 20 20" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KTableColor, var(--black-70, color(black-70)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    ID
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    Enabled
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="sr-only">
+                    actions
+                  </span>
+            <!----></span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Basic Auth</td>
+          <td>517526354743085</td>
+          <td>true</td>
+          <td><a href="#">Link</a></td>
+        </tr>
+        <tr>
+          <td>Website Desktop</td>
+          <td>328027447731198</td>
+          <td>false</td>
+          <td><a href="#">Link</a></td>
+        </tr>
+        <tr>
+          <td>Android App</td>
+          <td>405383051040955</td>
+          <td>true</td>
+          <td><a href="#">Link</a></td>
+        </tr>
+      </tbody>
+    </table>
+    <!---->
+  </section>
+</div>
 `;
 
 exports[`KTable sorting should allow disabling sorting 1`] = `
-<section class="k-table-wrapper">
-  <table data-tableid="test-table-id-1234" class="k-table has-hover">
-    <thead class="">
-      <tr class="">
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  Name
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  ID
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  Enabled
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="sr-only">
-                  actions
-                </span>
-          <!----></span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Basic Auth</td>
-        <td>517526354743085</td>
-        <td>true</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Website Desktop</td>
-        <td>328027447731198</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Android App</td>
-        <td>405383051040955</td>
-        <td>true</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <nav aria-label="Pagination Navigation" data-testid="k-pagination-container" class="pa-1">
-    <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 3</span>
-      of 3
-      </span>
-      <ul class="pagination-button-container">
-        <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><span class="kong-icon kong-icon-arrowLeft"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Back</title>  <g><!----> <!----> <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
-        <!---->
-        <!---->
-        <!---->
-        <!---->
-        <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Forward</title>  <g><!----> <!----> <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
-      </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg height="16" width="16" viewBox="2 2 15 15" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></button>
-    </div>
-    <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
-      <!---->
-      <div class="k-popover-content">
-        <ul class="k-select-list ma-0 pa-0">
-          <div>
-            <div data-testid="k-select-item-15" class="k-select-item">
-              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-25" class="k-select-item">
-              <li role="option" class="d-block"><button value="25" class=""><span class="k-select-item-label mr-2">25</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-50" class="k-select-item">
-              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-75" class="k-select-item">
-              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-100" class="k-select-item">
-              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-          </div>
-        </ul>
+<div>
+  <section class="k-table-wrapper">
+    <table data-tableid="test-table-id-1234" class="k-table has-hover">
+      <thead class="">
+        <tr class="">
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    Name
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    ID
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    Enabled
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="sr-only">
+                    actions
+                  </span>
+            <!----></span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Basic Auth</td>
+          <td>517526354743085</td>
+          <td>true</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Website Desktop</td>
+          <td>328027447731198</td>
+          <td>false</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Android App</td>
+          <td>405383051040955</td>
+          <td>true</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <nav aria-label="Pagination Navigation" data-testid="k-pagination-container" class="pa-1">
+      <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 3</span>
+        of 3
+        </span>
+        <ul class="pagination-button-container">
+          <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><span class="kong-icon kong-icon-arrowLeft"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Back</title>  <g><!----> <!----> <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
+          <!---->
+          <!---->
+          <!---->
+          <!---->
+          <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Forward</title>  <g><!----> <!----> <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
+        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg height="16" width="16" viewBox="2 2 15 15" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></button>
       </div>
-      <!---->
-    </div>
-    </div>
-    </div>
-    </div></span></div>
-  </nav>
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+        <!---->
+        <div class="k-popover-content">
+          <ul class="k-select-list ma-0 pa-0">
+            <div>
+              <div data-testid="k-select-item-15" class="k-select-item">
+                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-25" class="k-select-item">
+                <li role="option" class="d-block"><button value="25" class=""><span class="k-select-item-label mr-2">25</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-50" class="k-select-item">
+                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-75" class="k-select-item">
+                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-100" class="k-select-item">
+                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+            </div>
+          </ul>
+        </div>
+        <!---->
+      </div>
+</div>
+</div>
+</div></span></div>
+</nav>
 </section>
+</div>
 `;
 
 exports[`KTable sorting should have sortable class when passed 1`] = `
-<section class="k-table-wrapper">
-  <table data-tableid="test-table-id-1234" class="k-table has-hover">
-    <thead class="">
-      <tr class="">
-        <th class="sortable"><span class="d-flex align-items-center"><span class="">
-                  Name
-                </span> <span class="kong-icon caret ml-2 kong-icon-chevronDown"><svg height="12" width="12" viewBox="0 0 20 20" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KTableColor, var(--black-70, color(black-70)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  ID
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="">
-                  Enabled
-                </span>
-          <!----></span></th>
-        <th class=""><span class="d-flex align-items-center"><span class="sr-only">
-                  actions
-                </span>
-          <!----></span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Basic Auth</td>
-        <td>517526354743085</td>
-        <td>true</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Website Desktop</td>
-        <td>328027447731198</td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>Android App</td>
-        <td>405383051040955</td>
-        <td>true</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  <nav aria-label="Pagination Navigation" data-testid="k-pagination-container" class="pa-1">
-    <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 3</span>
-      of 3
-      </span>
-      <ul class="pagination-button-container">
-        <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><span class="kong-icon kong-icon-arrowLeft"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Back</title>  <g><!----> <!----> <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
-        <!---->
-        <!---->
-        <!---->
-        <!---->
-        <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Forward</title>  <g><!----> <!----> <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
-      </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg height="16" width="16" viewBox="2 2 15 15" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></button>
-    </div>
-    <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
-      <!---->
-      <div class="k-popover-content">
-        <ul class="k-select-list ma-0 pa-0">
-          <div>
-            <div data-testid="k-select-item-15" class="k-select-item">
-              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-25" class="k-select-item">
-              <li role="option" class="d-block"><button value="25" class=""><span class="k-select-item-label mr-2">25</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-50" class="k-select-item">
-              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-75" class="k-select-item">
-              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-100" class="k-select-item">
-              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-          </div>
-        </ul>
+<div>
+  <section class="k-table-wrapper">
+    <table data-tableid="test-table-id-1234" class="k-table has-hover">
+      <thead class="">
+        <tr class="">
+          <th class="sortable"><span class="d-flex align-items-center"><span class="">
+                    Name
+                  </span> <span class="kong-icon caret ml-2 kong-icon-chevronDown"><svg height="12" width="12" viewBox="0 0 20 20" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KTableColor, var(--black-70, color(black-70)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    ID
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="">
+                    Enabled
+                  </span>
+            <!----></span></th>
+          <th class=""><span class="d-flex align-items-center"><span class="sr-only">
+                    actions
+                  </span>
+            <!----></span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Basic Auth</td>
+          <td>517526354743085</td>
+          <td>true</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Website Desktop</td>
+          <td>328027447731198</td>
+          <td>false</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td>Android App</td>
+          <td>405383051040955</td>
+          <td>true</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+    <nav aria-label="Pagination Navigation" data-testid="k-pagination-container" class="pa-1">
+      <div class="card-pagination-bar"><span data-testid="visible-items" class="pagination-text"><span class="pagination-text-pages">1 to 3</span>
+        of 3
+        </span>
+        <ul class="pagination-button-container">
+          <li data-testid="prev-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the previous page"><span class="kong-icon kong-icon-arrowLeft"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Back</title>  <g><!----> <!----> <path d="M12.17 8.75H3M6.75 5 3 8.75l3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
+          <!---->
+          <!---->
+          <!---->
+          <!---->
+          <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg height="16" width="16" viewBox="0 0 16 14" role="img"><title>Forward</title>  <g><!----> <!----> <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></a></li>
+        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg height="16" width="16" viewBox="2 2 15 15" role="img"><title>Expand</title>  <g><!----> <!----> <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></g></svg></span></button>
       </div>
-      <!---->
-    </div>
-    </div>
-    </div>
-    </div></span></div>
-  </nav>
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+        <!---->
+        <div class="k-popover-content">
+          <ul class="k-select-list ma-0 pa-0">
+            <div>
+              <div data-testid="k-select-item-15" class="k-select-item">
+                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-25" class="k-select-item">
+                <li role="option" class="d-block"><button value="25" class=""><span class="k-select-item-label mr-2">25</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-50" class="k-select-item">
+                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-75" class="k-select-item">
+                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+              <div data-testid="k-select-item-100" class="k-select-item">
+                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+              </div>
+            </div>
+          </ul>
+        </div>
+        <!---->
+      </div>
+</div>
+</div>
+</div></span></div>
+</nav>
 </section>
+</div>
 `;
 
 exports[`KTable states displays a loading skeletion when the "isLoading" prop is set to true" 1`] = `
-<div class="d-flex flex-wrap w-100 opacity-0">
-  <div class="skeleton-table-wrapper">
-    <div class="skeleton-table-row">
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
-    </div>
-    <div class="skeleton-table-row">
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
-    </div>
-    <div class="skeleton-table-row">
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
-    </div>
-    <div class="skeleton-table-row">
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
-    </div>
-    <div class="skeleton-table-row">
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
-    </div>
-    <div class="skeleton-table-row">
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
-      <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+<div>
+  <div class="d-flex flex-wrap w-100 opacity-0">
+    <div class="skeleton-table-wrapper">
+      <div class="skeleton-table-row">
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+      </div>
+      <div class="skeleton-table-row">
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+      </div>
+      <div class="skeleton-table-row">
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+      </div>
+      <div class="skeleton-table-row">
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+      </div>
+      <div class="skeleton-table-row">
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+      </div>
+      <div class="skeleton-table-row">
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-10 height-1 mr-6 skeleton-cell"></div>
+        <div class="box width-6 height-1 ml-auto skeleton-cell"></div>
+      </div>
     </div>
   </div>
 </div>
 `;
 
+exports[`KTable states displays an empty state when no data is available (slot) 1`] = `
+<div pagesize="4">
+  <div data-testid="k-table-empty-state"><span>Look mah! I am empty! (except testMode)</span></div>
+</div>
+`;
+
 exports[`KTable states displays an empty state when no data is available 1`] = `
-<section class="empty-state-wrapper" pagesize="4">
-  <div class="empty-state-title">
-    <!---->
-    <div class="k-empty-state-title-header">No Data</div>
+<div pagesize="4">
+  <div data-testid="k-table-empty-state">
+    <section class="empty-state-wrapper">
+      <div class="empty-state-title">
+        <!---->
+        <div class="k-empty-state-title-header">No Data</div>
+      </div>
+      <div class="empty-state-content">
+        <div class="k-empty-state-message">There is no data to display.</div>
+        <div class="k-empty-state-cta">
+          <!---->
+        </div>
+      </div>
+    </section>
   </div>
-  <div class="empty-state-content">
-    <div class="k-empty-state-message">There is no data to display.</div>
-    <div class="k-empty-state-cta">
-      <!---->
-    </div>
-  </div>
-</section>
+</div>
+`;
+
+exports[`KTable states displays an error state (slot) 1`] = `
+<div>
+  <div data-testid="k-table-error-state"><span>Look mah! I am erroneous! (except testMode)</span></div>
+</div>
 `;
 
 exports[`KTable states displays an error state when the "hasError" prop is set to true" 1`] = `
-<section class="empty-state-wrapper is-error">
-  <div class="empty-state-title">
-    <div class="k-empty-state-icon card-icon mb-4 warning-icon"><span class="kong-icon kong-icon-warning"><!----></span></div>
-    <div class="k-empty-state-title-header">An error occurred</div>
+<div>
+  <div data-testid="k-table-error-state">
+    <section class="empty-state-wrapper is-error">
+      <div class="empty-state-title">
+        <div class="k-empty-state-icon card-icon mb-4 warning-icon"><span class="kong-icon kong-icon-warning"><!----></span></div>
+        <div class="k-empty-state-title-header">An error occurred</div>
+      </div>
+      <div class="empty-state-content">
+        <div class="k-empty-state-message">Data cannot be displayed due to an error.</div>
+        <div class="k-empty-state-cta">
+          <!---->
+        </div>
+      </div>
+    </section>
   </div>
-  <div class="empty-state-content">
-    <div class="k-empty-state-message">Data cannot be displayed due to an error.</div>
-    <div class="k-empty-state-cta">
-      <!---->
-    </div>
-  </div>
-</section>
+</div>
 `;


### PR DESCRIPTION
### Summary
Make empty/error state slottable in KTable/KCardCatalog

#### Changes made:
* Add `empty-state` / `error-state` slots
* Emit `sort` event when sortable headers are clicked

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
