### PR TITLE
fix(kselect): set up v-model

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -292,6 +292,40 @@ of the input, dropdown, and selected item.
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`. See [`KPop` docs](popover.html#positionfixed) for more information.
 
+### v-model
+
+KSelect works as regular inputs do using v-model for data binding:
+
+<Komponent :data="{myVal: 'test'}" v-slot="{ data }">
+  <div>
+    <KLabel>Value:</KLabel> {{ data.myVal }}
+    <KSelect width="100" v-model="data.myVal" :items="[{
+        label: 'test',
+        value: 'test'
+      }, {
+        label: 'Test 1',
+        value: 'test1'
+      }]"
+    />
+  </div>
+</Komponent>
+
+```vue
+<Komponent :data="{myVal: 'test'}" v-slot="{ data }">
+  <div>
+    <KLabel>Value:</KLabel> {{ data.myVal }}
+    <KSelect width="100" v-model="data.myVal" :items="[{
+        label: 'test',
+        value: 'test'
+      }, {
+        label: 'Test 1',
+        value: 'test1'
+      }]"
+    />
+  </div>
+</Komponent>
+```
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -84,7 +84,6 @@
               v-model="filterStr"
               :placeholder="placeholderText"
               class="k-select-input"
-              v-on="listeners"
               @keyup="triggerFocus(isToggled)" />
           </div>
           <template v-slot:content>

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -15,7 +15,6 @@
         v-if="selectedItem && appearance === 'dropdown'"
         class="k-select-item-selection px-3 py-1">
         <div
-          :value="selectedItem.value"
           class="selected-item-label">{{ selectedItem.label }}</div>
         <button
           class="clear-selection-icon cursor-pointer non-visual-button"
@@ -139,6 +138,10 @@ export default {
   components: { KButton, KIcon, KInput, KLabel, KPop, KSelectItem, KToggle },
   inheritAttrs: false,
   props: {
+    value: {
+      type: [String, Number],
+      default: ''
+    },
     kpopAttributes: {
       type: Object,
       default: () => ({
@@ -287,7 +290,8 @@ export default {
 
     for (let i = 0; i < this.selectItems.length; i++) {
       this.selectItems[i].key = `${this.selectItems[i].label.replace(' ', '-')}-${i}`
-      if (this.selectItems[i].selected) {
+      if (this.selectItems[i].value === this.value || this.selectItems[i].selected) {
+        this.selectItems[i].selected = true
         this.selectedItem = this.selectItems[i]
         this.selectItems[i].key += '-selected'
 
@@ -312,7 +316,7 @@ export default {
       this.filterStr = this.appearance === 'dropdown' ? '' : item.label
       this.$emit('selected', item)
       // this 'input' event must be emitted for v-model binding to work properly
-      this.$emit('input', item)
+      this.$emit('input', item.value)
       this.$emit('change', item)
     },
     clearSelection () {

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -73,7 +73,7 @@ exports[`KSelect renders with selected item 1`] = `
   <!---->
   <div id="test-select-id-1234" data-testid="k-select-selected-item">
     <div class="k-select-item-selection px-3 py-1">
-      <div value="label1" class="selected-item-label">Label 1</div> <button class="clear-selection-icon cursor-pointer non-visual-button"><span class="kong-icon kong-icon-clear"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <div class="selected-item-label">Label 1</div> <button class="clear-selection-icon cursor-pointer non-visual-button"><span class="kong-icon kong-icon-clear"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Clear</title>
   <circle cx="10" cy="10" r="6.25" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></circle>
   <path d="M12 12 8 8M12 8l-4 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>


### PR DESCRIPTION
### Summary
Fix `v-model` to work correctly on `KSelect`, should hook up to just the item's value you not the entire object.

#### Changes made:
* Fix v-model
* Update docs/tests

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
