### PR TITLE
feat(kmodalfullscreen): adds new kongponent [khcp-2879]

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -54,6 +54,7 @@ module.exports = {
               '/components/label',
               '/components/menu',
               '/components/modal',
+              '/components/modal-fullscreen',
               '/components/multiselect',
               '/components/pagination',
               '/components/popover',

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -24,6 +24,7 @@ import KLabel from '../../packages/KLabel/KLabel.vue'
 import KMenu from '../../packages/KMenu/KMenu.vue'
 import KMenuItem from '../../packages/KMenu/KMenuItem.vue'
 import KModal from '../../packages/KModal/KModal.vue'
+import KModalFullscreen from '../../packages/KModalFullscreen/KModalFullscreen.vue'
 import KoolTip from '../../packages/KoolTip/KoolTip.vue'
 import KPagination from '../../packages/KPagination/KPagination.vue'
 import KPop from '../../packages/KPop/KPop.vue'
@@ -68,6 +69,7 @@ export default ({
   Vue.component('KMenu', KMenu)
   Vue.component('KMenuItem', KMenuItem)
   Vue.component('KModal', KModal)
+  Vue.component('KModalFullscreen', KModalFullscreen)
   Vue.component('KoolTip', KoolTip)
   Vue.component('KPagination', KPagination)
   Vue.component('KPop', KPop)

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -1,43 +1,41 @@
-# KModalFullscreen
+# Modal Fullscreen
 
 The **KModalFullscreen** component is used to show content in a full screen modal on top of existing UI.
 
 <KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
 
-<template>
-  <KModalFullscreen
-    title="Hello There!"
-    :isVisible="defaultIsOpen"
-    @canceled="defaultIsOpen = false" >
-      <template v-slot:body-content>
-        <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
-        <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
-        <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
-        <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
-        <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
-        <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
-      </template>
-    </KModalFullscreen>
-</template>
+<KModalFullscreen
+  title="Hello There!"
+  :isVisible="defaultIsOpen"
+  @canceled="defaultIsOpen = false"
+  @proceed="defaultIsOpen = false" >
+  <template v-slot:body-content>
+    <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+    <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+    <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+    <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+    <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+    <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+  </template>
+</KModalFullscreen>
 
 ```vue
-<template>
-   <KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
-<template>
-  <KModalFullscreen
-    title="Hello There!"
-    :isVisible="defaultIsOpen"
-    @canceled="defaultIsOpen = false" >
-      <template v-slot:body-content>
-        <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
-        <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
-        <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
-        <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
-        <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
-        <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
-      </template>
-    </KModalFullscreen>
-</template>
+<KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
+
+<KModalFullscreen
+  title="Hello There!"
+  :isVisible="defaultIsOpen"
+  @canceled="defaultIsOpen = false"
+  @proceed="defaultIsOpen = false" >
+  <template v-slot:body-content>
+    <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+    <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+    <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+    <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+    <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+    <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+  </template>
+</KModalFullscreen>
 
 <script>
 export default {
@@ -52,264 +50,247 @@ export default {
 
 ## Props
 
-### Functional
+### title
 
-- `isVisible` - Tells the component whether or not to render the open modal
-- `@canceled` - Emitted when cancel/close button is clicked
+Text displayed in header.
 
-### Content
+### bodyHeaderDescription
 
-- `title` - Text displayed in header if not using slot (**Note**: this field is still required for accessibility reasons even if using the slot)
-- `hideTitle` - If not using the `header-content` slot, tells the component whether or not to display the title
-- `content` - Text to display in content if not using slot
+Text to display Page title and description.
 
-### Buttons & Appearance
+### type
 
-- `cancelButtonText` - Change the text content of the close/cancel button
-- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel button
+This prompt determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
+
+### content
+
+Sets the text of the body content if not using slot.
+
+### isVisible
+
+Tells the component whether or not to render modal.
+
+### cancelButtonText
+
+Change the text content of the close/cancel button.
+
+### cancelButtonAppearance
+
+Sets the appearance of the close/cancel button.
+
+### actionButtonText
+
+Change the text content of the save/proceed button.
+
+<KButton appearance="primary" @click="contentIsOpen = true">Open Modal</KButton>
+
+<KModalFullscreen
+  title="Hello There!"
+  :isVisible="contentIsOpen"
+  @canceled="contentIsOpen = false"
+  @proceed="contentIsOpen = false"
+  cancelButtonText="Abort"
+  cancelButtonAppearance="secondary"
+  content = "Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.
+  Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.
+  Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui."/>
+</KModalFullscreen>
+
+```vue
+<KButton appearance="primary" @click="contentIsOpen = true">Open Modal</KButton>
+
+<KModalFullscreen
+  title="Hello There!"
+  :isVisible="contentIsOpen"
+  @canceled="contentIsOpen = false"
+  @proceed="contentIsOpen = false"
+  cancelButtonText="Abort"
+  cancelButtonAppearance="secondary"
+  content = "Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.
+  Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.
+  Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui."/>
+</KModalFullscreen>
+```
 
 ## Slots
 
-There are 3 designated slots you can use to display content in the fullscreen modal.
+There are 5 designated slots you can use to display content in the fullscreen modal.
 
-- `header-content`
-- `body-content`  
-- `actionButtons` - Contains action buttons which are right-aligned.
-
----
-
-### Usage
-
-Using both the provided props and slot options we will now demonstrate how to customize the fullscreen modal.
-Notice that even though we are using the `header-content` slot we still specify the `title` attribute for accessibility.
+- `header-content` 
+- `action-buttons` - Contains action buttons which are right-aligned.
+- `body-header-description`
+- `body-content`
 
 <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
 
-<template>
-  <KModalFullscreen
-    :isVisible="exampleIsOpen"
-    title="Install Plugin"
-    @canceled="exampleIsOpen = false" >
-      <template v-slot:header-icon>
-        <KIcon icon="kong" class="mr-2" />
-      </template>
-      <template v-slot:header-content>
-        Install Plugin
-      </template>
-      <template v-slot:body-header-description>
-        <p>Select a plugin</p>
-        <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
-      </template>
-      <template v-slot:actionButtons>
-        <KButton appearance="secondary" size="small">Back</KButton>
-        <KButton appearance="primary" size="small">Save</KButton>
-      </template>
-      <template v-slot:body-content>
-        <h3>Security</h3>
-        <KCardCatalog :items="getItems(8)" />
-        <h3>Authentication</h3>
-        <KCardCatalog :items="getItems(16)" />
-      </template>
-    </KModalFullscreen>
-</template>
+<KModalFullscreen
+  :isVisible="exampleIsOpen"
+  title="Install Plugin"
+  @canceled="exampleIsOpen = false" iconHeader="immunity">
+  <template v-slot:header-content>
+    Install Plugin
+  </template>
+  <template v-slot:body-header-description>
+    <p>Select a plugin</p>
+    <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+  </template>
+  <template v-slot:action-buttons>
+    <KButton appearance="secondary" size="medium" @click="exampleIsOpen = false">Back</KButton>
+    <KButton appearance="primary" size="medium" @click="exampleIsOpen = false">Save</KButton>
+    <KButton appearance="outline" size="medium" @click="exampleIsOpen = false">Do It</KButton>
+  </template>
+  <template v-slot:body-content>
+    <h3>Security</h3>
+    <KCardCatalog :items="getItems(8)" />
+    <h3>Authentication</h3>
+    <KCardCatalog :items="getItems(16)" />
+  </template>
+</KModalFullscreen>
 
 ```vue
-<template>
-  <div>
-    <KModalFullscreen
-      :isVisible="exampleIsOpen"
-      title="Install Plugin"
-      @canceled="exampleIsOpen = false" >
-        <template v-slot:header-icon>
-          <KIcon icon="kong" class="mr-2" />
-        </template>
-        <template v-slot:header-content>
-          Install Plugin
-        </template>
-        <template v-slot:body-header-description>
-          <h2>Select a plugin</h2>
-          <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
-        </template>
-        <template v-slot:actionButtons>
-          <KButton appearance="secondary" size="small">Back</KButton>
-          <KButton appearance="primary" size="small">Save</KButton>
-        </template>
-        <template v-slot:body-content>
-          <h3>Security</h3>
-          <KCardCatalog :items="getItems(8)" />
-          <h3>Authentication</h3>
-          <KCardCatalog :items="getItems(16)" />
-        </template>
-      </KModalFullscreen>
+<KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
 
-    <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
-  </div>
-</template>
-
-<script>
-export default {
-  data () {
-    return {
-      exampleIsOpen: false
-    }
-  }
-}
-</script>
+<KModalFullscreen
+  :isVisible="exampleIsOpen"
+  title="Install Plugin"
+  @canceled="exampleIsOpen = false" iconHeader="immunity">
+  <template v-slot:header-content>
+    Install Plugin
+  </template>
+  <template v-slot:body-header-description>
+    <p>Select a plugin</p>
+    <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+  </template>
+  <template v-slot:action-buttons>
+    <KButton appearance="secondary" size="medium" @click="exampleIsOpen = false">Back</KButton>
+    <KButton appearance="primary" size="medium" @click="exampleIsOpen = false">Save</KButton>
+    <KButton appearance="outline" size="medium" @click="exampleIsOpen = false">Do It</KButton>
+  </template>
+  <template v-slot:body-content>
+    <h3>Security</h3>
+    <KCardCatalog :items="getItems(8)" />
+    <h3>Authentication</h3>
+    <KCardCatalog :items="getItems(16)" />
+  </template>
+</KModalFullscreen>
 ```
 
 <KButton appearance="primary" @click="sampleIsOpen = true">Open Form Modal</KButton>
 
-<template>
-  <KModalFullscreen
-    :isVisible="sampleIsOpen"
-    title="Install Plugin"
-    @canceled="sampleIsOpen = false" >
-      <template v-slot:header-icon>
-        <KIcon icon="kong" class="mr-2" />
-      </template>
-      <template v-slot:header-content>
-        Install Plugin
-      </template>
-      <template v-slot:body-header-description>
-        <p>Configure a key auth plugin</p>
-        <p>Lorem ipsum factum. <a>View documentation</a></p>
-      </template>
-      <template v-slot:actionButtons>
-        <KButton appearance="secondary" size="small">Back</KButton>
-        <KButton appearance="primary" size="small">Save</KButton>
-      </template>
-      <template v-slot:body-content>
-        <template>
-          <KInputSwitch v-model="checked" label="This plugin is enabled" />
-        </template>
-        <template>
-          <KInput label="Tags" class="mb-2" placeholder="Enter list of tags" />
-          <p class="help">e.g., tag1, tag2, tag3</p>
-        </template>
-        <template>
-          <KInput label="Configure Anonymous" class="mb-2" />
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox1" class="checked">
-            Config key in body
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox2" class="checked">
-            Config key in header
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox3" class="checked">
-            Config key in query
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox4" class="checked">
-            Config hide credentials
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KInput label="Health checks active healthy interval" class="mb-2" placeholder="0" />
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox5" class="checked">
-            Config run on preflight
-          </KCheckbox>
-        </template>
-      </template>
-    </KModalFullscreen>
-</template>
+<KModalFullscreen
+  :isVisible="sampleIsOpen"
+  title="Install Plugin"
+  @canceled="sampleIsOpen = false"
+  @proceed="sampleIsOpen = false" >
+  <template v-slot:header-icon>
+    <KIcon icon="kong" class="mr-2" />
+  </template>
+  <template v-slot:header-content>
+    Install Plugin
+  </template>
+  <template v-slot:body-header-description>
+    <div class="display">
+      <p>Configure a key auth plugin</p>
+      <p>Lorem ipsum factum. <a>View documentation</a></p>
+    </div>
+  </template>
+  <template v-slot:action-buttons>
+    <KButton appearance="secondary" size="medium" @click="sampleIsOpen = false">Back</KButton>
+    <KButton appearance="primary" size="medium" @click="sampleIsOpen = false">Save</KButton>
+  </template>
+  <template v-slot:body-content>
+    <div class="display">
+      <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
+      <KInput label="Tags" class="mb-2 display-items" placeholder="Enter list of tags" />
+      <p class="help display-items">e.g., tag1, tag2, tag3</p>
+      <KInput label="Configure Anonymous" class="mb-2 display-items" :style="{ width: '20px' }"  />
+      <br><br>
+      <KCheckbox v-model="checkedBox1" class="checked display-items">
+        Config key in body
+      </KCheckbox>
+      <br><br>
+      <KCheckbox v-model="checkedBox2" class="checked display-items">
+        Config key in header
+      </KCheckbox>
+      <br><br>
+      <KCheckbox v-model="checkedBox3" class="checked display-items">
+        Config key in query
+      </KCheckbox>
+      <br><br>
+      <KCheckbox v-model="checkedBox4" class="checked display-items">
+        Config hide credentials
+      </KCheckbox>
+      <br><br>
+      <KInput label="Health checks active healthy interval" class="mb-2 display-items" placeholder="0" />
+      <br><br>
+      <KCheckbox v-model="checkedBox5" class="checked display-items">
+        Config run on preflight
+      </KCheckbox>
+    </div>
+  </template>
+</KModalFullscreen>
 
 ```vue
-<template>
- <KButton appearance="primary" @click="sampleIsOpen = true">Open Form Modal</KButton>
+<KButton appearance="primary" @click="sampleIsOpen = true">Open Form Modal</KButton>
 
-<template>
-  <KModalFullscreen
-    :isVisible="sampleIsOpen"
-    title="Install Plugin"
-    @canceled="sampleIsOpen = false" >
-      <template v-slot:header-icon>
-        <KIcon icon="kong" class="mr-2" />
-      </template>
-      <template v-slot:header-content>
-        Install Plugin
-      </template>
-      <template v-slot:body-header-description>
-        <p>Configure a key auth plugin</p>
-        <p>Lorem ipsum factum. <a>View documentation</a></p>
-      </template>
-      <template v-slot:actionButtons>
-        <KButton appearance="secondary" size="small">Back</KButton>
-        <KButton appearance="primary" size="small">Save</KButton>
-      </template>
-      <template v-slot:body-content>
-        <template>
-          <KInputSwitch v-model="checked" label="This plugin is enabled" />
-        </template>
-        <template>
-          <KInput label="Tags" class="mb-2" placeholder="Enter list of tags" />
-          <p class="help">e.g., tag1, tag2, tag3</p>
-        </template>
-        <template>
-          <KInput label="Configure Anonymous" class="mb-2" />
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox1" class="checked">
-            Config key in body
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox2" class="checked">
-            Config key in header
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox3" class="checked">
-            Config key in query
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox4" class="checked">
-            Config hide credentials
-          </KCheckbox>
-        </template>
-          <br><br>
-        <template>
-          <KInput label="Health checks active healthy interval" class="mb-2" placeholder="0" />
-        </template>
-          <br><br>
-        <template>
-          <KCheckbox v-model="checkedBox5" class="checked">
-            Config run on preflight
-          </KCheckbox>
-        </template>
-      </template>
-    </KModalFullscreen>
-</template>
-</template>
-
-<script>
-export default {
-  data () {
-    return {
-      exampleIsOpen: false
-    }
-  }
-}
-</script>
+<KModalFullscreen
+  :isVisible="sampleIsOpen"
+  title="Install Plugin"
+  @canceled="sampleIsOpen = false"
+  @proceed="sampleIsOpen = false" >
+  <template v-slot:header-icon>
+    <KIcon icon="kong" class="mr-2" />
+  </template>
+  <template v-slot:header-content>
+    Install Plugin
+  </template>
+  <template v-slot:body-header-description>
+    <div class="display">
+      <p>Configure a key auth plugin</p>
+      <p>Lorem ipsum factum. <a>View documentation</a></p>
+    </div>
+  </template>
+  <template v-slot:action-buttons>
+    <KButton appearance="secondary" size="medium" @click="sampleIsOpen = false">Back</KButton>
+    <KButton appearance="primary" size="medium" @click="sampleIsOpen = false">Save</KButton>
+  </template>
+  <template v-slot:body-content>
+    <div class="display">
+      <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
+      <KInput label="Tags" class="mb-2 trial-items" placeholder="Enter list of tags" />
+      <p class="help trial-items">e.g., tag1, tag2, tag3</p>
+      <KInput label="Configure Anonymous" class="mb-2 trial-items" :style="{ width: '20px' }"  />
+      <br><br>
+      <KCheckbox v-model="checkedBox1" class="checked trial-items">
+        Config key in body
+      </KCheckbox>
+      <br><br>
+      <KCheckbox v-model="checkedBox2" class="checked trial-items">
+        Config key in header
+      </KCheckbox>
+      <br><br>
+      <KCheckbox v-model="checkedBox3" class="checked trial-items">
+        Config key in query
+      </KCheckbox>
+      <br><br>
+      <KCheckbox v-model="checkedBox4" class="checked trial-items">
+        Config hide credentials
+      </KCheckbox>
+      <br><br>
+      <KInput label="Health checks active healthy interval" class="mb-2 trial-items" placeholder="0" />
+      <br><br>
+      <KCheckbox v-model="checkedBox5" class="checked trial-items">
+        Config run on preflight
+      </KCheckbox>
+    </div>
+  </template>
+</KModalFullscreen>
 ```
+
+## Events
+
+- `@canceled` - Emitted when cancel/close button is clicked or the Escape key is pressed
+- `@proceed` - Emitted when action button is clicked or the Enter key is pressed
 
 ## Theming
 
@@ -327,46 +308,43 @@ An Example of changing the the colors of KModalFullscreen might look like.
 
 <KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
 
-  <template>
-    <div class="modal-wrapper">
-      <KModalFullscreen
-        title="Hello There!"
-        :isVisible="themeIsOpen"
-        @canceled="themeIsOpen = false" >
-          <template v-slot:body-content>
-            <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
-            <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
-            <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
-            <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
-            <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
-            <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
-          </template>
-        </KModalFullscreen>
-    </div>
-</template>
+<div class="modal-wrapper">
+  <KModalFullscreen
+    title="Hello There!"
+    :isVisible="themeIsOpen"
+    @canceled="themeIsOpen = false"
+    @proceed="themeIsOpen = false" >
+    <template v-slot:body-content>
+      <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+      <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+      <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+      <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+      <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+      <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+    </template>
+  </KModalFullscreen>
+</div>
 
 ```vue
 
-<template>
-  <KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
-    <template>
-      <div class="modal-wrapper">
-        <KModalFullscreen
-          title="Hello There!"
-          :isVisible="themeIsOpen"
-          @canceled="themeIsOpen = false" >
-            <template v-slot:body-content>
-              <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
-              <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
-              <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
-              <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
-              <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
-              <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
-            </template>
-          </KModalFullscreen>
-      </div>
-  </template>
-</template>
+<KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
+
+<div class="modal-wrapper">
+  <KModalFullscreen
+    title="Hello There!"
+    :isVisible="themeIsOpen"
+    @canceled="themeIsOpen = false"
+    @proceed="themeIsOpen = false" >
+    <template v-slot:body-content>
+      <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+      <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+      <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+      <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+      <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+      <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+    </template>
+  </KModalFullscreen>
+</div>
 
 <style>
 .modal-wrapper {
@@ -401,7 +379,8 @@ export default {
       exampleIsOpen: false,
       themeIsOpen: false,
       sampleIsOpen: false,
-      getItems
+      getItems,
+      contentIsOpen: false
     }
   },
   
@@ -424,5 +403,15 @@ export default {
   padding-top: 26px;
   border-bottom: 1px solid #eaecef;
   padding-bottom: 26px;
+}
+
+.display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.display-items {
+  min-width: 30%;
 }
 </style>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -201,9 +201,18 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   <template v-slot:body-content>
     <div class="display">
       <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
-      <KInput label="Tags" class="mb-2 display-items" placeholder="Enter list of tags" />
+      <br><br>
+      <div class="wrapper display-items">
+        <input type="text" placeholder="Enter list of tags">
+        <label for="">Tags</label>
+      </div>
+      <!-- <KInput label="Tags" class="mb-2 display-items" placeholder="Enter list of tags" /> -->
       <p class="help display-items">e.g., tag1, tag2, tag3</p>
-      <KInput label="Configure Anonymous" class="mb-2 display-items" :style="{ width: '20px' }"  />
+      <div class="wrapper display-items">
+        <input type="text" >
+        <label for="">Config anonymous</label>
+      </div>
+      <!-- <KInput label="Configure Anonymous" class="mb-2 display-items" :style="{ width: '20px' }"  /> -->
       <br><br>
       <KCheckbox v-model="checkedBox1" class="checked display-items">
         Config key in body
@@ -221,7 +230,11 @@ There are 5 designated slots you can use to display content in the fullscreen mo
         Config hide credentials
       </KCheckbox>
       <br><br>
-      <KInput label="Health checks active healthy interval" class="mb-2 display-items" placeholder="0" />
+      <div class="wrapper display-items">
+        <input type="text" placeholder="0" />
+        <label for="">Health checks active healthy interval</label>
+      </div>
+      <!-- <KInput label="Health checks active healthy interval" class="mb-2 display-items" placeholder="0" /> -->
       <br><br>
       <KCheckbox v-model="checkedBox5" class="checked display-items">
         Config run on preflight
@@ -355,6 +368,7 @@ An Example of changing the the colors of KModalFullscreen might look like.
 ```
 
 <script>
+
   function getItems(count) {
   let myItems = []
     for (let i = 0; i < count; i++) {
@@ -393,11 +407,6 @@ export default {
   --KModalFullscreenColor: green;
 }
 
-.divider {
-  margin-top: 21px;
-  margin-bottom: 25px;
-}
-
 .k-switch {
   border-top: 1px solid #eaecef;
   padding-top: 26px;
@@ -414,4 +423,29 @@ export default {
 .display-items {
   min-width: 30%;
 }
+
+.wrapper {
+  position: relative;
+  height: 56px;
+
+}
+.wrapper input {
+  width: 100%;
+  height: 80%;
+  border-radius: 4px;
+  border: 1px solid var(--grey-300);
+  background-color: var(--white);
+  text-indent: 10px;
+}
+
+.wrapper label {
+  position: absolute;
+  top: -10px;
+  left: 15px;
+  padding: 5px;
+  background-color: var(--white);
+  color: var(--grey-500);
+  font-size: 11px;
+}
+
 </style>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -421,31 +421,31 @@ export default {
 }
 
 .display-items {
-  min-width: 30%;
+  min-width: 70%;
 }
 
 .wrapper {
   position: relative;
   height: 56px;
 
-}
-.wrapper input {
-  width: 100%;
-  height: 80%;
-  border-radius: 4px;
-  border: 1px solid var(--grey-300);
-  background-color: var(--white);
-  text-indent: 10px;
-}
+  input {
+    width: 100%;
+    height: 80%;
+    border-radius: 4px;
+    border: 1px solid var(--grey-300);
+    background-color: var(--white);
+    text-indent: 10px;
+  }
 
-.wrapper label {
-  position: absolute;
-  top: -10px;
-  left: 15px;
-  padding: 5px;
-  background-color: var(--white);
-  color: var(--grey-500);
-  font-size: 11px;
+  label {
+    position: absolute;
+    top: -10px;
+    left: 15px;
+    padding: 5px;
+    background-color: var(--white);
+    color: var(--grey-500);
+    font-size: 11px;
+  }
 }
 
 </style>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -7,25 +7,38 @@ The **KModalFullscreen** component is used to show content in a full screen moda
 <template>
   <KModalFullscreen
     title="Hello There!"
-    content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est."
     :isVisible="defaultIsOpen"
-    @canceled="defaultIsOpen = false" />
+    @canceled="defaultIsOpen = false" >
+      <template v-slot:body-content>
+        <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+        <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+        <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+        <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+        <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+        <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+      </template>
+    </KModalFullscreen>
 </template>
 
 ```vue
 <template>
-  <div>
-    <KModalFullscreen
-      title="Hello There!"
-      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est."
-      :isVisible="isVisible"
-      @canceled="isVisible = false" />
-    
-    <KButton
-      appearance="primary"
-      @click="isVisible = true">Open Modal</KButton>
-  </div>
+   <KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
+<template>
+  <KModalFullscreen
+    title="Hello There!"
+    :isVisible="defaultIsOpen"
+    @canceled="defaultIsOpen = false" >
+      <template v-slot:body-content>
+        <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+        <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+        <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+        <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+        <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+        <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+      </template>
+    </KModalFullscreen>
 </template>
+
 <script>
 export default {
   data () {
@@ -77,61 +90,216 @@ Notice that even though we are using the `header-content` slot we still specify 
     :isVisible="exampleIsOpen"
     title="Install Plugin"
     @canceled="exampleIsOpen = false" >
-    <template v-slot:header-icon>
-      <KIcon icon="kong" class="mr-2" />
-    </template>
-    <template v-slot:header-content>
-      Install Plugin
-    </template>
-    <template v-slot:body-header-description>
-      <h2>Select a plugin</h2>
-      <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
-    </template>
-    <template v-slot:actionButtons>
-      <KButton appearance="secondary" size="small">Back</KButton>
-      <KButton appearance="outline" size="small">Save</KButton>
-    </template>
-    <template v-slot:body-content>
-      <h3>Security</h3>
-      <KCardCatalog :items="getItems(8)" />
-      <h3>Authentication</h3>
-      <KCardCatalog :items="getItems(16)" />
-    </template>
+      <template v-slot:header-icon>
+        <KIcon icon="kong" class="mr-2" />
+      </template>
+      <template v-slot:header-content>
+        Install Plugin
+      </template>
+      <template v-slot:body-header-description>
+        <p>Select a plugin</p>
+        <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+      </template>
+      <template v-slot:actionButtons>
+        <KButton appearance="secondary" size="small">Back</KButton>
+        <KButton appearance="primary" size="small">Save</KButton>
+      </template>
+      <template v-slot:body-content>
+        <h3>Security</h3>
+        <KCardCatalog :items="getItems(8)" />
+        <h3>Authentication</h3>
+        <KCardCatalog :items="getItems(16)" />
+      </template>
     </KModalFullscreen>
 </template>
 
 ```vue
 <template>
   <div>
-  <KModalFullscreen
-    :isVisible="exampleIsOpen"
-    title="Install Plugin"
-    @canceled="exampleIsOpen = false" >
-    <template v-slot:header-icon>
-      <KIcon icon="kong" class="mr-2" />
-    </template>
-    <template v-slot:header-content>
-      Install Plugin
-    </template>
-    <template v-slot:body-header-description>
-      <h2>Select a plugin</h2>
-      <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
-    </template>
-    <template v-slot:actionButtons>
-      <KButton appearance="secondary" size="small">Back</KButton>
-      <KButton appearance="outline" size="small">Save</KButton>
-    </template>
-    <template v-slot:body-content>
-      <h3>Security</h3>
-      <KCardCatalog :items="getItems(8)" />
-      <h3>Authentication</h3>
-      <KCardCatalog :items="getItems(16)" />
-    </template>
-    </KModalFullscreen>
+    <KModalFullscreen
+      :isVisible="exampleIsOpen"
+      title="Install Plugin"
+      @canceled="exampleIsOpen = false" >
+        <template v-slot:header-icon>
+          <KIcon icon="kong" class="mr-2" />
+        </template>
+        <template v-slot:header-content>
+          Install Plugin
+        </template>
+        <template v-slot:body-header-description>
+          <h2>Select a plugin</h2>
+          <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+        </template>
+        <template v-slot:actionButtons>
+          <KButton appearance="secondary" size="small">Back</KButton>
+          <KButton appearance="primary" size="small">Save</KButton>
+        </template>
+        <template v-slot:body-content>
+          <h3>Security</h3>
+          <KCardCatalog :items="getItems(8)" />
+          <h3>Authentication</h3>
+          <KCardCatalog :items="getItems(16)" />
+        </template>
+      </KModalFullscreen>
 
-  <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
+    <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
   </div>
 </template>
+
+<script>
+export default {
+  data () {
+    return {
+      exampleIsOpen: false
+    }
+  }
+}
+</script>
+```
+
+<KButton appearance="primary" @click="sampleIsOpen = true">Open Form Modal</KButton>
+
+<template>
+  <KModalFullscreen
+    :isVisible="sampleIsOpen"
+    title="Install Plugin"
+    @canceled="sampleIsOpen = false" >
+      <template v-slot:header-icon>
+        <KIcon icon="kong" class="mr-2" />
+      </template>
+      <template v-slot:header-content>
+        Install Plugin
+      </template>
+      <template v-slot:body-header-description>
+        <p>Configure a key auth plugin</p>
+        <p>Lorem ipsum factum. <a>View documentation</a></p>
+      </template>
+      <template v-slot:actionButtons>
+        <KButton appearance="secondary" size="small">Back</KButton>
+        <KButton appearance="primary" size="small">Save</KButton>
+      </template>
+      <template v-slot:body-content>
+        <template>
+          <KInputSwitch v-model="checked" label="This plugin is enabled" />
+        </template>
+        <template>
+          <KInput label="Tags" class="mb-2" placeholder="Enter list of tags" />
+          <p class="help">e.g., tag1, tag2, tag3</p>
+        </template>
+        <template>
+          <KInput label="Configure Anonymous" class="mb-2" />
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox1" class="checked">
+            Config key in body
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox2" class="checked">
+            Config key in header
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox3" class="checked">
+            Config key in query
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox4" class="checked">
+            Config hide credentials
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KInput label="Health checks active healthy interval" class="mb-2" placeholder="0" />
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox5" class="checked">
+            Config run on preflight
+          </KCheckbox>
+        </template>
+      </template>
+    </KModalFullscreen>
+</template>
+
+```vue
+<template>
+ <KButton appearance="primary" @click="sampleIsOpen = true">Open Form Modal</KButton>
+
+<template>
+  <KModalFullscreen
+    :isVisible="sampleIsOpen"
+    title="Install Plugin"
+    @canceled="sampleIsOpen = false" >
+      <template v-slot:header-icon>
+        <KIcon icon="kong" class="mr-2" />
+      </template>
+      <template v-slot:header-content>
+        Install Plugin
+      </template>
+      <template v-slot:body-header-description>
+        <p>Configure a key auth plugin</p>
+        <p>Lorem ipsum factum. <a>View documentation</a></p>
+      </template>
+      <template v-slot:actionButtons>
+        <KButton appearance="secondary" size="small">Back</KButton>
+        <KButton appearance="primary" size="small">Save</KButton>
+      </template>
+      <template v-slot:body-content>
+        <template>
+          <KInputSwitch v-model="checked" label="This plugin is enabled" />
+        </template>
+        <template>
+          <KInput label="Tags" class="mb-2" placeholder="Enter list of tags" />
+          <p class="help">e.g., tag1, tag2, tag3</p>
+        </template>
+        <template>
+          <KInput label="Configure Anonymous" class="mb-2" />
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox1" class="checked">
+            Config key in body
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox2" class="checked">
+            Config key in header
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox3" class="checked">
+            Config key in query
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox4" class="checked">
+            Config hide credentials
+          </KCheckbox>
+        </template>
+          <br><br>
+        <template>
+          <KInput label="Health checks active healthy interval" class="mb-2" placeholder="0" />
+        </template>
+          <br><br>
+        <template>
+          <KCheckbox v-model="checkedBox5" class="checked">
+            Config run on preflight
+          </KCheckbox>
+        </template>
+      </template>
+    </KModalFullscreen>
+</template>
+</template>
+
 <script>
 export default {
   data () {
@@ -157,27 +325,47 @@ export default {
 An Example of changing the the colors of KModalFullscreen might look like.  
 > Note: We are scoping the overrides to a wrapper in this example
 
-<template>
-  <div class="modal-wrapper">
-    <KModalFullscreen
-      :isVisible="themeIsOpen"
-      title="Hello There!"
-      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula."
-      @canceled="themeIsOpen = false" />
-    <KButton @click="themeIsOpen = true">Open Modal</KButton>
-  </div>
+<KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
+
+  <template>
+    <div class="modal-wrapper">
+      <KModalFullscreen
+        title="Hello There!"
+        :isVisible="themeIsOpen"
+        @canceled="themeIsOpen = false" >
+          <template v-slot:body-content>
+            <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+            <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+            <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+            <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+            <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+            <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+          </template>
+        </KModalFullscreen>
+    </div>
 </template>
 
 ```vue
+
 <template>
-  <div class="modal-wrapper">
-    <KModalFullscreen
-      :isVisible="themeIsOpen"
-      title="Hello There!"
-      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula."
-      @canceled="themeIsOpen = false" />
-    <KButton @click="themeIsOpen = true">Open Modal</KButton>
-  </div>
+  <KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
+    <template>
+      <div class="modal-wrapper">
+        <KModalFullscreen
+          title="Hello There!"
+          :isVisible="themeIsOpen"
+          @canceled="themeIsOpen = false" >
+            <template v-slot:body-content>
+              <p>Proin in magna quam. Sed congue diam nec libero pretium, at lobortis erat dapibus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Suspendisse id gravida tellus. Quisque venenatis ligula lobortis dui viverra, sed pellentesque quam molestie. Nulla viverra vel nunc ut blandit. Donec eget luctus nisl, ut dapibus risus. Nulla eros diam, finibus eu dignissim id, vehicula eu odio. Sed egestas eu sem a vestibulum. In nisl mi, tincidunt ut mi eu, suscipit faucibus eros.</p>
+              <p>Curabitur semper vitae neque elementum imperdiet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi urna felis, feugiat vitae quam quis, rhoncus vestibulum est. Vivamus diam neque, dictum vel urna nec, faucibus aliquet ipsum. Integer sodales ornare purus, sit amet efficitur elit. Fusce feugiat pharetra mollis. Proin sit amet metus sed massa laoreet feugiat eu id enim. Duis egestas lectus in dapibus accumsan.</p>
+              <p>Maecenas rutrum molestie dolor, sit amet volutpat sapien tristique vitae. Nam tortor nulla, malesuada vel lacus ut, consectetur sagittis nisi. Vestibulum convallis rhoncus ipsum, vitae porta nulla pharetra quis. Nam tristique eget metus sit amet blandit. Suspendisse porta nunc ut dapibus finibus. In hac habitasse platea dictumst. Morbi vel lectus vulputate, cursus augue ultrices, vulputate massa. Pellentesque bibendum et augue et placerat. Duis a est et quam blandit ornare. Phasellus quis mi eget magna vehicula pharetra eu et nunc. In hac habitasse platea dictumst. Nam eleifend purus ante, in porta mauris vulputate eget. Nunc in nulla aliquet metus vehicula rhoncus.</p>
+              <p>Praesent fringilla sapien vitae faucibus vestibulum. Integer viverra hendrerit purus quis consequat. Phasellus dolor enim, interdum in faucibus ut, congue eu quam. Donec eu metus eget eros accumsan feugiat. Donec a magna posuere, sagittis eros ac, bibendum erat. Donec aliquet velit et nunc mattis tincidunt. Nam eu nibh nec purus pretium fermentum. Proin interdum nunc ac turpis blandit, sed malesuada lectus convallis. Morbi quis aliquet lorem, non ultrices quam. Aliquam et consectetur lorem. Nam ac nisl tellus. Duis id nunc lectus. Etiam semper auctor enim, id hendrerit nisl vulputate nec.</p>
+              <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
+              <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
+            </template>
+          </KModalFullscreen>
+      </div>
+  </template>
 </template>
 
 <style>
@@ -203,9 +391,16 @@ An Example of changing the the colors of KModalFullscreen might look like.
 export default {
   data () {
     return {
+      checked: true,
+      checkedBox1: false,
+      checkedBox2: true,
+      checkedBox3: false,
+      checkedBox4: true,
+      checkedBox5: true,
       defaultIsOpen: false,
       exampleIsOpen: false,
       themeIsOpen: false,
+      sampleIsOpen: false,
       getItems
     }
   },
@@ -217,5 +412,17 @@ export default {
 .modal-wrapper {
   --KModalFullscreenHeaderColor: red;
   --KModalFullscreenColor: green;
+}
+
+.divider {
+  margin-top: 21px;
+  margin-bottom: 25px;
+}
+
+.k-switch {
+  border-top: 1px solid #eaecef;
+  padding-top: 26px;
+  border-bottom: 1px solid #eaecef;
+  padding-bottom: 26px;
 }
 </style>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -58,10 +58,6 @@ Text displayed in header.
 
 Text to display Page title and description.
 
-### type
-
-This prompt determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
-
 ### content
 
 Sets the text of the body content if not using slot.
@@ -141,7 +137,6 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   <template v-slot:action-buttons>
     <KButton appearance="secondary" size="medium" @click="exampleIsOpen = false">Back</KButton>
     <KButton appearance="primary" size="medium" @click="exampleIsOpen = false">Save</KButton>
-    <KButton appearance="outline" size="medium" @click="exampleIsOpen = false">Do It</KButton>
   </template>
   <template v-slot:body-content>
     <h3>Security</h3>
@@ -168,7 +163,6 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   <template v-slot:action-buttons>
     <KButton appearance="secondary" size="medium" @click="exampleIsOpen = false">Back</KButton>
     <KButton appearance="primary" size="medium" @click="exampleIsOpen = false">Save</KButton>
-    <KButton appearance="outline" size="medium" @click="exampleIsOpen = false">Do It</KButton>
   </template>
   <template v-slot:body-content>
     <h3>Security</h3>
@@ -186,7 +180,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   title="Install Plugin"
   @canceled="sampleIsOpen = false"
   @proceed="sampleIsOpen = false"
-  cancelButtonAppearance="creation"
+  cancelButtonAppearance="secondary"
   actionButtonText="Delete"
   actionButtonAppearance="danger" >
   <template v-slot:header-icon>
@@ -202,8 +196,8 @@ There are 5 designated slots you can use to display content in the fullscreen mo
     </div>
   </template>
   <template v-slot:action-buttons>
-    <KButton appearance="secondary" size="medium" @click="sampleIsOpen = false">Back</KButton>
-    <KButton appearance="outline" size="medium" @click="sampleIsOpen = false">Save</KButton>
+    <KButton size="medium" @click="sampleIsOpen = false">Back</KButton>
+    <KButton appearance="creation" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
   <template v-slot:body-content>
     <div class="display">
@@ -255,7 +249,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   title="Install Plugin"
   @canceled="sampleIsOpen = false"
   @proceed="sampleIsOpen = false"
-  cancelButtonAppearance="creation"
+  cancelButtonAppearance="secondary"
   actionButtonText="Delete"
   actionButtonAppearance="danger" >
   <template v-slot:header-icon>
@@ -271,8 +265,8 @@ There are 5 designated slots you can use to display content in the fullscreen mo
     </div>
   </template>
   <template v-slot:action-buttons>
-    <KButton appearance="secondary" size="medium" @click="sampleIsOpen = false">Back</KButton>
-    <KButton appearance="outline" size="medium" @click="sampleIsOpen = false">Save</KButton>
+    <KButton size="medium" @click="sampleIsOpen = false">Back</KButton>
+    <KButton appearance="creation" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
   <template v-slot:body-content>
     <div class="display">

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -76,11 +76,15 @@ Change the text content of the close/cancel button.
 
 ### cancelButtonAppearance
 
-Sets the appearance of the close/cancel button.
+Sets the [appearance](/components/button.html#props) of the close/cancel button.
 
 ### actionButtonText
 
 Change the text content of the save/proceed button.
+
+### actionButtonAppearance
+
+Change the [appearance](/components/button.html#props) of the save/proceed button.
 
 <KButton appearance="primary" @click="contentIsOpen = true">Open Modal</KButton>
 
@@ -181,7 +185,10 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   :isVisible="sampleIsOpen"
   title="Install Plugin"
   @canceled="sampleIsOpen = false"
-  @proceed="sampleIsOpen = false" >
+  @proceed="sampleIsOpen = false"
+  cancelButtonAppearance="creation"
+  actionButtonText="Delete"
+  actionButtonAppearance="danger" >
   <template v-slot:header-icon>
     <KIcon icon="kong" class="mr-2" />
   </template>
@@ -196,7 +203,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   </template>
   <template v-slot:action-buttons>
     <KButton appearance="secondary" size="medium" @click="sampleIsOpen = false">Back</KButton>
-    <KButton appearance="primary" size="medium" @click="sampleIsOpen = false">Save</KButton>
+    <KButton appearance="outline" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
   <template v-slot:body-content>
     <div class="display">
@@ -206,13 +213,11 @@ There are 5 designated slots you can use to display content in the fullscreen mo
         <input type="text" placeholder="Enter list of tags">
         <label for="">Tags</label>
       </div>
-      <!-- <KInput label="Tags" class="mb-2 display-items" placeholder="Enter list of tags" /> -->
       <p class="help display-items">e.g., tag1, tag2, tag3</p>
       <div class="wrapper display-items">
         <input type="text" >
         <label for="">Config anonymous</label>
       </div>
-      <!-- <KInput label="Configure Anonymous" class="mb-2 display-items" :style="{ width: '20px' }"  /> -->
       <br><br>
       <KCheckbox v-model="checkedBox1" class="checked display-items">
         Config key in body
@@ -234,7 +239,6 @@ There are 5 designated slots you can use to display content in the fullscreen mo
         <input type="text" placeholder="0" />
         <label for="">Health checks active healthy interval</label>
       </div>
-      <!-- <KInput label="Health checks active healthy interval" class="mb-2 display-items" placeholder="0" /> -->
       <br><br>
       <KCheckbox v-model="checkedBox5" class="checked display-items">
         Config run on preflight
@@ -250,7 +254,10 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   :isVisible="sampleIsOpen"
   title="Install Plugin"
   @canceled="sampleIsOpen = false"
-  @proceed="sampleIsOpen = false" >
+  @proceed="sampleIsOpen = false"
+  cancelButtonAppearance="creation"
+  actionButtonText="Delete"
+  actionButtonAppearance="danger" >
   <template v-slot:header-icon>
     <KIcon icon="kong" class="mr-2" />
   </template>
@@ -265,7 +272,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   </template>
   <template v-slot:action-buttons>
     <KButton appearance="secondary" size="medium" @click="sampleIsOpen = false">Back</KButton>
-    <KButton appearance="primary" size="medium" @click="sampleIsOpen = false">Save</KButton>
+    <KButton appearance="outline" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
   <template v-slot:body-content>
     <div class="display">
@@ -275,13 +282,11 @@ There are 5 designated slots you can use to display content in the fullscreen mo
         <input type="text" placeholder="Enter list of tags">
         <label for="">Tags</label>
       </div>
-      <!-- <KInput label="Tags" class="mb-2 display-items" placeholder="Enter list of tags" /> -->
       <p class="help display-items">e.g., tag1, tag2, tag3</p>
       <div class="wrapper display-items">
         <input type="text" >
         <label for="">Config anonymous</label>
       </div>
-      <!-- <KInput label="Configure Anonymous" class="mb-2 display-items" :style="{ width: '20px' }"  /> -->
       <br><br>
       <KCheckbox v-model="checkedBox1" class="checked display-items">
         Config key in body
@@ -303,7 +308,6 @@ There are 5 designated slots you can use to display content in the fullscreen mo
         <input type="text" placeholder="0" />
         <label for="">Health checks active healthy interval</label>
       </div>
-      <!-- <KInput label="Health checks active healthy interval" class="mb-2 display-items" placeholder="0" /> -->
       <br><br>
       <KCheckbox v-model="checkedBox5" class="checked display-items">
         Config run on preflight

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -126,7 +126,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
 <KModalFullscreen
   :isVisible="exampleIsOpen"
   title="Install Plugin"
-  @canceled="exampleIsOpen = false" iconHeader="immunity">
+  @canceled="exampleIsOpen = false" iconString="immunity">
   <template v-slot:header-content>
     Install Plugin
   </template>
@@ -152,7 +152,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
 <KModalFullscreen
   :isVisible="exampleIsOpen"
   title="Install Plugin"
-  @canceled="exampleIsOpen = false" iconHeader="immunity">
+  @canceled="exampleIsOpen = false" iconString="immunity">
   <template v-slot:header-content>
     Install Plugin
   </template>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -116,7 +116,7 @@ Change the text content of the save/proceed button.
 
 There are 5 designated slots you can use to display content in the fullscreen modal.
 
-- `header-content` 
+- `header-content`
 - `action-buttons` - Contains action buttons which are right-aligned.
 - `body-header-description`
 - `body-content`

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -270,29 +270,42 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   <template v-slot:body-content>
     <div class="display">
       <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
-      <KInput label="Tags" class="mb-2 trial-items" placeholder="Enter list of tags" />
-      <p class="help trial-items">e.g., tag1, tag2, tag3</p>
-      <KInput label="Configure Anonymous" class="mb-2 trial-items" :style="{ width: '20px' }"  />
       <br><br>
-      <KCheckbox v-model="checkedBox1" class="checked trial-items">
+      <div class="wrapper display-items">
+        <input type="text" placeholder="Enter list of tags">
+        <label for="">Tags</label>
+      </div>
+      <!-- <KInput label="Tags" class="mb-2 display-items" placeholder="Enter list of tags" /> -->
+      <p class="help display-items">e.g., tag1, tag2, tag3</p>
+      <div class="wrapper display-items">
+        <input type="text" >
+        <label for="">Config anonymous</label>
+      </div>
+      <!-- <KInput label="Configure Anonymous" class="mb-2 display-items" :style="{ width: '20px' }"  /> -->
+      <br><br>
+      <KCheckbox v-model="checkedBox1" class="checked display-items">
         Config key in body
       </KCheckbox>
       <br><br>
-      <KCheckbox v-model="checkedBox2" class="checked trial-items">
+      <KCheckbox v-model="checkedBox2" class="checked display-items">
         Config key in header
       </KCheckbox>
       <br><br>
-      <KCheckbox v-model="checkedBox3" class="checked trial-items">
+      <KCheckbox v-model="checkedBox3" class="checked display-items">
         Config key in query
       </KCheckbox>
       <br><br>
-      <KCheckbox v-model="checkedBox4" class="checked trial-items">
+      <KCheckbox v-model="checkedBox4" class="checked display-items">
         Config hide credentials
       </KCheckbox>
       <br><br>
-      <KInput label="Health checks active healthy interval" class="mb-2 trial-items" placeholder="0" />
+      <div class="wrapper display-items">
+        <input type="text" placeholder="0" />
+        <label for="">Health checks active healthy interval</label>
+      </div>
+      <!-- <KInput label="Health checks active healthy interval" class="mb-2 display-items" placeholder="0" /> -->
       <br><br>
-      <KCheckbox v-model="checkedBox5" class="checked trial-items">
+      <KCheckbox v-model="checkedBox5" class="checked display-items">
         Config run on preflight
       </KCheckbox>
     </div>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -1,71 +1,221 @@
 # KModalFullscreen
 
-**KModalFullscreen** - A Fullscreen Modal
+The **KModalFullscreen** component is used to show content in a full screen modal on top of existing UI.
 
-<KModalFullscreen />
+<KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
+
+<template>
+  <KModalFullscreen
+    title="Hello There!"
+    content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est."
+    :isVisible="defaultIsOpen"
+    @canceled="defaultIsOpen = false" />
+</template>
+
 ```vue
-<KModalFullscreen />
+<template>
+  <div>
+    <KModalFullscreen
+      title="Hello There!"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est."
+      :isVisible="isVisible"
+      @canceled="isVisible = false" />
+    
+    <KButton
+      appearance="primary"
+      @click="isVisible = true">Open Modal</KButton>
+  </div>
+</template>
+<script>
+export default {
+  data () {
+    return {
+      isVisible: false
+    }
+  }
+}
+</script>
 ```
 
 ## Props
 
-### Prop1
+### Functional
 
-Description of prop1
+- `isVisible` - Tells the component whether or not to render the open modal
+- `@canceled` - Emitted when cancel/close button is clicked
 
-Actual component using prop1
-<KModalFullscreen />
+### Content
 
-```vue
-<KModalFullscreen prop1="variation1" />
-<KModalFullscreen prop1="variation2" />
-<KModalFullscreen prop1="variation3" />
-```
+- `title` - Text displayed in header if not using slot (**Note**: this field is still required for accessibility reasons even if using the slot)
+- `hideTitle` - If not using the `header-content` slot, tells the component whether or not to display the title
+- `content` - Text to display in content if not using slot
+
+### Buttons & Appearance
+
+- `cancelButtonText` - Change the text content of the close/cancel button
+- `cancelButtonAppearance` - Change the [appearance](/components/button.html#props) of the cancel button
 
 ## Slots
 
-- `default` - default slot description
-- `slot1` - slot1 description
+There are 3 designated slots you can use to display content in the fullscreen modal.
+
+- `header-content`
+- `body-content`  
+- `actionButtons` - Contains action buttons which are right-aligned.
+
+---
+
+### Usage
+
+Using both the provided props and slot options we will now demonstrate how to customize the fullscreen modal.
+Notice that even though we are using the `header-content` slot we still specify the `title` attribute for accessibility.
+
+<KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
+
+<template>
+  <KModalFullscreen
+    :isVisible="exampleIsOpen"
+    title="Install Plugin"
+    @canceled="exampleIsOpen = false" >
+    <template v-slot:header-icon>
+      <KIcon icon="kong" class="mr-2" />
+    </template>
+    <template v-slot:header-content>
+      Install Plugin
+    </template>
+    <template v-slot:body-header-description>
+      <h2>Select a plugin</h2>
+      <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+    </template>
+    <template v-slot:actionButtons>
+      <KButton appearance="secondary" size="small">Back</KButton>
+      <KButton appearance="outline" size="small">Save</KButton>
+    </template>
+    <template v-slot:body-content>
+      <h3>Security</h3>
+      <KCardCatalog :items="getItems(8)" />
+      <h3>Authentication</h3>
+      <KCardCatalog :items="getItems(16)" />
+    </template>
+    </KModalFullscreen>
+</template>
 
 ```vue
-<KModalFullscreen>
-  here is some slot content
-</KModalFullscreen>
+<template>
+  <div>
+  <KModalFullscreen
+    :isVisible="exampleIsOpen"
+    title="Install Plugin"
+    @canceled="exampleIsOpen = false" >
+    <template v-slot:header-icon>
+      <KIcon icon="kong" class="mr-2" />
+    </template>
+    <template v-slot:header-content>
+      Install Plugin
+    </template>
+    <template v-slot:body-header-description>
+      <h2>Select a plugin</h2>
+      <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+    </template>
+    <template v-slot:actionButtons>
+      <KButton appearance="secondary" size="small">Back</KButton>
+      <KButton appearance="outline" size="small">Save</KButton>
+    </template>
+    <template v-slot:body-content>
+      <h3>Security</h3>
+      <KCardCatalog :items="getItems(8)" />
+      <h3>Authentication</h3>
+      <KCardCatalog :items="getItems(16)" />
+    </template>
+    </KModalFullscreen>
+
+  <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
+  </div>
+</template>
+<script>
+export default {
+  data () {
+    return {
+      exampleIsOpen: false
+    }
+  }
+}
+</script>
 ```
 
 ## Theming
 
 | Variable | Purpose
 |:-------- |:-------
-| `--KModalFullscreenBorderColor`| KModalFullscreen border color
+| `--KModalFullscreenMaxWidth` | Modal max width
+| `--KModalFullscreenHeaderColor` | Header text color
+| `--KModalFullscreenHeaderSize` | Header font size
+| `--KModalFullscreenHeaderWeight` | Header font weight
+| `--KModalFullscreenColor`| Main content text color
+| `--KModalFullscreenFontSize`| Main content text size
 
-An Example of changing the border color of KModalFullscreen to lime might look
-like:
-
+An Example of changing the the colors of KModalFullscreen might look like.  
 > Note: We are scoping the overrides to a wrapper in this example
 
 <template>
-  <div class="KModalFullscreen-wrapper">
-    <KModalFullscreen />
+  <div class="modal-wrapper">
+    <KModalFullscreen
+      :isVisible="themeIsOpen"
+      title="Hello There!"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula."
+      @canceled="themeIsOpen = false" />
+    <KButton @click="themeIsOpen = true">Open Modal</KButton>
   </div>
 </template>
 
 ```vue
 <template>
-  <div class="KModalFullscreen-wrapper">
-    <KModalFullscreen />
+  <div class="modal-wrapper">
+    <KModalFullscreen
+      :isVisible="themeIsOpen"
+      title="Hello There!"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula."
+      @canceled="themeIsOpen = false" />
+    <KButton @click="themeIsOpen = true">Open Modal</KButton>
   </div>
 </template>
 
 <style>
-.KModalFullscreen-wrapper {
-  --KModalFullscreen-wrapperBorderColor: lime;
+.modal-wrapper {
+  --KModalFullscreenHeaderColor: red;
+  --KModalFullscreenColor: green;
 }
 </style>
 ```
 
-<style lang="scss">
-.KModalFullscreen-wrapper {
-  --KModalFullscreen-wrapperBorderColor: lime;
+<script>
+  function getItems(count) {
+  let myItems = []
+    for (let i = 0; i < count; i++) {
+      myItems.push({
+      title: "Item " + i,
+      description: "The item's description for number " + i
+      })
+    }
+  return myItems
+}
+
+export default {
+  data () {
+    return {
+      defaultIsOpen: false,
+      exampleIsOpen: false,
+      themeIsOpen: false,
+      getItems
+    }
+  },
+  
+}
+</script>
+
+<style scoped lang="scss">
+.modal-wrapper {
+  --KModalFullscreenHeaderColor: red;
+  --KModalFullscreenColor: green;
 }
 </style>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -1,0 +1,71 @@
+# KModalFullscreen
+
+**KModalFullscreen** - A Fullscreen Modal
+
+<KModalFullscreen />
+```vue
+<KModalFullscreen />
+```
+
+## Props
+
+### Prop1
+
+Description of prop1
+
+Actual component using prop1
+<KModalFullscreen />
+
+```vue
+<KModalFullscreen prop1="variation1" />
+<KModalFullscreen prop1="variation2" />
+<KModalFullscreen prop1="variation3" />
+```
+
+## Slots
+
+- `default` - default slot description
+- `slot1` - slot1 description
+
+```vue
+<KModalFullscreen>
+  here is some slot content
+</KModalFullscreen>
+```
+
+## Theming
+
+| Variable | Purpose
+|:-------- |:-------
+| `--KModalFullscreenBorderColor`| KModalFullscreen border color
+
+An Example of changing the border color of KModalFullscreen to lime might look
+like:
+
+> Note: We are scoping the overrides to a wrapper in this example
+
+<template>
+  <div class="KModalFullscreen-wrapper">
+    <KModalFullscreen />
+  </div>
+</template>
+
+```vue
+<template>
+  <div class="KModalFullscreen-wrapper">
+    <KModalFullscreen />
+  </div>
+</template>
+
+<style>
+.KModalFullscreen-wrapper {
+  --KModalFullscreen-wrapperBorderColor: lime;
+}
+</style>
+```
+
+<style lang="scss">
+.KModalFullscreen-wrapper {
+  --KModalFullscreen-wrapperBorderColor: lime;
+}
+</style>

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -158,7 +158,7 @@ export default {
   width: auto;
   max-width: var(--KModalMaxWidth, 500px);
   margin: 50px auto;
-  padding: var(--spacing-xl, spacing(xl));
+  padding: var(--spacing-xl, spacing(xl)) 0 15px 0;
   border-radius: 3px;
   border: var(--KModalBorder);
   box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -158,7 +158,7 @@ export default {
   width: auto;
   max-width: var(--KModalMaxWidth, 500px);
   margin: 50px auto;
-  padding: var(--spacing-xl, spacing(xl)) 0 15px 0;
+  padding: var(--spacing-xl, spacing(xl));
   border-radius: 3px;
   border: var(--KModalBorder);
   box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));

--- a/packages/KModalFullscreen/KModalFullscreen.spec.js
+++ b/packages/KModalFullscreen/KModalFullscreen.spec.js
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils'
+import KModalFullscreen from '@/KModalFullscreen/KModalFullscreen'
+
+describe('KModalFullscreen', () => {
+  it('matches snapshot', () => {
+    const wrapper = mount(KModalFullscreen)
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/KModalFullscreen/KModalFullscreen.spec.js
+++ b/packages/KModalFullscreen/KModalFullscreen.spec.js
@@ -2,8 +2,109 @@ import { mount } from '@vue/test-utils'
 import KModalFullscreen from '@/KModalFullscreen/KModalFullscreen'
 
 describe('KModalFullscreen', () => {
+  it('renders proper content when using slots', () => {
+    const headerText = 'This is some header text'
+    const bodyText = 'This is some body text'
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        isVisible: true,
+        title: headerText
+      },
+      slots: {
+        'header-content': `<div>${headerText}</div>`,
+        'body-content': `<div>${bodyText}</div>`
+      }
+    })
+
+    expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(headerText))
+    expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(bodyText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('hides the title when using hideTitle prop', () => {
+    const titleText = "You can't see me"
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        isVisible: true,
+        title: titleText,
+        hideTitle: true
+      }
+    })
+
+    expect(wrapper.find('.k-modal-title').exists()).toBeFalsy()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders proper content when using action-buttons slot', () => {
+    const actionButtonsText = 'This is some action buttons text'
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        isVisible: true,
+        title: 'Test Me'
+      },
+      slots: {
+        'actionButtons': `<div>${actionButtonsText}</div>`
+      }
+    })
+
+    expect(wrapper.find('.k-modal-action').html()).toEqual(expect.stringContaining(actionButtonsText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders proper content when using props', () => {
+    const title = 'Sweet prop title'
+    const content = 'Sweet prop content'
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        isVisible: true,
+        title,
+        content
+      }
+    })
+
+    expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(content))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('emits close when hitting escape', () => {
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        title: 'Test Me',
+        isVisible: true
+      },
+      attachToDocument: true
+    })
+
+    wrapper.find('.k-modal').trigger('keydown.esc')
+    expect(wrapper.emitted().canceled).toHaveLength(1)
+  })
+
+  it('tears down event listeners', () => {
+    const AEL = jest.fn()
+    const REL = jest.fn()
+
+    window.document.addEventListener = AEL
+    window.document.removeEventListener = REL
+
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        title: 'Test Me'
+      },
+      attachToDocument: true
+    })
+
+    wrapper.destroy()
+    expect(AEL).toHaveBeenCalledTimes(1)
+    expect(REL).toHaveBeenCalledTimes(1)
+  })
+
   it('matches snapshot', () => {
-    const wrapper = mount(KModalFullscreen)
+    const wrapper = mount(KModalFullscreen, {
+      propsData: {
+        title: 'Test Me'
+      }
+    })
 
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/packages/KModalFullscreen/KModalFullscreen.spec.js
+++ b/packages/KModalFullscreen/KModalFullscreen.spec.js
@@ -16,8 +16,8 @@ describe('KModalFullscreen', () => {
       }
     })
 
-    expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(headerText))
-    expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(bodyText))
+    expect(wrapper.find('.k-modal-fullscreen-header').html()).toEqual(expect.stringContaining(headerText))
+    expect(wrapper.find('.k-modal-fullscreen-body').html()).toEqual(expect.stringContaining(bodyText))
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -33,7 +33,7 @@ describe('KModalFullscreen', () => {
       }
     })
 
-    expect(wrapper.find('.k-modal-action').html()).toEqual(expect.stringContaining(actionButtonsText))
+    expect(wrapper.find('.k-modal-fullscreen-action').html()).toEqual(expect.stringContaining(actionButtonsText))
     expect(wrapper.html()).toMatchSnapshot()
   })
 
