### PR TITLE
feat(kselect): allow custom item content and filter

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -270,6 +270,17 @@ of the input, dropdown, and selected item.
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`. See [`KPop` docs](popover.html#positionfixed) for more information.
 
+### filterFunc
+
+Use this prop to override the default filter function if you want to do something like filter on an attribute other than `label`. Your filter function
+should take as parameter a JSON object containing the items to filter on (`items`) and the query string (`query`) and return the filtered items. See [Slots](#slots) for an example.
+
+```js
+myCustomFilter ({ items, query }) {
+  return items.filter(anItem => anItem.label.includes(query))
+}
+```
+
 ### v-model
 
 KSelect works as regular inputs do using v-model for data binding:
@@ -316,18 +327,18 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ## Slots
 
-You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the item data.
+You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
-<KSelect :items="myItems">
-  <template v-slot:item-template="{item}" width="500">
-    <div class="select-item-label">{{item.label}}</div>
-    <div class="select-item-desc">{{item.description}}</div>
+<KSelect :items="myItems" width="500" :filterFunc="customFilter">
+  <template v-slot:item-template="{ item }">
+    <div class="select-item-label">{{ item.label }}</div>
+    <div class="select-item-desc">{{ item.description }}</div>
   </template>
 </KSelect>
 
 ```vue
-<KSelect :items="myItems">
-  <template v-slot:item-template="{item}" width="500">
+<KSelect :items="myItems" width="500" :filterFunc="customFilter">
+  <template v-slot:item-template="{ item }">
     <div class="select-item-label">{{item.label}}</div>
     <div class="select-item-desc">{{item.description}}</div>
   </template>
@@ -351,6 +362,12 @@ export default {
           })
         }
       return myItems
+    },
+    customFilter (items, queryStr) {
+      return items.filter(item => {
+        return item.label.toLowerCase().includes(queryStr.toLowerCase()) ||
+          item.description.toLowerCase().includes(queryStr.toLowerCase())
+      })
     }
   }
 }
@@ -395,6 +412,9 @@ export default {
   methods: {
     handleItemSelect (item) {
       this.mySelect = item.label
+    },
+    customFilter ({items, query}) {
+      return items.filter(item => item.label.toLowerCase().includes(query.toLowerCase()) || item.description.toLowerCase().includes(query.toLowerCase()))
     }
   }
 }

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -207,28 +207,6 @@ You can configure the button text when an item is selected, if `appearance` is t
 
 <KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
 
-<script>
-export default {
-  data() {
-    return {
-      mySelect: '',
-      items: [{
-        label: '25',
-        value: '25'
-      }, {
-        label: '50',
-        value: '50'
-      }]
-    }
-  },
-  methods: {
-    handleItemSelect (item) {
-      this.mySelect = item.label
-    }
-  }
-}
-</script>
-
 ```vue
 <KSelect
   appearance='button'
@@ -263,10 +241,10 @@ export default {
 
 ### width
 
-You can pass a `width` string for dropdown. By default the `width` is `170px`. This is the width
+You can pass a `width` string for dropdown. By default the `width` is `200px`. This is the width
 of the input, dropdown, and selected item.
 
-<KSelect width="100" :items="[{
+<KSelect width="250" :items="[{
     label: 'test',
     value: 'test',
     selected: true
@@ -336,6 +314,49 @@ You can pass any input attribute and it will get properly bound to the element.
 <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
 ```
 
+## Slots
+
+You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the item data.
+
+<KSelect :items="myItems">
+  <template v-slot:item-template="{item}" width="500">
+    <div class="select-item-label">{{item.label}}</div>
+    <div class="select-item-desc">{{item.description}}</div>
+  </template>
+</KSelect>
+
+```vue
+<KSelect :items="myItems">
+  <template v-slot:item-template="{item}" width="500">
+    <div class="select-item-label">{{item.label}}</div>
+    <div class="select-item-desc">{{item.description}}</div>
+  </template>
+</KSelect>
+
+<script>
+export default {
+  data() {
+    return {
+      myItems: this.getItems(5),
+    }
+  },
+  methods: {
+    getItems(count) {
+      let myItems = []
+        for (let i = 0; i < count; i++) {
+          myItems.push({
+            label: "Item " + i,
+            value: "item_" + i,
+            description: "The item's description for number " + i
+          })
+        }
+      return myItems
+    }
+  }
+}
+</script>
+```
+
 ## Events
 
 | Event     | returns             |
