### PR TITLE
feat(kcardcatalog): fix item slotting

### DIFF
--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -47,7 +47,7 @@ The catalog title.
 
 ### items
 
-The content of the cards. Expects a `title` and a `description`.
+**DEPRECATED -** The content of the cards. Expects a `title` and a `description`.
 
 <KCardCatalog :items="getItems(6)" />
 ```vue

--- a/docs/components/card-catalog.md
+++ b/docs/components/card-catalog.md
@@ -420,8 +420,11 @@ Set the `isLoading` prop to `true` to enable the loading state.
 
 ## Slots
 
-- `body` - The body of the card catalog, we expect this to be an array of `KCatalogItem` components.
-This should be used instead of the `items` property.
+Both the `title` & `description` of the card items as well as the entire catalog `body` are slottable.
+
+- `body` - The body of the card catalog, if you do not want to use `KCatalogItem` components for the children.
+- `cardHeader` - Will slot the card title for each entry
+- `cardBody` - Will slot the card body for each entry
 
 <KCardCatalog title="I'm slotted baby!" >
   <template v-slot:body>
@@ -431,33 +434,6 @@ This should be used instead of the `items` property.
       :item="item"
       class="catalog-item"
     />
-    <KCatalogItem
-      :item="longItem"
-      :truncate="true"
-      class="catalog-item"
-    />
-    <KCatalogItem>
-      <template v-slot:cardTitle>
-        <h4 class="d-flex">
-          <KIcon
-            icon="profile"
-            color="#7F01FE"
-            size="24" />
-          <span class="ml-2">Call Me!</span>
-        </h4>
-      </template>
-      <template v-slot:cardBody>
-        <span class="mr-2">Take action!</span>
-        <KButton size="small">
-          <KIcon
-            icon="gearFilled"
-            size="16"
-            view-box="0 0 16 16"
-            class="pr-0"
-          />
-        </KButton>
-      </template>
-    </KCatalogItem>
   </template>
 </KCardCatalog>
 
@@ -470,33 +446,58 @@ This should be used instead of the `items` property.
       :item="item"
       class="catalog-item"
     />
-    <KCatalogItem
-      :item="longItem"
-      :truncate="true"
-      class="catalog-item"
-    />
-    <KCatalogItem>
-      <template v-slot:cardTitle>
-        <h4 class="d-flex">
-          <KIcon
-            icon="profile"
-            color="#7F01FE"
-            size="24" />
-          <span class="ml-2">Call Me!</span>
-        </h4>
-      </template>
-      <template v-slot:cardBody>
-        <span class="mr-2">Take action!</span>
-        <KButton size="small">
-          <KIcon
-            icon="gearFilled"
-            size="16"
-            view-box="0 0 16 16"
-            class="pr-0"
-          />
-        </KButton>
-      </template>
-    </KCatalogItem>
+  </template>
+</KCardCatalog>
+```
+
+If used in conjuction with a `fetcher` you have the option of using the returned `data`.
+
+<KCardCatalog :fetcher="fetcherSm" title="Customized body">
+  <template v-slot:body="{ data }">
+    <div v-for="item in data">
+      <h4>{{ item.title }}</h4>
+      <p>{{ item.description }}</p>
+    </div>
+  </template>
+</KCardCatalog>
+
+```vue
+<KCardCatalog :fetcher="fetcher" title="Customized body">
+  <template v-slot:body="{ data }">
+    <div v-for="item in data">
+      <h4>{{ item.title }}</h4>
+      <p>{{ item.description }}</p>
+    </div>
+  </template>
+</KCardCatalog>
+```
+
+Use the `cardTitle` and `cardBody` slots to access `item` specific data.
+
+<KCardCatalog :fetcher="fetcherSm" title="Customized cards">
+  <template v-slot:cardTitle="{ item }">
+    <div class="color-blue-500">
+      {{ item.title }}
+    </div>
+  </template>
+  <template v-slot:cardBody="{ item }">
+    <span class="color-purple-400">
+    {{ item.description }}
+    </span>
+  </template>
+</KCardCatalog>
+
+```vue
+<KCardCatalog :fetcher="fetcher" title="Customized cards">
+  <template v-slot:cardTitle="{ item }">
+    <div class="color-blue-500">
+      {{ item.title }}
+    </div>
+  </template>
+  <template v-slot:cardBody="{ item }">
+    <span class="color-purple-400">
+    {{ item.description }}
+    </span>
   </template>
 </KCardCatalog>
 ```
