### PR TITLE
feat(kpop): add positionFixed prop

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -61,6 +61,10 @@ Title shown above the list of items.
   :items="data.items" />
 ```
 
+### positionFixed
+
+Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`. See [`KPop` docs](popover.html#positionfixed) for more information.
+
 ### width
 
 Sets the width of the popup container. Defaults to auto.
@@ -150,7 +154,7 @@ Enables a filter input to search the items
   <KMultiselect
     button-text="Car Makers"
     has-filter
-    title="Select car makers" 
+    title="Select car makers"
     :items="data.items" />
 </Komponent>
 ```

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -45,7 +45,7 @@ the default slot.
 </KPop>
 ```
 
-### Target
+### target
 
 This is the target `element` that the <code>popover</code> is appended to. By default its the body tag.
 
@@ -67,7 +67,7 @@ This is the target `element` that the <code>popover</code> is appended to. By de
 </KPop>
 ```
 
-### Tag
+### tag
 
 This is the tag that the popover is wrapped around. By default its the div tag.
 
@@ -85,7 +85,7 @@ This is the tag that the popover is wrapped around. By default its the div tag.
   </template>
 </KPop>
 
-### Title
+### title
 
 This is the Title of the popover. Either this or the title slot needs to be filled.
 
@@ -125,7 +125,7 @@ or alternatively, via the slot:
 </KPop>
 ```
 
-### Trigger
+### trigger
 
 What the popover is triggered by - by default it's triggered on click.
 Here are the different options:
@@ -149,7 +149,7 @@ Here are the different options:
 </KPop>
 ```
 
-### Placement
+### placement
 
 The position of where the popover appears - by default it appears on top.
 Here are the different options:
@@ -221,7 +221,7 @@ export default {
 </script>
 ```
 
-### PositionFixed
+### positionFixed
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`.
 
@@ -283,7 +283,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
 </div>
 ```
 
-### Width
+### width
 
 The width of the popover body - by default it is 200px.
 
@@ -303,7 +303,7 @@ The width of the popover body - by default it is 200px.
 </KPop>
 ```
 
-### Popover Classes
+### popoverClasses
 
 Custom classes that you want to append to the popover - by default it has a `k-popover` class on it.
 
@@ -316,7 +316,7 @@ Custom classes that you want to append to the popover - by default it has a `k-p
 </KPop>
 ```
 
-### Popover Transitions
+### popoverTransitions
 
 Custom transitions that you want the popover to have - by default it uses a `fade` transition.
 
@@ -329,7 +329,7 @@ Custom transitions that you want the popover to have - by default it uses a `fad
 </KPop>
 ```
 
-### Popover Timeout
+### popoverTimeout
 
 Custom timeout setting that you want the popover to have - by default it is set
 to 300 milliseconds.
@@ -350,7 +350,7 @@ to 300 milliseconds.
 </KPop>
 ```
 
-### Hide Popover Flag
+### hidePopover
 
 You can pass in an optional flag to trigger the popover to hide - useful for external events like zooming or panning - by default it is set to `false`.
 
@@ -363,7 +363,7 @@ You can pass in an optional flag to trigger the popover to hide - useful for ext
 </KPop>
 ```
 
-### Disabled Flag
+### disabled
 
 You can pass in an optional flag to disable the popover - by default it is set to `false`.
 
@@ -376,7 +376,7 @@ You can pass in an optional flag to disable the popover - by default it is set t
 </KPop>
 ```
 
-### Hide Caret
+### hideCaret
 
 You can pass in an optional flag to not show the caret on the edge of the popover.
 
@@ -435,7 +435,7 @@ The callback function can optionally return a boolean, which will show or hide t
 </script>
 ```
 
-### isSVG Flag
+### isSVG
 
 To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` prop.
 This will wrap the content of the KPop in a `<foreignObject>` tag, so that normal

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -184,7 +184,7 @@ Here are the different options:
   <option
     v-for="p in positions"
     :key="p"
-    :value="p">{{ p }}</option> 
+    :value="p">{{ p }}</option>
 </select>
 
 <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
@@ -219,6 +219,68 @@ export default {
   }
 }
 </script>
+```
+
+### PositionFixed
+
+Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`.
+
+<div style="width: 300px; height: 125px; position: relative; overflow: hidden; z-index: 1; background-color: var(--red-100);">
+  <KPop
+    title="Look Mah!"
+    width="170"
+    placement="right"
+  >
+    <KButton>Click</KButton>
+    <template v-slot:content>
+      My parent is too small 😭
+    </template>
+  </KPop>
+</div>
+
+```vue
+<div style="width: 300px; height: 125px; position: relative; overflow: hidden; z-index: 1; background-color: var(--red-100);">
+  <KPop
+    title="Look Mah!"
+    width="170"
+    placement="right"
+  >
+    <KButton>Click</KButton>
+    <template v-slot:content>
+      My parent is too small 😭
+    </template>
+  </KPop>
+</div>
+```
+
+<div style="width: 300px; height: 125px; position: relative; overflow: hidden; z-index: 1; background-color: var(--blue-100);">
+  <KPop
+    title="Look Mah!"
+    width="170"
+    placement="right"
+    :position-fixed="true"
+  >
+    <KButton>Click</KButton>
+    <template v-slot:content>
+      My parent is too small, but I don't care 😎
+    </template>
+  </KPop>
+</div>
+
+```vue
+<div style="width: 300px; height: 125px; position: relative; overflow: hidden; z-index: 1; background-color: var(--blue-100);">
+  <KPop
+    title="Look Mah!"
+    width="170"
+    placement="right"
+    :position-fixed="true"
+  >
+    <KButton>Click</KButton>
+    <template v-slot:content>
+      My parent is too small, but I don't care 😎
+    </template>
+  </KPop>
+</div>
 ```
 
 ### Width

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -252,6 +252,10 @@ of the input, dropdown, and selected item.
 />
 ```
 
+### positionFixed
+
+Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`. See [`KPop` docs](popover.html#positionfixed) for more information.
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -37,8 +37,8 @@ Here you can pass in the text to display in the toolip.
 This is where the tooltip will appear - by default it appears on top.
 Here are the different options:
 
-- `top`  
-- `bottom`  
+- `top`
+- `bottom`
 - `left`
 - `right`
 
@@ -63,6 +63,10 @@ Here are the different options:
 </KoolTip>
 ```
 
+### positionFixed
+
+Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`. See [`KPop` docs](popover.html#positionfixed) for more information.
+
 ## Slots
 
 - `Default` There is a main slot that takes in the element you want the popover to be triggered over.
@@ -71,7 +75,7 @@ Here are the different options:
 <KoolTip label="a cool label">
   <!-- Your element goes here -->
   <KButton>button</KButton>
-</KPop>
+</KoolTip>
 ```
 
 - `Content` This allows you to slot in any html content
@@ -96,7 +100,7 @@ Here are the different options:
 
 | Variable | Purpose
 |:-------- |:-------
-| `--KPopBackground`| Background color
+| `--KoolTipBackground`| Background color
 | `--KoolTipColor`| Color of text
 
 Example:
@@ -113,7 +117,7 @@ Example:
 </template>
 <style>
 .tooltip-blue {
-  --KPopBackground: var(--blue-300);
+  --KoolTipBackground: var(--blue-300);
   --KoolTipColor: var(--blue-500);
 }
 </style>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -16,7 +16,7 @@ At least the label prop must be passed in for the tooltip to display anything. F
 
 ## Props
 
-### Label
+### label
 
 Here you can pass in the text to display in the toolip.
 
@@ -32,7 +32,7 @@ Here you can pass in the text to display in the toolip.
 </KoolTip>
 ```
 
-### Position
+### position
 
 This is where the tooltip will appear - by default it appears on top.
 Here are the different options:

--- a/packages/KMultiselect/KMultiselect.vue
+++ b/packages/KMultiselect/KMultiselect.vue
@@ -3,6 +3,7 @@
     :width="width"
     :popover-timeout="0"
     :hide-popover="hidePopover"
+    :position-fixed="positionFixed"
     :test-mode="testMode"
     hide-caret
     placement="bottomStart"
@@ -103,6 +104,13 @@ export default {
       // Items must have a label and a selected property
       validator: (items) => items
         .some(i => i.hasOwnProperty('label') && i.hasOwnProperty('selected'))
+    },
+    /**
+     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+     */
+    positionFixed: {
+      type: Boolean,
+      default: false
     },
     /**
      * Test mode - for testing only, strips out generated ids

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -233,6 +233,13 @@ export default {
       default: null
     },
     /**
+     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+     */
+    positionFixed: {
+      type: Boolean,
+      default: false
+    },
+    /**
      * Test mode - for testing only, strips out generated ids
      */
     testMode: {
@@ -331,6 +338,8 @@ export default {
       await this.$nextTick()
       this.popper = new Popper(this.reference, popperEl, {
         placement,
+        // Use positionFixed to avoid popover content being cut off by parent boundaries
+        positionFixed: this.positionFixed,
         removeOnDestroy: true,
         modifiers: {
           // Ensures element does not ovflow outside of boundary

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -33,6 +33,7 @@
             toggle()
             return isToggled
           }"
+          :position-fixed="positionFixed"
           :test-mode="testMode"
           :target="`[id='${selectInputId}']`"
           @opened="() => {
@@ -189,6 +190,13 @@ export default {
       default: () => [],
       // Items must have a label & value
       validator: (items) => !items.length || items.some(i => i.hasOwnProperty('label') && i.hasOwnProperty('value'))
+    },
+    /**
+     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+     */
+    positionFixed: {
+      type: Boolean,
+      default: false
     },
     /**
      * Test mode - for testing only, strips out generated ids

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -2,6 +2,7 @@
   <KPop
     :placement="placement"
     :popover-classes="`kooltip ${computedClass} ${className}`"
+    :position-fixed="positionFixed"
     :test-mode="testMode"
     trigger="hover"
     width="auto"
@@ -49,6 +50,13 @@ export default {
           'right'
         ].indexOf(value) !== -1
       }
+    },
+    /**
+     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+     */
+    positionFixed: {
+      type: Boolean,
+      default: false
     },
     /**
      * Test mode - for testing only, strips out generated ids


### PR DESCRIPTION
### Summary

Add `positionFixed` prop to allow prevention of popover content being clipped.

![image](https://user-images.githubusercontent.com/67973710/152597932-048aa6de-493b-4f5a-84d9-57b418f28f9c.png)


#### Changes made:
* Add `positionFixed` prop to `KPop`
* Add support for `positionFixed` to kongponents using `KPop`

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
