### PR TITLE
chore(docs): update docs with configs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,20 +84,6 @@ module.exports = () => ({
 })
 ```
 
-### Without Bundle System
-
-You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended.
-
-:::tip Note
-You must import the CSS from the `@kongponents/styles` package along with Vue.
-:::
-
-<iframe width="100%" height="300" style="width: 100%;" scrolling="no" title="Vue 2 with Kongponents" src="https://codepen.io/adamdehaven/embed/RwLVQLw?default-tab=html%2Cresult" frameborder="no" loading="lazy" allowtransparency="true" allowfullscreen="true">
-  See the Pen <a href="https://codepen.io/adamdehaven/pen/RwLVQLw">
-  Vue 2 with Kongponents</a> by Adam DeHaven (<a href="https://codepen.io/adamdehaven">@adamdehaven</a>)
-  on <a href="https://codepen.io">CodePen</a>.
-</iframe>
-
 ## Usage
 
 You can import and register components globally (e.g. in your Vue entry file, like `main.js`)
@@ -117,3 +103,17 @@ export default {
   ...
 };
 ```
+
+## Without Bundle System
+
+You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended.
+
+:::tip Note
+You must import the CSS from the `@kongponents/styles` package along with Vue.
+:::
+
+<iframe width="100%" height="300" style="width: 100%;" scrolling="no" title="Vue 2 with Kongponents" src="https://codepen.io/adamdehaven/embed/RwLVQLw?default-tab=html%2Cresult" frameborder="no" loading="lazy" allowtransparency="true" allowfullscreen="true">
+  See the Pen <a href="https://codepen.io/adamdehaven/pen/RwLVQLw">
+  Vue 2 with Kongponents</a> by Adam DeHaven (<a href="https://codepen.io/adamdehaven">@adamdehaven</a>)
+  on <a href="https://codepen.io">CodePen</a>.
+</iframe>

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@ export default {
 
 ## Without Bundle System
 
-You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended.
+You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent [is packaged as a `umd.js` file](https://cli.vuejs.org/guide/build-targets.html#library), so as long as you have loaded Vue in your project the Kongponent will work as intended.
 
 :::tip Note
 You must import the CSS from the `@kongponents/styles` package along with Vue.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,12 @@ module.exports = () => ({
 })
 ```
 
+### Without Bundle System
+
+You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
+
+<iframe width="100%" height="300" src="//jsfiddle.net/darrenjennings/khesrbLc/embedded/js,html,result/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
+
 ## Usage
 
 You can import and register components globally (e.g. in your Vue entry file, like `main.js`)
@@ -103,9 +109,3 @@ export default {
   ...
 };
 ```
-
-### Without Bundle System
-
-You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
-
-<iframe width="100%" height="300" src="//jsfiddle.net/darrenjennings/khesrbLc/embedded/js,html,result/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ module.exports = {
 }
 ```
 
-If your project does not have a `vue.config.js` file and instead uses webpack config files, you can add a loadcer rule (for example, for `babel-loader`) similar to the following (only showing the relevant entries)
+If your project does not have a `vue.config.js` file and instead uses webpack config files, you can add a loader rule (for example, for `babel-loader`) similar to the following (only showing the relevant entries)
 
 ```js
 // webpack.config.js

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,28 +7,93 @@ next: false
 
 Kongponents is a Vue component library of frequently needed UI elements. They were developed to solve [Kong](https://konghq.com)'s application needs, but are generic enough to use in any web application.
 
-## Local Installation
+## Installation
 
 To begin using Kongponents, you must first import the base `@kongponents/styles` package. [Read more about the style guide usage](./style-guide/usage.md).
 
-Next, you will need to import each component individually.
+Next, you will need to install each desired component. You can install multiple components at once, or one at a time as needed.
 
 ```bash
-$ yarn add  @kongponents/kbutton
+$ yarn add @kongponents/styles @kongponents/kbutton
 
 # or
 
-$ npm install @kongponents/kbutton
+$ npm install @kongponents/styles @kongponents/kbutton
 ```
 
-You can import and register components globally
+You will likely need to transpile all of the `@kongponents` packages in your project. If your project already has a `vue.config.js` file, just add the following `transpileDependencies` entry
+
+```js
+// vue.config.js
+
+module.exports = {
+  transpileDependencies: [
+    /@kongponents\/.*/
+  ]
+}
+```
+
+If your project does not have a `vue.config.js` file and instead uses webpack config files, you can add a loadcer rule (for example, for `babel-loader`) similar to the following (only showing the relevant entries)
+
+```js
+// webpack.config.js
+
+module.exports = (env) => {
+  return {
+    module: {
+      loaders: [
+        // transpile @kongponents packages
+        {
+          test: /\.js$/,
+          include: /(node_modules)\/(@kongponents)/,
+          loader: 'babel-loader',
+        },
+        // process all .js files, but ignore all other node_modules not listed above
+        {
+          test: /\.js$/,
+          exclude: /(node_modules)/,
+          loader: 'babel-loader'
+        },
+      ]
+    }
+  }
+}
+```
+
+If you choose to utilize any of the [CSS custom properties (variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) included in the `@kongponents` packages and your project uses [PostCSS](https://postcss.org/), you will likely need use the [`postcss-custom-properties` PostCSS plugin](https://github.com/postcss/postcss-custom-properties) so that the variables are preserved in their original form.
+
+```sh
+$ yarn add postcss-custom-properties --dev
+
+# or
+
+$ npm install postcss-custom-properties --save-dev
+```
+
+Next, add a `postcss.config.js` file to your project with the following content
+
+```js
+// postcss.config.js
+
+module.exports = () => ({
+  plugins: {
+    'postcss-custom-properties': {
+      preserve: true
+    }
+  }
+})
+```
+
+## Usage
+
+You can import and register components globally (e.g. in your Vue entry file, like `main.js`)
 
 ```js
 import KButton from '@kongponents/kbutton';
 Vue.component('KButton', KButton);
 ```
 
-Or register locally inside another component
+Or locally inside another component
 
 ```js
 import KButton from '@kongponents/kbutton';
@@ -39,9 +104,8 @@ export default {
 };
 ```
 
-## Without Bundle System
+### Without Bundle System
 
-You can also install Kongponents into a project where there is no build system
-as long as Vue is included. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
+You can also install Kongponents into a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
 
 <iframe width="100%" height="300" src="//jsfiddle.net/darrenjennings/khesrbLc/embedded/js,html,result/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,9 +86,17 @@ module.exports = () => ({
 
 ### Without Bundle System
 
-You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
+You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended.
 
-<iframe width="100%" height="300" src="//jsfiddle.net/darrenjennings/khesrbLc/embedded/js,html,result/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>
+:::tip Note
+You must import the CSS from the `@kongponents/styles` package along with Vue.
+:::
+
+<iframe width="100%" height="300" style="width: 100%;" scrolling="no" title="Vue 2 with Kongponents" src="https://codepen.io/adamdehaven/embed/RwLVQLw?default-tab=html%2Cresult" frameborder="no" loading="lazy" allowtransparency="true" allowfullscreen="true">
+  See the Pen <a href="https://codepen.io/adamdehaven/pen/RwLVQLw">
+  Vue 2 with Kongponents</a> by Adam DeHaven (<a href="https://codepen.io/adamdehaven">@adamdehaven</a>)
+  on <a href="https://codepen.io">CodePen</a>.
+</iframe>
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,6 @@ export default {
 
 ### Without Bundle System
 
-You can also install Kongponents into a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
+You can also use Kongponents in a project where there is no build system as long as Vue is included on the page. Each Kongponent is packaged as a `umd.js` file, so as long as you have loaded Vue in your project the Kongponent will work as intended. You will still need to [install the base styles package](./style-guide/usage.md).
 
 <iframe width="100%" height="300" src="//jsfiddle.net/darrenjennings/khesrbLc/embedded/js,html,result/" allowfullscreen="allowfullscreen" allowpaymentrequest frameborder="0"></iframe>


### PR DESCRIPTION
### Summary

Update Getting Started docs with up-to-date install and usage instructions.

#### Changes made:
* Add instructions for `transpileDependencies` and PostCSS preserve properties.
* Updated jsfiddle (tied to Darren's account) to a new CodePen that also properly imports `@kongponents/styles`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
