### PR TITLE
chore: revert publish to protected branch changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,6 @@ jobs:
         node: [12.x]
     steps:
     - uses: actions/checkout@v2
-      with:
-        persist-credentials: false
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v1
       with:
@@ -42,8 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-          persist-credentials: false
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
@@ -68,6 +64,3 @@ jobs:
       run: |
         yarn lerna bootstrap
         yarn publish:ci
-      env:
-        #lerna uses GH_TOKEN to 
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

These approaches don't work. For future travellers, I believe what we need is a personal access token from something like a service account that has admin privileges as long as the repo allows pushing from admins

https://github.com/lerna/lerna/issues/1957 

#### Changes made:

* revert 
  * #447 
  * #446 
  * #444 

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
