### PR TITLE
feat(ktable): add cacheKey prop

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -145,7 +145,7 @@ will default to the following values:
 
 ### fetcherCacheKey
 
-The fetcher functionality makes use of SWRV to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
+The fetcher functionality makes use of [SWRV](https://docs-swrv.netlify.app/) to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
 refire and repopulate the table data.
 
 ```vue

--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -143,6 +143,36 @@ will default to the following values:
 { pageSize: 15, page: 1 }
 ```
 
+### fetcherCacheKey
+
+The fetcher functionality makes use of SWRV to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
+refire and repopulate the table data.
+
+```vue
+<template>
+  <KTable
+    :fetcher="fetcher"
+    :headers="headers"
+    :fetcherCacheKey="cacheKey" />
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      cacheKey: 1
+    }
+  },
+  methods: {
+    itemDeleted () {
+      // take an action on the DOM
+      cacheKey++ // triggers refetch
+    }
+  }
+}
+</script>
+```
+
 ### paginationTotalItems
 
 Pass the total number of items in the set to populate the pagination text:

--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -150,9 +150,8 @@ refire and repopulate the table data.
 
 ```vue
 <template>
-  <KTable
+  <KCardCatalog
     :fetcher="fetcher"
-    :headers="headers"
     :fetcherCacheKey="cacheKey" />
 </template>
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -232,7 +232,7 @@ object these features should be explicitly disabled.
 
 ### fetcherCacheKey
 
-The fetcher functionality makes use of SWRV to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
+The fetcher functionality makes use of [SWRV](https://docs-swrv.netlify.app/) to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
 refire and repopulate the table data.
 
 ```vue

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -230,6 +230,36 @@ object these features should be explicitly disabled.
 </template>
 ```
 
+### fetcherCacheKey
+
+The fetcher functionality makes use of SWRV to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
+refire and repopulate the table data.
+
+```vue
+<template>
+  <KTable
+    :fetcher="fetcher"
+    :headers="headers"
+    :fetcherCacheKey="cacheKey" />
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      cacheKey: 1
+    }
+  },
+  methods: {
+    itemDeleted () {
+      // take an action on the DOM
+      cacheKey++ // triggers refetch
+    }
+  }
+}
+</script>
+```
+
 ### searchInput
 
 Pass in a string of search input for server-side table filtering. See [the Server-side function section](#server-side-functions)

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -305,6 +305,14 @@ export default defineComponent({
       default: null
     },
     /**
+     * A prop to trigger a revalidate of the fetcher function. Modifying this value
+     * will trigger a manual refetch of the table data.
+     */
+    fetcherCacheKey: {
+      type: String,
+      default: ''
+    },
+    /**
      * A prop to pass in a the number of pagination neighbors used by the pagination component
      */
     paginationNeighbors: {
@@ -392,7 +400,7 @@ export default defineComponent({
     }
 
     const { revalidate } = useRequest(
-      () => props.fetcher && `catalog-item_${Math.floor(Math.random() * 1000)}`,
+      () => props.fetcher && `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
       () => fetchData(),
       { revalidateOnFocus: false }
     )

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -381,6 +381,14 @@ export default defineComponent({
       default: undefined
     },
     /**
+     * A prop to trigger a revalidate of the fetcher function. Modifying this value
+     * will trigger a manual refetch of the table data.
+     */
+    fetcherCacheKey: {
+      type: String,
+      default: ''
+    },
+    /**
      * A prop to pass in a search string for server-side search
      */
     searchInput: {
@@ -568,7 +576,7 @@ export default defineComponent({
 
     const { query, search } = useDebounce('', 350)
     const { revalidate } = useRequest(
-      () => props.fetcher && `k-table_${Math.floor(Math.random() * 1000)}`,
+      () => props.fetcher && `k-table_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
       () => fetchData(),
       { revalidateOnFocus: false }
     )


### PR DESCRIPTION
### Summary
Add `fetcherCacheKey` prop to allow manual revalidate of fetcher.

#### Changes made:
*

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
