### PR TITLE
chore(kmodal): remove aria-hidden as it isnt necessary (TDX-1659)

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     v-if="isVisible"
-    :aria-hidden="!isVisible ? 'true' : 'false'"
     :aria-label="title"
     class="k-modal"
     role="dialog"

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KModal hides the title when using hideTitle prop 1`] = `
-<div aria-hidden="false" aria-label="You can't see me" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="You can't see me" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -23,7 +23,7 @@ exports[`KModal hides the title when using hideTitle prop 1`] = `
 exports[`KModal matches snapshot 1`] = `undefined`;
 
 exports[`KModal renders custom button text & appearance 1`] = `
-<div aria-hidden="false" aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -43,7 +43,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
 `;
 
 exports[`KModal renders proper content when using action-buttons slot 1`] = `
-<div aria-hidden="false" aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -63,7 +63,7 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
 `;
 
 exports[`KModal renders proper content when using props 1`] = `
-<div aria-hidden="false" aria-label="Sweet prop title" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="Sweet prop title" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -83,7 +83,7 @@ exports[`KModal renders proper content when using props 1`] = `
 `;
 
 exports[`KModal renders proper content when using slots 1`] = `
-<div aria-hidden="false" aria-label="This is some header text" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="This is some header text" role="dialog" aria-modal="" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">


### PR DESCRIPTION
### Summary
The KModal has an aria-hidden property, but the component is not rendered when isVisible is false
which means we shouldn't need this property.
#### Changes made:
* Remove `aria-hidden` attribute in `KModal`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
