### PR TITLE
feat(kinput): add standard label support

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -9,7 +9,44 @@
 
 ## Props
 
-### Size
+### label
+
+String to be used as the input label.
+
+<KInput label="Name" placeholder="I'm labelled!" class="mb-2" />
+<KInput label="Disabled" disabled placeholder="I'm disabled!" />
+
+```vue
+<KInput label="Name" placeholder="I'm labelled!" class="mb-2" />
+<KInput label="Disabled" disabled placeholder="I'm disabled!" />
+```
+
+If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KInput** and will be styled appropriately.
+
+<KLabel for="my-input">Label</KLabel>
+<KInput id="my-input" type="text" placeholder="I have a label" />
+
+```vue
+<template>
+  <KLabel for="my-input">Label</KLabel>
+  <KInput id="my-input" type="text" placeholder="I have a label" />
+</template>
+```
+
+### overlayLabel
+
+Enable this prop to overlay the label on the input element's border. Defaults to `false`.
+Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
+
+<KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />
+<KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" />
+
+```vue
+<KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />
+<KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" />
+```
+
+### size
 
 You can specify `small`, `medium` (default), or `large` for the size.
 
@@ -23,13 +60,11 @@ You can specify `small`, `medium` (default), or `large` for the size.
 <KInput label="Large" size="large" />
 ```
 
-### Help
+### help
 
 String to be displayed as help text.
 
-- `help`
-
-<KInput help="I can help with that" placeholder="Need help?" />
+<KInput help="I can help with that" placeholder="Need help?" class="mb-2" />
 
 ```vue
 <KInput help="I can help with that" placeholder="Need help?" />
@@ -47,20 +82,21 @@ You also have the option of using the `.help` utility class. This is meant to be
 </template>
 ```
 
-### Error State
+### hasError
 
-- `hasError`
+Boolean value to indicate whether the element has an error and should apply error styling. By default this is `false`.
 
-Boolean value that is by default false.
+### errorMessage
 
-- `errorMessage`
-
-String to be displayed as error message.
+String to be displayed as error message if `hasError` prop is `true`.
 
 <KInput class="w-100" hasError errorMessage="Service name should not contain “_”"/>
+
 ```vue
 <KInput class="w-100"
-  hasError errorMessage="Service name should not contain “_”"/>
+  hasError
+  errorMessage="Service name should not contain “_”"
+/>
 ```
 
 <KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain “_”" />
@@ -71,45 +107,47 @@ String to be displayed as error message.
 <KInput
   label="Small" size="small" class="mb-2"
   hasError
-  errorMessage="Service name should not contain “_”" />
+  errorMessage="Service name should not contain “_”"
+/>
 <KInput
   label="Medium"
   class="mb-2"
   hasError
-  errorMessage="Service name should not contain “_”" />
+  errorMessage="Service name should not contain “_”"
+/>
 <KInput
   label="Large"
   size="large"
   hasError
-  errorMessage="Service name should not contain “_”" />
+  errorMessage="Service name should not contain “_”"
+/>
 ```
 
-### Label
-
-String to be used as the input label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
-
-- `label`
-
-<KInput label="Name" placeholder="I'm labelled!"/>
-<KInput label="Error" class="input-error" placeholder="I'm erroneous!" />
-<KInput label="Disabled" disabled placeholder="I'm disabled!" />
+<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain “_”" :overlay-label="true" />
+<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain “_”" :overlay-label="true" />
+<KInput label="Large" size="large" hasError errorMessage="Service name should not contain “_”" :overlay-label="true" />
 
 ```vue
-<KInput label="Name" placeholder="I'm labelled!" />
-<KInput label="Error" class="input-error" placeholder="I'm erroneous!" />
-<KInput label="Disabled" disabled placeholder="I'm disabled!" />
-```
-
-If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KInput** and will be styled appropriately.
-
-<KLabel for="my-input">Label</KLabel>
-<KInput id="my-input" type="text" placeholder="I have a label" />
-
-```vue
-<template>
-  <KLabel for="my-input">Label</KLabel>
-  <KInput id="my-input" type="text" placeholder="I have a label" />
-</template>
+<KInput
+  label="Small" size="small" class="mb-2"
+  hasError
+  errorMessage="Service name should not contain “_”"
+  :overlay-label="true"
+/>
+<KInput
+  label="Medium"
+  class="mb-2"
+  hasError
+  errorMessage="Service name should not contain “_”"
+  :overlay-label="true"
+/>
+<KInput
+  label="Large"
+  size="large"
+  hasError
+  errorMessage="Service name should not contain “_”"
+  :overlay-label="true"
+/>
 ```
 
 ## Attribute Binding

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -127,7 +127,7 @@ to prevent spam clicking.
 
 ### type
 
