### PR TITLE
fix(kbreadcrumbs): icon size

### DIFF
--- a/packages/Krumbs/Krumbs.vue
+++ b/packages/Krumbs/Krumbs.vue
@@ -18,8 +18,7 @@
           :icon="item.icon"
           :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
           hide-title
-          size="16"
-          view-box="0 0 20 20"
+          size="20"
           color="var(--grey-500)"
         />
         <span
@@ -40,7 +39,7 @@
           :icon="item.icon"
           :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
           hide-title
-          size="15"
+          size="20"
           color="var(--grey-500)"
         />
         <span

--- a/packages/Krumbs/Krumbs.vue
+++ b/packages/Krumbs/Krumbs.vue
@@ -18,7 +18,7 @@
           :icon="item.icon"
           :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
           hide-title
-          size="20"
+          size="18"
           color="var(--grey-500)"
         />
         <span
@@ -39,7 +39,7 @@
           :icon="item.icon"
           :class="[ 'breadcrumb-icon', {'has-no-text': !item.text} ]"
           hide-title
-          size="20"
+          size="18"
           color="var(--grey-500)"
         />
         <span


### PR DESCRIPTION
### Summary

Fix `Krumbs` icon size to allow the icon itself to control its own viewBox.

Already ported to `next` branch.

#### Before (notice no icon)

![image](https://user-images.githubusercontent.com/2229946/160520328-b84071ce-ffbf-47f1-bace-9e194ede00e1.png)

#### After (icon properly renders)

![image](https://user-images.githubusercontent.com/2229946/160520623-10fae401-fa2b-4bd3-8158-a1b01198504c.png)

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
