### PR TITLE
feat(kinput): add css variable for optional kinput placeholder text color overrides

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -195,6 +195,7 @@ KInput transparently binds to events:
 | `--KInputFocus` | Input border / label focus color
 | `--KInputDisabledBackground` | Input disabled background color
 | `--KInputError` | Input error border color
+| `--KInputPlaceholderColor`| Placeholder text color
 
 An Example of changing the error border color of KInput to pink might look like:
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -138,6 +138,7 @@ KTextArea also transparently binds to events:
 | `--KInputFocus` | Input border / label focus color
 | `--KInputDisabledBackground` | Input disabled background color
 | `--KInputError` | Input error border color
+| `--KInputPlaceholderColor`| Placeholder text color
 
 An Example of changing the error border color of KInput to pink might look like:
 

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -12,6 +12,7 @@ You can override or "theme" some parts of components by setting [CSS Custom Prop
 | `--KInputFocus`| Focus color
 | `--KInputDisabledBackground`| Disabled background
 | `--KInputError`| Error border
+| `--KInputPlaceholderColor`| Placeholder text color
 
 > Note: Add the `input-error` class to add error styling
 

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -147,7 +147,7 @@ export default {
     resize: none;
 
     &::placeholder {
-      color: var(--grey-500);
+      color: var(--KInputPlaceholderColor, var(--grey-500, color(grey-500)));
     }
 
     &:hover {
@@ -155,7 +155,7 @@ export default {
     }
 
     &:hover::placeholder {
-      color: var(--grey-600);
+      color: var(--KInputPlaceholderColor, var(--grey-600, color(grey-600)));
     }
 
     &:focus::placeholder {

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -115,7 +115,7 @@
 
     /* Browser Overrides */
     &::placeholder {
-      color: var(--black-45, color(black-45));
+      color: var(--KInputPlaceholderColor, var(--black-45, color(black-45)));
       font-weight: normal;
       opacity: 1;
     }


### PR DESCRIPTION
### Summary

This change allows overriding the default placeholder text color used in `KInput` and other inputs using `k-input` or `form-control` classes. It helps customizing the user experience and introduces more theming options without the need to write specific CSS selectors for placeholders.

#### Changes made:
* Modify the color of KInput placeholder to use the newly introduced `--KInputPlaceholderColor` CSS variable and fallback to its default color if not defined
* Add `--KInputPlaceholderColor` to the table of available Input variables in theming guide docs

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
