### PR TITLE
fix(ktable/kcardcatalog): fetch after init

### DIFF
--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -361,6 +361,7 @@ export default defineComponent({
     const page = ref(1)
     const pageSize = ref(15)
     const isCardLoading = ref(true)
+    const hasInitialized = ref(false)
 
     const fetchData = async () => {
       isCardLoading.value = true
@@ -385,6 +386,7 @@ export default defineComponent({
 
       page.value = fetcherParams.page
       pageSize.value = fetcherParams.pageSize
+      hasInitialized.value = true
 
       // get data
       if (props.fetcher) {
@@ -400,7 +402,7 @@ export default defineComponent({
     }
 
     const { revalidate } = useRequest(
-      () => props.fetcher && `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
+      () => props.fetcher && hasInitialized.value && `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
       () => fetchData(),
       { revalidateOnFocus: false }
     )

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -119,7 +119,7 @@ describe('KTable', () => {
         }
       })
 
-      await tick(wrapper.vm, 1)
+      await tick(wrapper.vm, 2)
 
       const actions = wrapper.findAll('.k-table td:last-of-type > *')
 
@@ -138,7 +138,7 @@ describe('KTable', () => {
         }
       })
 
-      await tick(wrapper.vm, 1)
+      await tick(wrapper.vm, 2)
 
       expect(wrapper.find('.k-table').classes()).toContain('has-hover')
       expect(wrapper.html()).toMatchSnapshot()
@@ -155,7 +155,7 @@ describe('KTable', () => {
         }
       })
 
-      await tick(wrapper.vm, 1)
+      await tick(wrapper.vm, 2)
 
       const actions = wrapper.findAll('th')
 

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -478,6 +478,7 @@ export default defineComponent({
     const sortColumnKey = ref('')
     const sortColumnOrder = ref('desc')
     const isClickable = ref(false)
+    const hasInitialized = ref(false)
 
     /**
      * Grabs listeners from this.$listeners matching a prefix to attach the
@@ -553,6 +554,7 @@ export default defineComponent({
       filterQuery.value = fetcherParams.query
       sortColumnKey.value = fetcherParams.sortColumnKey
       sortColumnOrder.value = fetcherParams.sortColumnOrder
+      hasInitialized.value = true
 
       // get data
       if (props.fetcher) {
@@ -576,7 +578,7 @@ export default defineComponent({
 
     const { query, search } = useDebounce('', 350)
     const { revalidate } = useRequest(
-      () => props.fetcher && `k-table_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
+      () => props.fetcher && hasInitialized.value && `k-table_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
       () => fetchData(),
       { revalidateOnFocus: false }
     )


### PR DESCRIPTION
### Summary
Don't call the fetcher until initialization has completed

#### Changes made:
*

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
