### PR TITLE
fix(kmodalfullscreen): fix body header alignment

### DIFF
--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -207,17 +207,17 @@ There are 5 designated slots you can use to display content in the fullscreen mo
     Install Plugin
   </template>
    <template v-slot:body-header>
-    Configure a key auth plugin
+    <div class="ml-25">Configure a key auth plugin</div>
   </template>
   <template v-slot:body-header-description>
-    Lorem ipsum factum. <a>View documentation</a>
+    <div class="ml-25">Lorem ipsum factum. <a>View documentation</a></div>
   </template>
   <template v-slot:action-buttons>
     <KButton size="medium" @click="sampleIsOpen = false">Back</KButton>
     <KButton appearance="creation" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
   <template v-slot:body-content>
-    <div class="display">
+    <div class="ml-25">
       <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
       <br><br>
       <div class="wrapper display-items">
@@ -273,17 +273,17 @@ There are 5 designated slots you can use to display content in the fullscreen mo
     Install Plugin
   </template>
    <template v-slot:body-header>
-    Configure a key auth plugin
+    <div class="ml-25">Configure a key auth plugin</div>
   </template>
   <template v-slot:body-header-description>
-    Lorem ipsum factum. <a>View documentation</a>
+    <div class="ml-25">Lorem ipsum factum. <a>View documentation</a></div>
   </template>
   <template v-slot:action-buttons>
     <KButton size="medium" @click="sampleIsOpen = false">Back</KButton>
     <KButton appearance="creation" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
   <template v-slot:body-content>
-    <div class="display">
+    <div class="ml-25">
       <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
       <br><br>
       <div class="wrapper display-items">
@@ -432,6 +432,10 @@ export default {
   --KModalFullscreenColor: green;
 }
 
+.ml-25 {
+  margin-left: 25%;
+}
+
 .k-switch {
   border-top: 1px solid #eaecef;
   padding-top: 26px;
@@ -446,7 +450,7 @@ export default {
 }
 
 .display-items {
-  min-width: 70%;
+  width: 50%;
 }
 
 .wrapper {

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -258,6 +258,7 @@ $screen-md: 992px;
   border-right: 1px solid var(--grey-300);
 }
 
+.k-modal-fullscreen-body-header,
 .k-modal-fullscreen-body-description,
 .k-modal-fullscreen-body {
   margin-left: 230px;
@@ -268,9 +269,6 @@ $screen-md: 992px;
 .k-modal-fullscreen-body-header {
   margin-top: 64px;
   margin-bottom: 54px;
-  margin-left: auto;
-  margin-right: auto;
-  width: fit-content;
 
   .body-header {
     font-size: 32px;


### PR DESCRIPTION
### Summary
Body header content should align with body.

Before:

![image](https://user-images.githubusercontent.com/67973710/156826049-8be94dfa-364f-4fb2-bc45-b7bbcf522f1a.png)

After:

![image](https://user-images.githubusercontent.com/67973710/156826002-0bb348d8-2bf3-4949-93cb-445880e9e898.png)


#### Changes made:
*

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [x] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
