### PR TITLE
fix(ktable): update sort styling

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -737,6 +737,10 @@ export default defineComponent({
       font-size: var(--KTableHeaderSize, var(--type-sm, type(sm)));
       font-weight: 500;
 
+      &.active-sort {
+        color: var(--blue-500);
+      }
+
       .sr-only {
         position: absolute;
         width: 1px;
@@ -750,20 +754,16 @@ export default defineComponent({
       }
 
       .caret {
+        position: relative;
         transform: rotate(0deg);
-        transition: 250ms ease;
       }
 
       &.sortable {
         cursor: pointer;
 
         &.asc .caret {
+          top: -4px;
           transform: rotate(-180deg);
-          transition: 250ms ease;
-        }
-
-        &.desc .caret {
-          transition: 250ms ease;
         }
       }
     }


### PR DESCRIPTION
### Summary

#### Changes made:
* Adjust position of sort icons
* Currently sorted column heading color is blue

Before:

![image](https://user-images.githubusercontent.com/67973710/149206140-1879a35e-4127-4961-bdf6-dbcd1c83b2b2.png)


After:

![image](https://user-images.githubusercontent.com/67973710/149206584-833486b2-dcfa-448c-a53a-d1a3700699ae.png)


### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