@@ -48,8 +48,8 @@ describe('KModalFullscreen', () => {
       }
     })
 
-    expect(wrapper.find('.k-modal-header').html()).toEqual(expect.stringContaining(title))
-    expect(wrapper.find('.k-modal-body').html()).toEqual(expect.stringContaining(content))
+    expect(wrapper.find('.k-modal-fullscreen-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.k-modal-fullscreen-body').html()).toEqual(expect.stringContaining(content))
     expect(wrapper.html()).toMatchSnapshot()
   })
 

--- a/packages/KModalFullscreen/KModalFullscreen.spec.js
+++ b/packages/KModalFullscreen/KModalFullscreen.spec.js
@@ -21,20 +21,6 @@ describe('KModalFullscreen', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
 
-  it('hides the title when using hideTitle prop', () => {
-    const titleText = "You can't see me"
-    const wrapper = mount(KModalFullscreen, {
-      propsData: {
-        isVisible: true,
-        title: titleText,
-        hideTitle: true
-      }
-    })
-
-    expect(wrapper.find('.k-modal-title').exists()).toBeFalsy()
-    expect(wrapper.html()).toMatchSnapshot()
-  })
-
   it('renders proper content when using action-buttons slot', () => {
     const actionButtonsText = 'This is some action buttons text'
     const wrapper = mount(KModalFullscreen, {
@@ -43,7 +29,7 @@ describe('KModalFullscreen', () => {
         title: 'Test Me'
       },
       slots: {
-        'actionButtons': `<div>${actionButtonsText}</div>`
+        'action-buttons': `<div>${actionButtonsText}</div>`
       }
     })
 
@@ -76,7 +62,7 @@ describe('KModalFullscreen', () => {
       attachToDocument: true
     })
 
-    wrapper.find('.k-modal').trigger('keydown.esc')
+    wrapper.find('.k-modal-fullscreen').trigger('keydown.esc')
     expect(wrapper.emitted().canceled).toHaveLength(1)
   })
 

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -255,7 +255,6 @@ $screen-md: 992px;
 
 .k-modal-body-description,
 .k-modal-body {
-  margin-top: 56px;
   margin-left: 230px;
   margin-right: 230px;
   color: var(--KModalFullscreenColor, var(--black-500, color(black-500)));

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -26,19 +26,22 @@
             </span>
           </div>
           <div class="k-modal-action ml-3">
-            <slot name="action-buttons">
-              <KButton
-                appearance="outline"
-                class=" mr-2"
-                @click="close">
-                {{ cancelButtonText }}
-              </KButton>
-              <KButton
-                :appearance="type === 'danger' ? 'danger' : 'primary'"
-                @click="proceed">
-                {{ actionButtonText }}
-              </KButton>
-            </slot>
+            <KButton
+              :appearance="cancelButtonAppearance"
+              @click="close"
+              @keyup.esc="close">
+              {{ cancelButtonText }}
+            </KButton>
+            <div class="k-modal-action-buttons">
+              <slot name="action-buttons">
+                <KButton
+                  :appearance="actionButtonAppearance"
+                  @click="proceed"
+                  @keyup.enter="proceed">
+                  {{ actionButtonText }}
+                </KButton>
+              </slot>
+            </div>
           </div>
         </div>
         <div>
@@ -78,17 +81,6 @@ export default {
       type: String,
       default: ''
     },
-    type: {
-      type: String,
-      default: 'info',
-      validator: (value) => {
-        return [
-          'info',
-          'warning',
-          'danger'
-        ].includes(value)
-      }
-    },
     /**
      * Set the text of the body content
      */
@@ -110,9 +102,19 @@ export default {
       type: String,
       default: 'Cancel'
     },
+    /**
+     * Set the text of the action/proceed button
+     */
     actionButtonText: {
       type: String,
       default: 'Save'
+    },
+    /**
+     * Set the appearance of the action/proceed button
+     */
+    actionButtonAppearance: {
+      type: String,
+      default: 'primary'
     },
     /**
      * Set the appearance of the close/cancel button
@@ -149,20 +151,6 @@ export default {
 
   mounted () {
     document.addEventListener('keydown', this.handleKeydown)
-    // window.onbeforeunload = function () {
-    //   return self.form_dirty ? 'If you leave this page you will lose your unsaved changes.' : null
-    // }
-
-    // window.onbeforeunload = function () {
-    //   return 'handle your events or msgs here'
-    // }
-
-    // window.addEventListener('beforeunload', function (e) {
-    //   // Cancel the event
-    //   e.preventDefault() // If you prevent default behavior in Mozilla Firefox prompt will always be shown
-    //   // Chrome requires returnValue to be set
-    //   e.returnValue = ''
-    // })
   },
 
   beforeDestroy () {
@@ -289,6 +277,10 @@ $screen-md: 992px;
 .header-content {
   display: inline-block;
   margin-top: var(--spacing-xxs, spacing(xxs))
+}
+
+.k-modal-action-buttons {
+    margin-left: auto;
 }
 
 @media only screen and (max-width: $screen-md) {

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -106,7 +106,7 @@ export default {
       default: 'Cancel'
     },
     /**
-     * Set the appearnace of the close/cancel button
+     * Set the appearance of the close/cancel button
      */
     cancelButtonAppearance: {
       type: String,
@@ -181,8 +181,8 @@ export default {
   .k-modal-header-description {
     display: flex;
     align-items: center;
-    font-size: var(--KModalHeaderSize, 20px);
-    font-weight: var(--KModalHeaderWeight, 500);
+    font-size: var(--KModalFullscreenHeaderSize, 20px);
+    font-weight: var(--KModalFullscreenHeaderWeight, 500);
     color: var(--KModalFullscreenHeaderColor, var(--black-500, color(black-500)));
   }
 
@@ -190,7 +190,6 @@ export default {
     text-align: center;
     position: relative;
     flex: 1 1 auto;
-    // margin-bottom: var(--KModalFullscreenBottomMargin, var(--spacing-lg, spacing(lg)));
     font-size: var(--KModalFullscreenFontSize, 13px);
     line-height: 20px;
   }
@@ -225,14 +224,32 @@ export default {
   margin-top: 56px;
   margin-left: 230px;
   margin-right: 230px;
-  color: var(--KModalFullscreenColor, var(--grey-500, color(grey-500)));
+  color: var(--KModalFullscreenColor, var(--black-500, color(black-500)));
+}
+
+.k-modal-body-description {
+  font-size: 32px;
+  line-height: 32px;
+  font-weight: 600;
+
+    p:first-child {
+      margin-bottom: -4px;
+    }
+
+    p:last-child {
+      font-weight: normal;
+      font-size: 14px;
+      line-height: 22px;
+      color: var(--grey-600);
+      margin-top: 20px;
+    }
 }
 
 .k-modal-body-description h2 {
   border: none;
 }
 
-.k-modal.isOpen .k-modal-dialog{
+.k-modal.isOpen .k-modal-dialog {
   overflow-y: auto;
 }
 

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -125,7 +125,6 @@ export default {
 
   watch: {
     isVisible: function () {
-      // whenever this prop gets updated, hide the popper
       if (this.isOpen) {
         document.querySelector('body').style.overflow = 'hidden'
         window.scrollTo(0, 0)
@@ -192,7 +191,7 @@ export default {
     position: relative;
     flex: 1 1 auto;
     // margin-bottom: var(--KModalFullscreenBottomMargin, var(--spacing-lg, spacing(lg)));
-    font-size: var(--KModalFontSize, 13px);
+    font-size: var(--KModalFullscreenFontSize, 13px);
     line-height: 20px;
   }
 }

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -1,26 +1,248 @@
 <template>
   <div
-    v-on="listeners">
-    <span>{{ description }}</span>
-    <slot/>
+    v-if="isVisible"
+    :aria-label="title"
+    class="k-modal isOpen"
+    role="dialog"
+    aria-modal="true">
+    <div
+      class="k-modal-dialog"
+    >
+      <div class="k-modal-header">
+        <div
+          v-if="$scopedSlots.title || !hideTitle"
+          class="k-modal-header-description mb-5"
+          role="heading"
+          aria-level="2">
+          <div class="k-modal-title">
+            <span class="header-icon">
+              <slot name="header-icon"/>
+            </span>
+            <span class="header-content">
+              <slot name="header-content">{{ title }}</slot>
+            </span>
+          </div>
+          <div
+            class="k-modal-action ml-3">
+            <KButton
+              :appearance="cancelButtonAppearance"
+              @click="close"
+              @keyup.esc="close">
+              {{ cancelButtonText }}
+            </KButton>
+            <!-- @slot Use this slot to pass extra buttons other than Cancel  -->
+            <slot
+              v-if="hasActionButtons"
+              name="actionButtons">
+              <KButton
+                size="small"
+                @click="proceed"
+                @keyup.enter="proceed"/>
+            </slot>
+          </div>
+        </div>
+        <div class="divider">
+          <hr>
+        </div>
+      </div>
+      <div class="k-modal-body-description">
+        <slot name="body-header-description">{{ bodyHeaderDescription }}</slot>
+      </div>
+      <div class="k-modal-body">
+        <slot name="body-content">{{ content }}</slot>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
+import KButton from '@kongponents/kbutton/KButton.vue'
+
 export default {
-  name: 'KModalFullscreen',
+  name: 'KModalfullscreen',
+  components: { KButton },
+
   props: {
     /**
-     * Example documentation comment for a prop
+     * Set the text of the title, if using title slot, this text is for the aria-label
      */
-    description: {
+    title: {
       type: String,
-      required: false,
-      default: 'A default description'
+      required: true
+    },
+    /**
+     * Title is required for aria-labelling, toggle if the title is visible on the modal
+     */
+    hideTitle: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * NEW
+     */
+    bodyHeaderDescription: {
+      type: String,
+      default: ''
+    },
+    /**
+     * Set the text of the body content
+     */
+    content: {
+      type: String,
+      default: ''
+    },
+    /**
+      *  Pass whether or not the modal should be visible
+      */
+    isVisible: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Set the text of the close/cancel button
+     */
+    cancelButtonText: {
+      type: String,
+      default: 'Cancel'
+    },
+    /**
+     * Set the appearnace of the close/cancel button
+     */
+    cancelButtonAppearance: {
+      type: String,
+      default: 'outline'
+    }
+  },
+
+  computed: {
+    hasActionButtons () {
+      return !!this.$slots.actionButtons
+    },
+    isOpen () {
+      return !!this.isVisible
+    }
+  },
+
+  watch: {
+    isVisible: function () {
+      // whenever this prop gets updated, hide the popper
+      if (this.isOpen) {
+        document.querySelector('body').style.overflow = 'hidden'
+        window.scrollTo(0, 0)
+      } else {
+        document.querySelector('body').style.overflow = 'visible'
+      }
+    }
+  },
+
+  mounted () {
+    document.addEventListener('keydown', this.handleKeydown)
+  },
+
+  beforeDestroy () {
+    document.removeEventListener('keydown', this.handleKeydown)
+  },
+  methods: {
+    handleKeydown (e) {
+      if (this.isVisible && e.keyCode === 27) {
+        this.close()
+      }
+    },
+    close () {
+      this.$emit('canceled')
+    },
+    proceed () {
+      this.$emit('proceed')
     }
   }
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '~@kongponents/styles/variables';
+
+.k-modal-dialog {
+  padding: 32px 0px 14px 0;
+  background: #fff;
+  z-index: 9999;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100vw;
+}
+
+.k-modal-header {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  margin-top: 15px;
+
+  .k-modal-header-description {
+    display: flex;
+    align-items: center;
+    font-size: var(--KModalHeaderSize, 20px);
+    font-weight: var(--KModalHeaderWeight, 500);
+    color: var(--KModalFullscreenHeaderColor, var(--black-500, color(black-500)));
+  }
+
+  .k-modal-body {
+    text-align: center;
+    position: relative;
+    flex: 1 1 auto;
+    // margin-bottom: var(--KModalFullscreenBottomMargin, var(--spacing-lg, spacing(lg)));
+    font-size: var(--KModalFontSize, 13px);
+    line-height: 20px;
+  }
+}
+
+.k-modal-action {
+  display: inline-flex;
+  position: absolute;
+  right: 32px;
+  & button {
+    height: 30px;
+    margin-left: 16px;
+    font-weight: 400;
+    font-size: 13px;
+    line-height: 13px;
+  }
+}
+
+.k-modal-title {
+  display: inline-flex;
+  position: absolute;
+  left: 36px;
+  margin-top: 7px;
+}
+
+.header-icon {
+  margin-right: 6px;
+}
+
+.k-modal-body-description,
+.k-modal-body {
+  margin-top: 56px;
+  margin-left: 230px;
+  margin-right: 230px;
+  color: var(--KModalFullscreenColor, var(--grey-500, color(grey-500)));
+}
+
+.k-modal-body-description h2 {
+  border: none;
+}
+
+.k-modal.isOpen .k-modal-dialog{
+  overflow-y: auto;
+}
+
+.header-content {
+  display: inline-block;
+  margin-top: 4px;
+}
+
+.divider hr {
+  margin-top: 26px;
+}
 </style>

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -126,10 +126,10 @@ export default {
   watch: {
     isVisible: function () {
       if (this.isOpen) {
-        document.querySelector('body').style.overflow = 'hidden'
+        document.body.style.overflow = this.isOpen ? 'hidden' : ''
         window.scrollTo(0, 0)
       } else {
-        document.querySelector('body').style.overflow = 'visible'
+        document.body.style.overflow = this.isOpen ? 'hidden' : ''
       }
     }
   },
@@ -141,6 +141,10 @@ export default {
   beforeDestroy () {
     document.removeEventListener('keydown', this.handleKeydown)
   },
+  destroyed () {
+    document.body.style.overflow = ''
+  },
+
   methods: {
     handleKeydown (e) {
       if (this.isVisible && e.keyCode === 27) {

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -4,7 +4,9 @@
     :aria-label="title"
     class="k-modal-fullscreen isOpen"
     role="dialog"
-    aria-modal="true">
+    aria-modal="true"
+    @keyup.esc="close"
+    @keyup.enter="proceed" >
     <div
       class="k-modal-fullscreen-dialog"
     >
@@ -27,20 +29,20 @@
           </div>
           <div
             class="k-modal-fullscreen-action ml-3"
-            @click="close"
-            @keyup.esc="close" >
+          >
             <KButton
               :appearance="cancelButtonAppearance"
+              @click="close"
             >
               {{ cancelButtonText }}
             </KButton>
             <div
               class="k-modal-fullscreen-action-buttons"
-              @click="proceed"
-              @keyup.enter="proceed" >
+            >
               <slot name="action-buttons">
                 <KButton
                   :appearance="actionButtonAppearance"
+                  @click="proceed"
                 >
                   {{ actionButtonText }}
                 </KButton>

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -6,38 +6,42 @@
     role="dialog"
     aria-modal="true">
     <div
-      class="k-modal-dialog"
+      class="k-modal-fullscreen-dialog"
     >
-      <div class="k-modal-header">
+      <div class="k-modal-fullscreen-header">
         <div
           v-if="!$scopedSlots.title"
-          class="k-modal-header-description mb-5"
+          class="k-modal-fullscreen-header-description mb-5"
           role="heading"
           aria-level="2">
-          <div class="k-modal-title">
+          <div class="k-modal-fullscreen-title">
             <span
               class="header-icon">
               <KIcon
-                :icon="iconHeader"
+                :icon="iconString"
                 class="mr-2" />
             </span>
             <span class="header-content">
               <slot name="header-content">{{ title }}</slot>
             </span>
           </div>
-          <div class="k-modal-action ml-3">
+          <div
+            class="k-modal-fullscreen-action ml-3"
+            @click="close"
+            @keyup.esc="close" >
             <KButton
               :appearance="cancelButtonAppearance"
-              @click="close"
-              @keyup.esc="close">
+            >
               {{ cancelButtonText }}
             </KButton>
-            <div class="k-modal-action-buttons">
+            <div
+              class="k-modal-fullscreen-action-buttons"
+              @click="proceed"
+              @keyup.enter="proceed" >
               <slot name="action-buttons">
                 <KButton
                   :appearance="actionButtonAppearance"
-                  @click="proceed"
-                  @keyup.enter="proceed">
+                >
                   {{ actionButtonText }}
                 </KButton>
               </slot>
@@ -48,10 +52,10 @@
           <hr>
         </div>
       </div>
-      <div class="k-modal-body-description">
+      <div class="k-modal-fullscreen-body-description">
         <slot name="body-header-description">{{ bodyHeaderDescription }}</slot>
       </div>
-      <div class="k-modal-body">
+      <div class="k-modal-fullscreen-body">
         <slot name="body-content">{{ content }}</slot>
       </div>
     </div>
@@ -124,9 +128,9 @@ export default {
       default: 'outline'
     },
     /**
-      *  Pass whether or not the modal should have icon in the header on the left
+      *  Pass the type of icon for the header on the left
       */
-    iconHeader: {
+    iconString: {
       type: String,
       default: 'kong'
     }
@@ -184,7 +188,7 @@ export default {
 @import '~@kongponents/styles/variables';
 $screen-md: 992px;
 
-.k-modal-dialog {
+.k-modal-fullscreen-dialog {
   padding: var(--spacing-xl, spacing(xl)) 0 14px 0;
   background: var(--white);
   z-index: 9999;
@@ -196,12 +200,12 @@ $screen-md: 992px;
   width: 100vw;
 }
 
-.k-modal-header {
+.k-modal-fullscreen-header {
   position: relative;
   display: flex;
   flex-direction: column;
 
-  .k-modal-header-description {
+  .k-modal-fullscreen-header-description {
     display: flex;
     justify-content: space-between;
     font-size: var(--KModalFullscreenHeaderSize, 20px);
@@ -209,7 +213,7 @@ $screen-md: 992px;
     color: var(--KModalFullscreenHeaderColor, var(--black-500, color(black-500)));
   }
 
-  .k-modal-body {
+  .k-modal-fullscreen-body {
     text-align: center;
     position: relative;
     flex: 1 1 auto;
@@ -218,13 +222,13 @@ $screen-md: 992px;
   }
 }
 
-.k-modal-title {
+.k-modal-fullscreen-title {
   display: inline-flex;
   position: relative;
   margin-left: 36px;
 }
 
-.k-modal-action {
+.k-modal-fullscreen-action {
   display: inline-flex;
   margin-right: var(--spacing-xl, spacing(xl));
    & button {
@@ -241,14 +245,14 @@ $screen-md: 992px;
   border-right: 1px solid var(--grey-300);
 }
 
-.k-modal-body-description,
-.k-modal-body {
+.k-modal-fullscreen-body-description,
+.k-modal-fullscreen-body {
   margin-left: 230px;
   margin-right: 230px;
   color: var(--KModalFullscreenColor, var(--black-500, color(black-500)));
 }
 
-.k-modal-body-description {
+.k-modal-fullscreen-body-description {
   font-size: 32px;
   line-height: 32px;
   font-weight: 600;
@@ -266,11 +270,11 @@ $screen-md: 992px;
     }
 }
 
-.k-modal-body-description h2 {
+.k-modal-fullscreen-body-description h2 {
   border: none;
 }
 
-.k-modal-fullscreen.isOpen .k-modal-dialog {
+.k-modal-fullscreen.isOpen .k-modal-fullscreen-dialog {
   overflow-y: auto;
 }
 
@@ -279,14 +283,14 @@ $screen-md: 992px;
   margin-top: var(--spacing-xxs, spacing(xxs))
 }
 
-.k-modal-action-buttons {
+.k-modal-fullscreen-action-buttons {
     margin-left: auto;
 }
 
 @media only screen and (max-width: $screen-md) {
-  .k-modal-dialog {
-    .k-modal-body-description,
-    .k-modal-body {
+  .k-modal-fullscreen-dialog {
+    .k-modal-fullscreen-body-description,
+    .k-modal-fullscreen-body {
       padding: 0 10%;
       margin: 0 auto;
     }

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -1,0 +1,26 @@
+<template>
+  <div
+    v-on="listeners">
+    <span>{{ description }}</span>
+    <slot/>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'KModalFullscreen',
+  props: {
+    /**
+     * Example documentation comment for a prop
+     */
+    description: {
+      type: String,
+      required: false,
+      default: 'A default description'
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -145,10 +145,10 @@ export default {
   watch: {
     isVisible: function () {
       if (this.isOpen) {
-        document.body.style.overflow = this.isOpen ? 'hidden' : ''
+        document.body.style.overflow = 'hidden'
         window.scrollTo(0, 0)
       } else {
-        document.body.style.overflow = this.isOpen ? 'hidden' : ''
+        document.body.style.overflow = ''
       }
     }
   },

--- a/packages/KModalFullscreen/README.md
+++ b/packages/KModalFullscreen/README.md
@@ -1,0 +1,9 @@
+# @kongponents/kmodalfullscreen
+
+[![](https://img.shields.io/npm/v/@kongponents/kmodalfullscreen.svg?style=flat-square)](https://www.npmjs.com/package/@kongponents/kmodalfullscreen)
+
+```vue
+<KModalFullscreen :description="'hello world'">
+  Hello from a slot
+</KModalFullscreen>
+```

--- a/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
+++ b/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
@@ -4,10 +4,10 @@ exports[`KModalFullscreen matches snapshot 1`] = `undefined`;
 
 exports[`KModalFullscreen renders proper content when using action-buttons slot 1`] = `
 <div aria-label="Test Me" role="dialog" aria-modal="true" class="k-modal-fullscreen isOpen">
-  <div class="k-modal-dialog">
-    <div class="k-modal-header">
-      <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
-        <div class="k-modal-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="k-modal-fullscreen-dialog">
+    <div class="k-modal-fullscreen-header">
+      <div role="heading" aria-level="2" class="k-modal-fullscreen-header-description mb-5">
+        <div class="k-modal-fullscreen-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Kong</title>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
@@ -15,10 +15,10 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content">Test Me</span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+        <div class="k-modal-fullscreen-action ml-3"><button type="button" class="k-button medium rounded outline">
             Cancel
             <!----></button>
-          <div class="k-modal-action-buttons">
+          <div class="k-modal-fullscreen-action-buttons">
             <div>This is some action buttons text</div>
           </div>
         </div>
@@ -27,18 +27,18 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
         <hr>
       </div>
     </div>
-    <div class="k-modal-body-description"></div>
-    <div class="k-modal-body"></div>
+    <div class="k-modal-fullscreen-body-description"></div>
+    <div class="k-modal-fullscreen-body"></div>
   </div>
 </div>
 `;
 
 exports[`KModalFullscreen renders proper content when using props 1`] = `
 <div aria-label="Sweet prop title" role="dialog" aria-modal="true" class="k-modal-fullscreen isOpen">
-  <div class="k-modal-dialog">
-    <div class="k-modal-header">
-      <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
-        <div class="k-modal-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="k-modal-fullscreen-dialog">
+    <div class="k-modal-fullscreen-header">
+      <div role="heading" aria-level="2" class="k-modal-fullscreen-header-description mb-5">
+        <div class="k-modal-fullscreen-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Kong</title>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
@@ -46,10 +46,10 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content">Sweet prop title</span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+        <div class="k-modal-fullscreen-action ml-3"><button type="button" class="k-button medium rounded outline">
             Cancel
             <!----></button>
-          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
+          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded primary">
               Save
               <!----></button></div>
         </div>
@@ -58,18 +58,18 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
         <hr>
       </div>
     </div>
-    <div class="k-modal-body-description"></div>
-    <div class="k-modal-body">Sweet prop content</div>
+    <div class="k-modal-fullscreen-body-description"></div>
+    <div class="k-modal-fullscreen-body">Sweet prop content</div>
   </div>
 </div>
 `;
 
 exports[`KModalFullscreen renders proper content when using slots 1`] = `
 <div aria-label="This is some header text" role="dialog" aria-modal="true" class="k-modal-fullscreen isOpen">
-  <div class="k-modal-dialog">
-    <div class="k-modal-header">
-      <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
-        <div class="k-modal-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div class="k-modal-fullscreen-dialog">
+    <div class="k-modal-fullscreen-header">
+      <div role="heading" aria-level="2" class="k-modal-fullscreen-header-description mb-5">
+        <div class="k-modal-fullscreen-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Kong</title>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
@@ -77,10 +77,10 @@ exports[`KModalFullscreen renders proper content when using slots 1`] = `
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content"><div>This is some header text</div></span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+        <div class="k-modal-fullscreen-action ml-3"><button type="button" class="k-button medium rounded outline">
             Cancel
             <!----></button>
-          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
+          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded primary">
               Save
               <!----></button></div>
         </div>
@@ -89,8 +89,8 @@ exports[`KModalFullscreen renders proper content when using slots 1`] = `
         <hr>
       </div>
     </div>
-    <div class="k-modal-body-description"></div>
-    <div class="k-modal-body">
+    <div class="k-modal-fullscreen-body-description"></div>
+    <div class="k-modal-fullscreen-body">
       <div>This is some body text</div>
     </div>
   </div>

--- a/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
+++ b/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
@@ -1,35 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KModalFullscreen hides the title when using hideTitle prop 1`] = `
-<div aria-label="You can't see me" role="dialog" aria-modal="true" class="k-modal isOpen">
-  <div class="k-modal-dialog">
-    <div class="k-modal-header">
-      <!---->
-      <div class="divider">
-        <hr>
-      </div>
-    </div>
-    <div class="k-modal-body-description"></div>
-    <div class="k-modal-body"></div>
-  </div>
-</div>
-`;
-
 exports[`KModalFullscreen matches snapshot 1`] = `undefined`;
 
 exports[`KModalFullscreen renders proper content when using action-buttons slot 1`] = `
-<div aria-label="Test Me" role="dialog" aria-modal="true" class="k-modal isOpen">
+<div aria-label="Test Me" role="dialog" aria-modal="true" class="k-modal-fullscreen isOpen">
   <div class="k-modal-dialog">
     <div class="k-modal-header">
       <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
-        <div class="k-modal-title"><span class="header-icon"></span> <span class="header-content">Test Me</span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
-            Cancel
-            <!----></button>
+        <div class="k-modal-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Kong</title>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
+</svg>
+</span></span> <span class="header-content">Test Me</span></div>
+        <div class="k-modal-action ml-3">
           <div>This is some action buttons text</div>
         </div>
       </div>
-      <div class="divider">
+      <div>
         <hr>
       </div>
     </div>
@@ -40,18 +30,25 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
 `;
 
 exports[`KModalFullscreen renders proper content when using props 1`] = `
-<div aria-label="Sweet prop title" role="dialog" aria-modal="true" class="k-modal isOpen">
+<div aria-label="Sweet prop title" role="dialog" aria-modal="true" class="k-modal-fullscreen isOpen">
   <div class="k-modal-dialog">
     <div class="k-modal-header">
       <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
-        <div class="k-modal-title"><span class="header-icon"></span> <span class="header-content">Sweet prop title</span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+        <div class="k-modal-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Kong</title>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
+</svg>
+</span></span> <span class="header-content">Sweet prop title</span></div>
+        <div class="k-modal-action ml-3"><button type="button" class="k-button  mr-2 medium rounded outline">
             Cancel
-            <!----></button>
-          <!---->
-        </div>
+            <!----></button> <button type="button" class="k-button medium rounded primary">
+            Save
+            <!----></button></div>
       </div>
-      <div class="divider">
+      <div>
         <hr>
       </div>
     </div>
@@ -62,18 +59,25 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
 `;
 
 exports[`KModalFullscreen renders proper content when using slots 1`] = `
-<div aria-label="This is some header text" role="dialog" aria-modal="true" class="k-modal isOpen">
+<div aria-label="This is some header text" role="dialog" aria-modal="true" class="k-modal-fullscreen isOpen">
   <div class="k-modal-dialog">
     <div class="k-modal-header">
       <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
-        <div class="k-modal-title"><span class="header-icon"></span> <span class="header-content"><div>This is some header text</div></span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+        <div class="k-modal-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Kong</title>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
+</svg>
+</span></span> <span class="header-content"><div>This is some header text</div></span></div>
+        <div class="k-modal-action ml-3"><button type="button" class="k-button  mr-2 medium rounded outline">
             Cancel
-            <!----></button>
-          <!---->
-        </div>
+            <!----></button> <button type="button" class="k-button medium rounded primary">
+            Save
+            <!----></button></div>
       </div>
-      <div class="divider">
+      <div>
         <hr>
       </div>
     </div>

--- a/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
+++ b/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
@@ -15,8 +15,12 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content">Test Me</span></div>
-        <div class="k-modal-action ml-3">
-          <div>This is some action buttons text</div>
+        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+            Cancel
+            <!----></button>
+          <div class="k-modal-action-buttons">
+            <div>This is some action buttons text</div>
+          </div>
         </div>
       </div>
       <div>
@@ -42,11 +46,13 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content">Sweet prop title</span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button  mr-2 medium rounded outline">
+        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
             Cancel
-            <!----></button> <button type="button" class="k-button medium rounded primary">
-            Save
-            <!----></button></div>
+            <!----></button>
+          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
+              Save
+              <!----></button></div>
+        </div>
       </div>
       <div>
         <hr>
@@ -71,11 +77,13 @@ exports[`KModalFullscreen renders proper content when using slots 1`] = `
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content"><div>This is some header text</div></span></div>
-        <div class="k-modal-action ml-3"><button type="button" class="k-button  mr-2 medium rounded outline">
+        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
             Cancel
-            <!----></button> <button type="button" class="k-button medium rounded primary">
-            Save
-            <!----></button></div>
+            <!----></button>
+          <div class="k-modal-action-buttons"><button type="button" class="k-button medium rounded primary">
+              Save
+              <!----></button></div>
+        </div>
       </div>
       <div>
         <hr>

--- a/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
+++ b/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KModalFullscreen hides the title when using hideTitle prop 1`] = `
+<div aria-label="You can't see me" role="dialog" aria-modal="true" class="k-modal isOpen">
+  <div class="k-modal-dialog">
+    <div class="k-modal-header">
+      <!---->
+      <div class="divider">
+        <hr>
+      </div>
+    </div>
+    <div class="k-modal-body-description"></div>
+    <div class="k-modal-body"></div>
+  </div>
+</div>
+`;
+
+exports[`KModalFullscreen matches snapshot 1`] = `undefined`;
+
+exports[`KModalFullscreen renders proper content when using action-buttons slot 1`] = `
+<div aria-label="Test Me" role="dialog" aria-modal="true" class="k-modal isOpen">
+  <div class="k-modal-dialog">
+    <div class="k-modal-header">
+      <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
+        <div class="k-modal-title"><span class="header-icon"></span> <span class="header-content">Test Me</span></div>
+        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+            Cancel
+            <!----></button>
+          <div>This is some action buttons text</div>
+        </div>
+      </div>
+      <div class="divider">
+        <hr>
+      </div>
+    </div>
+    <div class="k-modal-body-description"></div>
+    <div class="k-modal-body"></div>
+  </div>
+</div>
+`;
+
+exports[`KModalFullscreen renders proper content when using props 1`] = `
+<div aria-label="Sweet prop title" role="dialog" aria-modal="true" class="k-modal isOpen">
+  <div class="k-modal-dialog">
+    <div class="k-modal-header">
+      <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
+        <div class="k-modal-title"><span class="header-icon"></span> <span class="header-content">Sweet prop title</span></div>
+        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+            Cancel
+            <!----></button>
+          <!---->
+        </div>
+      </div>
+      <div class="divider">
+        <hr>
+      </div>
+    </div>
+    <div class="k-modal-body-description"></div>
+    <div class="k-modal-body">Sweet prop content</div>
+  </div>
+</div>
+`;
+
+exports[`KModalFullscreen renders proper content when using slots 1`] = `
+<div aria-label="This is some header text" role="dialog" aria-modal="true" class="k-modal isOpen">
+  <div class="k-modal-dialog">
+    <div class="k-modal-header">
+      <div role="heading" aria-level="2" class="k-modal-header-description mb-5">
+        <div class="k-modal-title"><span class="header-icon"></span> <span class="header-content"><div>This is some header text</div></span></div>
+        <div class="k-modal-action ml-3"><button type="button" class="k-button medium rounded outline">
+            Cancel
+            <!----></button>
+          <!---->
+        </div>
+      </div>
+      <div class="divider">
+        <hr>
+      </div>
+    </div>
+    <div class="k-modal-body-description"></div>
+    <div class="k-modal-body">
+      <div>This is some body text</div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/KModalFullscreen/package.json
+++ b/packages/KModalFullscreen/package.json
@@ -21,5 +21,10 @@
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kbutton": "^6.13.0",
+    "@kongponents/kicon": "^6.13.0",
+    "@kongponents/styles": "^6.13.0"
   }
 }

--- a/packages/KModalFullscreen/package.json
+++ b/packages/KModalFullscreen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmodalfullscreen",
-  "version": "0.1.0",
+  "version": "6.13.0",
   "description": "A full screen Modal",
   "main": "dist/KModalFullscreen.umd.min.js",
   "componentName": "KModalFullscreen",

--- a/packages/KModalFullscreen/package.json
+++ b/packages/KModalFullscreen/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@kongponents/kmodalfullscreen",
+  "version": "0.1.0",
+  "description": "A full screen Modal",
+  "main": "dist/KModalFullscreen.umd.min.js",
+  "componentName": "KModalFullscreen",
+  "source": "KModalFullscreen.vue",
+  "files": [
+    "dist",
+    "KModalFullscreen.vue"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kong/kongponents.git"
+  },
+  "author": "Kong Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Kong/kongponents/issues"
+  },
+  "homepage": "https://github.com/Kong/kongponents#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
### Summary
New Fullscreen Modal kongponent. [KHCP-2879](https://konghq.atlassian.net/browse/KHCP-2879)

#### Changes made:
New tests for the kongponent

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-2879]: https://konghq.atlassian.net/browse/KHCP-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