@@ -552,7 +553,12 @@ is triggered and will be resolved when the fetcher returns. You can override thi
 :::
 
 <KCardCatalog
-  :fetcher="fetcher" />
+  :fetcher="fetcher"
+  :initial-fetcher-params="{
+    pageSize: 15,
+    page: 1
+  }"
+/>
 
 ```http
 Example URL
@@ -654,6 +660,16 @@ export default {
         _page: payload.page,
         data: await this.resolveAfter5MiliSec(25, payload.pageSize, payload.page),
         total: 25
+      }
+
+      return params
+    },
+    async fetcherSm(payload) {
+      const params = {
+        _limit: payload.pageSize,
+        _page: payload.page,
+        data: await this.resolveAfter5MiliSec(6, payload.pageSize, payload.page),
+        total: 6
       }
 
       return params

--- a/packages/KCardCatalog/KCardCatalog.spec.js
+++ b/packages/KCardCatalog/KCardCatalog.spec.js
@@ -124,6 +124,29 @@ describe('KCardCatalog', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
 
+    it('renders slotted cards when passed', async () => {
+      const slotHeader = 'Look mah!'
+      const slotBody = 'My body'
+
+      const wrapper = mount(KCardCatalog, {
+        localVue,
+        propsData: {
+          testMode: true,
+          items: getItems(1)
+        },
+        scopedSlots: {
+          'cardTitle': `<span>${slotHeader}</span>`,
+          'cardBody': `<span>${slotBody}</span>`
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+
+      expect(wrapper.find('.k-card-header').html()).toEqual(expect.stringContaining(slotHeader))
+      expect(wrapper.find('.k-card-body').html()).toEqual(expect.stringContaining(slotBody))
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
     it('renders slots when passed (with empty)', async () => {
       const emptySlotContent = 'Look mah! I am empty! (except testMode)'
 

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -151,6 +151,7 @@
           :current-page="page"
           :neighbors="paginationNeighbors"
           :page-sizes="paginationPageSizes"
+          :initial-page-size="pageSize"
           :disable-page-jump="disablePaginationPageJump"
           class="pa-1"
           @pageChanged="pageChangeHandler"

--- a/packages/KCardCatalog/KCardCatalog.vue
+++ b/packages/KCardCatalog/KCardCatalog.vue
@@ -88,7 +88,9 @@
       v-else
       :class="`k-card-${cardSize}`"
       class="k-catalog-page">
-      <slot name="body">
+      <slot
+        :data="data"
+        name="body">
         <template v-for="item in data">
           <router-link
             v-if="item.locationParam"
@@ -99,7 +101,22 @@
               :truncate="!noTruncation"
               :test-mode="testMode"
               class="catalog-item"
-            />
+            >
+              <template #cardTitle>
+                <slot
+                  :item="item"
+                  name="cardTitle">
+                  {{ item.title }}
+                </slot>
+              </template>
+              <template #cardBody>
+                <slot
+                  :item="item"
+                  name="cardBody">
+                  {{ item.description }}
+                </slot>
+              </template>
+            </KCatalogItem>
           </router-link>
           <KCatalogItem
             v-else
@@ -108,7 +125,22 @@
             :truncate="!noTruncation"
             :test-mode="testMode"
             class="catalog-item"
-          />
+          >
+            <template #cardTitle>
+              <slot
+                :item="item"
+                name="cardTitle">
+                {{ item.title }}
+              </slot>
+            </template>
+            <template #cardBody>
+              <slot
+                :item="item"
+                name="cardBody">
+                {{ item.description }}
+              </slot>
+            </template>
+          </KCatalogItem>
         </template>
       </slot>
       <div

--- a/packages/KCardCatalog/__snapshots__/KCardCatalog.spec.js.snap
+++ b/packages/KCardCatalog/__snapshots__/KCardCatalog.spec.js.snap
@@ -79,6 +79,32 @@ exports[`KCardCatalog general renders slots when passed 1`] = `
 </div>
 `;
 
+exports[`KCardCatalog general renders slotted cards when passed 1`] = `
+<div class="k-card-catalog">
+  <!---->
+  <div class="k-catalog-page k-card-medium">
+    <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-0-catalog-item" role="button" tabindex="0">
+      <div class="k-card-header d-flex mb-4">
+        <div>
+          <!---->
+          <div id="test-title-id-1234" class="k-card-title">
+            <h4><span>Look mah!</span></h4>
+          </div>
+        </div>
+        <div class="k-card-actions"></div>
+      </div>
+      <div class="k-card-content d-flex">
+        <div id="test-content-id-1234" class="k-card-body">
+          <div class="multi-line-truncate"><span>My body</span></div>
+        </div>
+        <!---->
+      </div>
+    </section>
+    <!---->
+  </div>
+</div>
+`;
+
 exports[`KCardCatalog states displays a loading skeletion when the "isLoading" prop is set to true" 1`] = `
 <div class="k-card-catalog">
   <!---->

