### PR TITLE
fix(kmodalfullscreen): misc changes

### DIFF
--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -50,13 +50,21 @@ export default {
 
 ## Props
 
+### iconString
+
+Name of KIcon to be displayed in the header.
+
 ### title
 
-Text displayed in header.
+Title displayed in header. This prop is required for accessibility purposes even if you are slotting the title.
+
+### bodyHeader
+
+Text to display for the title in the body section.
 
 ### bodyHeaderDescription
 
-Text to display Page title and description.
+Text to display beneath the `bodyHeader` as a description.
 
 ### content
 
@@ -116,9 +124,11 @@ Change the [appearance](/components/button.html#props) of the save/proceed butto
 
 There are 5 designated slots you can use to display content in the fullscreen modal.
 
-- `header-content`
-- `action-buttons` - Contains action buttons which are right-aligned. If not used, provide default Cancel/Submit buttons
-- `body-header-description`
+- `header-icon`
+- `header-content` - title text in the header
+- `action-buttons` - contains action buttons which are right-aligned. If not used, provide default Cancel/Submit buttons
+- `body-header` - title to display in the body section
+- `body-header-description` - description text displayed beneath the `body-header`
 - `body-content`
 
 <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
@@ -126,13 +136,18 @@ There are 5 designated slots you can use to display content in the fullscreen mo
 <KModalFullscreen
   :isVisible="exampleIsOpen"
   title="Install Plugin"
-  @canceled="exampleIsOpen = false" iconString="immunity">
+  @canceled="exampleIsOpen = false">
+  <template v-slot:header-icon>
+    <KIcon icon="immunity" />
+  </template>
   <template v-slot:header-content>
     Install Plugin
   </template>
+  <template v-slot:body-header>
+    Select a plugin
+  </template>
   <template v-slot:body-header-description>
-    <p>Select a plugin</p>
-    <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+    Choose a plugin from our catalog to install for your organization. <a>View documentation</a>
   </template>
   <template v-slot:action-buttons>
     <KButton appearance="secondary" size="medium" @click="exampleIsOpen = false">Back</KButton>
@@ -152,13 +167,18 @@ There are 5 designated slots you can use to display content in the fullscreen mo
 <KModalFullscreen
   :isVisible="exampleIsOpen"
   title="Install Plugin"
-  @canceled="exampleIsOpen = false" iconString="immunity">
+  @canceled="exampleIsOpen = false">
+  <template v-slot:header-icon>
+    <KIcon icon="immunity" />
+  </template>
   <template v-slot:header-content>
     Install Plugin
   </template>
+  <template v-slot:body-header>
+    Select a plugin
+  </template>
   <template v-slot:body-header-description>
-    <p>Select a plugin</p>
-    <p>Choose a plugin from our catalog to install for your organization. <a>View documentation</a></p>
+    Choose a plugin from our catalog to install for your organization. <a>View documentation</a>
   </template>
   <template v-slot:action-buttons>
     <KButton appearance="secondary" size="medium" @click="exampleIsOpen = false">Back</KButton>
@@ -182,18 +202,15 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   @proceed="sampleIsOpen = false"
   cancelButtonAppearance="secondary"
   actionButtonText="Delete"
-  actionButtonAppearance="danger" >
-  <template v-slot:header-icon>
-    <KIcon icon="kong" class="mr-2" />
-  </template>
+  actionButtonAppearance="danger">
   <template v-slot:header-content>
     Install Plugin
   </template>
+   <template v-slot:body-header>
+    Configure a key auth plugin
+  </template>
   <template v-slot:body-header-description>
-    <div class="display">
-      <p>Configure a key auth plugin</p>
-      <p>Lorem ipsum factum. <a>View documentation</a></p>
-    </div>
+    Lorem ipsum factum. <a>View documentation</a>
   </template>
   <template v-slot:action-buttons>
     <KButton size="medium" @click="sampleIsOpen = false">Back</KButton>
@@ -251,18 +268,15 @@ There are 5 designated slots you can use to display content in the fullscreen mo
   @proceed="sampleIsOpen = false"
   cancelButtonAppearance="secondary"
   actionButtonText="Delete"
-  actionButtonAppearance="danger" >
-  <template v-slot:header-icon>
-    <KIcon icon="kong" class="mr-2" />
-  </template>
+  actionButtonAppearance="danger">
   <template v-slot:header-content>
     Install Plugin
   </template>
+   <template v-slot:body-header>
+    Configure a key auth plugin
+  </template>
   <template v-slot:body-header-description>
-    <div class="display">
-      <p>Configure a key auth plugin</p>
-      <p>Lorem ipsum factum. <a>View documentation</a></p>
-    </div>
+    Lorem ipsum factum. <a>View documentation</a>
   </template>
   <template v-slot:action-buttons>
     <KButton size="medium" @click="sampleIsOpen = false">Back</KButton>

--- a/packages/KModalFullscreen/KModalFullscreen.spec.js
+++ b/packages/KModalFullscreen/KModalFullscreen.spec.js
@@ -3,7 +3,10 @@ import KModalFullscreen from '@/KModalFullscreen/KModalFullscreen'
 
 describe('KModalFullscreen', () => {
   it('renders proper content when using slots', () => {
+    const headerIcon = 'This is some header icon text'
     const headerText = 'This is some header text'
+    const bodyHeader = 'This is some body header text'
+    const bodyHeaderDescription = 'This is some body header description text'
     const bodyText = 'This is some body text'
     const wrapper = mount(KModalFullscreen, {
       propsData: {
@@ -11,12 +14,18 @@ describe('KModalFullscreen', () => {
         title: headerText
       },
       slots: {
+        'header-icon': `<div>${headerIcon}</div>`,
         'header-content': `<div>${headerText}</div>`,
+        'body-header': `<div>${bodyHeader}</div>`,
+        'body-header-description': `<div>${bodyHeaderDescription}</div>`,
         'body-content': `<div>${bodyText}</div>`
       }
     })
 
+    expect(wrapper.find('.k-modal-fullscreen-title .header-icon').html()).toEqual(expect.stringContaining(headerIcon))
     expect(wrapper.find('.k-modal-fullscreen-header').html()).toEqual(expect.stringContaining(headerText))
+    expect(wrapper.find('.k-modal-fullscreen-body-header .body-header').html()).toEqual(expect.stringContaining(bodyHeader))
+    expect(wrapper.find('.k-modal-fullscreen-body-header .body-header-description').html()).toEqual(expect.stringContaining(bodyHeaderDescription))
     expect(wrapper.find('.k-modal-fullscreen-body').html()).toEqual(expect.stringContaining(bodyText))
     expect(wrapper.html()).toMatchSnapshot()
   })
@@ -39,16 +48,30 @@ describe('KModalFullscreen', () => {
 
   it('renders proper content when using props', () => {
     const title = 'Sweet prop title'
+    const actionButtonText = 'Sweet prop actionButton'
+    const cancelButtonText = 'Sweet prop cancelButton'
+    const bodyHeader = 'Sweet prop bodyHeader'
+    const bodyHeaderDescription = 'Sweet prop bodyHeaderDescription'
     const content = 'Sweet prop content'
     const wrapper = mount(KModalFullscreen, {
       propsData: {
         isVisible: true,
         title,
-        content
+        actionButtonText,
+        cancelButtonText,
+        bodyHeader,
+        bodyHeaderDescription,
+        content,
+        iconString: 'immunity'
       }
     })
 
+    expect(wrapper.find('.k-modal-fullscreen-title .header-icon .kong-icon-immunity').exists()).toBeTruthy()
+    expect(wrapper.find('.cancel-button').html()).toEqual(expect.stringContaining(cancelButtonText))
+    expect(wrapper.find('.proceed-button').html()).toEqual(expect.stringContaining(actionButtonText))
     expect(wrapper.find('.k-modal-fullscreen-header').html()).toEqual(expect.stringContaining(title))
+    expect(wrapper.find('.k-modal-fullscreen-body-header .body-header').html()).toEqual(expect.stringContaining(bodyHeader))
+    expect(wrapper.find('.k-modal-fullscreen-body-header .body-header-description').html()).toEqual(expect.stringContaining(bodyHeaderDescription))
     expect(wrapper.find('.k-modal-fullscreen-body').html()).toEqual(expect.stringContaining(content))
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -12,18 +12,16 @@
     >
       <div class="k-modal-fullscreen-header">
         <div
-          v-if="!$scopedSlots.title"
           class="k-modal-fullscreen-header-description mb-5"
           role="heading"
           aria-level="2">
           <div class="k-modal-fullscreen-title">
-            <span
-              class="header-icon">
-              <KIcon
-                :icon="iconString"
-                class="mr-2" />
+            <span class="header-icon pr-2 my-auto">
+              <slot name="header-icon">
+                <KIcon :icon="iconString" />
+              </slot>
             </span>
-            <span class="header-content">
+            <span class="header-content my-auto">
               <slot name="header-content">{{ title }}</slot>
             </span>
           </div>
@@ -32,12 +30,14 @@
               <slot name="action-buttons">
                 <KButton
                   :appearance="cancelButtonAppearance"
+                  class="cancel-button"
                   @click="close"
                 >
                   {{ cancelButtonText }}
                 </KButton>
                 <KButton
                   :appearance="actionButtonAppearance"
+                  class="proceed-button"
                   @click="proceed"
                 >
                   {{ actionButtonText }}
@@ -50,9 +50,16 @@
           <hr>
         </div>
       </div>
-      <div class="k-modal-fullscreen-body-description">
-        <slot name="body-header-description">{{ bodyHeaderDescription }}</slot>
+
+      <div class="k-modal-fullscreen-body-header">
+        <div class="body-header">
+          <slot name="body-header">{{ bodyHeader }}</slot>
+        </div>
+        <div class="body-header-description">
+          <slot name="body-header-description">{{ bodyHeaderDescription }}</slot>
+        </div>
       </div>
+
       <div class="k-modal-fullscreen-body">
         <slot name="body-content">{{ content }}</slot>
       </div>
@@ -77,7 +84,14 @@ export default {
       required: true
     },
     /**
-     * Text to display Page title and description
+     * Set the title in the body
+     */
+    bodyHeader: {
+      type: String,
+      default: ''
+    },
+    /**
+     * Text to display as a description of the body's title
      */
     bodyHeaderDescription: {
       type: String,
@@ -229,7 +243,8 @@ $screen-md: 992px;
 .k-modal-fullscreen-action {
   display: inline-flex;
   margin-right: var(--spacing-xl, spacing(xl));
-   & button {
+
+  & button {
     height: 40px;
     margin-left: var(--spacing-md, spacing(md));
     font-weight: 400;
@@ -250,22 +265,27 @@ $screen-md: 992px;
   color: var(--KModalFullscreenColor, var(--black-500, color(black-500)));
 }
 
-.k-modal-fullscreen-body-description {
-  font-size: 32px;
-  line-height: 32px;
-  font-weight: 600;
+.k-modal-fullscreen-body-header {
+  margin-top: 64px;
+  margin-bottom: 54px;
+  margin-left: auto;
+  margin-right: auto;
+  width: fit-content;
 
-    p:first-child {
-      margin-bottom: -4px;
-    }
+  .body-header {
+    font-size: 32px;
+    line-height: 32px;
+    font-weight: 600;
+    margin-bottom: -4px;
+  }
 
-    p:last-child {
-      font-weight: normal;
-      font-size: 14px;
-      line-height: 22px;
-      color: var(--grey-600);
-      margin-top: 20px;
-    }
+  .body-header-description {
+    font-weight: 200;
+    font-size: 14px;
+    line-height: 22px;
+    color: var(--grey-600);
+    margin-top: var(--spacing-md);
+  }
 }
 
 .k-modal-fullscreen-body-description h2 {

--- a/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
+++ b/packages/KModalFullscreen/__snapshots__/KModalFullscreen.spec.js.snap
@@ -7,14 +7,14 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
   <div class="k-modal-fullscreen-dialog">
     <div class="k-modal-fullscreen-header">
       <div role="heading" aria-level="2" class="k-modal-fullscreen-header-description mb-5">
-        <div class="k-modal-fullscreen-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <div class="k-modal-fullscreen-title"><span class="header-icon pr-2 my-auto"><span class="kong-icon kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Kong</title>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
   <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
   <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
 </svg>
-</span></span> <span class="header-content">Test Me</span></div>
+</span></span> <span class="header-content my-auto">Test Me</span></div>
         <div class="k-modal-fullscreen-action ml-3">
           <div class="k-modal-fullscreen-action-buttons">
             <div>This is some action buttons text</div>
@@ -25,7 +25,10 @@ exports[`KModalFullscreen renders proper content when using action-buttons slot 
         <hr>
       </div>
     </div>
-    <div class="k-modal-fullscreen-body-description"></div>
+    <div class="k-modal-fullscreen-body-header">
+      <div class="body-header"></div>
+      <div class="body-header-description"></div>
+    </div>
     <div class="k-modal-fullscreen-body"></div>
   </div>
 </div>
@@ -36,19 +39,19 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
   <div class="k-modal-fullscreen-dialog">
     <div class="k-modal-fullscreen-header">
       <div role="heading" aria-level="2" class="k-modal-fullscreen-header-description mb-5">
-        <div class="k-modal-fullscreen-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>Kong</title>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
+        <div class="k-modal-fullscreen-title"><span class="header-icon pr-2 my-auto"><span class="kong-icon kong-icon-immunity"><svg width="32" height="32" viewBox="-2 -2 28 28" xmlns="http://www.w3.org/2000/svg">
+  <title>Immunity</title>
+  <path transform="rotate(-45 11.7 12)" d="M7.710000000000001,12a4,12 0 1,0 8,0a4,12 0 1,0 -8,0" stroke="#A3BBCC" stroke-width="2" fill="none"></path>
+  <path d="M3 5.3a2 2 0 100-4 2 2 0 000 4z" stroke="#A3BBCC" stroke-width="2" fill="none"></path>
+  <path transform="rotate(45 11.7 12)" d="M7.710000000000001,12a4,12 0 1,0 8,0a4,12 0 1,0 -8,0" stroke="#A3BBCC" stroke-width="2" fill="none"></path>
+  <path d="M21 5.3a2 2 0 100-4 2 2 0 000 4zM21 22.3a2 2 0 100-4 2 2 0 000 4zM3 22.3a2 2 0 100-4 2 2 0 000 4z" stroke="#A3BBCC" stroke-width="2" fill="none"></path>
 </svg>
-</span></span> <span class="header-content">Sweet prop title</span></div>
+</span></span> <span class="header-content my-auto">Sweet prop title</span></div>
         <div class="k-modal-fullscreen-action ml-3">
-          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded outline">
-              Cancel
-              <!----></button> <button type="button" class="k-button medium rounded primary">
-              Save
+          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button cancel-button medium rounded outline">
+              Sweet prop cancelButton
+              <!----></button> <button type="button" class="k-button proceed-button medium rounded primary">
+              Sweet prop actionButton
               <!----></button></div>
         </div>
       </div>
@@ -56,7 +59,10 @@ exports[`KModalFullscreen renders proper content when using props 1`] = `
         <hr>
       </div>
     </div>
-    <div class="k-modal-fullscreen-body-description"></div>
+    <div class="k-modal-fullscreen-body-header">
+      <div class="body-header">Sweet prop bodyHeader</div>
+      <div class="body-header-description">Sweet prop bodyHeaderDescription</div>
+    </div>
     <div class="k-modal-fullscreen-body">Sweet prop content</div>
   </div>
 </div>
@@ -67,18 +73,11 @@ exports[`KModalFullscreen renders proper content when using slots 1`] = `
   <div class="k-modal-fullscreen-dialog">
     <div class="k-modal-fullscreen-header">
       <div role="heading" aria-level="2" class="k-modal-fullscreen-header-description mb-5">
-        <div class="k-modal-fullscreen-title"><span class="header-icon"><span class="kong-icon mr-2 kong-icon-kong"><svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>Kong</title>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="m16.28 36.66 1-1.3h7.45l3.88 4.96-.7 1.68h-9.6l.24-1.68-2.27-3.66Z" fill="#169FCC"></path>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="m18.55 19.75 3.6-6.21h4.19L45.1 35.35 43.65 42H35.6l.5-1.87-17.55-20.38Z" fill="#14B59A"></path>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="m22.92 12.36 1.72-3.19L29.8 5l8.85 6.94-1.15 1.17 1.54 2.13v2.28l-4.4 3.6-7.4-8.76h-4.32Z" fill="#1BC263"></path>
-  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.25 26.23h2.33l6.1-5.1 8.08 9.4-2.28 3.41h-7.46l-5.15 6.55L9.7 42H3v-8.03l6.25-7.74Z" fill="#16BDCC"></path>
-</svg>
-</span></span> <span class="header-content"><div>This is some header text</div></span></div>
+        <div class="k-modal-fullscreen-title"><span class="header-icon pr-2 my-auto"><div>This is some header icon text</div></span> <span class="header-content my-auto"><div>This is some header text</div></span></div>
         <div class="k-modal-fullscreen-action ml-3">
-          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button medium rounded outline">
+          <div class="k-modal-fullscreen-action-buttons"><button type="button" class="k-button cancel-button medium rounded outline">
               Cancel
-              <!----></button> <button type="button" class="k-button medium rounded primary">
+              <!----></button> <button type="button" class="k-button proceed-button medium rounded primary">
               Save
               <!----></button></div>
         </div>
@@ -87,7 +86,14 @@ exports[`KModalFullscreen renders proper content when using slots 1`] = `
         <hr>
       </div>
     </div>
-    <div class="k-modal-fullscreen-body-description"></div>
+    <div class="k-modal-fullscreen-body-header">
+      <div class="body-header">
+        <div>This is some body header text</div>
+      </div>
+      <div class="body-header-description">
+        <div>This is some body header description text</div>
+      </div>
+    </div>
     <div class="k-modal-fullscreen-body">
       <div>This is some body text</div>
     </div>


### PR DESCRIPTION
### Summary
Misc fixes for KModalFullscreen

#### Changes made:
* Separate `bodyHeaderDescription` into two props
* Add `header-icon`, `body-header`, and `body-header-description` slots
* Move classes outside of <slot> element
* Update docs
* Add missing tests
* Update snaps

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
