### PR TITLE
fix(ktabs): add bottom border for tabs

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -165,7 +165,8 @@ export default {
 
 | Variable | Purpose
 |:-------- |:-------
-| `--KTabsBottomBorder`| Border between the tabs items and the tab content
+| `--KTabsBottomBorderColor`| Border between the tabs and the tab content
+| `--KTabBottomBorderColor`| Border on the bottom of each tab
 | `--KTabsActiveColor`| Active color of tab and underline
 | `--KTabsColor`| Default text color of the tab items
 

--- a/packages/KTabs/KTabs.vue
+++ b/packages/KTabs/KTabs.vue
@@ -89,6 +89,7 @@ export default {
     list-style: none;
     font-size: 18px;
     line-height: 20px;
+    border-bottom: 2px solid var(--KTabsBottomBorderColor, var(--grey-300, color(grey-300)));
 
     .tab-item {
       position: relative;
@@ -107,7 +108,7 @@ export default {
       }
       &.active,
       &:hover {
-        border-bottom: 4px solid var(--KTabsBottomBorder, var(--teal-300, color(teal-300)));
+        border-bottom: 4px solid var(--KTabBottomBorderColor, var(--teal-300, color(teal-300)));
         .tab-link { color: var(--KTabsActiveColor, var(--black-500, color(black-500))); }
       }
     }


### PR DESCRIPTION
### Summary
Adds a bottom border to tab group
  
#### Changes made:
* Added bottom border to tab group
* Changed variable name for bottom border color for individual tabs (from `KTabsBottomBorder` to `KTabBottomBorderColor`).

#### Screenshots:
**Before**
![Screen Shot 2022-02-15 at 11 04 00 AM](https://user-images.githubusercontent.com/2080476/154131051-8c5bde5c-1a58-468a-b8b1-6beb4a21dac0.png)

**After**
![Screen Shot 2022-02-15 at 11 00 49 AM](https://user-images.githubusercontent.com/2080476/154130863-141790af-46ed-4fe3-a0e2-ca8cc211dc8f.png)

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