-This prompt determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
+This prop determines the look and feel of the dialog. Can be `danger`, `warning`, or `info`. Defaults to `info`.
 
 #### Information
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -36,10 +36,10 @@ If the label is omitted it can be handled with another component, like **KLabel*
 Enable this prop to overlay the label on the input element's border. Defaults to `false`.
 Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
 
-<KTextArea label="Name" placeholder="I'm labelled!" :overlayLabel="true" />
+<KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 
 ```vue
-<KTextArea label="Name" placeholder="I'm labelled!" :overlayLabel="true" />
+<KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 ```
 
 ### size

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -7,13 +7,13 @@
 <KTextArea />
 ```
 
-## Label
+## Props
 
-String to be used as the textarea label. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the textarea element.
+### label
 
-- `label` (**Note**: this field is required for accessibility reasons)
+String to be used as the textarea label.
 
-<KTextArea label="Name" placeholder="I'm labelled!" id="adam"/>
+<KTextArea label="Name" placeholder="I'm labelled!" />
 
 ```vue
 <KTextArea label="Name" placeholder="I'm labelled!" />
@@ -31,9 +31,18 @@ If the label is omitted it can be handled with another component, like **KLabel*
 </template>
 ```
 
-## Props
+### overlayLabel
 
-### Size
+Enable this prop to overlay the label on the input element's border. Defaults to `false`.
+Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
+
+<KTextArea label="Name" placeholder="I'm labelled!" :overlayLabel="true" />
+
+```vue
+<KTextArea label="Name" placeholder="I'm labelled!" :overlayLabel="true" />
+```
+
+### size
 
 You can specify `rows`, `cols` for the textarea size.
 

--- a/packages/KInput/KInput.spec.js
+++ b/packages/KInput/KInput.spec.js
@@ -29,6 +29,18 @@ describe('KInput', () => {
       }
     })
 
+    expect(wrapper.find('.k-input-label').element.innerHTML).toContain('A Label!')
+  })
+
+  it('renders overlayed label when value is passed', () => {
+    const wrapper = mount(KInput, {
+      propsData: {
+        testMode: true,
+        label: 'A Label!',
+        overlayLabel: true
+      }
+    })
+
     expect(wrapper.find('.text-on-input label').element.innerHTML).toContain('A Label!')
   })
 

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -88,10 +88,12 @@
 </template>
 
 <script>
+import KLabel from '@kongponents/klabel/KLabel.vue'
 import { uuid } from 'vue-uuid'
 
 export default {
   name: 'KInput',
+  components: { KLabel },
   inheritAttrs: false,
   props: {
     value: {

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -2,21 +2,9 @@
   <div
     :class="{'input-error' : hasError}"
     class="k-input-wrapper">
-    <input
-      v-if="!label"
-      v-bind="$attrs"
-      :value="value"
-      :class="`k-input-${size}`"
-      :aria-invalid="hasError ? hasError : null"
-      class="form-control k-input"
-      @input="e => {
-        $emit('input', e.target.value)
-      }"
-      v-on="listeners">
-
     <div
-      v-else
-      :class="`k-input-label-${size}`"
+      v-if="label && overlayLabel"
+      :class="`k-input-label-wrapper-${size}`"
       class="col-md-4 mt-5">
       <div class="text-on-input">
         <label
@@ -41,16 +29,60 @@
           @blur="() => isFocused = false"
           v-on="listeners">
       </div>
+      <p
+        v-if="hasError"
+        class="has-error">
+        {{ errorMessage }}
+      </p>
     </div>
+
+    <div
+      v-else-if="label"
+      :class="`k-input-label-wrapper-${size}`">
+      <KLabel
+        for="inputId">
+        {{ label }}
+      </KLabel>
+      <input
+        v-bind="$attrs"
+        :id="inputId"
+        :value="value"
+        :class="`k-input-${size}`"
+        :aria-invalid="hasError ? hasError : null"
+        class="form-control k-input"
+        @input="e => {
+          $emit('input', e.target.value)
+        }"
+        v-on="listeners">
+      <p
+        v-if="hasError"
+        class="has-error">
+        {{ errorMessage }}
+      </p>
+    </div>
+
+    <input
+      v-else
+      v-bind="$attrs"
+      :value="value"
+      :class="`k-input-${size}`"
+      :aria-invalid="hasError ? hasError : null"
+      class="form-control k-input"
+      @input="e => {
+        $emit('input', e.target.value)
+      }"
+      v-on="listeners">
+
+    <p
+      v-if="hasError && !label"
+      class="has-error">
+      {{ errorMessage }}
+    </p>
+
     <p
       v-if="help"
       class="help">
       {{ help }}
-    </p>
-    <p
-      v-if="hasError"
-      class="has-error">
-      {{ errorMessage }}
     </p>
   </div>
 </template>
@@ -69,6 +101,13 @@ export default {
     label: {
       type: String,
       default: ''
+    },
+    /**
+     * Overlay the label on the input's border
+     */
+    overlayLabel: {
+      type: Boolean,
+      default: false
     },
     help: {
       type: String,
@@ -145,36 +184,21 @@ export default {
     -webkit-appearance: none;
   }
 
-  & .k-input-label-large + .has-error {
-    font-size: 12px;
-    line-height: 15px;
-    margin-top: 4px;
-  }
-
-  & .k-input-label-medium + .has-error {
-    font-size: 10px;
-    line-height: 13px;
-    margin-top: 3px;
-  }
-
-  & .k-input-label-small + .has-error {
-    font-size: 9px;
-    line-height: 11px;
-    margin-top: 2px;
-  }
-
+  & .k-input-label-wrapper-large .has-error,
   & .k-input-large + .has-error {
     font-size: 12px;
     line-height: 15px;
     margin-top: 4px;
   }
 
+  & .k-input-label-wrapper-medium .has-error,
   & .k-input-medium + .has-error {
     font-size: 10px;
     line-height: 13px;
     margin-top: 3px;
   }
 
+  & .k-input-label-wrapper-small .has-error,
   & .k-input-small + .has-error {
     font-size: 9px;
     line-height: 11px;

--- a/packages/KInput/package.json
+++ b/packages/KInput/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@kongponents/klabel": "^6.15.0",
     "@kongponents/styles": "^6.15.0",
     "vue-uuid": "^2.0.2"
   }

--- a/packages/KTextArea/KTextArea.spec.js
+++ b/packages/KTextArea/KTextArea.spec.js
@@ -30,6 +30,18 @@ describe('KTextArea', () => {
       }
     })
 
+    expect(wrapper.find('.k-input-label').element.innerHTML).toContain('A Label!')
+  })
+
+  it('renders overlayed label when value is passed', () => {
+    const wrapper = mount(KTextArea, {
+      propsData: {
+        testMode: true,
+        label: 'A Label!',
+        overlayLabel: true
+      }
+    })
+
     expect(wrapper.find('.text-on-input label').element.innerHTML).toContain('A Label!')
   })
 

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -12,7 +12,7 @@
     />
 
     <div
-      v-else
+      v-else-if="label && overlayLabel"
       class="col-md-4 mt-5">
       <div class="text-on-input">
         <label
@@ -34,6 +34,28 @@
           @blur="() => isFocused = false"
           v-on="listeners" />
       </div>
+    </div>
+
+    <div
+      v-else
+      class="col-md-4 mt-5">
+      <KLabel
+        :for="textAreaId">
+        {{ label }}
+      </KLabel>
+      <textarea
+        v-bind="$attrs"
+        :id="textAreaId"
+        :value="currValue ? currValue : value"
+        :rows="rows"
+        :cols="cols"
+        class="form-control k-input style-body-lg"
+        @input="inputHandler"
+        @mouseenter="() => isHovered = true"
+        @mouseleave="() => isHovered = false"
+        @focus="() => isFocused = true"
+        @blur="() => isFocused = false"
+        v-on="listeners" />
     </div>
 
     <div
@@ -60,6 +82,10 @@ export default {
     label: {
       type: String,
       default: ''
+    },
+    overlayLabel: {
+      type: Boolean,
+      default: false
     },
     characterLimit: {
       type: Number,

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -68,11 +68,13 @@
 </template>
 
 <script>
+import KLabel from '@kongponents/klabel/KLabel.vue'
 import { uuid } from 'vue-uuid'
 const CHARACTER_LIMIT = 2048
 
 export default {
   name: 'KTextArea',
+  components: { KLabel },
   inheritAttrs: false,
   props: {
     value: {

--- a/packages/KTextArea/package.json
+++ b/packages/KTextArea/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@kongponents/klabel": "^6.15.0",
     "@kongponents/styles": "^6.15.0",
     "vue-uuid": "^2.0.2"
   }


### PR DESCRIPTION
### Summary
Add support for standard `KLabel` if `label` prop provided to `KInput` and `KTextArea`.
Address KHCP-2895.

#### Changes made:
* Add `overlayLabel` prop - default false
* Restructure location of `errorMessage`
* Restructure docs
* Update dependencies
* Update tests/snaps

![image](https://user-images.githubusercontent.com/67973710/156235977-ff80ca03-88af-47be-979e-df8ef7ec6791.png)

![image](https://user-images.githubusercontent.com/67973710/156236106-c1289ab1-74b6-451c-b108-945204133eb0.png)



### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
