### PR TITLE
chore(kmodal): add aria-modal and aria-level to kmodal

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -16,8 +16,7 @@
           <div
             v-if="$scopedSlots.title || !hideTitle"
             class="k-modal-header modal-header mb-5"
-            role="heading"
-            aria-level="1">
+            role="heading">
             <slot name="header-content">{{ title }}</slot>
           </div>
           <div class="k-modal-body modal-body">

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -4,7 +4,7 @@
     :aria-label="title"
     class="k-modal"
     role="dialog"
-    aria-modal>
+    aria-modal="true">
     <div
       class="k-modal-backdrop modal-backdrop"
       @click="close">
@@ -16,7 +16,8 @@
           <div
             v-if="$scopedSlots.title || !hideTitle"
             class="k-modal-header modal-header mb-5"
-            role="heading">
+            role="heading"
+            aria-level="1">
             <slot name="header-content">{{ title }}</slot>
           </div>
           <div class="k-modal-body modal-body">

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -16,7 +16,8 @@
           <div
             v-if="$scopedSlots.title || !hideTitle"
             class="k-modal-header modal-header mb-5"
-            role="heading">
+            role="heading"
+            aria-level="2">
             <slot name="header-content">{{ title }}</slot>
           </div>
           <div class="k-modal-body modal-body">

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KModal hides the title when using hideTitle prop 1`] = `
-<div aria-label="You can't see me" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="You can't see me" role="dialog" aria-modal="true" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
@@ -23,11 +23,11 @@ exports[`KModal hides the title when using hideTitle prop 1`] = `
 exports[`KModal matches snapshot 1`] = `undefined`;
 
 exports[`KModal renders custom button text & appearance 1`] = `
-<div aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="Test Me" role="dialog" aria-modal="true" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
@@ -43,11 +43,11 @@ exports[`KModal renders custom button text & appearance 1`] = `
 `;
 
 exports[`KModal renders proper content when using action-buttons slot 1`] = `
-<div aria-label="Test Me" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="Test Me" role="dialog" aria-modal="true" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -63,11 +63,11 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
 `;
 
 exports[`KModal renders proper content when using props 1`] = `
-<div aria-label="Sweet prop title" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="Sweet prop title" role="dialog" aria-modal="true" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">Sweet prop title</div>
+        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">Sweet prop title</div>
         <div class="k-modal-body modal-body">Sweet prop content</div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -83,11 +83,11 @@ exports[`KModal renders proper content when using props 1`] = `
 `;
 
 exports[`KModal renders proper content when using slots 1`] = `
-<div aria-label="This is some header text" role="dialog" aria-modal="" class="k-modal">
+<div aria-label="This is some header text" role="dialog" aria-modal="true" class="k-modal">
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">
+        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">
           <div>This is some header text</div>
         </div>
         <div class="k-modal-body modal-body">

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -27,7 +27,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
@@ -47,7 +47,7 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -67,7 +67,7 @@ exports[`KModal renders proper content when using props 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">Sweet prop title</div>
+        <div role="heading" class="k-modal-header modal-header mb-5">Sweet prop title</div>
         <div class="k-modal-body modal-body">Sweet prop content</div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -87,7 +87,7 @@ exports[`KModal renders proper content when using slots 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" aria-level="1" class="k-modal-header modal-header mb-5">
+        <div role="heading" class="k-modal-header modal-header mb-5">
           <div>This is some header text</div>
         </div>
         <div class="k-modal-body modal-body">

--- a/packages/KModal/__snapshots__/KModal.spec.js.snap
+++ b/packages/KModal/__snapshots__/KModal.spec.js.snap
@@ -27,7 +27,7 @@ exports[`KModal renders custom button text & appearance 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded danger">
             click to cancel
@@ -47,7 +47,7 @@ exports[`KModal renders proper content when using action-buttons slot 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">Test Me</div>
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">Test Me</div>
         <div class="k-modal-body modal-body"></div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -67,7 +67,7 @@ exports[`KModal renders proper content when using props 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">Sweet prop title</div>
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">Sweet prop title</div>
         <div class="k-modal-body modal-body">Sweet prop content</div>
         <div class="k-modal-footer modal-footer d-flex"><button type="button" class="k-button medium rounded outline">
             Cancel
@@ -87,7 +87,7 @@ exports[`KModal renders proper content when using slots 1`] = `
   <div class="k-modal-backdrop modal-backdrop">
     <div class="k-modal-dialog modal-dialog">
       <div class="k-modal-content modal-content">
-        <div role="heading" class="k-modal-header modal-header mb-5">
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">
           <div>This is some header text</div>
         </div>
         <div class="k-modal-body modal-body">


### PR DESCRIPTION
### Summary
![Screen Shot 2021-11-29 at 5 13 32 PM](https://user-images.githubusercontent.com/40131297/143951186-4b594c9a-b0e4-4132-b7e4-1589967d35f2.png)
![Screen Shot 2021-11-29 at 5 13 37 PM](https://user-images.githubusercontent.com/40131297/143951193-47f47038-f746-4f07-a4a2-52c2b00b27f7.png)

Addresses a few a11y issues in the `KModal`




#### Changes made:
* fixed blank `aria-modal`
* added `aria-level` to `role="heading"`

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
