### PR TITLE
feat(kprompt): add kprompt kongponent

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -57,6 +57,7 @@ module.exports = {
               '/components/multiselect',
               '/components/pagination',
               '/components/popover',
+              '/components/prompt',
               '/components/input-radio',
               '/components/segmented-control',
               '/components/select',

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -27,6 +27,7 @@ import KModal from '../../packages/KModal/KModal.vue'
 import KoolTip from '../../packages/KoolTip/KoolTip.vue'
 import KPagination from '../../packages/KPagination/KPagination.vue'
 import KPop from '../../packages/KPop/KPop.vue'
+import KPrompt from '../../packages/KPrompt/KPrompt.vue'
 import Krumbs from '../../packages/Krumbs/Krumbs.vue'
 import KSegmentedControl from '../../packages/KSegmentedControl/KSegmentedControl.vue'
 import KSelect from '../../packages/KSelect/KSelect.vue'
@@ -70,6 +71,7 @@ export default ({
   Vue.component('KoolTip', KoolTip)
   Vue.component('KPagination', KPagination)
   Vue.component('KPop', KPop)
+  Vue.component('KPrompt', KPrompt)
   Vue.component('Krumbs', Krumbs)
   Vue.component('Komponent', Komponent)
   Vue.component('KSegmentedControl', KSegmentedControl)

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -4,7 +4,12 @@ The **KPrompt** component is used to display a dialog that prompts a user to tak
 
 <KButton appearance="primary" @click="defaultIsOpen = true">Prompt</KButton>
 
-<KPrompt :is-visible="defaultIsOpen" @canceled="defaultIsOpen = false" @proceed="defaultIsOpen = false" />
+<KPrompt
+  :is-visible="defaultIsOpen"
+  message="Hello, World?"
+  @canceled="defaultIsOpen = false"
+  @proceed="defaultIsOpen = false"
+/>
 
 ```vue
 <KButton
@@ -16,6 +21,7 @@ The **KPrompt** component is used to display a dialog that prompts a user to tak
 
 <KPrompt
   :is-visible="defaultIsOpen"
+  message="Hello, World?"
   @canceled="defaultIsOpen = false"
   @proceed="defaultIsOpen = false"
 />
@@ -105,10 +111,10 @@ export default {
 
 ### Variations
 
-- `type` - Can be `danger`, `warning`, or `information`. Defaults to `information`
+- `type` - Can be `danger`, `warning`, or `info`. Defaults to `info`
 - `confirmationText` - Provide a string the user must type before the action button becomes enabled
 
-Use the `information` prompt type to notify the user abbout general information associated with the action about
+Use the `info` prompt type to notify the user about general information associated with the action about
 to be taken.
 
 <KButton appearance="primary" @click="infoIsOpen = true">Prompt</KButton>

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -1,0 +1,247 @@
+# Prompt
+
+The **KPrompt** component is used to display a dialog that prompts a user to take an action.
+
+<KButton appearance="primary" @click="defaultIsOpen = true">Prompt</KButton>
+
+<KPrompt :is-visible="defaultIsOpen" @canceled="defaultIsOpen = false" @proceed="defaultIsOpen = false" />
+
+```vue
+<KButton
+  appearance="primary"
+  @click="defaultIsOpen = true"
+>
+  Prompt
+</KButton>
+
+<KPrompt
+  :is-visible="defaultIsOpen"
+  @canceled="defaultIsOpen = false"
+  @proceed="defaultIsOpen = false"
+/>
+```
+
+```js
+export default {
+  data () {
+    return {
+      defaultIsOpen: false
+    }
+  }
+}
+```
+
+## Props
+
+### Functional
+
+- `isVisible` - Tells the component whether or not to render the open prompt
+- `@canceled` - Emitted when cancel/close button is clicked
+- `@proceed` - Emitted when action button is clicked
+
+### Content
+
+- `title` - Text displayed in header if not using slot. If no title provided, the prompt `type` is used
+- `message` - Text to display in body section if not using slot
+
+<KButton appearance="primary" @click="contentIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="contentIsOpen"
+  title="Look Mah!"
+  message="I'm prompting you"
+  @canceled="contentIsOpen = false"
+  @proceed="contentIsOpen = false"
+/>
+
+```vue
+<KButton
+  appearance="primary"
+  @click="contentIsOpen = true"
+>
+  Prompt
+</KButton>
+
+<KPrompt
+  :is-visible="contentIsOpen"
+  title="Look Mah!"
+  message="I'm prompting you"
+  @canceled="contentIsOpen = false"
+  @proceed="contentIsOpen = false"
+/>
+```
+
+### Buttons
+
+- `actionButtonText` - Change the text content of the submit/proceed button
+- `cancelButtonText` - Change the text content of the close/cancel button
+
+<KButton appearance="primary" @click="buttonsIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="buttonsIsOpen"
+  actionButtonText="Let's do it!"
+  cancelButtonText="Abort"
+  @canceled="buttonsIsOpen = false"
+  @proceed="buttonsIsOpen = false"
+/>
+
+```vue
+<KButton
+  appearance="primary"
+  @click="buttonsIsOpen = true"
+>
+  Prompt
+</KButton>
+
+<KPrompt
+  :is-visible="contentIsOpen"
+  actionButtonText="Let's do it!"
+  cancelButtonText="Abort"
+  @canceled="buttonsIsOpen = false"
+  @proceed="buttonsIsOpen = false"
+/>
+```
+
+### Variations
+
+- `type` - Can be `danger`, `warning`, or `information`. Defaults to `information`
+- `confirmationText` - Provide a string the user must type before the action button becomes enabled
+
+Use the `information` prompt type to notify the user abbout general information associated with the action about
+to be taken.
+
+<KButton appearance="primary" @click="infoIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="infoIsOpen"
+  message="You have been informed 🕵🏻‍♂️"
+  @canceled="infoIsOpen = false"
+  @proceed="infoIsOpen = false"
+/>
+
+```vue
+<KPrompt
+  :is-visible="infoIsOpen"
+  message="You have been informed 🕵🏻‍♂️"
+  @canceled="infoIsOpen = false"
+  @proceed="infoIsOpen = false"
+/>
+```
+
+Use the `warning` prompt type if the user needs to be notified that there is a risk associated with the action
+about to be taken. We will display a warning icon and prepend the 'Warning:' in the title for this flavor.
+
+<KButton appearance="primary" @click="warningIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="warningIsOpen"
+  title="Pay attention"
+  message="I'm warning you 🤔"
+  type="warning"
+  @canceled="warningIsOpen = false"
+  @proceed="warningIsOpen = false"
+/>
+
+```vue
+<KPrompt
+  :is-visible="warningIsOpen"
+  message="I'm warning you 🤔"
+  type="warning"
+  @canceled="warningIsOpen = false"
+  @proceed="warningIsOpen = false"
+/>
+```
+
+Use the `danger` prompt type if the user is taking an irreversible action, like deleting an item. You can use this
+type in conjuction with `confirmationText` to further restrict the action.
+
+<KButton appearance="primary" @click="dangerIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="dangerIsOpen"
+  type="danger"
+  message="This is dangerous ☠️"
+  confirmationText="I Agree"
+  @canceled="dangerIsOpen = false"
+  @proceed="dangerIsOpen = false"
+/>
+
+```vue
+<KPrompt
+  :is-visible="dangerIsOpen"
+  type="danger"
+  message="This is dangerous ☠️"
+  confirmationText="I Agree"
+  @canceled="dangerIsOpen = false"
+  @proceed="dangerIsOpen = false"
+/>
+```
+
+## Slots
+
+There are 3 designated slots you can use to display content in the modal.
+
+- `header-content`
+- `body-content`
+- `action-buttons` - Contains cancel & action buttons by default.
+
+<KButton appearance="primary" @click="slotsIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="slotsIsOpen"
+  @canceled="slotsIsOpen = false"
+  @proceed="slotsIsOpen = false">
+  <template v-slot:header-content>
+    <KIcon
+      icon="immunity"
+      color="#7F01FE"
+      class="mr-2"
+      size="20" />
+    Look Mah!
+  </template>
+  <template v-slot:body-content>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
+  </template>
+  <template v-slot:action-buttons>
+    <KButton appearance="outline" @click="slotsIsOpen = false" class="non-visual-button">Close</KButton>
+  </template>
+</KPrompt>
+
+```vue
+<KPrompt
+  :is-visible="slotsIsOpen"
+  @canceled="slotsIsOpen = false"
+  @proceed="slotsIsOpen = false">
+  <template v-slot:header-content>
+    <KIcon
+      icon="immunity"
+      color="#7F01FE"
+      class="mr-2"
+      size="20" />
+    Look Mah!
+  </template>
+  <template v-slot:body-content>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
+  </template>
+  <template v-slot:action-buttons>
+    <KButton appearance="outline" @click="slotsIsOpen = false" class="non-visual-button">Close</KButton>
+  </template>
+</KPrompt>
+```
+
+<script>
+export default {
+  data () {
+    return {
+      buttonsIsOpen: false,
+      contentIsOpen: false,
+      dangerIsOpen: false,
+      defaultIsOpen: false,
+      infoIsOpen: false,
+      slotsIsOpen: false,
+      warningIsOpen: false
+    }
+  }
+}
+</script>

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -39,16 +39,17 @@ export default {
 
 ## Props
 
-### Functional
+### isVisible
 
-- `isVisible` - Tells the component whether or not to render the open prompt
-- `@canceled` - Emitted when cancel/close button is clicked
-- `@proceed` - Emitted when action button is clicked
+Tells the component whether or not to render the open prompt.
 
-### Content
+### title
 
-- `title` - Text displayed in header if not using slot. If no title provided, the prompt `type` is used
-- `message` - Text to display in body section if not using slot
+Text displayed in header if not using slot. If no title is provided, the prompt `type` is used.
+
+### message
+
+Text to display in body section if not using slot.
 
 <KButton appearance="primary" @click="contentIsOpen = true">Prompt</KButton>
 
@@ -61,13 +62,6 @@ export default {
 />
 
 ```vue
-<KButton
-  appearance="primary"
-  @click="contentIsOpen = true"
->
-  Prompt
-</KButton>
-
 <KPrompt
   :is-visible="contentIsOpen"
   title="Look Mah!"
@@ -77,15 +71,19 @@ export default {
 />
 ```
 
-### Buttons
+### actionButtonText
 
-- `actionButtonText` - Change the text content of the submit/proceed button
-- `cancelButtonText` - Change the text content of the close/cancel button
+Change the text content of the submit/proceed button.
+
+### cancelButtonText
+
+Change the text content of the close/cancel button.
 
 <KButton appearance="primary" @click="buttonsIsOpen = true">Prompt</KButton>
 
 <KPrompt
   :is-visible="buttonsIsOpen"
+  message="Look at my button customizations"
   actionButtonText="Let's do it!"
   cancelButtonText="Abort"
   @canceled="buttonsIsOpen = false"
@@ -93,13 +91,6 @@ export default {
 />
 
 ```vue
-<KButton
-  appearance="primary"
-  @click="buttonsIsOpen = true"
->
-  Prompt
-</KButton>
-
 <KPrompt
   :is-visible="contentIsOpen"
   actionButtonText="Let's do it!"
@@ -109,10 +100,9 @@ export default {
 />
 ```
 
-### Variations
+### type
 
-- `type` - Can be `danger`, `warning`, or `info`. Defaults to `info`
-- `confirmationText` - Provide a string the user must type before the action button becomes enabled
+This prompt determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
 
 Use the `info` prompt type to notify the user about general information associated with the action about
 to be taken.
@@ -168,7 +158,6 @@ type in conjuction with `confirmationText` to further restrict the action.
   :is-visible="dangerIsOpen"
   type="danger"
   message="This is dangerous ☠️"
-  confirmationText="I Agree"
   @canceled="dangerIsOpen = false"
   @proceed="dangerIsOpen = false"
 />
@@ -178,9 +167,34 @@ type in conjuction with `confirmationText` to further restrict the action.
   :is-visible="dangerIsOpen"
   type="danger"
   message="This is dangerous ☠️"
-  confirmationText="I Agree"
   @canceled="dangerIsOpen = false"
   @proceed="dangerIsOpen = false"
+/>
+```
+
+### confirmationText
+
+Provide a string the user must type before the action button becomes enabled
+
+<KButton appearance="primary" @click="dangerConfirmIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="dangerConfirmIsOpen"
+  type="danger"
+  message="This is dangerous ☠️"
+  confirmationText="I Agree"
+  @canceled="dangerConfirmIsOpen = false"
+  @proceed="dangerConfirmIsOpen = false"
+/>
+
+```vue
+<KPrompt
+  :is-visible="dangerConfirmIsOpen"
+  type="danger"
+  message="This is dangerous ☠️"
+  confirmationText="I Agree"
+  @canceled="dangerConfirmIsOpen = false"
+  @proceed="dangerConfirmIsOpen = false"
 />
 ```
 
@@ -236,6 +250,11 @@ There are 3 designated slots you can use to display content in the modal.
 </KPrompt>
 ```
 
+## Events
+
+- `@canceled` - Emitted when cancel/close button is clicked or the Escape key is pressed
+- `@proceed` - Emitted when action button is clicked or the Enter key is pressed
+
 <script>
 export default {
   data () {
@@ -243,6 +262,7 @@ export default {
       buttonsIsOpen: false,
       contentIsOpen: false,
       dangerIsOpen: false,
+      dangerConfirmIsOpen: false,
       defaultIsOpen: false,
       infoIsOpen: false,
       slotsIsOpen: false,

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -104,6 +104,8 @@ Change the text content of the close/cancel button.
 
 This prompt determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
 
+#### Information
+
 Use the `info` prompt type to notify the user about general information associated with the action about
 to be taken.
 
@@ -124,6 +126,8 @@ to be taken.
   @proceed="infoIsOpen = false"
 />
 ```
+
+#### Warning
 
 Use the `warning` prompt type if the user needs to be notified that there is a risk associated with the action
 about to be taken. We will display a warning icon and prepend the 'Warning:' in the title for this flavor.
@@ -148,6 +152,8 @@ about to be taken. We will display a warning icon and prepend the 'Warning:' in 
   @proceed="warningIsOpen = false"
 />
 ```
+
+#### Danger
 
 Use the `danger` prompt type if the user is taking an irreversible action, like deleting an item. You can use this
 type in conjuction with `confirmationText` to further restrict the action.

--- a/packages/KPrompt/KPrompt.spec.js
+++ b/packages/KPrompt/KPrompt.spec.js
@@ -1,0 +1,112 @@
+import { mount } from '@vue/test-utils'
+import KPrompt from '@/KPrompt/KPrompt'
+
+describe('KPrompt', () => {
+  it('renders proper content when using slots', () => {
+    const headerText = 'This is some header text'
+    const bodyText = 'This is some body text'
+    const actionButtonsText = 'This is some footer text'
+
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true,
+        title: headerText
+      },
+      slots: {
+        'header-content': `<div>${headerText}</div>`,
+        'body-content': `<div>${bodyText}</div>`,
+        'action-buttons': `<div>${actionButtonsText}</div>`
+      }
+    })
+
+    expect(wrapper.find('.k-prompt-header').html()).toEqual(expect.stringContaining(headerText))
+    expect(wrapper.find('.k-prompt-body').html()).toEqual(expect.stringContaining(bodyText))
+    expect(wrapper.find('.k-prompt-action-buttons').html()).toEqual(expect.stringContaining(actionButtonsText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders proper content when using props', () => {
+    const title = 'Sweet prop title'
+    const message = 'Sweet prop content'
+
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true,
+        title,
+        message
+      }
+    })
+
+    expect(wrapper.find('.k-prompt-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.k-prompt-body').html()).toEqual(expect.stringContaining(message))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders custom button text', () => {
+    const actionButtonText = 'Sweet prop action button'
+    const cancelButtonText = 'Sweet prop cancel button'
+
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true,
+        actionButtonText,
+        cancelButtonText
+      }
+    })
+
+    const buttons = wrapper.findAll('button')
+
+    // button at 0 is close button in top right corner
+    expect(buttons.at(1).text()).toBe(cancelButtonText)
+    expect(buttons.at(2).text()).toBe(actionButtonText)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('proceeds when clicking action button', () => {
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true
+      },
+      attachToDocument: true
+    })
+
+    wrapper.find('.k-prompt-action-buttons .k-prompt-proceed').trigger('click')
+
+    expect(wrapper.emitted().proceed).toHaveLength(1)
+  })
+
+  it('proceeds when clicking cancel buttons', () => {
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true
+      },
+      attachToDocument: true
+    })
+
+    wrapper.find('.k-prompt-header .close-button button').trigger('click')
+
+    expect(wrapper.emitted().canceled).toHaveLength(1)
+
+    wrapper.find('.k-prompt-action-buttons .k-prompt-cancel').trigger('click')
+
+    expect(wrapper.emitted().canceled).toHaveLength(2)
+  })
+
+  it('tears down event listeners', () => {
+    const AEL = jest.fn()
+    const REL = jest.fn()
+
+    window.document.addEventListener = AEL
+    window.document.removeEventListener = REL
+
+    const wrapper = mount(KPrompt, {
+      propsData: {
+      },
+      attachToDocument: true
+    })
+
+    wrapper.destroy()
+    expect(AEL).toHaveBeenCalledTimes(1)
+    expect(REL).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/KPrompt/KPrompt.spec.js
+++ b/packages/KPrompt/KPrompt.spec.js
@@ -106,7 +106,7 @@ describe('KPrompt', () => {
     })
 
     wrapper.destroy()
-    expect(AEL).toHaveBeenCalledTimes(1)
-    expect(REL).toHaveBeenCalledTimes(1)
+    expect(AEL).toHaveBeenCalled()
+    expect(REL).toHaveBeenCalled()
   })
 })

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -1,0 +1,220 @@
+<template>
+  <KModal
+    :is-visible="isVisible"
+    :title="displayTitle"
+    class="k-prompt"
+    @keyup.esc="close">
+    <template v-slot:header-content>
+      <div class="k-prompt-header w-100">
+        <div class="k-prompt-header-content d-flex w-100">
+          <slot name="header-content">
+            <KIcon
+              v-if="type === 'warning'"
+              icon="warning"
+              color="var(--white)"
+              secondary-color="var(--yellow-400)"
+              size="20"
+              class="mr-2" />
+            {{ displayTitle }}
+          </slot>
+          <div class="close-button">
+            <KButton
+              class="non-visual-button"
+              @click="close">
+              <KIcon
+                icon="close"
+                color="var(--grey-600)"
+                size="15" />
+            </KButton>
+          </div>
+        </div>
+        <hr class="divider">
+      </div>
+    </template>
+    <template v-slot:body-content>
+      <div class="k-prompt-body">
+        <div class="k-prompt-body-content">
+          <slot name="body-content">
+            {{ message }}
+          </slot>
+
+          <div
+            v-if="confirmationText"
+            class="k-prompt-confirm-text">
+            Type "<span class="bold-600">{{ confirmationText }}</span>" to confirm your action.
+
+            <KInput
+              v-model="confirmationInput"
+              class="pt-2" />
+          </div>
+        </div>
+        <hr class="divider">
+      </div>
+    </template>
+    <template v-slot:footer-content>
+      <div class="k-prompt-action-buttons">
+        <slot name="action-buttons">
+          <KButton
+            appearance="outline"
+            class="k-prompt-cancel mr-2"
+            @click="close"
+            @keyup.esc="close">{{ cancelButtonText }}</KButton>
+          <KButton
+            :appearance="type === 'danger' ? 'danger' : 'primary'"
+            :disabled="disableProceedButton"
+            class="k-prompt-proceed"
+            @keyup.enter="proceed"
+            @click="proceed">{{ actionButtonText }}</KButton>
+        </slot>
+      </div>
+    </template>
+  </KModal>
+</template>
+
+<script>
+import KButton from '@kongponents/kbutton/KButton.vue'
+import KIcon from '@kongponents/kicon/KIcon.vue'
+import KInput from '@kongponents/kinput/KInput.vue'
+import KModal from '@kongponents/kmodal/KModal.vue'
+
+export default {
+  name: 'KPrompt',
+  components: { KButton, KIcon, KInput, KModal },
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    type: {
+      type: String,
+      default: 'information',
+      validator: (value) => {
+        return [
+          'information',
+          'warning',
+          'danger'
+        ].indexOf(value) !== -1
+      }
+    },
+    message: {
+      type: String,
+      default: 'Body content'
+    },
+    actionButtonText: {
+      type: String,
+      default: 'OK'
+    },
+    cancelButtonText: {
+      type: String,
+      default: 'Cancel'
+    },
+    isVisible: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Use this prop to require a confirmation string be typed correctly
+     * before the submit button will be enabled.
+     */
+    confirmationText: {
+      type: String,
+      default: ''
+    }
+  },
+  data () {
+    return {
+      confirmationInput: ''
+    }
+  },
+  computed: {
+    displayTitle () {
+      if (this.title) {
+        if (this.type === 'warning') {
+          return 'Warning: ' + this.title
+        }
+
+        return this.title
+      }
+
+      return this.capitalize(this.type)
+    },
+    disableProceedButton () {
+      if (!this.confirmationText.length) {
+        return false
+      }
+
+      return this.confirmationText !== this.confirmationInput
+    }
+  },
+  methods: {
+    capitalize (str) {
+      const capitalizeRegEx = /(?:^|[\s-:'"])\w/g
+
+      return str.replace(capitalizeRegEx, (a) => a.toUpperCase())
+    },
+    close () {
+      this.$emit('canceled')
+    },
+    proceed () {
+      this.$emit('proceed')
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import '~@kongponents/styles/variables';
+
+.k-prompt {
+  --KModalBottomMargin: var(--spacing-md);
+
+  .k-modal-dialog.modal-dialog {
+    padding: var(--spacing-lg);
+    padding-bottom: var(--spacing-md);
+
+    .close-button {
+      margin-left: auto;
+    }
+
+    .divider {
+      /** subtract parents padding from margin to take full width of modal */
+      margin-left: calc(var(--spacing-lg) * -1);
+      margin-right: calc(var(--spacing-lg) * -1);
+      color: var(--grey-300);
+    }
+
+    .k-modal-content {
+      .k-modal-header.modal-header {
+        width: 100%;
+        display: flex;
+
+        .close-button .k-button {
+          padding-right: 0;
+          padding-top: 0;
+        }
+      }
+
+      .k-modal-body.modal-body .k-prompt-body {
+        font-size: var(--type-md);
+        text-align: start;
+        color: var(--grey-600);
+        line-height: 24px;
+
+        .k-prompt-body-content {
+          padding-bottom: var(--spacing-lg);
+
+          .k-prompt-confirm-text {
+            margin-top: var(--spacing-lg);
+          }
+        }
+      }
+
+      .k-modal-footer.modal-footer {
+        .k-prompt-action-buttons {
+          margin-left: auto;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -204,9 +204,10 @@ export default {
     }
 
     .divider {
-      /** subtract parents padding from margin to take full width of modal */
-      margin-left: calc(var(--spacing-lg) * -1);
-      margin-right: calc(var(--spacing-lg) * -1);
+      /* subtract parents padding from margin to take full width of modal */
+      /* use interpolation for the var in calc to not break postcss */
+      margin-left: calc(#{var(--spacing-lg)} * -1);
+      margin-right: calc(#{var(--spacing-lg)}  * -1);
       color: var(--grey-300);
     }
 

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -40,11 +40,11 @@
 
           <div
             v-if="confirmationText"
-            class="k-prompt-confirm-text">
+            class="k-prompt-confirm-text w-100">
             Type "<span class="bold-600">{{ confirmationText }}</span>" to confirm your action.
 
             <KInput
-              v-model="confirmationInput"
+              v-model.trim="confirmationInput"
               class="pt-2" />
           </div>
         </div>
@@ -205,6 +205,10 @@ export default {
 
           .k-prompt-confirm-text {
             margin-top: var(--spacing-lg);
+
+            .k-input {
+              width: 100%;
+            }
           }
         }
       }

--- a/packages/KPrompt/README.md
+++ b/packages/KPrompt/README.md
@@ -1,0 +1,11 @@
+
+
+# @kongponents/kprompt
+
+[![](https://img.shields.io/npm/v/@kongponents/kprompt.svg?style=flat-square)](https://www.npmjs.com/package/@kongponents/kprompt)
+
+```vue
+<KPrompt :description="'hello world'">
+  Hello from a slot
+</KPrompt>
+```

--- a/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
+++ b/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KPrompt renders custom button text 1`] = `
+<div aria-label="Information" role="dialog" aria-modal="true" class="k-modal k-prompt">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">
+          <div class="k-prompt-header w-100">
+            <div class="k-prompt-header-content d-flex w-100">
+              <!---->
+              Information
+              <div class="close-button"><button type="button" class="k-button non-visual-button medium rounded outline"> <span class="kong-icon kong-icon-close"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Close</title>
+  <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
+</svg>
+</span>
+                  <!----></button></div>
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-body modal-body">
+          <div class="k-prompt-body">
+            <div class="k-prompt-body-content">
+              Body content
+              <!---->
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-footer modal-footer d-flex w-100">
+          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline"> Sweet prop cancel button
+              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary"> Sweet prop action button
+              <!----></button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KPrompt renders proper content when using props 1`] = `
+<div aria-label="Sweet prop title" role="dialog" aria-modal="true" class="k-modal k-prompt">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">
+          <div class="k-prompt-header w-100">
+            <div class="k-prompt-header-content d-flex w-100">
+              <!---->
+              Sweet prop title
+              <div class="close-button"><button type="button" class="k-button non-visual-button medium rounded outline"> <span class="kong-icon kong-icon-close"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Close</title>
+  <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
+</svg>
+</span>
+                  <!----></button></div>
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-body modal-body">
+          <div class="k-prompt-body">
+            <div class="k-prompt-body-content">
+              Sweet prop content
+              <!---->
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-footer modal-footer d-flex w-100">
+          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline"> Cancel
+              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary"> OK
+              <!----></button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KPrompt renders proper content when using slots 1`] = `
+<div aria-label="This is some header text" role="dialog" aria-modal="true" class="k-modal k-prompt">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">
+          <div class="k-prompt-header w-100">
+            <div class="k-prompt-header-content d-flex w-100">
+              <div>This is some header text</div>
+              <div class="close-button"><button type="button" class="k-button non-visual-button medium rounded outline"> <span class="kong-icon kong-icon-close"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Close</title>
+  <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
+</svg>
+</span>
+                  <!----></button></div>
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-body modal-body">
+          <div class="k-prompt-body">
+            <div class="k-prompt-body-content">
+              <div>This is some body text</div>
+              <!---->
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-footer modal-footer d-flex w-100">
+          <div class="k-prompt-action-buttons">
+            <div>This is some footer text</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
+++ b/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
@@ -29,7 +29,7 @@ exports[`KPrompt renders custom button text 1`] = `
             <hr class="divider">
           </div>
         </div>
-        <div class="k-modal-footer modal-footer d-flex w-100">
+        <div class="k-modal-footer modal-footer d-flex">
           <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline"> Sweet prop cancel button
               <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary"> Sweet prop action button
               <!----></button></div>
@@ -69,7 +69,7 @@ exports[`KPrompt renders proper content when using props 1`] = `
             <hr class="divider">
           </div>
         </div>
-        <div class="k-modal-footer modal-footer d-flex w-100">
+        <div class="k-modal-footer modal-footer d-flex">
           <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline"> Cancel
               <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary"> OK
               <!----></button></div>
@@ -108,7 +108,7 @@ exports[`KPrompt renders proper content when using slots 1`] = `
             <hr class="divider">
           </div>
         </div>
-        <div class="k-modal-footer modal-footer d-flex w-100">
+        <div class="k-modal-footer modal-footer d-flex">
           <div class="k-prompt-action-buttons">
             <div>This is some footer text</div>
           </div>

--- a/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
+++ b/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
@@ -23,15 +23,17 @@ exports[`KPrompt renders custom button text 1`] = `
         <div class="k-modal-body modal-body">
           <div class="k-prompt-body">
             <div class="k-prompt-body-content">
-              Body content
+
               <!---->
             </div>
             <hr class="divider">
           </div>
         </div>
         <div class="k-modal-footer modal-footer d-flex">
-          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline"> Sweet prop cancel button
-              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary"> Sweet prop action button
+          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
+              Sweet prop cancel button
+              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary">
+              Sweet prop action button
               <!----></button></div>
         </div>
       </div>
@@ -70,8 +72,10 @@ exports[`KPrompt renders proper content when using props 1`] = `
           </div>
         </div>
         <div class="k-modal-footer modal-footer d-flex">
-          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline"> Cancel
-              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary"> OK
+          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
+              Cancel
+              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary">
+              OK
               <!----></button></div>
         </div>
       </div>

--- a/packages/KPrompt/package.json
+++ b/packages/KPrompt/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@kongponents/kprompt",
+  "version": "0.1.0",
+  "description": "A dialog that prompts a user to take an action",
+  "main": "dist/KPrompt.umd.min.js",
+  "componentName": "KPrompt",
+  "source": "KPrompt.vue",
+  "files": [
+    "dist",
+    "KPrompt.vue"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kong/kongponents.git"
+  },
+  "author": "Kong Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Kong/kongponents/issues"
+  },
+  "homepage": "https://github.com/Kong/kongponents#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kbutton": "^6.10.3",
+    "@kongponents/kicon": "^6.10.3",
+    "@kongponents/kinput": "^6.10.3",
+    "@kongponents/kmodal": "^6.10.3",
+    "@kongponents/styles": "^6.10.3"
+  }
+}

