### PR TITLE
fix(kpagination): fix currentPage prop

### DIFF
--- a/packages/KPagination/KPagination.spec.js
+++ b/packages/KPagination/KPagination.spec.js
@@ -87,6 +87,28 @@ describe('KPagination', () => {
     expect(wrapper.find('[data-testid="k-select-input"] .k-button').html()).toEqual(expect.stringContaining('4 items per page'))
   })
 
+  it('correctly updates text and active page button when currentPage prop is updated', () => {
+    const wrapper = mount(KPagination, {
+      propsData: {
+        totalCount: 9,
+        pageSizes,
+        currentPage: 1,
+        items: myItems,
+        testMode: true
+      }
+    })
+
+    expect(wrapper.find('[data-testid="visible-items"]').html()).toEqual(expect.stringContaining('1 to 2'))
+    expect(wrapper.find('[data-testid="visible-items"]').html()).toEqual(expect.stringContaining('of 9'))
+    expect(wrapper.find('.pagination-button.active a').html()).toEqual(expect.stringContaining('1'))
+
+    wrapper.setProps({ currentPage: 2 })
+
+    expect(wrapper.find('[data-testid="visible-items"]').html()).toEqual(expect.stringContaining('3 to 4'))
+    expect(wrapper.find('[data-testid="visible-items"]').html()).toEqual(expect.stringContaining('of 9'))
+    expect(wrapper.find('.pagination-button.active a').html()).toEqual(expect.stringContaining('2'))
+  })
+
   it('matches snapshot', () => {
     const wrapper = mount(KPagination, {
       propsData: {

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -220,6 +220,11 @@ export default {
       if (newval === true) {
         this.returnToFirstPage()
       }
+    },
+    currentPage (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.changePage(newVal)
+      }
     }
   },
   methods: {


### PR DESCRIPTION
### Summary

The `currentPage` prop should update both the active page button and the text detailing which items are currently displayed.

#### Changes made:
* Added a watcher for the `currentPage` prop
* Added a test to cover this case

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
