### PR TITLE
fix(kbutton): danger button hover color

### DIFF
--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -272,14 +272,14 @@ export default {
     color: var(--white, #fff);
     background-color: var(--KButtonDangerBase, var(--red-500, color(red-500)));
     &:hover:not(:disabled) {
-      $hover: rgba(color(red-500), .85);
+      $hover: rgba(color(red-700), .85);
       background-color: var(--KButtonDangerHover, $hover);
     }
     &:active {
-      background-color: var(--KButtonDangerActive, var(--red-600, color(red-600)));
+      background-color: var(--KButtonDangerActive, var(--red-700, color(red-700)));
     }
     &:focus {
-      @include boxShadow(var(--KButtonDangerBase, var(--red-500, color(red-500))));
+      @include boxShadow(var(--KButtonDangerBase, var(--red-700, color(red-700))));
     }
   }
   &.creation {
@@ -328,7 +328,7 @@ export default {
       text-decoration: underline;
     }
     &:focus {
-      @include boxShadow(var(--red-500, color(red-500)), 0, 2px);
+      @include boxShadow(var(--red-700, color(red-700)), 0, 2px);
     }
   }
   &.rounded {

--- a/packages/KInputSwitch/KInputSwitch.vue
+++ b/packages/KInputSwitch/KInputSwitch.vue
@@ -1,6 +1,6 @@
 <template>
   <KoolTip
-    v-if="$attrs.disabled !== undefined && disabledTooltipText"
+    v-if="($attrs.disabled === true || $attrs.disabled === '') && disabledTooltipText"
     :label="disabledTooltipText"
   >
     <label

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -247,6 +247,7 @@ export default {
         text-align: start;
         color: var(--grey-600);
         line-height: 24px;
+        white-space: normal; // in case inside KTable
 
         .k-prompt-body-content {
           padding-bottom: var(--spacing-lg);


### PR DESCRIPTION

### Summary

Danger button hover color should be red-700.

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [x] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - Already pushed to `next` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