--- a/packages/KPrompt/package.json
+++ b/packages/KPrompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kprompt",
-  "version": "0.1.0",
+  "version": "6.12.0",
   "description": "A dialog that prompts a user to take an action",
   "main": "dist/KPrompt.umd.min.js",
   "componentName": "KPrompt",
@@ -23,10 +23,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.10.3",
-    "@kongponents/kicon": "^6.10.3",
-    "@kongponents/kinput": "^6.10.3",
-    "@kongponents/kmodal": "^6.10.3",
-    "@kongponents/styles": "^6.10.3"
+    "@kongponents/kbutton": "^6.12.0",
+    "@kongponents/kicon": "^6.12.0",
+    "@kongponents/kinput": "^6.12.0",
+    "@kongponents/kmodal": "^6.12.0",
+    "@kongponents/styles": "^6.12.0"
   }
 }

--- a/packages/KTableLegacy/package.json
+++ b/packages/KTableLegacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktablelegacy",
-  "version": "0.6.0",
+  "version": "6.12.0",
   "description": "Legacy version of KTable prior to fetcher support",
   "main": "dist/KTableLegacy.umd.min.js",
   "componentName": "KTableLegacy",


### PR DESCRIPTION
### Summary

Add new `KPrompt` dialog for modals that prompt a user to take an action.

Warning:

![image](https://user-images.githubusercontent.com/67973710/154740939-aeb4cb4a-da64-4fe8-81fe-8fa4f0b6b1a4.png)


Danger:

![image](https://user-images.githubusercontent.com/67973710/154741861-8d86eb25-a36b-436d-be1f-f3018a74b245.png)


#### Changes made:
* Add new kongponent
* Add tests
* Add docs
* Manually set version of `KTableLegacy` to match other kongponents versions

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
