### PR TITLE
ci: don't persist credentials after checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
         node: [12.x]
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
### Summary

The default is for `persist-credentials` is true, which configs the ssh key that git uses. We want to use the token for `GITHUB_TOKEN`.

#### Changes made:
* don't persist credentials after checkout

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
