### PR TITLE
feat(kinput): support label attrs

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -33,6 +33,21 @@ If the label is omitted it can be handled with another component, like **KLabel*
 </template>
 ```
 
+### labelAttributes
+
+Use the `labelAttributes` prop to configure the the **KLabel's** props if using the `label` prop.
+
+<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
+
+```vue
+<KInput
+  label="Name"
+  :label-attributes="{
+    help: 'I use the KLabel `help` prop'
+  }"
+/>
+```
+
 ### overlayLabel
 
 Enable this prop to overlay the label on the input element's border. Defaults to `false`.

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -35,9 +35,9 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the the **KLabel's** props if using the `label` prop.
+Use the `labelAttributes` prop to configure the the **KLabel's** [props](/components/label.html) if using the `label` prop.
 
-<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
+<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' }" />
 
 ```vue
 <KInput

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -35,7 +35,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the the **KLabel's** [props](/components/label.html) if using the `label` prop.
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label.html) if using the `label` prop.
 
 <KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' }" />
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -31,6 +31,21 @@ If the label is omitted it can be handled with another component, like **KLabel*
 </template>
 ```
 
+### labelAttributes
+
+Use the `labelAttributes` prop to configure the the **KLabel's** props if using the `label` prop.
+
+<KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
+
+```vue
+<KTextArea
+  label="Name"
+  :label-attributes="{
+    help: 'I use the KLabel `help` prop'
+  }"
+/>
+```
+
 ### overlayLabel
 
 Enable this prop to overlay the label on the input element's border. Defaults to `false`.

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -33,7 +33,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the the **KLabel's** [props](/components/label.html) if using the `label` prop.
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label.html) if using the `label` prop.
 
 <KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -33,7 +33,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the the **KLabel's** props if using the `label` prop.
+Use the `labelAttributes` prop to configure the the **KLabel's** [props](/components/label.html) if using the `label` prop.
 
 <KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 

--- a/packages/KInput/KInput.spec.js
+++ b/packages/KInput/KInput.spec.js
@@ -32,6 +32,22 @@ describe('KInput', () => {
     expect(wrapper.find('.k-input-label').element.innerHTML).toContain('A Label!')
   })
 
+  it('renders label with labelAttributes applied', () => {
+    const labelText = 'A Label'
+    const wrapper = mount(KInput, {
+      propsData: {
+        testMode: true,
+        label: labelText,
+        labelAttributes: {
+          help: 'some help text'
+        }
+      }
+    })
+
+    expect(wrapper.find('.k-input-label').element.innerHTML).toContain(labelText)
+    expect(wrapper.find('.k-input-label .kong-icon-help').exists()).toBeTruthy()
+  })
+
   it('renders overlayed label when value is passed', () => {
     const wrapper = mount(KInput, {
       propsData: {

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -9,6 +9,7 @@
       <div class="text-on-input">
         <label
           :for="inputId"
+          v-bind="labelAttributes"
           :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled }">
           <span>{{ label }}</span>
         </label>
@@ -40,7 +41,8 @@
       v-else-if="label"
       :class="`k-input-label-wrapper-${size}`">
       <KLabel
-        :for="inputId">
+        :for="inputId"
+        v-bind="labelAttributes">
         {{ label }}
       </KLabel>
       <input
@@ -110,6 +112,10 @@ export default {
     overlayLabel: {
       type: Boolean,
       default: false
+    },
+    labelAttributes: {
+      type: Object,
+      default: () => ({})
     },
     help: {
       type: String,

--- a/packages/KTextArea/KTextArea.spec.js
+++ b/packages/KTextArea/KTextArea.spec.js
@@ -33,6 +33,22 @@ describe('KTextArea', () => {
     expect(wrapper.find('.k-input-label').element.innerHTML).toContain('A Label!')
   })
 
+  it('renders label with labelAttributes applied', () => {
+    const labelText = 'A Label'
+    const wrapper = mount(KTextArea, {
+      propsData: {
+        testMode: true,
+        label: labelText,
+        labelAttributes: {
+          help: 'some help text'
+        }
+      }
+    })
+
+    expect(wrapper.find('.k-input-label').element.innerHTML).toContain(labelText)
+    expect(wrapper.find('.k-input-label .kong-icon-help').exists()).toBeTruthy()
+  })
+
   it('renders overlayed label when value is passed', () => {
     const wrapper = mount(KTextArea, {
       propsData: {

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -17,6 +17,7 @@
       <div class="text-on-input">
         <label
           :for="textAreaId"
+          v-bind="labelAttributes"
           :class="{ focused: isFocused, hovered: isHovered }">
           <span>{{ label }}</span>
         </label>
@@ -40,7 +41,8 @@
       v-else
       class="mt-5">
       <KLabel
-        :for="textAreaId">
+        :for="textAreaId"
+        v-bind="labelAttributes">
         {{ label }}
       </KLabel>
       <textarea
@@ -88,6 +90,10 @@ export default {
     overlayLabel: {
       type: Boolean,
       default: false
+    },
+    labelAttributes: {
+      type: Object,
+      default: () => ({})
     },
     characterLimit: {
       type: Number,


### PR DESCRIPTION
### Summary
Add `labelAttributes` prop.

#### Changes made:
* Add `labelAttributes` prop to `KInput` and `KTextArea`
* Update docs
* Add tests

![image](https://user-images.githubusercontent.com/67973710/157128156-8fdd606e-2c78-47b8-a4fc-7835f5d53b74.png)


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
