### PR TITLE
fix(kmodalfullscreen): misc fixes

### DIFF
--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -117,7 +117,7 @@ Change the [appearance](/components/button.html#props) of the save/proceed butto
 There are 5 designated slots you can use to display content in the fullscreen modal.
 
 - `header-content`
-- `action-buttons` - Contains action buttons which are right-aligned.
+- `action-buttons` - Contains action buttons which are right-aligned. If not used, provide default Cancel/Submit buttons
 - `body-header-description`
 - `body-content`
 
@@ -327,7 +327,7 @@ There are 5 designated slots you can use to display content in the fullscreen mo
 | `--KModalFullscreenColor`| Main content text color
 | `--KModalFullscreenFontSize`| Main content text size
 
-An Example of changing the the colors of KModalFullscreen might look like.  
+An Example of changing the the colors of KModalFullscreen might look like.
 > Note: We are scoping the overrides to a wrapper in this example
 
 <KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
@@ -408,7 +408,7 @@ export default {
       contentIsOpen: false
     }
   },
-  
+
 }
 </script>
 

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -6,7 +6,7 @@
     role="dialog"
     aria-modal="true"
     @keyup.esc="close"
-    @keyup.enter="proceed" >
+    @keyup.enter="proceed">
     <div
       class="k-modal-fullscreen-dialog"
     >
@@ -27,19 +27,15 @@
               <slot name="header-content">{{ title }}</slot>
             </span>
           </div>
-          <div
-            class="k-modal-fullscreen-action ml-3"
-          >
-            <KButton
-              :appearance="cancelButtonAppearance"
-              @click="close"
-            >
-              {{ cancelButtonText }}
-            </KButton>
-            <div
-              class="k-modal-fullscreen-action-buttons"
-            >
+          <div class="k-modal-fullscreen-action ml-3">
+            <div class="k-modal-fullscreen-action-buttons">
               <slot name="action-buttons">
+                <KButton
+                  :appearance="cancelButtonAppearance"
+                  @click="close"
+                >
+                  {{ cancelButtonText }}
+                </KButton>
                 <KButton
                   :appearance="actionButtonAppearance"
                   @click="proceed"
@@ -194,7 +190,7 @@ $screen-md: 992px;
   padding: var(--spacing-xl, spacing(xl)) 0 14px 0;
   background: var(--white);
   z-index: 9999;
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   left: 0;

--- a/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
+++ b/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
@@ -15,9 +15,7 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content">Test Me</span></div>
-        <div class="k-modal-fullscreen-action ml-3"><button type="button" class="k-button medium rounded outline">
-            Cancel
-            <!----></button>
+        <div class="k-modal-fullscreen-action ml-3">
           <div class="k-modal-fullscreen-action-buttons">
             <div>This is some action buttons text</div>
           </div>
@@ -46,10 +44,10 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content">Sweet prop title</span></div>
-        <div class="k-modal-fullscreen-action ml-3"><button type="button" class="k-button medium rounded outline">
-            Cancel
-            <!----></button>
-          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded primary">
+        <div class="k-modal-fullscreen-action ml-3">
+          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded outline">
+              Cancel
+              <!----></button> <button type="button" class="k-button medium rounded primary">
               Save
               <!----></button></div>
         </div>
@@ -77,10 +75,10 @@ exports[`KModalFullscreen renders proper content when using slots 1`] = `
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
 </span></span> <span class="header-content"><div>This is some header text</div></span></div>
-        <div class="k-modal-fullscreen-action ml-3"><button type="button" class="k-button medium rounded outline">
-            Cancel
-            <!----></button>
-          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded primary">
+        <div class="k-modal-fullscreen-action ml-3">
+          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded outline">
+              Cancel
+              <!----></button> <button type="button" class="k-button medium rounded primary">
               Save
               <!----></button></div>
         </div>

--- a/packages/KModalFullscreen/package.json
+++ b/packages/KModalFullscreen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmodalfullscreen",
-  "version": "6.17.0",
+  "version": "6.18.0",
   "description": "A full screen Modal",
   "main": "dist/KModalFullscreen.umd.min.js",
   "componentName": "KModalFullscreen",


### PR DESCRIPTION
### Summary
Misc fixes for kmodalfullscreen

#### Changes made:
* Change from `absolute` to `fixed` positioning
* Move the cancel button into the `action-buttons` slot - allow full control over form buttons
* Bump the version up to match rest of kongponents
* Update snaps

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
