### PR TITLE
feat(kprompt): add actionPending prop

### DIFF
--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -100,6 +100,31 @@ Change the text content of the close/cancel button.
 />
 ```
 
+### actionPending
+
+This boolean indicates if an action is being taken on the dialog and we should disable the action button
+to prevent spam clicking.
+
+<KButton appearance="primary" @click="pendingIsOpen = true">Prompt</KButton>
+
+<KPrompt
+  :is-visible="pendingIsOpen"
+  message="Click Cancel to close me"
+  :action-pending="true"
+  @canceled="pendingIsOpen = false"
+  @proceed="pendingIsOpen = false"
+/>
+
+```vue
+<KPrompt
+  :is-visible="pendingIsOpen"
+  message="Click Cancel to close me"
+  :action-pending="true"
+  @canceled="pendingIsOpen = false"
+  @proceed="pendingIsOpen = false"
+/>
+```
+
 ### type
 
 This prompt determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
@@ -271,6 +296,7 @@ export default {
       dangerConfirmIsOpen: false,
       defaultIsOpen: false,
       infoIsOpen: false,
+      pendingIsOpen: false,
       slotsIsOpen: false,
       warningIsOpen: false
     }

--- a/packages/KPrompt/KPrompt.spec.js
+++ b/packages/KPrompt/KPrompt.spec.js
@@ -62,6 +62,45 @@ describe('KPrompt', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
+  it('has a pending state', () => {
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true,
+        actionPending: true
+      }
+    })
+
+    expect(wrapper.find('.k-prompt-proceed .kong-icon-spinner').exists()).toBe(true)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('enables correctly with confirmationText', () => {
+    const confirmationText = 'I Agree'
+
+    const wrapper = mount(KPrompt, {
+      propsData: {
+        isVisible: true,
+        confirmationText
+      },
+      attachToDocument: true
+    })
+
+    // disabled
+    expect(wrapper.find('.k-prompt-action-buttons .k-prompt-proceed[disabled="disabled"]').exists()).toBe(true)
+
+    const input = wrapper.find('[data-testid="confirmation-input"]')
+
+    // bad input, still disabled
+    input.setValue(confirmationText + 'x')
+    // enable
+    input.setValue(confirmationText)
+    expect(wrapper.find('.k-prompt-action-buttons .k-prompt-proceed[disabled="disabled"]').exists()).toBe(false)
+    wrapper.find('.k-prompt-action-buttons .k-prompt-proceed').trigger('click')
+
+    expect(wrapper.emitted().proceed).toHaveLength(1)
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('proceeds when clicking action button', () => {
     const wrapper = mount(KPrompt, {
       propsData: {

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -72,6 +72,7 @@
               slot="icon"
               icon="spinner"
               size="16"
+              color="var(--white)"
             />
             {{ actionButtonText }}
           </KButton>

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -46,6 +46,7 @@
 
             <KInput
               v-model="confirmationInput"
+              data-testid="confirmation-input"
               class="pt-2" />
           </div>
         </div>
@@ -66,6 +67,12 @@
             :disabled="disableProceedButton"
             class="k-prompt-proceed"
             @click="proceed">
+            <KIcon
+              v-if="actionPending"
+              slot="icon"
+              icon="spinner"
+              size="16"
+            />
             {{ actionButtonText }}
           </KButton>
         </slot>
@@ -111,6 +118,14 @@ export default {
       type: String,
       default: 'Cancel'
     },
+    /**
+     * Boolean to disable action buttons while a submission is occurring. Display
+     * spinner on action button.
+     */
+    actionPending: {
+      type: Boolean,
+      default: false
+    },
     isVisible: {
       type: Boolean,
       default: false
@@ -144,6 +159,10 @@ export default {
       return this.capitalize(this.type)
     },
     disableProceedButton () {
+      if (this.actionPending) {
+        return true
+      }
+
       if (!this.confirmationText.length) {
         return false
       }

--- a/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
+++ b/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
@@ -1,5 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KPrompt enables correctly with confirmationText 1`] = `
+<div aria-label="Information" role="dialog" aria-modal="true" class="k-modal k-prompt">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">
+          <div class="k-prompt-header w-100">
+            <div class="k-prompt-header-content d-flex w-100">
+              <!---->
+              Information
+              <div class="close-button"><button type="button" class="k-button non-visual-button medium rounded outline"> <span class="kong-icon kong-icon-close"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Close</title>
+  <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
+</svg>
+</span>
+                  <!----></button></div>
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-body modal-body">
+          <div class="k-prompt-body">
+            <div class="k-prompt-body-content">
+
+              <div class="k-prompt-confirm-text w-100">
+                Type "<span class="bold-600">I Agree</span>" to confirm your action.
+
+                <div class="k-input-wrapper pt-2"><input data-testid="confirmation-input" class="form-control k-input k-input-medium">
+                  <!---->
+                  <!---->
+                </div>
+              </div>
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-footer modal-footer d-flex">
+          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
+              Cancel
+              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary" disabled="disabled">
+              <!---->
+              OK
+              <!----></button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KPrompt has a pending state 1`] = `
+<div aria-label="Information" role="dialog" aria-modal="true" class="k-modal k-prompt">
+  <div class="k-modal-backdrop modal-backdrop">
+    <div class="k-modal-dialog modal-dialog">
+      <div class="k-modal-content modal-content">
+        <div role="heading" aria-level="2" class="k-modal-header modal-header mb-5">
+          <div class="k-prompt-header w-100">
+            <div class="k-prompt-header-content d-flex w-100">
+              <!---->
+              Information
+              <div class="close-button"><button type="button" class="k-button non-visual-button medium rounded outline"> <span class="kong-icon kong-icon-close"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Close</title>
+  <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
+</svg>
+</span>
+                  <!----></button></div>
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-body modal-body">
+          <div class="k-prompt-body">
+            <div class="k-prompt-body-content">
+
+              <!---->
+            </div>
+            <hr class="divider">
+          </div>
+        </div>
+        <div class="k-modal-footer modal-footer d-flex">
+          <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
+              Cancel
+              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary" disabled="disabled"><span class="kong-icon kong-icon-spinner" viewbox="0 0 16 16"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Loading</title>
+  <g>
+    <path d="M5 10a5 5 0 1 0 5-5" fill="none" stroke="#A3BBCC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  </g>
+</svg>
+</span>
+              OK
+              <!----></button></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`KPrompt renders custom button text 1`] = `
 <div aria-label="Information" role="dialog" aria-modal="true" class="k-modal k-prompt">
   <div class="k-modal-backdrop modal-backdrop">
@@ -33,6 +131,7 @@ exports[`KPrompt renders custom button text 1`] = `
           <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
               Sweet prop cancel button
               <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary">
+              <!---->
               Sweet prop action button
               <!----></button></div>
         </div>
@@ -75,6 +174,7 @@ exports[`KPrompt renders proper content when using props 1`] = `
           <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
               Cancel
               <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary">
+              <!---->
               OK
               <!----></button></div>
         </div>


### PR DESCRIPTION
### Summary
Add `actionPending` prop.

![image](https://user-images.githubusercontent.com/67973710/155198689-859f8d5d-dfd7-4f08-a1c1-f16172d96b70.png)


#### Changes made:
* Add tests
* Update snaps

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
