### PR TITLE
feat(kmodal): fix overlay color [khcp-2929]

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -149,7 +149,7 @@ export default {
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: rgb(11, 23, 45, .6);
+  background-color: var(--KModalBackdrop, rgb(11, 23, 45, .6));
   z-index: 1100;
 }
 

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -149,7 +149,7 @@ export default {
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: var(--KModalBackdrop, var(--black-45, color(black-45)));
+  background-color: rgb(11, 23, 45, .6);
   z-index: 1100;
 }
 


### PR DESCRIPTION
### Summary
Fix the overlay to be the right color as per metalab designs.
Fix khcp-2929.

#### Changes made:
* Update overlay color

Before:

![image](https://user-images.githubusercontent.com/67973710/156457663-935e86b5-e2f3-48de-b317-d99db2945c01.png)


After:

![image](https://user-images.githubusercontent.com/67973710/156457556-d308ff98-e0ba-4dc4-93ad-ec72f8a63943.png)


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
