### PR TITLE
fix(imports): fix imports to resolve icons

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -7,6 +7,12 @@ The `KCardCatalog` component requires the [`@vue/composition-api`](https://githu
 yarn add @vue/composition-api
 ```
 
+When importing `KCardCatalog` into your project, you will likely need to explicity import the vue file as shown below
+
+```js
+import KCardCatalog from '@kongponents/kcardcatalog/KCardCatalog.vue'
+```
+
 :::
 
 **KCardCatalog** - A grid view of KCards

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -10,6 +10,12 @@ The `KTable` component requires the [`@vue/composition-api`](https://github.com/
 yarn add @vue/composition-api
 ```
 
+When importing `KTable` into your project, you will likely need to explicity import the vue file as shown below
+
+```js
+import KTable from '@kongponents/ktable/KTable.vue'
+```
+
 :::
 
 Pass a fetcher function to build a slot-able table.

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -3,6 +3,7 @@
   "version": "6.9.6",
   "description": "Button component",
   "main": "dist/KButton.umd.min.js",
+  "module": "KButton.vue",
   "componentName": "KButton",
   "source": "KButton.vue",
   "files": [

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -131,12 +131,11 @@
 
 <script>
 import { defineComponent, ref, onMounted, watch } from '@vue/composition-api'
-import KButton from '@kongponents/kbutton/KButton.vue'
-import KEmptyState from '@kongponents/kemptystate/KEmptyState.vue'
-import KSkeleton from '@kongponents/kskeleton/KSkeleton.vue'
+import KButton from '@kongponents/kbutton'
+import KEmptyState from '@kongponents/kemptystate'
+import { KSkeleton, KSkeletonBox } from '@kongponents/kskeleton'
 import KCatalogItem from './KCatalogItem.vue'
-import KPagination from '@kongponents/kpagination/KPagination.vue'
-import KSkeletonBox from '@kongponents/kskeleton/KSkeletonBox.vue'
+import KPagination from '@kongponents/kpagination'
 import { useRequest } from '@kongponents/utils/utils.js'
 
 export default defineComponent({

--- a/packages/KEmptyState/package.json
+++ b/packages/KEmptyState/package.json
@@ -3,6 +3,7 @@
   "version": "6.9.6",
   "description": "Empty state component",
   "main": "dist/KEmptyState.umd.min.js",
+  "module": "KEmptyState.vue",
   "componentName": "KEmptyState",
   "source": "KEmptyState.vue",
   "files": [

--- a/packages/KIcon/package.json
+++ b/packages/KIcon/package.json
@@ -3,6 +3,7 @@
   "version": "6.9.6",
   "description": "Icon component.",
   "main": "dist/KIcon.umd.min.js",
+  "module": "KIcon",
   "componentName": "KIcon",
   "source": "KIcon.vue",
   "files": [

--- a/packages/KPagination/package.json
+++ b/packages/KPagination/package.json
@@ -3,6 +3,7 @@
   "version": "6.9.6",
   "description": "Pagination component",
   "main": "dist/KPagination.umd.min.js",
+  "module": "KPagination.vue",
   "componentName": "KPagination",
   "source": "KPagination.vue",
   "files": [

--- a/packages/KSkeleton/package.json
+++ b/packages/KSkeleton/package.json
@@ -3,6 +3,7 @@
   "version": "6.9.6",
   "description": "Loading/Skeleton state component.",
   "main": "dist/KSkeleton.umd.min.js",
+  "module": "KSkeleton.vue",
   "componentName": "KSkeleton",
   "source": "index.js",
   "files": [

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -159,11 +159,11 @@
 <script>
 import { uuid } from 'vue-uuid'
 import { computed, defineComponent, onMounted, ref, watch } from '@vue/composition-api'
-import KButton from '@kongponents/kbutton/KButton.vue'
-import KEmptyState from '@kongponents/kemptystate/KEmptyState.vue'
-import KSkeleton from '@kongponents/kskeleton/KSkeleton.vue'
-import KPagination from '@kongponents/kpagination/KPagination.vue'
-import KIcon from '@kongponents/kicon/KIcon.vue'
+import KButton from '@kongponents/kbutton'
+import KEmptyState from '@kongponents/kemptystate'
+import { KSkeleton } from '@kongponents/kskeleton'
+import KPagination from '@kongponents/kpagination'
+import KIcon from '@kongponents/kicon'
 import { clientSideSorter, useDebounce, useRequest } from '@kongponents/utils/utils.js'
 
 /**


### PR DESCRIPTION
### Summary

Fix component imports to fix icons and properly resolve components.
  
#### Changes made:
* Import from `@kongponents/*` packages without the `*.vue` suffix. Related to [KHCP-1922](https://konghq.atlassian.net/browse/KHCP-1922)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
