### PR TITLE
feat(ktable): default sort to asc

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -85,7 +85,7 @@
                     $emit('sort', {
                       prevKey: sortColumnKey,
                       sortColumnKey: column.key,
-                      sortColumnOrder: sortColumnOrder === 'desc' ? 'asc' : 'desc' // display opposite because sortColumnOrder outdated
+                      sortColumnOrder: sortColumnOrder === 'asc' ? 'desc' : 'asc' // display opposite because sortColumnOrder outdated
                     })
                     sortClickHandler(column.key)
                   }
@@ -586,10 +586,11 @@ export default defineComponent({
           }
         } else {
           sortColumnKey.value = key
-          sortColumnOrder.value = 'desc'
+          sortColumnOrder.value = 'asc'
         }
       } else {
         sortColumnKey.value = key
+        sortColumnOrder.value = 'asc'
       }
 
       // Use deprecated sort function to sort data passed in via

--- a/packages/utils/utils.js
+++ b/packages/utils/utils.js
@@ -93,7 +93,7 @@ export const clientSideSorter = (key, previousKey, sortOrder, items) => {
     sortOrder = 'ascending'
   } else {
     items.reverse()
-    if (sortOrder === 'descending') {
+    if (sortOrder === 'descending' || sortOrder === 'desc') {
       sortOrder = 'ascending'
     } else {
       sortOrder = 'descending'


### PR DESCRIPTION
### Summary
Fix sorting in KTable.

#### Changes made:
* Default sort to ascending on first click
* Arrow should point upward for ascending and downward for descending

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
