### PR TITLE
feat(comment): add global comment in output file

### DIFF
--- a/packages/styles/styles.scss
+++ b/packages/styles/styles.scss
@@ -1,3 +1,6 @@
+/*! KONGPONENTS_STYLES */
+// Do not remove the comment above; it's vital for @kong/kong-auth-elements
+
 @import "variables";
 @import "fonts";
 @import "typography";


### PR DESCRIPTION
### Summary
Add a global CSS comment to the top of the outputted styles.css file to allow consuming applications to recognize the style block as needed (e.g. @kong/kong-auth-elements).

#### Changes made:
* Adds `/*! KONGPONENTS_STYLES */` comment block to the outputted `styles.css` file.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
