### PR TITLE
ci: use gh token to authenticate to github

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,3 +64,6 @@ jobs:
       run: |
         yarn lerna bootstrap
         yarn publish:ci
+      env:
+        #lerna uses GH_TOKEN to 
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

We want to lock down who can push to master, but this breaks the publish step and the publish actions pushes to master.

Lerna uses `GH_TOKEN` in it's github-client to authenticate to GitHub https://github.com/lerna/lerna/blob/6cb8ab2d4af7ce25c812e8fb05cd04650105705f/utils/github-client/lib/github-client.js#L25

`GITHUB_TOKEN` is an environment variable that can be used by actions to authenticate to github https://docs.github.com/en/actions/security-guides/automatic-token-authentication

#### Changes made:
* Pass the `GITHUB_TOKEN` to lerna via `GH_TOKEN`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
