### PR TITLE
feat(kinputswitch): add label-position prop

### DIFF
--- a/docs/components/switch.md
+++ b/docs/components/switch.md
@@ -51,6 +51,22 @@ Will place label text to the right of the switch. Can also be [slotted](#slots).
 
 <KInputSwitch v-model="labelPropChecked" :label="labelPropChecked ? 'on' : 'off'" />
 
+### labelPosition
+
+- `label-position`
+
+Position the label to the left or right of the switch, default to `right`.
+
+<KInputSwitch v-model="labelPropChecked" label="Label on the right" />
+<br>
+<br>
+<KInputSwitch v-model="labelPropChecked" label="Label on the left" labelPosition="left" />
+
+```vue
+<KInputSwitch label="Label on the right" />
+<KInputSwitch label="Label on the left" label-position="left" />
+```
+
 ### disabled
 
 You can add `disabled` to the input to disallow interactivity.

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -7,13 +7,16 @@
       :for="$attrs.id ? $attrs.id : null"
       :disabled="$attrs.disabled"
       class="k-switch">
+      <span v-if="(label || $scopedSlots.label) && labelPosition === 'left'">
+        <slot name="label">{{ label }}</slot>
+      </span>
       <input
         :checked="value"
         v-bind="$attrs"
         type="checkbox"
         v-on="listeners">
-      <div class="switch-control"/>
-      <span v-if="label || $scopedSlots.label">
+      <div :class="['switch-control', labelPosition === 'right' ? 'has-label-right' : 'has-label-left' ]" />
+      <span v-if="(label || $scopedSlots.label) && labelPosition === 'right'">
         <slot name="label">{{ label }}</slot>
       </span>
     </label>
@@ -25,17 +28,20 @@
     :disabled="$attrs.disabled"
     :class="{ 'switch-with-icon' : enabledIcon }"
     class="k-switch">
+    <span v-if="(label || $scopedSlots.label) && labelPosition === 'left'">
+      <slot name="label">{{ label }}</slot>
+    </span>
     <input
       :checked="value"
       v-bind="$attrs"
       type="checkbox"
       v-on="listeners">
-    <div class="switch-control"/>
+    <div :class="['switch-control', labelPosition === 'right' ? 'has-label-right' : 'has-label-left' ]" />
     <KIcon
       v-if="enabledIcon && value === true"
       color="var(--white)"
       icon="check" />
-    <span v-if="label || $scopedSlots.label">
+    <span v-if="(label || $scopedSlots.label) && labelPosition === 'right'">
       <slot name="label">{{ label }}</slot>
     </span>
   </label>
@@ -65,6 +71,17 @@ export default {
     label: {
       type: String,
       default: ''
+    },
+
+    /**
+     * Should the switch be positioned to the left or right of the label
+     */
+    labelPosition: {
+      type: String,
+      default: 'right',
+      validator: (position) => {
+        return ['left', 'right'].includes(position)
+      }
     },
 
     /**

--- a/packages/KInputSwitch/__snapshots__/KInputSwitch.spec.js.snap
+++ b/packages/KInputSwitch/__snapshots__/KInputSwitch.spec.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KInputSwitch matches snapshot 1`] = `
-<label class="k-switch"><input type="checkbox">
-  <div class="switch-control"></div>
+<label class="k-switch">
+  <!----> <input type="checkbox">
+  <div class="switch-control has-label-right"></div>
   <!---->
   <!---->
 </label>

--- a/packages/styles/forms/_switch.scss
+++ b/packages/styles/forms/_switch.scss
@@ -26,10 +26,17 @@ $transition: 0.2s linear;
     display: block;
     width: $width;
     height: $height;
-    margin-right: 1rem;
     border-radius: 12px;
     background-color: var(--KInputSwitchBackground, var(--grey-400, color(grey-400)));
     transition: $transition;
+
+    &.has-label-left {
+      margin-left: 1rem;
+    }
+    &.has-label-right {
+      margin-right: 1rem;
+    }
+
     // Toggle
     &:after {
       position: absolute;


### PR DESCRIPTION


### Summary
Allow the label to be positioned on the left or right of the switch.

#### Changes made:
* Adds `label-position` prop, defaults to `right`

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
