### PR TITLE
fix(ktextarea): fix v-model

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -91,7 +91,7 @@ KTextArea works as regular texarea do using v-model for data binding:
 
 KTextArea has a couple of natural event bindings.
 
-- `ktextarea` - Fired on change, returns the content of the textarea
+- `input` - Fired on change, returns the content of the textarea
 - `char-limit-exceeded` - Fired when the text starts or stops exceeding the limit, returns an object:
 
     ```json

--- a/packages/KTextArea/KTextArea.spec.js
+++ b/packages/KTextArea/KTextArea.spec.js
@@ -57,8 +57,8 @@ describe('KTextArea', () => {
     expect(textarea.element.value).toBe('hey')
     textarea.setValue('hey, dude')
 
-    expect(wrapper.emitted().textarea).toHaveLength(1)
-    expect(wrapper.emitted().textarea[0]).toEqual(['hey, dude'])
+    expect(wrapper.emitted().input).toHaveLength(1)
+    expect(wrapper.emitted().input[0]).toEqual(['hey, dude'])
     expect(textarea.element.value).toBe('hey, dude')
   })
 

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -7,10 +7,7 @@
       :rows="rows"
       :cols="cols"
       class="form-control k-input style-body-lg"
-      @input="e => {
-        $emit('textarea', e.target.value),
-        currValue = e.target.value
-      }"
+      @input="inputHandler"
       v-on="listeners"
     />
 
@@ -30,10 +27,7 @@
           :rows="rows"
           :cols="cols"
           class="form-control k-input style-body-lg"
-          @input="e => {
-            $emit('textarea', e.target.value),
-            currValue = e.target.value
-          }"
+          @input="inputHandler"
           @mouseenter="() => isHovered = true"
           @mouseleave="() => isHovered = false"
           @focus="() => isFocused = true"
@@ -124,6 +118,13 @@ export default {
           limitExceeded: newval
         })
       }
+    }
+  },
+  methods: {
+    inputHandler (e) {
+      // this 'input' event must be emitted for v-model binding to work properly
+      this.$emit('input', e.target.value)
+      this.currValue = e.target.value
     }
   }
 }


### PR DESCRIPTION
### Summary
Fixes v-model binding.

#### Changes made:
* Fixed the emitted event to be  `input`, which is required for proper v-model binding
* Updated the docs to reference the `input` event rather than the `textarea` event
* Updated the tests to test the `input` event rather than the `textarea` event

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
