### PR TITLE
fix(kpop): fix kpop toggle behavior [khcp-3244]

### DIFF
--- a/packages/KPop/KPop.spec.js
+++ b/packages/KPop/KPop.spec.js
@@ -113,7 +113,7 @@ describe('KPop', () => {
 
     expect(wrapper.vm.isOpen).toBe(false)
     slottedEl.trigger('click')
-    expect(wrapper.vm.isOpen).toBe(true)
+    expect(wrapper.vm.isOpen).toBe(false)
   })
 
   it('shows element on hover', () => {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -388,7 +388,6 @@ export default {
           popper.addEventListener('blur', this.hidePopper)
         }
 
-        this.reference.addEventListener('click', this.handleClick)
         popper.addEventListener('click', this.showPopper)
         document.documentElement.addEventListener('click', this.handleClick)
       }

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -35,15 +35,15 @@ exports[`KSelect renders props when passed 1`] = `
   <!---->
   <div id="test-select-id-1234" data-testid="k-select-selected-item">
     <!---->
-    <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" aria-expanded="true">
+    <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
-        <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium" is-open="true">
+        <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">


### PR DESCRIPTION
### Summary
[https://konghq.atlassian.net/browse/KHCP-3244](https://konghq.atlassian.net/browse/KHCP-3244)

#### Changes made:
*

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
