### PR TITLE
fix(kmodal): hide body overflow

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -119,12 +119,14 @@ export default {
   watch: {
     isVisible: {
       handler (visible) {
-        if (visible) {
-          // Hide body overflow
-          document.body.classList.add('k-modal-overflow-hidden')
-        } else {
-          // Reset body overflow
-          document.body.classList.remove('k-modal-overflow-hidden')
+        if (typeof document !== 'undefined') {
+          if (visible) {
+            // Hide body overflow
+            document.body.classList.add('k-modal-overflow-hidden')
+          } else {
+            // Reset body overflow
+            document.body.classList.remove('k-modal-overflow-hidden')
+          }
         }
       },
       immediate: true

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -116,12 +116,29 @@ export default {
     }
   },
 
+  watch: {
+    isVisible: {
+      handler (visible) {
+        if (visible) {
+          // Hide body overflow
+          document.body.classList.add('k-modal-overflow-hidden')
+        } else {
+          // Reset body overflow
+          document.body.classList.remove('k-modal-overflow-hidden')
+        }
+      },
+      immediate: true
+    }
+  },
+
   mounted () {
     document.addEventListener('keydown', this.handleKeydown)
   },
 
   beforeDestroy () {
     document.removeEventListener('keydown', this.handleKeydown)
+    // Reset body overflow
+    document.body.classList.remove('k-modal-overflow-hidden')
   },
 
   methods: {
@@ -151,6 +168,11 @@ export default {
   right: 0;
   background-color: var(--KModalBackdrop, rgba(11, 23, 45, .6));
   z-index: 1100;
+}
+
+// Allow modal backdrop to scroll if viewport is shorter than modal
+.k-modal-overflow-hidden .k-modal-backdrop {
+  overflow: auto;
 }
 
 .k-modal-dialog {
@@ -195,5 +217,12 @@ export default {
   .k-modal-footer .k-modal-action-buttons {
     margin-left: auto;
   }
+}
+</style>
+
+<style lang="scss">
+// Leave unscoped to target 'body' element
+body.k-modal-overflow-hidden {
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
### Summary

Hide body overflow when `KModal` is open. 

Also adds rule to allow backdrop to scroll as needed.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
