### PR TITLE
feat(*): fix dependencies and styles

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -620,6 +620,7 @@ export default {
     resolveAfter5MiliSec(count, pageSize, page) {
       // simulate pagination
       let limit = count
+      // <!-- markdownlint-disable-next-line MD037 -->
       if ((pageSize * page) < count) { limit = pageSize * page }
 
       let myItems = []

--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -204,10 +204,7 @@ Set this to `true` to limit pagination navigation to `previous` / `next` page on
   :paginationPageSizes="[4, 5, 6]"
   :initial-fetcher-params="{
     pageSize: 4,
-    page: 1,
-    query: '',
-    sortColumnKey: '',
-    sortColumnOrder: ''
+    page: 1
   }" />
 
 ```vue
@@ -501,10 +498,7 @@ the section above or completely slot in your own content.
 
 <KCard>
   <template v-slot:body>
-    <KCardCatalog
-      :fetcher="emptyFetcher"
-      :headers="headers"
-    >
+    <KCardCatalog :fetcher="emptyFetcher">
       <template v-slot:empty-state>
         <div class="w-100" style="text-align: center;">
           <KIcon icon="warning" />
@@ -521,10 +515,7 @@ the section above or completely slot in your own content.
 
 ```vue
 <template>
-  <KCardCatalog
-    :fetcher="() => { return { data: [] } }"
-    :headers="headers"
-  >
+  <KCardCatalog :fetcher="() => { return { data: [] } }">
     <template v-slot:empty-state>
       <KIcon icon="warning" />
       No Content!!!
@@ -629,9 +620,7 @@ export default {
     resolveAfter5MiliSec(count, pageSize, page) {
       // simulate pagination
       let limit = count
-      if ((pageSize * page) < count) {
-        limit = pageSize
-      }
+      if ((pageSize * page) < count) { limit = pageSize * page }
 
       let myItems = []
       for (let i = ((page-1) * pageSize); i < limit; i++) {
@@ -656,7 +645,10 @@ export default {
       }
 
       return params
-    }
+    },
+    emptyFetcher () {
+      return { data: [] }
+    },
   }
 }
 </script>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -15,16 +15,16 @@
 />
 
 ```vue
-<KSelect label="Pick Something:" :items="[{ 
-    label: 'test', 
+<KSelect label="Pick Something:" :items="[{
+    label: 'test',
     value: 'test'
-  }, { 
-    label: 'Test 1', 
-    value: 'test1' 
-  }, { 
-    label: 'TEST 2', 
-    value: 'test2' 
-  }]" 
+  }, {
+    label: 'Test 1',
+    value: 'test1'
+  }, {
+    label: 'TEST 2',
+    value: 'test2'
+  }]"
 />
 ```
 
@@ -49,17 +49,17 @@ by default.
 />
 
 ```vue
-<KSelect :items="[{ 
-    label: 'test', 
-    value: 'test', 
-    selected: true 
-  }, { 
-    label: 'Test 1', 
-    value: 'test1' 
-  }, { 
-    label: 'TEST 2', 
-    value: 'test2' 
-  }]" 
+<KSelect :items="[{
+    label: 'test',
+    value: 'test',
+    selected: true
+  }, {
+    label: 'Test 1',
+    value: 'test1'
+  }, {
+    label: 'TEST 2',
+    value: 'test2'
+  }]"
 />
 ```
 
@@ -78,14 +78,14 @@ The label for the select.
 />
 
 ```vue
-<KSelect label="Cool label" :items="[{ 
-    label: 'test', 
+<KSelect label="Cool label" :items="[{
+    label: 'test',
     value: 'test',
     selected: true
-  }, { 
-    label: 'Test 1', 
+  }, {
+    label: 'Test 1',
     value: 'test1'
-  }]" 
+  }]"
 />
 ```
 
@@ -107,14 +107,14 @@ the Clear icon.
 />
 
 ```vue
-<KSelect :items="[{ 
-    label: 'test', 
+<KSelect :items="[{
+    label: 'test',
     value: 'test',
     selected: true
-  }, { 
-    label: 'Test 1', 
+  }, {
+    label: 'Test 1',
     value: 'test1'
-  }]" 
+  }]"
 />
 ```
 
@@ -132,14 +132,14 @@ way to clear the selection once it is made.
 />
 
 ```vue
-<KSelect appearance='select' :items="[{ 
-    label: 'test', 
+<KSelect appearance='select' :items="[{
+    label: 'test',
     value: 'test',
     selected: true
-  }, { 
-    label: 'Test 1', 
+  }, {
+    label: 'Test 1',
     value: 'test1'
-  }]" 
+  }]"
 />
 ```
 
@@ -155,13 +155,13 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 />
 
 ```vue
-<KSelect appearance='button' :items="[{ 
-    label: 'test', 
+<KSelect appearance='button' :items="[{
+    label: 'test',
     value: 'test'
-  }, { 
-    label: 'Test 1', 
+  }, {
+    label: 'Test 1',
     value: 'test1'
-  }]" 
+  }]"
 />
 ```
 
@@ -194,12 +194,12 @@ export default {
 </script>
 
 ```vue
-<KSelect 
-  appearance='button' 
-  width="225" 
-  @selected="item => handleItemSelect(item)" 
-  :buttonText="`Show ${mySelect} per page`" 
-  :items="items" 
+<KSelect
+  appearance='button'
+  width="225"
+  @selected="item => handleItemSelect(item)"
+  :buttonText="`Show ${mySelect} per page`"
+  :items="items"
 />
 
 <script>
@@ -207,11 +207,11 @@ export default {
   data() {
     return {
       mySelect: '',
-      items: [{ 
-        label: '25', 
+      items: [{
+        label: '25',
         value: '25'
-      }, { 
-        label: '50', 
+      }, {
+        label: '50',
         value: '50'
       }]
     }
@@ -241,14 +241,14 @@ of the input, dropdown, and selected item.
 />
 
 ```vue
-<KSelect width="100" :items="[{ 
-    label: 'test', 
+<KSelect width="100" :items="[{
+    label: 'test',
     value: 'test',
     selected: true
-  }, { 
-    label: 'Test 1', 
+  }, {
+    label: 'Test 1',
     value: 'test1'
-  }]" 
+  }]"
 />
 ```
 
@@ -267,3 +267,5 @@ You can pass any input attribute and it will get properly bound to the element.
 | Event     | returns             |
 | :-------- | :------------------ |
 | `selected` | `selectedItem` Object |
+| `input` | `selectedItem` Object or null |
+| `change` | `selectedItem` Object or null |

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -258,7 +258,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .k-alert {
   position: relative;

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -259,6 +259,7 @@ export default {
 
 <style scoped lang="scss">
 @import '~@kongponents/styles/_variables.scss';
+
 .k-alert {
   position: relative;
   display: flex;

--- a/packages/KAlert/package.json
+++ b/packages/KAlert/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kbutton": "^6.7.2",
-    "@kongponents/kicon": "^6.7.2"
+    "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KBadge/package.json
+++ b/packages/KBadge/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/styles": "^6.6.3"
   }
 }

--- a/packages/KBadge/package.json
+++ b/packages/KBadge/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.6.3"
+    "@kongponents/styles": "^6.7.0"
   }
 }

--- a/packages/KBadge/package.json
+++ b/packages/KBadge/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.7.0"
+    "@kongponents/styles": "^6.7.1"
   }
 }

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -149,7 +149,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 @mixin boxShadow($color, $whiteShadowSpred: 2px, $colorShadowSpread: 4px) {
   box-shadow: 0 0 0 $whiteShadowSpred var(--white, color(white)), 0 0 0 $colorShadowSpread $color;

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.7.2"
+    "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KCard/package.json
+++ b/packages/KCard/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@kongponents/styles": "^6.6.3",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KCard/package.json
+++ b/packages/KCard/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.7.0",
+    "@kongponents/styles": "^6.7.1",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KCard/package.json
+++ b/packages/KCard/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.6.3",
+    "@kongponents/styles": "^6.7.0",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -437,6 +437,8 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
+@import '~@kongponents/styles/variables';
+
 .k-card-catalog {
   $cardHeight: 181px;
 

--- a/packages/KCardCatalog/package.json
+++ b/packages/KCardCatalog/package.json
@@ -29,6 +29,7 @@
     "@kongponents/kemptystate": "^6.7.2",
     "@kongponents/kpagination": "^6.7.2",
     "@kongponents/kskeleton": "^6.7.2",
+    "@kongponents/styles": "^6.7.2",
     "@kongponents/utils": "^6.7.2"
   },
   "peerDependencies": {

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -41,6 +41,7 @@
 <script>
 import KButton from '@kongponents/kbutton/KButton.vue'
 import KIcon from '@kongponents/kicon/KIcon.vue'
+
 export default {
   name: 'KEmptyState',
   components: { KButton, KIcon },
@@ -77,7 +78,9 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
 .empty-state-wrapper {
   padding: 42px 0;
   text-align: center;

--- a/packages/KEmptyState/package.json
+++ b/packages/KEmptyState/package.json
@@ -23,6 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.7.2"
+    "@kongponents/kbutton": "^6.7.2",
+    "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -109,8 +109,8 @@ Example usage:
 </script>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
-@import '~@kongponents/styles/forms/_inputs.scss';
+@import '~@kongponents/styles/variables';
+@import '~@kongponents/styles/forms/inputs';
 
 .k-inline-edit {
   --padding: var(--spacing-xxs) var(--spacing-xs);

--- a/packages/KInlineEdit/package.json
+++ b/packages/KInlineEdit/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/styles": "^6.6.3"
   }
 }

--- a/packages/KInlineEdit/package.json
+++ b/packages/KInlineEdit/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.6.3"
+    "@kongponents/styles": "^6.7.0"
   }
 }

--- a/packages/KInlineEdit/package.json
+++ b/packages/KInlineEdit/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.7.0"
+    "@kongponents/styles": "^6.7.1"
   }
 }

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -121,8 +121,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@import '~@kongponents/styles/_variables.scss';
-@import '~@kongponents/styles/forms/_inputs.scss';
+@import '~@kongponents/styles/variables';
+@import '~@kongponents/styles/forms/inputs';
 
 .form-control {
   box-shadow: none !important;
@@ -141,7 +141,6 @@ export default {
 }
 
 .k-input-wrapper {
-
   input.k-input {
     -webkit-appearance: none;
   }

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -110,8 +110,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
-@import '~@kongponents/styles/forms/_switch.scss';
+@import '~@kongponents/styles/variables';
+@import '~@kongponents/styles/forms/switch';
 
 .k-switch {
   position: relative;

--- a/packages/KInputSwitch/package.json
+++ b/packages/KInputSwitch/package.json
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.6.3",
-    "@kongponents/kooltip": "^6.6.3",
-    "@kongponents/styles": "^6.6.3"
+    "@kongponents/kicon": "^6.7.0",
+    "@kongponents/kooltip": "^6.7.0",
+    "@kongponents/styles": "^6.7.0"
   }
 }

--- a/packages/KInputSwitch/package.json
+++ b/packages/KInputSwitch/package.json
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.7.0",
-    "@kongponents/kooltip": "^6.7.0",
-    "@kongponents/styles": "^6.7.0"
+    "@kongponents/kicon": "^6.7.1",
+    "@kongponents/kooltip": "^6.7.1",
+    "@kongponents/styles": "^6.7.1"
   }
 }

--- a/packages/KInputSwitch/package.json
+++ b/packages/KInputSwitch/package.json
@@ -21,5 +21,10 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kicon": "^6.6.3",
+    "@kongponents/kooltip": "^6.6.3",
+    "@kongponents/styles": "^6.6.3"
   }
 }

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -61,6 +61,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import '~@kongponents/styles/_variables.scss';
-  @import '~@kongponents/styles/forms/_labels.scss';
+  @import '~@kongponents/styles/variables';
+  @import '~@kongponents/styles/forms/labels';
 </style>

--- a/packages/KLabel/package.json
+++ b/packages/KLabel/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kicon": "^6.7.2",
-    "@kongponents/kooltip": "^6.7.2"
+    "@kongponents/kooltip": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KMenu/KMenu.vue
+++ b/packages/KMenu/KMenu.vue
@@ -81,6 +81,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import '~@kongponents/styles/variables';
+
 .k-menu {
   background-color: var(--white);
   border: 1px solid var(--grey-300);

--- a/packages/KMenu/KMenuDivider.vue
+++ b/packages/KMenu/KMenuDivider.vue
@@ -11,7 +11,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.k-menu-item-divider{
+.k-menu-item-divider {
   padding: 0 19px 0 19px;
 }
 </style>

--- a/packages/KMenu/KMenuItem.vue
+++ b/packages/KMenu/KMenuItem.vue
@@ -115,6 +115,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@import '~@kongponents/styles/variables';
+
 .k-menu-item {
   list-style: none;
   margin: 0;

--- a/packages/KMenu/index.js
+++ b/packages/KMenu/index.js
@@ -1,0 +1,18 @@
+import KMenu from './KMenu'
+import KMenuDivider from './KMenuDivider'
+import KMenuItem from './KMenuItem'
+
+const Plugin = {
+  install (Vue) {
+    Vue.component('KMenu', KMenu)
+    Vue.component('KMenuDivider', KMenuDivider)
+    Vue.component('KMenuItem', KMenuItem)
+  }
+}
+
+export default Plugin
+export { KMenu, KMenuDivider, KMenuItem }
+
+if (typeof window !== 'undefined' && window.Vue) {
+  window.Vue.use(Plugin)
+}

--- a/packages/KMenu/package.json
+++ b/packages/KMenu/package.json
@@ -4,10 +4,11 @@
   "description": "<Menu component>",
   "main": "dist/KMenu.umd.min.js",
   "componentName": "KMenu",
-  "source": "KMenu.vue",
+  "source": "index.js",
   "files": [
     "dist",
-    "KMenu.vue"
+    "*.vue",
+    "index.js"
   ],
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
   "dependencies": {
     "@kongponents/kbutton": "^6.7.2",
     "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -141,7 +141,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .k-modal-backdrop {
   position: fixed;

--- a/packages/KModal/package.json
+++ b/packages/KModal/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.7.2"
+    "@kongponents/kbutton": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KMultiselect/KMultiselect.vue
+++ b/packages/KMultiselect/KMultiselect.vue
@@ -178,8 +178,8 @@ export default {
 </script>
 
 <style scoped lang="scss">
-@import '~@kongponents/styles/_variables.scss';
-@import '~@kongponents/styles/forms/_inputs.scss';
+@import '~@kongponents/styles/variables';
+@import '~@kongponents/styles/forms/inputs';
 
 .k-multiselect {
   &-trigger {

--- a/packages/KMultiselect/package.json
+++ b/packages/KMultiselect/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kbutton": "^6.7.2",
-    "@kongponents/kpop": "^6.7.2"
+    "@kongponents/kpop": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -333,6 +333,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
 .card-pagination-bar {
   display: flex;
   align-items: center;

--- a/packages/KPagination/package.json
+++ b/packages/KPagination/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kicon": "^6.7.2",
-    "@kongponents/kselect": "^6.7.2"
+    "@kongponents/kselect": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -89,6 +89,7 @@
     </transition>
   </component>
 </template>
+
 <script>
 import Popper from 'popper.js'
 import KButton from '@kongponents/kbutton/KButton.vue'
@@ -395,8 +396,9 @@ export default {
   }
 }
 </script>
+
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .k-popover {
   z-index: 1000;

--- a/packages/KPop/package.json
+++ b/packages/KPop/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kbutton": "^6.7.2",
+    "@kongponents/styles": "^6.7.2",
     "popper.js": "^1.15.0",
     "vue-uuid": "^2.0.2"
   }

--- a/packages/KRadio/KRadio.vue
+++ b/packages/KRadio/KRadio.vue
@@ -50,6 +50,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  @import '~@kongponents/styles/_variables.scss';
-  @import '~@kongponents/styles/forms/_checkbox-radio.scss';
+  @import '~@kongponents/styles/variables';
+  @import '~@kongponents/styles/forms/checkbox-radio';
 </style>

--- a/packages/KSegmentedControl/KSegmentedControl.vue
+++ b/packages/KSegmentedControl/KSegmentedControl.vue
@@ -17,6 +17,7 @@
 
 <script>
 import KButton from '@kongponents/kbutton/KButton.vue'
+
 export default {
   name: 'KSegmentedControl',
   components: { KButton },
@@ -69,8 +70,9 @@ export default {
   }
 }
 </script>
+
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .segmented-control .k-button {
   --KButtonPrimaryBase: var(--blue-100);

--- a/packages/KSegmentedControl/package.json
+++ b/packages/KSegmentedControl/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.7.2"
+    "@kongponents/kbutton": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -295,6 +295,7 @@ export default {
       })
       this.filterStr = this.appearance === 'dropdown' ? '' : item.label
       this.$emit('selected', item)
+      this.$emit('input', item)
     },
     clearSelection () {
       this.items.forEach(anItem => {
@@ -315,6 +316,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import '~@kongponents/styles/variables';
+
 .k-select {
   width: fit-content; // necessary for correct placement of popup
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -205,7 +205,8 @@ export default {
       selectedItem: null,
       selectId: !this.testMode ? uuid.v1() : 'test-select-id-1234',
       selectInputId: !this.testMode ? uuid.v1() : 'test-select-input-id-1234',
-      selectTextId: !this.testMode ? uuid.v1() : 'test-select-text-id-1234'
+      selectTextId: !this.testMode ? uuid.v1() : 'test-select-text-id-1234',
+      selectItems: []
     }
   },
 
@@ -242,7 +243,7 @@ export default {
       }
     },
     filteredItems: function () {
-      return this.items.filter(item => item.label.toLowerCase().includes(this.filterStr.toLowerCase()))
+      return this.selectItems.filter(item => item.label.toLowerCase().includes(this.filterStr.toLowerCase()))
     },
     placeholderText () {
       if (this.placeholder) {
@@ -269,11 +270,13 @@ export default {
   },
   beforeMount () {
     // items need keys
-    for (let i = 0; i < this.items.length; i++) {
-      this.items[i].key = `${this.items[i].label.replace(' ', '-')}-${i}`
-      if (this.items[i].selected) {
-        this.selectedItem = this.items[i]
-        this.items[i].key += '-selected'
+    this.selectItems = this.items
+
+    for (let i = 0; i < this.selectItems.length; i++) {
+      this.selectItems[i].key = `${this.selectItems[i].label.replace(' ', '-')}-${i}`
+      if (this.selectItems[i].selected) {
+        this.selectedItem = this.selectItems[i]
+        this.selectItems[i].key += '-selected'
 
         if (this.appearance === 'select') {
           this.filterStr = this.selectedItem.label
@@ -283,26 +286,29 @@ export default {
   },
   methods: {
     handleItemSelect (item) {
-      this.items.forEach(anItem => {
+      this.selectItems.forEach(anItem => {
         if (anItem.key === item.key) {
           anItem.selected = true
           anItem.key += '-selected'
           this.selectedItem = anItem
-        } else {
+        } else if (anItem.selected) {
           delete anItem.selected
           anItem.key = anItem.key.split('-selected')[0]
         }
       })
       this.filterStr = this.appearance === 'dropdown' ? '' : item.label
       this.$emit('selected', item)
+      // this 'input' event must be emitted for v-model binding to work properly
       this.$emit('input', item)
     },
     clearSelection () {
-      this.items.forEach(anItem => {
+      this.selectItems.forEach(anItem => {
         delete anItem.selected
         anItem.key = anItem.key.split('-selected')[0]
       })
       this.selectedItem = null
+      // this 'input' event must be emitted for v-model binding to work properly
+      this.$emit('input', null)
     },
     triggerFocus (isToggled) {
       const inputElem = document.getElementById(this.selectTextId)

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -300,6 +300,7 @@ export default {
       this.$emit('selected', item)
       // this 'input' event must be emitted for v-model binding to work properly
       this.$emit('input', item)
+      this.$emit('change', item)
     },
     clearSelection () {
       this.selectItems.forEach(anItem => {
@@ -309,6 +310,7 @@ export default {
       this.selectedItem = null
       // this 'input' event must be emitted for v-model binding to work properly
       this.$emit('input', null)
+      this.$emit('change', null)
     },
     triggerFocus (isToggled) {
       const inputElem = document.getElementById(this.selectTextId)

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -50,6 +50,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
 .k-select-item {
   margin-bottom: 6px;
 

--- a/packages/KSelect/package.json
+++ b/packages/KSelect/package.json
@@ -29,6 +29,7 @@
     "@kongponents/kinput": "^6.7.2",
     "@kongponents/klabel": "^6.7.2",
     "@kongponents/kpop": "^6.7.2",
+    "@kongponents/styles": "^6.7.2",
     "@kongponents/ktoggle": "^6.7.2",
     "vue-uuid": "^2.0.2"
   }

--- a/packages/KSkeleton/FullScreenKongSkeleton.vue
+++ b/packages/KSkeleton/FullScreenKongSkeleton.vue
@@ -58,6 +58,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
 .fullscreen-loading-container {
   position: fixed;
   top: 0;

--- a/packages/KSkeleton/KSkeleton.vue
+++ b/packages/KSkeleton/KSkeleton.vue
@@ -103,6 +103,7 @@ export default {
   }
 }
 </script>
+
 <style>
 .opacity-0 .box {
   opacity: 0;

--- a/packages/KSkeleton/package.json
+++ b/packages/KSkeleton/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.7.2"
+    "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KSlideout/KSlideout.vue
+++ b/packages/KSlideout/KSlideout.vue
@@ -77,7 +77,7 @@ export default {
 </style>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .k-slideout {
   --KCardPaddingY: 2rem;

--- a/packages/KSlideout/package.json
+++ b/packages/KSlideout/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kcard": "^6.7.2",
-    "@kongponents/kicon": "^6.7.2"
+    "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -669,7 +669,7 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .k-table-wrapper {
   width: 100%;

--- a/packages/KTable/package.json
+++ b/packages/KTable/package.json
@@ -28,6 +28,7 @@
     "@kongponents/kicon": "^6.7.2",
     "@kongponents/kpagination": "^6.7.2",
     "@kongponents/kskeleton": "^6.7.2",
+    "@kongponents/styles": "^6.7.2",
     "@kongponents/utils": "^6.7.2",
     "vue-uuid": "^2.0.2"
   },

--- a/packages/KTabs/KTabs.vue
+++ b/packages/KTabs/KTabs.vue
@@ -79,7 +79,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
 
 .k-tabs {
   ul {

--- a/packages/KTabs/package.json
+++ b/packages/KTabs/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/styles": "^6.7.0"
   }
 }

--- a/packages/KTabs/package.json
+++ b/packages/KTabs/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.7.0"
+    "@kongponents/styles": "^6.7.1"
   }
 }

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -131,8 +131,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
-@import '~@kongponents/styles/forms/_inputs.scss';
+@import '~@kongponents/styles/variables';
+@import '~@kongponents/styles/forms/inputs';
 
 .k-input-wrapper {
   width: fit-content;

--- a/packages/KTextArea/package.json
+++ b/packages/KTextArea/package.json
@@ -23,7 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/klabel": "^6.7.2",
     "@kongponents/styles": "^6.7.2",
     "vue-uuid": "^2.0.2"
   }

--- a/packages/KToaster/KToaster.vue
+++ b/packages/KToaster/KToaster.vue
@@ -62,7 +62,8 @@ export default {
 </style>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/_variables.scss';
+@import '~@kongponents/styles/variables';
+
 $transition: all .3s;
 
 .toaster-container-outer {

--- a/packages/KToaster/package.json
+++ b/packages/KToaster/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kalert": "^6.7.2"
+    "@kongponents/kalert": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/KViewSwitcher/KViewSwitcher.vue
+++ b/packages/KViewSwitcher/KViewSwitcher.vue
@@ -60,7 +60,9 @@ export default {
 </script>
 
 <style lang="scss">
+@import '~@kongponents/styles/variables';
 // Originally forked and modified from https://codepen.io/aaroniker/pen/dyoKeMP
+
 .view-switch-button {
   --KButtonPaddingY: 6px;
   --KButtonPaddingX: 6px;

--- a/packages/KViewSwitcher/package.json
+++ b/packages/KViewSwitcher/package.json
@@ -21,5 +21,9 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kbutton": "^6.7.0",
+    "@kongponents/styles": "^6.7.0"
   }
 }

--- a/packages/KViewSwitcher/package.json
+++ b/packages/KViewSwitcher/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.7.0",
-    "@kongponents/styles": "^6.7.0"
+    "@kongponents/kbutton": "^6.7.1",
+    "@kongponents/styles": "^6.7.1"
   }
 }

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -80,6 +80,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import '~@kongponents/styles/variables';
+
 .kooltip {
   --KPopColor: var(--KoolTipColor, var(--white, color(white)));
   --KPopBackground: var(--KoolTipBackground, var(--black-400, color(black-400)));

--- a/packages/KoolTip/package.json
+++ b/packages/KoolTip/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kpop": "^6.7.2"
+    "@kongponents/kpop": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }

--- a/packages/Krumbs/Krumbs.vue
+++ b/packages/Krumbs/Krumbs.vue
@@ -59,7 +59,9 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
 .krumbs {
   display: flex;
   -ms-flex-wrap: wrap;

--- a/packages/Krumbs/package.json
+++ b/packages/Krumbs/package.json
@@ -29,6 +29,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.7.2"
+    "@kongponents/kicon": "^6.7.2",
+    "@kongponents/styles": "^6.7.2"
   }
 }


### PR DESCRIPTION
### Summary
Fix dependencies of all kongponents.

#### Changes made:
* Fix docs / pagination example in `KCardCatalog`
* Update dependencies for all kongponents
* Emit `input` event in `KSelect` for `v-bind`
* Adjust imports of scss partials to use partials syntax
* Add `index.js` for `KMenu` to allow using subcomponents
* Make sure to include import of `_variables.scss` if it is used in the style blocks

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
