### PR TITLE
fix(kbreadcrumbs): fix icon size

### DIFF
--- a/packages/Krumbs/Krumbs.vue
+++ b/packages/Krumbs/Krumbs.vue
@@ -18,8 +18,7 @@
           :icon="item.icon"
           :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
           hide-title
-          size="16"
-          view-box="0 0 20 20"
+          size="20"
           color="var(--grey-500)"
         />
         <span
@@ -40,7 +39,7 @@
           :icon="item.icon"
           :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
           hide-title
-          size="15"
+          size="20"
           color="var(--grey-500)"
         />
         <span


### PR DESCRIPTION

### Summary

Fix `Krumbs` icon size to allow the icon itself to control its own `viewBox`.

Already ported to `next` branch.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