--- a/packages/KPagination/KPagination.vue
+++ b/packages/KPagination/KPagination.vue
@@ -162,7 +162,7 @@ export default {
   data () {
     const currPage = this.currentPage ? this.currentPage : 1
     const currentPageSize = this.initialPageSize ? this.initialPageSize : this.pageSizes[0]
-    const pageCount = Math.ceil(this.totalCount / currentPageSize)
+    const pageCount = Math.ceil(this.totalCount / currentPageSize) || 1
 
     const pageSizeOptions = this.pageSizes.map((size, i) => ({
       label: `${size}`,

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -60,11 +60,14 @@ exports[`KTable default has hover class when passed 1`] = `
 </span></a></li>
           <!---->
           <!---->
+          <li data-testid="page-1-btn" class="pagination-button active"><a aria-label="Go to page 1" aria-current="page" href="#">
+              1
+            </a></li>
           <!---->
           <!---->
-          <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg viewBox="0 0 16 14" fill="var(--blue-400)" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          <li data-testid="next-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg viewBox="0 0 16 14" fill="var(--grey-500)" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Forward</title>
-  <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
         </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
@@ -215,11 +218,14 @@ exports[`KTable sorting should allow disabling sorting 1`] = `
 </span></a></li>
           <!---->
           <!---->
+          <li data-testid="page-1-btn" class="pagination-button active"><a aria-label="Go to page 1" aria-current="page" href="#">
+              1
+            </a></li>
           <!---->
           <!---->
-          <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg viewBox="0 0 16 14" fill="var(--blue-400)" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          <li data-testid="next-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg viewBox="0 0 16 14" fill="var(--grey-500)" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Forward</title>
-  <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
         </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
@@ -320,11 +326,14 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
 </span></a></li>
           <!---->
           <!---->
+          <li data-testid="page-1-btn" class="pagination-button active"><a aria-label="Go to page 1" aria-current="page" href="#">
+              1
+            </a></li>
           <!---->
           <!---->
-          <li data-testid="next-btn" class="pagination-button square"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg viewBox="0 0 16 14" fill="var(--blue-400)" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          <li data-testid="next-btn" class="pagination-button square disabled"><a href="#" aria-label="Go to the next page"><span class="kong-icon kong-icon-arrowRight"><svg viewBox="0 0 16 14" fill="var(--grey-500)" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Forward</title>
-  <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--blue-400)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
+  <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
         </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">


### PR DESCRIPTION
### Summary
Fix slotting behavior in `KCardCatalog`.

#### Changes made:
* Add `cardTitle` and `cardBody` slots
* Return `data` on `body` slot
* Return `item` on card slots

![image](https://user-images.githubusercontent.com/67973710/161302608-301db606-31b1-425f-9e09-72861a963d06.png)

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
