### PR TITLE
feat(krumbs): update breadcrumb kongponent with icon [KHCP-2655]

### DIFF
--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -12,6 +12,7 @@
 <template>
   <Krumbs :items="breadcrumbItems" />
 </template>
+
 <script>
 export default {
   data () {
@@ -21,7 +22,8 @@ export default {
           key: 'home',
           to: { path: '/' },
           title: 'Go Home',
-          text: 'Home'
+          text: 'Home',
+          icon: 'kong'
         },
         {
           key: 'button',
@@ -44,15 +46,20 @@ An array of Breadcrumb items
 
 ```html
 <!--
- * @typedef {Object} Item - breacrumb item holding router-link properties
+ * @typedef {Object} Item - breadcrumb item holding router-link properties
  * @property {RawLocation} to - router-link 'to' object or href string
- * @property {string} text - The anchor text displayed
+ * @property {string} text - The anchor text displayed (optional, can be used with or without 'icon')
  * @property {string} title - The anchor title shown when hovering the link
+ * @property {string} icon - Display a KIcon before the anchor title (optional, can be used with or without 'text')
  * @property {string} [key] - An ID when the list is generated. Defaults to text if not set.
  * @property {string} [maxWidth] - maxWidth of item, overrides itemMaxWidth
  -->
-<Krumbs :items="[{ key: 'home', to: { path: '/' }, title: 'Home', text: 'Home' }]" />
+<Krumbs :items="[{ key: 'home', to: { path: '/' }, title: 'Home', icon: 'kong', text: 'Home' }]" />
  ```
+
+#### Breadcrumb content
+
+Each breadcrumb item can display `text`, an `icon`, or both.
 
 #### Breadcrumb link
 
@@ -68,6 +75,7 @@ The `to` property can be a Vue route or traditional URL. When using a URL though
 <template>
   <Krumbs :items="breadcrumbItems" />
 </template>
+
 <script>
 export default {
   data () {
@@ -115,7 +123,8 @@ export default {
           key: 'home',
           to: { path: '/' },
           title: 'Go Home',
-          text: 'Home'
+          text: 'Home',
+          icon: 'kong'
         },
         {
           key: 'button',

--- a/packages/Krumbs/Krumbs.spec.js
+++ b/packages/Krumbs/Krumbs.spec.js
@@ -43,6 +43,25 @@ describe('Krumbs', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('renders an icon breadcrumb', () => {
+    const wrapper = mount(Krumbs, {
+      propsData: {
+        items: [
+          {
+            key: 'docs',
+            to: 'https://docs.konghq.com',
+            title: 'Go to Kong Docs',
+            icon: 'kong'
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.findAll(`ul li`)).toHaveLength(1)
+    expect(wrapper.findAll(`li .breadcrumb-icon`)).toHaveLength(1)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('renders breadcrumb links without needing a router', () => {
     const wrapper = mount(Krumbs, {
       propsData: {

--- a/packages/Krumbs/Krumbs.vue
+++ b/packages/Krumbs/Krumbs.vue
@@ -1,29 +1,59 @@
 <template>
   <ul
-    class="krumbs style-body-bc"
-    v-on="$listeners"
-  >
+    class="krumbs"
+    v-on="$listeners">
     <li
       v-for="item in items"
       :key="item.key || item.text"
-      :style="{ maxWidth: item.maxWidth || itemMaxWidth }"
       class="krumb-item truncate"
     >
       <router-link
         v-if="typeof item.to === 'object'"
         :to="item.to"
         :title="item.title"
-      >{{ item.text }}</router-link>
+        :class="{'no-underline': !item.text}"
+      >
+        <KIcon
+          v-if="item.icon"
+          :icon="item.icon"
+          :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
+          hide-title
+          size="16"
+          viewbox="0 0 16 16"
+          color="var(--grey-500)"
+        />
+        <span
+          v-if="item.text"
+          :style="{maxWidth: item.maxWidth || itemMaxWidth}"
+          class="breadcrumb-text truncate">{{ item.text }}</span>
+      </router-link>
+
       <a
         v-else
         :title="item.title"
         :href="item.to"
-        target="_blank">{{ item.text }}</a>
+        :class="{'no-underline': !item.text}"
+        target="_blank"
+      >
+        <KIcon
+          v-if="item.icon"
+          :icon="item.icon"
+          :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
+          hide-title
+          size="15"
+          color="var(--grey-500)"
+        />
+        <span
+          v-if="item.text"
+          :style="{maxWidth: item.maxWidth || itemMaxWidth}"
+          class="breadcrumb-text truncate">{{ item.text }}</span>
+      </a>
+
       <KIcon
         hide-title
         icon="chevronRight"
         size="15"
-        color="var(--grey-500)"/>
+        color="var(--grey-500)" />
     </li>
   </ul>
 </template>
@@ -36,12 +66,13 @@ import KIcon from '@kongponents/kicon/KIcon.vue'
  * @property {Object|String} to - router-link "to" object or href string
  * @property {string} text - anchor text
  * @property {string} title - anchor title
+ * @property {string} icon - icon before anchor
  * @property {string} [key] - list item key
  * @property {string} [maxWidth] - maxWidth of item, overrides itemMaxWidth
  */
 export default {
   name: 'Krumbs',
-  components: { KIcon },
+  components: {KIcon},
   props: {
     /**
      * @type {{ new(): Item[]}}
@@ -60,7 +91,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '~@kongponents/styles/variables';
+@import "~@kongponents/styles/variables";
 
 .krumbs {
   display: flex;
@@ -70,22 +101,54 @@ export default {
   margin-bottom: 1rem;
   list-style: none;
   border-radius: 0.25rem;
+  font-size: 15px;
+  font-weight: 500 !important;
+  line-height: 24px !important;
 }
 
 .krumbs .krumb-item .kong-icon {
   display: inline-flex;
-  padding: 0 var(--spacing-xs);
+  padding: 0 12px 0 var(--spacing-xs);
   color: var(--grey-500);
-  vertical-align: middle
+  vertical-align: middle;
+
+  &.breadcrumb-icon {
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--spacing-xs);
+
+    &.has-no-text {
+      padding-right: 0;
+    }
+  }
 }
 
-.krumbs li a {
-  color: var(--grey-500);
-  letter-spacing: 1px;
+.krumbs li {
+  display: inline-flex;
+
+  a {
+    display: inline-flex;
+    color: var(--grey-500);
+    letter-spacing: 1px;
+    font-size: 15px;
+
+    &:hover,
+    &.no-underline {
+      text-decoration: none !important;
+    }
+
+    > .breadcrumb-text {
+      transition: all 0.2s ease-in-out;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 }
 
 .truncate {
-  display: block;
+  display: inline-block;
   align-items: center;
   justify-content: center;
 }

--- a/packages/Krumbs/__snapshots__/Krumbs.spec.js.snap
+++ b/packages/Krumbs/__snapshots__/Krumbs.spec.js.snap
@@ -1,13 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Krumbs renders breadcrumb links 1`] = `
-<ul class="krumbs style-body-bc">
-  <li class="krumb-item truncate" style="max-width: 38ch;"><a href="/services" class="" title="Services">Services</a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+exports[`Krumbs renders an icon breadcrumb 1`] = `
+<ul class="krumbs">
+  <li class="krumb-item truncate"><a title="Go to Kong Docs" href="https://docs.konghq.com" target="_blank" class="no-underline"><span class="kong-icon kong-icon-kong breadcrumb-icon has-no-text"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Kong</title>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
+</svg>
+</span>
+      <!----></a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Forward</title>
   <path d="m7.3 14.7 5-5.2-5-5.2" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></li>
-  <li class="krumb-item truncate" style="max-width: 38ch;"><a title="Go to Kong Docs" href="https://docs.konghq.com" target="_blank">External Link</a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+</ul>
+`;
+
+exports[`Krumbs renders breadcrumb links 1`] = `
+<ul class="krumbs">
+  <li class="krumb-item truncate"><a href="/services" class="" title="Services">
+      <!----> <span class="breadcrumb-text truncate" style="max-width: 38ch;">Services</span></a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Forward</title>
+  <path d="m7.3 14.7 5-5.2-5-5.2" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>
+</span></li>
+  <li class="krumb-item truncate"><a title="Go to Kong Docs" href="https://docs.konghq.com" target="_blank" class="">
+      <!----> <span class="breadcrumb-text truncate" style="max-width: 38ch;">External Link</span></a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Forward</title>
   <path d="m7.3 14.7 5-5.2-5-5.2" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -16,8 +36,9 @@ exports[`Krumbs renders breadcrumb links 1`] = `
 `;
 
 exports[`Krumbs renders breadcrumb links without needing a router 1`] = `
-<ul class="krumbs style-body-bc">
-  <li class="krumb-item truncate" style="max-width: 38ch;"><a title="Go to Kong Docs" href="https://docs.konghq.com" target="_blank">External Link</a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<ul class="krumbs">
+  <li class="krumb-item truncate"><a title="Go to Kong Docs" href="https://docs.konghq.com" target="_blank" class="">
+      <!----> <span class="breadcrumb-text truncate" style="max-width: 38ch;">External Link</span></a> <span class="kong-icon kong-icon-chevronRight"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Forward</title>
   <path d="m7.3 14.7 5-5.2-5-5.2" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>

--- a/packages/styles/_typography.scss
+++ b/packages/styles/_typography.scss
@@ -102,13 +102,6 @@
   font-weight: 400 !important;
 }
 
-.style-body-bc {
-  font-size: 12px !important;
-  line-height: 24px !important;
-  font-weight: 400 !important;
-  text-transform: uppercase !important;
-}
-
 .style-body-code {
   font-size: 13px !important;
   line-height: 24px !important;


### PR DESCRIPTION
### Summary

Add `icons` property to `items` object to allow for using a `KIcon` component with or without breadcrumb text.

Update breadcrumb (Krumbs) Kongponent styling and structure, including wrapping breadcrumb text in a `span.breadcrumb-text` element.

#### Changes made:
* Breadcrumb text is now wrapped in a `<span class="breadcrumb-text" />` tag.
* Add `icon` property to `items` object.
* Style tweaks.
* Updated docs for changes.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
