### PR TITLE
fix(kcatalog): fix state display with body slot

### DIFF
--- a/packages/KCatalog/KCatalog.vue
+++ b/packages/KCatalog/KCatalog.vue
@@ -6,7 +6,7 @@
       <h3>{{ title }}</h3>
     </div>
     <KSkeleton
-      v-if="!testMode && !$scopedSlots.body && (isCardLoading || isLoading) && !hasError"
+      v-if="!testMode && (isCardLoading || isLoading) && !hasError"
       :card-count="4"
       class="k-skeleton-grid"
       type="card"
@@ -59,7 +59,7 @@
     </div>
 
     <div
-      v-else-if="!$scopedSlots.body && !hasError && (!isCardLoading && !isLoading) && (data && !data.length)"
+      v-else-if="!hasError && (!isCardLoading && !isLoading) && (data && !data.length)"
       data-testid="k-card-catalog-empty-state">
       <slot name="empty-state">
         <KEmptyState


### PR DESCRIPTION
### Summary
Show `empty` and `loading` states as expected if using `body` slot.

#### Changes made:
*

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