@@ -343,3 +364,49 @@ You can pass any input attribute and it will get properly bound to the element.
 | `selected` | `selectedItem` Object |
 | `input` | `selectedItem` Object or null |
 | `change` | `selectedItem` Object or null |
+
+<script>
+function getItems(count) {
+  let myItems = []
+    for (let i = 0; i < count; i++) {
+      myItems.push({
+        label: "Item " + i,
+        value: "item_" + i,
+        description: "The item's description for number " + i
+      })
+    }
+  return myItems
+}
+
+export default {
+  data() {
+    return {
+      myItems: getItems(5),
+      mySelect: '',
+      items: [{
+        label: '25',
+        value: '25'
+      }, {
+        label: '50',
+        value: '50'
+      }]
+    }
+  },
+  methods: {
+    handleItemSelect (item) {
+      this.mySelect = item.label
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+  .select-item-label {
+    color: blue;
+    font-weight: bold;
+  }
+
+  .select-item-desc {
+    color: red;
+  }
+</style>

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -98,6 +98,7 @@
           :test-mode="testMode"
           :button-text="pageSizeText"
           :kpop-attributes="kpopAttrs"
+          width="200"
           appearance="button"
           @selected="updatePageSize"
         />

--- a/packages/KPagination/__snapshots__/KPagination.spec.js.snap
+++ b/packages/KPagination/__snapshots__/KPagination.spec.js.snap
@@ -35,13 +35,13 @@ exports[`KPagination correctly renders props 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 230px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 230px;"> 2 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 2 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></button>
   </div>
-  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">
@@ -110,13 +110,13 @@ exports[`KPagination matches snapshot 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 230px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 230px;"> 10 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 10 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></button>
   </div>
-  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">

--- a/packages/KPagination/__snapshots__/KPagination.spec.js.snap
+++ b/packages/KPagination/__snapshots__/KPagination.spec.js.snap
@@ -35,7 +35,7 @@ exports[`KPagination correctly renders props 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 2 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 230px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 230px;"> 2 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -45,17 +45,16 @@ exports[`KPagination correctly renders props 1`] = `
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">
-        <div>
-          <div data-testid="k-select-item-2" class="k-select-item">
-            <li role="option" class="d-block"><button value="2" class=""><span class="k-select-item-label mr-2">2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-          </div>
-          <div data-testid="k-select-item-4" class="k-select-item">
-            <li role="option" class="d-block"><button value="4" class=""><span class="k-select-item-label mr-2">4</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-          </div>
-          <div data-testid="k-select-item-6" class="k-select-item">
-            <li role="option" class="d-block"><button value="6" class=""><span class="k-select-item-label mr-2">6</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-          </div>
+        <div data-testid="k-select-item-2" class="k-select-item mx-4">
+          <li role="option" class="d-block"><button value="2" class=""><span class="k-select-item-label mr-2">2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
         </div>
+        <div data-testid="k-select-item-4" class="k-select-item mx-4">
+          <li role="option" class="d-block"><button value="4" class=""><span class="k-select-item-label mr-2">4</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+        </div>
+        <div data-testid="k-select-item-6" class="k-select-item mx-4">
+          <li role="option" class="d-block"><button value="6" class=""><span class="k-select-item-label mr-2">6</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+        </div>
+        <!---->
       </ul>
     </div>
     <!---->
@@ -111,7 +110,7 @@ exports[`KPagination matches snapshot 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"> 10 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 230px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 230px;"> 10 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -121,17 +120,16 @@ exports[`KPagination matches snapshot 1`] = `
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">
-        <div>
-          <div data-testid="k-select-item-10" class="k-select-item">
-            <li role="option" class="d-block"><button value="10" class=""><span class="k-select-item-label mr-2">10</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-          </div>
-          <div data-testid="k-select-item-20" class="k-select-item">
-            <li role="option" class="d-block"><button value="20" class=""><span class="k-select-item-label mr-2">20</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-          </div>
-          <div data-testid="k-select-item-30" class="k-select-item">
-            <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-          </div>
+        <div data-testid="k-select-item-10" class="k-select-item mx-4">
+          <li role="option" class="d-block"><button value="10" class=""><span class="k-select-item-label mr-2">10</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
         </div>
+        <div data-testid="k-select-item-20" class="k-select-item mx-4">
+          <li role="option" class="d-block"><button value="20" class=""><span class="k-select-item-label mr-2">20</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+        </div>
+        <div data-testid="k-select-item-30" class="k-select-item mx-4">
+          <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+        </div>
+        <!---->
       </ul>
     </div>
     <!---->

--- a/packages/KSelect/KSelect.spec.js
+++ b/packages/KSelect/KSelect.spec.js
@@ -176,6 +176,27 @@ describe('KSelect', () => {
     expect(wrapper.find('.selected-item-label').html()).toEqual(expect.stringContaining(labels[0]))
   })
 
+  it('allows slotting content into the items', async () => {
+    const itemSlotContent = 'I am slotted baby!'
+    const itemLabel = 'Label 1'
+    const itemValue = 'label1'
+    const wrapper = mount(KSelect, {
+      propsData: {
+        testMode: true,
+        appearance: 'button',
+        items: [{
+          label: itemLabel,
+          value: itemValue
+        }]
+      },
+      scopedSlots: {
+        'item-template': `<span>${itemSlotContent}</span>`
+      }
+    })
+
+    expect(wrapper.find(`[data-testid="k-select-item-${itemValue}"]`).html()).toEqual(expect.stringContaining(itemSlotContent))
+  })
+
   it('matches snapshot', () => {
     const wrapper = mount(KSelect, {
       propsData: {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -210,6 +210,13 @@ export default {
       default: false
     },
     /**
+     * Override default filter functionality of case-insensitive search on label
+     */
+    filterFunc: {
+      type: Function,
+      default: ({ items, query }) => items.filter(item => item.label.toLowerCase().includes(query.toLowerCase()))
+    },
+    /**
      * Test mode - for testing only, strips out generated ids
      */
     testMode: {
@@ -262,7 +269,7 @@ export default {
       }
     },
     filteredItems: function () {
-      return this.selectItems.filter(item => item.label.toLowerCase().includes(this.filterStr.toLowerCase()))
+      return this.filterFunc({ items: this.selectItems, query: this.filterStr })
     },
     placeholderText () {
       if (this.placeholder) {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -383,6 +383,12 @@ export default {
     }
   }
 
+  .k-select-button {
+    .k-button.btn-link:hover {
+      text-decoration: none;
+    }
+  }
+
   .k-select-input {
     position: relative;
     display: inline-block;

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -93,16 +93,20 @@
                 :is-open="isToggled"
                 name="items"
               >
-                <div v-if="filteredItems.length">
-                  <KSelectItem
-                    v-for="item in filteredItems"
-                    :key="item.key"
-                    :item="item"
-                    @selected="handleItemSelect"
-                  />
-                </div>
                 <KSelectItem
-                  v-else
+                  v-for="item in filteredItems"
+                  :key="item.key"
+                  :item="item"
+                  @selected="handleItemSelect">
+                  <template v-slot:content>
+                    <slot
+                      :item="item"
+                      name="item-template"
+                    />
+                  </template>
+                </KSelectItem>
+                <KSelectItem
+                  v-if="!filteredItems.length"
                   key="k-select-empty-state"
                   :item="{ label: 'No results', value: 'no_results' }"
                   class="k-select-empty-item"/>
@@ -242,9 +246,9 @@ export default {
       let w
 
       if (!this.width) {
-        w = 170
+        w = 200
         if (this.appearance === 'button') {
-          w = 200
+          w = 230
         }
       } else {
         w = this.width

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -2,7 +2,7 @@
   <div
     :key="item.key"
     :data-testid="`k-select-item-${item.value}`"
-    class="k-select-item"
+    class="k-select-item mx-4"
     @click="handleClick">
     <li
       role="option"
@@ -10,7 +10,9 @@
       <button
         :class="{ disabled, selected: item.selected }"
         :value="item.value">
-        <span class="k-select-item-label mr-2"><slot>{{ item.label }}</slot></span>
+        <span class="k-select-item-label mr-2">
+          <slot name="content">{{ item.label }}</slot>
+        </span>
         <span class="k-select-selected-icon-container">
           <KIcon
             v-if="item.selected"

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KSelect matches snapshot 1`] = `
-<div class="k-select" style="width: 170px;">
+<div class="k-select" style="width: 200px;">
   <!---->
   <div id="test-select-id-1234" data-testid="k-select-selected-item">
     <!---->
@@ -17,11 +17,10 @@ exports[`KSelect matches snapshot 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div>
-              <div data-testid="k-select-item-label1" class="k-select-item">
-                <li role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+            <div data-testid="k-select-item-label1" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
             </div>
+            <!---->
           </ul>
         </div>
         <!---->
@@ -32,7 +31,7 @@ exports[`KSelect matches snapshot 1`] = `
 `;
 
 exports[`KSelect renders props when passed 1`] = `
-<div class="k-select" style="width: 170px;">
+<div class="k-select" style="width: 200px;">
   <!---->
   <div id="test-select-id-1234" data-testid="k-select-selected-item">
     <!---->
@@ -48,17 +47,16 @@ exports[`KSelect renders props when passed 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div>
-              <div data-testid="k-select-item-label1" class="k-select-item">
-                <li role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-label2" class="k-select-item">
-                <li role="option" class="d-block"><button value="label2" class=""><span class="k-select-item-label mr-2">Label 2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-label3" class="k-select-item">
-                <li role="option" class="d-block"><button value="label3" class=""><span class="k-select-item-label mr-2">Label 3</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+            <div data-testid="k-select-item-label1" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
             </div>
+            <div data-testid="k-select-item-label2" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="label2" class=""><span class="k-select-item-label mr-2">Label 2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-label3" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="label3" class=""><span class="k-select-item-label mr-2">Label 3</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <!---->
           </ul>
         </div>
         <!---->
@@ -69,7 +67,7 @@ exports[`KSelect renders props when passed 1`] = `
 `;
 
 exports[`KSelect renders with selected item 1`] = `
-<div class="k-select" style="width: 170px;">
+<div class="k-select" style="width: 200px;">
   <!---->
   <div id="test-select-id-1234" data-testid="k-select-selected-item">
     <div class="k-select-item-selection px-3 py-1">
@@ -92,14 +90,13 @@ exports[`KSelect renders with selected item 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div>
-              <div data-testid="k-select-item-label1" class="k-select-item">
-                <li role="option" class="d-block"><button value="label1" class="selected"><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><span class="kong-icon selected-item-icon kong-icon-check"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <div data-testid="k-select-item-label1" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="label1" class="selected"><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><span class="kong-icon selected-item-icon kong-icon-check"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="m14 7-6 6-3-3" fill="none" stroke="#A3BBCC" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></span></button></li>
-              </div>
             </div>
+            <!---->
           </ul>
         </div>
         <!---->

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -77,23 +77,22 @@ exports[`KTable default has hover class when passed 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div>
-              <div data-testid="k-select-item-15" class="k-select-item">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+            <div data-testid="k-select-item-15" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
             </div>
+            <div data-testid="k-select-item-30" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-50" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-75" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-100" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <!---->
           </ul>
         </div>
         <!---->
@@ -233,23 +232,22 @@ exports[`KTable sorting should allow disabling sorting 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div>
-              <div data-testid="k-select-item-15" class="k-select-item">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+            <div data-testid="k-select-item-15" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
             </div>
+            <div data-testid="k-select-item-30" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-50" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-75" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-100" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <!---->
           </ul>
         </div>
         <!---->
@@ -339,23 +337,22 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div>
-              <div data-testid="k-select-item-15" class="k-select-item">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+            <div data-testid="k-select-item-15" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
             </div>
+            <div data-testid="k-select-item-30" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-50" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-75" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <div data-testid="k-select-item-100" class="k-select-item mx-4">
+              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
+            </div>
+            <!---->
           </ul>
         </div>
         <!---->

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -73,7 +73,7 @@ exports[`KTable default has hover class when passed 1`] = `
 </svg>
 </span></button>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -228,7 +228,7 @@ exports[`KTable sorting should allow disabling sorting 1`] = `
 </svg>
 </span></button>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -333,7 +333,7 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
 </svg>
 </span></button>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">


### PR DESCRIPTION
### Summary
Add support for customizable items and custom filtering.
  
#### Changes made:
* Add slot `item-template` for customizing items
* Add `filterFunc` prop 

![image](https://user-images.githubusercontent.com/67973710/153673965-11420440-b912-40a8-b8f9-05080b7f8d71.png)

### Vue 3 Upgrade

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction). 

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
