### PR TITLE
feat(kviewswitcher): metalab style updates

### DIFF
--- a/packages/KViewSwitcher/KViewSwitcher.vue
+++ b/packages/KViewSwitcher/KViewSwitcher.vue
@@ -5,7 +5,7 @@
     :title="`Toggle to ${view === 'table' ? 'grid' : 'table'} view`"
     size="small"
     appearance="outline"
-    class="view-switch-button"
+    class="view-switch-button non-visual-button"
     @click="toggleView"
   >
     <div class="icon">
@@ -84,7 +84,7 @@ export default {
       border-radius: 2px;
       width: var(--width, 7px);
       height: var(--height, 7px);
-      background-color: var(--steel-300);
+      background-color: var(--grey-500);
       animation: var(--name, var(--dots-name, none)) var(--duration, var(--dots-duration, .5s)) var(--easing, var(--dots-easing, linear)) forwards var(--delay, var(--dots-delay, 0s));
       transition: background-color 200ms ease;
     }

--- a/packages/KViewSwitcher/__snapshots__/KViewSwitcher.spec.js.snap
+++ b/packages/KViewSwitcher/__snapshots__/KViewSwitcher.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KViewSwitcher matches snapshot 1`] = `
-<button type="button" class="k-button view-switch-button small outline table paused" title="Toggle to grid view">
+<button type="button" class="k-button view-switch-button non-visual-button small outline table paused" title="Toggle to grid view">
   <!---->
   <div class="icon">
     <div class="dots"><i></i><i></i><i></i><i></i></div>


### PR DESCRIPTION
### Summary
Metalab style updates

![image](https://user-images.githubusercontent.com/67973710/161276310-0e849b1a-3b76-4b86-8d86-013d0721fea2.png)


#### Changes made:
* Style updates for KViewSwitcher
* Update snaps

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
