### PR TITLE
fix(kalert): fix invalid html structure

### DIFF
--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -60,20 +60,20 @@
         class="k-alert-icon" />
     </span>
     <div class="k-alert-msg-text">
-      <span
+      <div
         :class="type === 'banner' && size === 'large' ? 'k-alert-text' : ''"
         class="k-alert-msg">
         <!-- @slot Use this slot to pass default alert message  -->
         <slot name="alertMessage">{{ alertMessage }}
         </slot>
-      </span>
-      <span
+      </div>
+      <div
         v-if="type === 'banner' && (size === 'large') && hasAlertDescription"
         class="k-alert-description-text">
         <!-- @slot Use this slot to pass alert message description for large banner type alert  -->
         <slot name="description">{{ description }}
         </slot>
-      </span>
+      </div>
     </div>
   </div>
 </template>
@@ -352,6 +352,10 @@ export default {
     line-height: var(--type-md, type(md));
     padding: 2px 0;
     margin-left: 2px;
+
+    p:last-of-type {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -9,8 +9,9 @@ exports[`KAlert Renders danger variant 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="k-alert-msg-text"><span class="k-alert-msg">
-      </span>
+  <div class="k-alert-msg-text">
+    <div class="k-alert-msg">
+    </div>
     <!---->
   </div>
 </div>
@@ -25,8 +26,9 @@ exports[`KAlert Renders info variant 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="k-alert-msg-text"><span class="k-alert-msg">
-      </span>
+  <div class="k-alert-msg-text">
+    <div class="k-alert-msg">
+    </div>
     <!---->
   </div>
 </div>
@@ -41,8 +43,9 @@ exports[`KAlert Renders success variant 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="k-alert-msg-text"><span class="k-alert-msg">
-      </span>
+  <div class="k-alert-msg-text">
+    <div class="k-alert-msg">
+    </div>
     <!---->
   </div>
 </div>
@@ -57,8 +60,9 @@ exports[`KAlert Renders warning variant 1`] = `
   </div>
   <!---->
   <!---->
-  <div class="k-alert-msg-text"><span class="k-alert-msg">
-      </span>
+  <div class="k-alert-msg-text">
+    <div class="k-alert-msg">
+    </div>
     <!---->
   </div>
 </div>
@@ -71,6 +75,9 @@ exports[`KAlert renders slots when passed 1`] = `
       Dismiss
       <!----></button></div>
   <!----> <span><span class="kong-icon k-alert-icon kong-icon-notificationInbox"><!----></span></span>
-  <div class="k-alert-msg-text"><span class="k-alert-msg k-alert-text"><span>Hello World</span></span> <span class="k-alert-description-text"><span>I am an alert</span></span></div>
+  <div class="k-alert-msg-text">
+    <div class="k-alert-msg k-alert-text"><span>Hello World</span></div>
+    <div class="k-alert-description-text"><span>I am an alert</span></div>
+  </div>
 </div>
 `;

--- a/packages/KToaster/KToaster.spec.js
+++ b/packages/KToaster/KToaster.spec.js
@@ -19,7 +19,7 @@ describe('KToaster', () => {
 
       expect(wrapper.findAll('div[role="alert"].success')).toHaveLength(1)
       expect(wrapper.findAll('div[role="alert"].danger')).toHaveLength(2)
-      expect(wrapper.findAll('.toaster-container-outer span.k-alert-msg')).toHaveLength(4)
+      expect(wrapper.findAll('.toaster-container-outer div.k-alert-msg')).toHaveLength(4)
 
       expect(wrapper).toMatchSnapshot()
     })

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -8,7 +8,10 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
 </div>
 <!---->
 <!---->
-<div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
+<div class="k-alert-msg-text">
+  <div class="k-alert-msg">
+    <div class="message">hey toasty</div>
+  </div>
   <!---->
 </div>
 </div>
@@ -21,7 +24,10 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
+    <div class="k-alert-msg-text">
+      <div class="k-alert-msg">
+        <div class="message">hey toasty</div>
+      </div>
       <!---->
     </div>
   </div>
@@ -34,7 +40,10 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
+    <div class="k-alert-msg-text">
+      <div class="k-alert-msg">
+        <div class="message">hey toasty</div>
+      </div>
       <!---->
     </div>
   </div>
@@ -47,7 +56,10 @@ exports[`KToaster KToaster.vue renders toaster 1`] = `
     </div>
     <!---->
     <!---->
-    <div class="k-alert-msg-text"><span class="k-alert-msg"><div class="message">hey toasty</div></span>
+    <div class="k-alert-msg-text">
+      <div class="k-alert-msg">
+        <div class="message">hey toasty</div>
+      </div>
       <!---->
     </div>
   </div>


### PR DESCRIPTION
## Summary

Fix invalid HTML structure within `KAlert`. Slot elements should not be wrapped with `<span>` tags as the content for a `KAlert` slot is typically HTML, meaning a `<div>` or `<p>` tag inside the slot renders invalid HTML, which is also adversely impacting styles.

#### Changes made:
* Change `slot` wrapping elements to `<div>`
* Add CSS rule to remove margin of last `<p>` tag inside `.k-alert-msg`
* Updated test snapshots to match tag structure.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
