### PR TITLE
feat(kselect): add support for labelattrs

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -89,6 +89,42 @@ The label for the select.
 />
 ```
 
+### labelAttributes
+
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label.html) if using the `label` prop.
+
+<KSelect
+  label="Name"
+  :label-attributes="{
+    help: 'I use the KLabel `help` prop',
+    'data-testid': 'test'
+  }"
+  :items="[{
+    label: 'test',
+    value: 'test'
+  }, {
+    label: 'Test 1',
+    value: 'test1'
+  }]"
+/>
+
+```vue
+<KSelect
+  label="Name"
+  :label-attributes="{
+    help: 'I use the KLabel `help` prop',
+    'data-testid': 'test'
+  }"
+  :items="[{
+    label: 'test',
+    value: 'test'
+  }, {
+    label: 'Test 1',
+    value: 'test1'
+  }]"
+/>
+```
+
 ### appearance
 
 There are three styles of selects, `select` and `dropdown` (default) which are filterable, and lastly `button` which is not.

--- a/packages/KSelect/KSelect.spec.js
+++ b/packages/KSelect/KSelect.spec.js
@@ -92,6 +92,26 @@ describe('KSelect', () => {
     expect(selectLabel.text()).toEqual('Cool Beans!')
   })
 
+  it('renders label with labelAttributes applied', () => {
+    const labelText = 'A Label'
+    const wrapper = mount(KSelect, {
+      propsData: {
+        testMode: true,
+        label: labelText,
+        labelAttributes: {
+          help: 'some help text'
+        },
+        items: [{
+          label: 'Label 1',
+          value: 'label1'
+        }]
+      }
+    })
+
+    expect(wrapper.find('.k-input-label').element.innerHTML).toContain(labelText)
+    expect(wrapper.find('.k-input-label .kong-icon-help').exists()).toBeTruthy()
+  })
+
   it('renders with correct appearance - select', () => {
     const wrapper = mount(KSelect, {
       propsData: {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -6,6 +6,7 @@
     <KLabel
       v-if="label"
       :for="selectId"
+      v-bind="labelAttributes"
       data-testid="k-select-label">{{ label }}</KLabel>
     <div
       :id="selectId"
@@ -147,6 +148,10 @@ export default {
     label: {
       type: String,
       default: ''
+    },
+    labelAttributes: {
+      type: Object,
+      default: () => ({})
     },
     /**
      * The width of the select and popover's min-width


### PR DESCRIPTION
### Summary
Add support for `labelAttributes`

#### Changes made:
* Add new prop
* Update docs
* Update tests

![image](https://user-images.githubusercontent.com/67973710/158701141-1dacc210-6865-4814-876b-79d97e8b1165.png)


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
