### PR TITLE
feat(kcard): dom fix

### DIFF
--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -6,30 +6,32 @@
     :aria-describedby="contentId"
     class="kong-card">
     <div
-      v-if="title || $scopedSlots.title || $slots.title || $scopedSlots.actions || status || $scopedSlots.statusHat"
+      v-if="$scopedSlots.actions || status || $scopedSlots.statusHat"
       :class="{ 'has-status': status || $scopedSlots.statusHat }"
-      class="k-card-header d-flex mb-4">
-      <div>
-        <div
-          v-if="status || $scopedSlots.statusHat"
-          class="k-card-status-hat mb-4">
-          <!-- @slot Use this slot to pass status text above title -->
-          <slot name="statusHat">{{ status }}</slot>
-        </div>
-        <div
-          :id="title ? null : titleId"
-          class="k-card-title">
-          <h4>
-            <!-- @slot Use this slot to pass title content -->
-            <slot name="title">{{ title }}</slot>
-          </h4>
-        </div>
+      class="k-card-header d-flex mb-3">
+      <div
+        v-if="status || $scopedSlots.statusHat"
+        class="k-card-status-hat">
+        <!-- @slot Use this slot to pass status text above title -->
+        <slot name="statusHat">{{ status }}</slot>
       </div>
+
       <div class="k-card-actions">
         <!-- @slot Use this slot to pass actions to right side of header -->
         <slot name="actions"/>
       </div>
     </div>
+
+    <div
+      v-if="title || $scopedSlots.title || $slots.title"
+      :id="title ? null : titleId"
+      class="k-card-title mb-3">
+      <h4>
+        <!-- @slot Use this slot to pass title content -->
+        <slot name="title">{{ title }}</slot>
+      </h4>
+    </div>
+
     <div class="k-card-content d-flex">
       <div
         :id="contentId"
@@ -37,6 +39,7 @@
         <!-- @slot Use this slot to pass in body content -->
         <slot name="body">{{ body }}</slot>
       </div>
+
       <div
         v-if="$scopedSlots.notifications"
         class="k-card-notifications ml-3">
@@ -142,7 +145,6 @@ export default {
 
   .k-card-header {
     align-items: center;
-    min-height: 38px;
 
     &.has-status {
       align-items: flex-start;

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`KCard has hover class when passed 1`] = `
 <section aria-describedby="test-content-id-1234" class="kong-card border hover">
   <!---->
+  <!---->
   <div class="k-card-content d-flex">
     <div id="test-content-id-1234" class="k-card-body"></div>
     <!---->
@@ -12,6 +13,7 @@ exports[`KCard has hover class when passed 1`] = `
 
 exports[`KCard has shadow class when passed 1`] = `
 <section aria-describedby="test-content-id-1234" class="kong-card border kcard-shadow">
+  <!---->
   <!---->
   <div class="k-card-content d-flex">
     <div id="test-content-id-1234" class="k-card-body"></div>
@@ -23,6 +25,7 @@ exports[`KCard has shadow class when passed 1`] = `
 exports[`KCard matches snapshot 1`] = `
 <section aria-describedby="test-content-id-1234" class="kong-card border">
   <!---->
+  <!---->
   <div class="k-card-content d-flex">
     <div id="test-content-id-1234" class="k-card-body"></div>
     <!---->
@@ -32,14 +35,12 @@ exports[`KCard matches snapshot 1`] = `
 
 exports[`KCard renders proper content when using props 1`] = `
 <section aria-label="Card Title" aria-describedby="test-content-id-1234" class="kong-card border">
-  <div class="k-card-header d-flex mb-4 has-status">
-    <div>
-      <div class="k-card-status-hat mb-4">Card Status</div>
-      <div class="k-card-title">
-        <h4>Card Title</h4>
-      </div>
-    </div>
+  <div class="k-card-header d-flex mb-3 has-status">
+    <div class="k-card-status-hat">Card Status</div>
     <div class="k-card-actions"></div>
+  </div>
+  <div class="k-card-title mb-3">
+    <h4>Card Title</h4>
   </div>
   <div class="k-card-content d-flex">
     <div id="test-content-id-1234" class="k-card-body">Card Body</div>
@@ -50,14 +51,12 @@ exports[`KCard renders proper content when using props 1`] = `
 
 exports[`KCard renders slots when passed 1`] = `
 <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card border">
-  <div class="k-card-header d-flex mb-4 has-status">
-    <div>
-      <div class="k-card-status-hat mb-4"><span>Card Status Hat</span></div>
-      <div id="test-title-id-1234" class="k-card-title">
-        <h4><span>Card Title</span></h4>
-      </div>
-    </div>
+  <div class="k-card-header d-flex mb-3 has-status">
+    <div class="k-card-status-hat"><span>Card Status Hat</span></div>
     <div class="k-card-actions"><span>Card Actions</span></div>
+  </div>
+  <div id="test-title-id-1234" class="k-card-title mb-3">
+    <h4><span>Card Title</span></h4>
   </div>
   <div class="k-card-content d-flex">
     <div id="test-content-id-1234" class="k-card-body">

--- a/packages/KCardCatalog/KCardCatalog.spec.js
+++ b/packages/KCardCatalog/KCardCatalog.spec.js
@@ -142,7 +142,7 @@ describe('KCardCatalog', () => {
 
       await tick(wrapper.vm, 1)
 
-      expect(wrapper.find('.k-card-header').html()).toEqual(expect.stringContaining(slotHeader))
+      expect(wrapper.find('.k-card-title').html()).toEqual(expect.stringContaining(slotHeader))
       expect(wrapper.find('.k-card-body').html()).toEqual(expect.stringContaining(slotBody))
       expect(wrapper.html()).toMatchSnapshot()
     })

--- a/packages/KCardCatalog/KCatalogItem.vue
+++ b/packages/KCardCatalog/KCatalogItem.vue
@@ -1,6 +1,6 @@
 <template>
   <KCard
-    :data-testid="item ? `${item.title.replace(' ', '-')}-catalog-item` : 'catalog-item'"
+    :data-testid="item && item.title ? `${item.title.replace(' ', '-')}-catalog-item` : 'catalog-item'"
     :test-mode="testMode"
     class="grid-item d-flex flex-column overflow-hidden k-card-catalog-item"
     has-hover

--- a/packages/KCardCatalog/__snapshots__/KCardCatalog.spec.js.snap
+++ b/packages/KCardCatalog/__snapshots__/KCardCatalog.spec.js.snap
@@ -84,14 +84,9 @@ exports[`KCardCatalog general renders slotted cards when passed 1`] = `
   <!---->
   <div class="k-catalog-page k-card-medium">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-0-catalog-item" role="button" tabindex="0">
-      <div class="k-card-header d-flex mb-4">
-        <div>
-          <!---->
-          <div id="test-title-id-1234" class="k-card-title">
-            <h4><span>Look mah!</span></h4>
-          </div>
-        </div>
-        <div class="k-card-actions"></div>
+      <!---->
+      <div id="test-title-id-1234" class="k-card-title mb-3">
+        <h4><span>Look mah!</span></h4>
       </div>
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">


### PR DESCRIPTION
### Summary
Long title should not affect placement of `actions` content.

Fix this:

![image](https://user-images.githubusercontent.com/67973710/161556728-f10e4692-8d31-4c62-aa14-bf152a94447b.png)


#### Changes made:
* Allow the `title` slot to take full width below the `statusHat` and `actions` slots
* Check for `title` in `KCatalogItem`
* Update snaps

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
