### PR TITLE
fix(composition-api): fix usage of composition api

### DIFF
--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -2,6 +2,8 @@
 import '../../packages/styles/styles.css'
 import icons from '../../packages/KIcon/icons' // KIcon icons
 
+import VueCompositionAPI from '@vue/composition-api'
+
 // Globally import all Kongponents
 import KAlert from '../../packages/KAlert/KAlert.vue'
 import KBadge from '../../packages/KBadge/KBadge.vue'
@@ -45,6 +47,7 @@ export default ({
   router,
   siteData
 }) => {
+  Vue.use(VueCompositionAPI)
   Vue.component('KAlert', KAlert)
   Vue.component('KBadge', KBadge)
   Vue.component('KButton', KButton)

--- a/packages/KCardCatalog/KCardCatalog.spec.js
+++ b/packages/KCardCatalog/KCardCatalog.spec.js
@@ -61,9 +61,11 @@ const largeDataSet = [
   }
 ]
 
+let localVue
+
 // Use the Composition API
 beforeEach(() => {
-  const localVue = createLocalVue()
+  localVue = createLocalVue()
 
   localVue.use(VueCompositionAPI)
 })
@@ -91,6 +93,7 @@ describe('KCardCatalog', () => {
     it('renders proper cards when using props', () => {
       const title = 'Cool beans!'
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           title,
           items: getItems(5),
@@ -108,6 +111,7 @@ describe('KCardCatalog', () => {
       const slotContent = 'Look mah! No props (except testMode)'
 
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           testMode: true
         },
@@ -124,6 +128,7 @@ describe('KCardCatalog', () => {
       const emptySlotContent = 'Look mah! I am empty! (except testMode)'
 
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           testMode: true,
           isLoading: false,
@@ -144,6 +149,7 @@ describe('KCardCatalog', () => {
       const errorSlotContent = 'Look mah! I am erroneous! (except testMode)'
 
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           testMode: true,
           hasError: true
@@ -159,6 +165,7 @@ describe('KCardCatalog', () => {
 
     it('can change card sizes - small', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           items: getItems(5),
           cardSize: 'small',
@@ -172,6 +179,7 @@ describe('KCardCatalog', () => {
 
     it('can change card sizes - large', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           items: getItems(5),
           cardSize: 'large',
@@ -185,6 +193,7 @@ describe('KCardCatalog', () => {
 
     it('handles truncation', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           items: [longItem],
           testMode: true
@@ -197,6 +206,7 @@ describe('KCardCatalog', () => {
 
     it('can disable truncation', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           items: [longItem],
           noTruncation: true,
@@ -210,6 +220,7 @@ describe('KCardCatalog', () => {
 
     it('matches snapshot', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           testMode: true
         }
@@ -223,6 +234,7 @@ describe('KCardCatalog', () => {
     it('displays an empty state when no data is available', async () => {
       const fetcher = () => new Promise(resolve => resolve({ data: [] }))
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           fetcher: fetcher,
           pageSize: 4
@@ -237,6 +249,7 @@ describe('KCardCatalog', () => {
 
     it('displays a loading skeletion when the "isLoading" prop is set to true"', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           items: [],
           isLoading: true,
@@ -250,6 +263,7 @@ describe('KCardCatalog', () => {
 
     it('displays an error state when the "hasError" prop is set to true"', () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           options: [],
           hasError: true,
@@ -265,6 +279,7 @@ describe('KCardCatalog', () => {
   describe('pagination', () => {
     it('displays pagination when fetcher is provided', async () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           fetcher: () => {
             return largeDataSet
@@ -282,6 +297,7 @@ describe('KCardCatalog', () => {
 
     it('allows disabling pagination', async () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           fetcher: () => {
             return largeDataSet
@@ -300,6 +316,7 @@ describe('KCardCatalog', () => {
 
     it('does not display pagination when no fetcher', async () => {
       const wrapper = mount(KCardCatalog, {
+        localVue,
         propsData: {
           items: [],
           paginationPageSizes: [10, 20, 30, 40]

--- a/packages/KCardCatalog/KCardCatalog.spec.js
+++ b/packages/KCardCatalog/KCardCatalog.spec.js
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
+import VueCompositionAPI from '@vue/composition-api'
 import KCardCatalog from '@/KCardCatalog/KCardCatalog'
 // import KCatalogItem from '@/KCardCatalog/KCatalogItem'
 
@@ -59,6 +60,13 @@ const largeDataSet = [
     description: "The item's description for number 10"
   }
 ]
+
+// Use the Composition API
+beforeEach(() => {
+  const localVue = createLocalVue()
+
+  localVue.use(VueCompositionAPI)
+})
 
 describe('KCardCatalog', () => {
   function getItems (count) {

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -130,8 +130,7 @@
 </template>
 
 <script>
-import Vue from 'vue'
-import VueCompositionAPI, { defineComponent, ref, onMounted, watch } from '@vue/composition-api'
+import { defineComponent, ref, onMounted, watch } from '@vue/composition-api'
 import KButton from '@kongponents/kbutton/KButton.vue'
 import KEmptyState from '@kongponents/kemptystate/KEmptyState.vue'
 import KSkeleton from '@kongponents/kskeleton/KSkeleton.vue'
@@ -139,8 +138,6 @@ import KCatalogItem from './KCatalogItem.vue'
 import KPagination from '@kongponents/kpagination/KPagination.vue'
 import KSkeletonBox from '@kongponents/kskeleton/KSkeletonBox.vue'
 import { useRequest } from '@kongponents/utils/utils.js'
-
-Vue.use(VueCompositionAPI)
 
 export default defineComponent({
   name: 'KCardCatalog',

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -106,9 +106,11 @@ const options = {
  * }
  */
 
+let localVue
+
 // Use the Composition API
 beforeEach(() => {
-  const localVue = createLocalVue()
+  localVue = createLocalVue()
 
   localVue.use(VueCompositionAPI)
 })
@@ -117,6 +119,7 @@ describe('KTable', () => {
   describe('default', () => {
     it('renders link in action slot', async () => {
       const wrapper = await mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           headers: options.headers,
@@ -139,6 +142,7 @@ describe('KTable', () => {
 
     it('has hover class when passed', async () => {
       const wrapper = await mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           headers: options.headers,
@@ -157,6 +161,7 @@ describe('KTable', () => {
   describe('sorting', () => {
     it('should have sortable class when passed', async () => {
       const wrapper = await mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           headers: options.headers,
@@ -174,6 +179,7 @@ describe('KTable', () => {
 
     it('should allow disabling sorting', async () => {
       const wrapper = await mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           headers: options.headers,
@@ -195,6 +201,7 @@ describe('KTable', () => {
     it('@row:event', async () => {
       const evtTrigger = jest.fn()
       const wrapper = await mount(KTable, {
+        localVue,
         attachToDocument: true,
         propsData: {
           testMode: 'true',
@@ -217,6 +224,7 @@ describe('KTable', () => {
     it('@cell:event', async () => {
       const evtTrigger = jest.fn()
       const wrapper = await mount(KTable, {
+        localVue,
         attachToDocument: true,
         propsData: {
           testMode: 'true',
@@ -248,6 +256,7 @@ describe('KTable', () => {
     it('displays an empty state when no data is available', async () => {
       const fetcher = () => new Promise(resolve => resolve({ data: [] }))
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           fetcher: fetcher,
@@ -266,6 +275,7 @@ describe('KTable', () => {
       const emptySlotContent = 'Look mah! I am empty! (except testMode)'
       const fetcher = () => new Promise(resolve => resolve({ data: [] }))
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           fetcher: fetcher,
@@ -285,6 +295,7 @@ describe('KTable', () => {
 
     it('displays a loading skeletion when the "isLoading" prop is set to true"', () => {
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'loading',
           isLoading: true
@@ -297,6 +308,7 @@ describe('KTable', () => {
 
     it('displays an error state when the "hasError" prop is set to true"', () => {
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           hasError: true
@@ -311,6 +323,7 @@ describe('KTable', () => {
     it('displays an error state (slot)', async () => {
       const errorSlotContent = 'Look mah! I am erroneous! (except testMode)'
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           hasError: true
@@ -335,6 +348,7 @@ describe('KTable', () => {
       }
 
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'loading',
           fetcher: slowFetcher,
@@ -351,6 +365,7 @@ describe('KTable', () => {
   describe('pagination', () => {
     it('displays pagination when fetcher provided', async () => {
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           fetcher: () => {
@@ -369,6 +384,7 @@ describe('KTable', () => {
 
     it('does not display pagination when pagination disabled', async () => {
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           fetcher: () => {
@@ -388,6 +404,7 @@ describe('KTable', () => {
 
     it('does not display pagination when no fetcher', async () => {
       const wrapper = mount(KTable, {
+        localVue,
         propsData: {
           testMode: 'true',
           options,

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -1,6 +1,6 @@
 import { mount, createLocalVue } from '@vue/test-utils'
-import KTable from '@/KTable/KTable'
 import VueCompositionAPI from '@vue/composition-api'
+import KTable from '@/KTable/KTable'
 
 const tick = async (vm, times) => {
   for (let i = 0; i < times; ++i) {

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -1,5 +1,6 @@
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 import KTable from '@/KTable/KTable'
+import VueCompositionAPI from '@vue/composition-api'
 
 const tick = async (vm, times) => {
   for (let i = 0; i < times; ++i) {
@@ -104,6 +105,14 @@ const options = {
  *   testMode: 'true' || 'loading'
  * }
  */
+
+// Use the Composition API
+beforeEach(() => {
+  const localVue = createLocalVue()
+
+  localVue.use(VueCompositionAPI)
+})
+
 describe('KTable', () => {
   describe('default', () => {
     it('renders link in action slot', async () => {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -158,16 +158,13 @@
 
 <script>
 import { uuid } from 'vue-uuid'
-import Vue from 'vue'
-import VueCompositionAPI, { computed, defineComponent, onMounted, ref, watch } from '@vue/composition-api'
+import { computed, defineComponent, onMounted, ref, watch } from '@vue/composition-api'
 import KButton from '@kongponents/kbutton/KButton.vue'
 import KEmptyState from '@kongponents/kemptystate/KEmptyState.vue'
 import KSkeleton from '@kongponents/kskeleton/KSkeleton.vue'
 import KPagination from '@kongponents/kpagination/KPagination.vue'
 import KIcon from '@kongponents/kicon/KIcon.vue'
 import { clientSideSorter, useDebounce, useRequest } from '@kongponents/utils/utils.js'
-
-Vue.use(VueCompositionAPI)
 
 /**
  * @deprecated


### PR DESCRIPTION
### Summary
Fix usage of composition API.

### Vue 3 Upgrade

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction). 

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
