### PR TITLE
ci: use kongponents-bot to publish packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,14 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+          token: ${{ secrets.KONGPONENTS_BOT_PAT }}
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
 
     - name: setup git
       run: |
-        git config --global user.name 'kongponents'
-        git config --global user.email 'npm@konghq.com'
+        git config --global user.name 'kongponents-bot'
+        git config --global user.email '95302551+kongponents-bot@users.noreply.github.com'
 
     - name: install
       run: |
@@ -64,3 +66,6 @@ jobs:
       run: |
         yarn lerna bootstrap
         yarn publish:ci
+      env:
+        # lerna uses GH_TOKEN to init it's gh lib
+        GH_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}


### PR DESCRIPTION
### Summary

I created a bot, that is totally not self aware, named @kongponents-bot. It has special privileges ~to conquer the planet~ push to the master branch. This allows us to lock down master while still being able to publish.

#### Changes made:
* use the kongponents-bot personal access token secret in publish step

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
