### PR TITLE
feat(ktable): add empty-state-action-button-icon

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -780,6 +780,7 @@ Set the following properties to handle empty state:
 - `emptyStateIconSize` - Size for empty state icon
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
+- `emptyStateActionButtonIcon` - Icon for the empty state action button
 
 If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when clicked.
 
@@ -811,6 +812,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
       emptyStateTitle="No Workspaces exist"
       emptyStateMessage="Adding a new Workspace will populate this table."
       emptyStateActionMessage="Create a Workspace"
+      emptyStateActionButtonIcon="plus"
       emptyStateActionRoute="#empty-state-full-example"
       emptyStateIcon="workspaces"
       emptyStateIconColor="#5996ff"
@@ -829,6 +831,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
         emptyStateTitle="No Workspaces exist"
         emptyStateMessage="Adding a new Workspace will populate this table."
         emptyStateActionMessage="Create a Workspace"
+        emptyStateActionButtonIcon="plus"
         emptyStateActionRoute="create-workspace"
         emptyStateIcon="workspaces"
         emptyStateIconColor="#5996ff"
@@ -847,6 +850,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
         emptyStateTitle="No Workspaces exist"
         emptyStateMessage="Adding a new Workspace will populate this table."
         emptyStateActionMessage="Create a Workspace"
+        emptyStateActionButtonIcon="plus"
         emptyStateActionRoute="{
           name: 'create-workspace',
           params: {

--- a/packages/KIcon/KIcon.vue
+++ b/packages/KIcon/KIcon.vue
@@ -238,15 +238,15 @@ export default {
     visibility: hidden !important;
   }
 }
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(1turn); }
-}
 </style>
 
 <style lang="scss">
 // unscoped, so the svg <g> element can be accessed from the imported file
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(1turn); }
+}
+
 .kong-icon.kong-icon-spinner svg g {
   transform-box: fill-box;
   transform-origin: 50% 50%;

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -52,6 +52,15 @@
               appearance="primary"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
+              <template
+                v-slot:icon
+                v-if="emptyStateActionButtonIcon">
+                <KIcon
+                  :icon="emptyStateActionButtonIcon"
+                  color="white"
+                  view-box="0 0 20 20"
+                  size="16" />
+              </template>
               {{ emptyStateActionMessage }}
             </KButton>
           </template>
@@ -289,6 +298,13 @@ export default defineComponent({
      * A prop to pass in a custom empty state action message
      */
     emptyStateActionMessage: {
+      type: String,
+      default: ''
+    },
+    /**
+     * A prop to pass in a custom empty state action message
+     */
+    emptyStateActionButtonIcon: {
       type: String,
       default: ''
     },


### PR DESCRIPTION
### Summary

Adds a new `emptyStateActionButtonIcon` prop to `KTable` which accepts a `string` name of an icon to display next to the action button. (optional).
  
![image](https://user-images.githubusercontent.com/2229946/154118081-4502478b-c37e-4be8-ab56-26ff68eb96a8.png)

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
