### PR TITLE
fix(kinput): allow numbers to be passed in as value

### DIFF
--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -63,7 +63,7 @@ export default {
   inheritAttrs: false,
   props: {
     value: {
-      type: String,
+      type: [String, Number],
       default: ''
     },
     label: {


### PR DESCRIPTION
### Summary
Sets the KInput value prop type to `[String, Number]` to prevent warnings in the browser console when using inputs with `type="number"`.

#### Changes made:
* Small addition to KInput value prop type

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
