### PR TITLE
chore(swrv): match version in konnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@vue/composition-api": "^1.2.4",
-    "swrv": "0.9.4",
+    "swrv": "0.9.6",
     "vue": "2.6.10",
     "vue-uuid": "^2.0.2"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "dependencies": {
-    "swrv": "0.9.4",
+    "swrv": "0.9.6",
     "vue": "2.6.10"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14684,6 +14684,13 @@ swrv@0.9.4:
   dependencies:
     swrv "^1.0.0-beta.8"
 
+swrv@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/swrv/-/swrv-0.9.6.tgz#27fd005577d40b5b9b827a8d75c316e9510f177b"
+  integrity sha512-5C5f4BhzLzfDWt/XM9XS1W3yBuv5wbrrrgynkF7oXSugw2fk6K73jKpnUVYN3e/fmKccAt52Pab02OdQZjUxSA==
+  dependencies:
+    swrv "^1.0.0-beta.8"
+
 swrv@^1.0.0-beta.8:
   version "1.0.0-beta.8"
   resolved "https://registry.yarnpkg.com/swrv/-/swrv-1.0.0-beta.8.tgz#745723f5ca8a7a7e290e911cf7da34cecaf356d3"


### PR DESCRIPTION
### Summary
Bump the version of `swrv` up to `0.9.6` matching the version used in Konnect.
  
#### Changes made:
*

### Vue 3 Upgrade

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction). 

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
