### PR TITLE
fix(kcard): title positioning

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -11,11 +11,9 @@
 
 ## Props
 
-### Title
+### title
 
 String to be used in the title slot.
-
-- `title`
 
 <KCard title="Title">
   <template v-slot:body>
@@ -85,12 +83,10 @@ Example composing `KCard` with other Kongponents to make another component:
 </KCard>
 ```
 
-### Status
+### status
 
 String to be used in the `statusHat` slot.
 
-- `status`
-
 <KCard
   status="My status"
   title="My title"
@@ -105,19 +101,17 @@ String to be used in the `statusHat` slot.
 />
 ```
 
-### Body
+### body
 
 String to be used in the body slot.
 
-- `body`
-
 <KCard body="I am the body."/>
 
 ```vue
 <KCard body="I am the body."/>
 ```
 
-### Border Variants
+### borderVariant
 
 Sets top border or no border. If neither set default will have border
 
@@ -128,43 +122,35 @@ Sets top border or no border. If neither set default will have border
   <KCard
     title="Card without border"
     body="Body Content"
-    borderVariant="noBorder"/>
+    border-variant="noBorder"/>
 
   <KCard
     title="Card with top border"
     body="Body Content"
-    borderVariant="borderTop"/>
+    border-variant="borderTop"/>
 </div>
 
 ```vue
 <KCard
   title="Card without border"
   body="Body Content"
-  borderVariant="noBorder"/>
+  border-variant="noBorder"/>
 
 <KCard
   title="Card with top border"
   body="Body Content"
-  borderVariant="borderTop"/>
+  border-variant="borderTop"/>
 ```
 
-### Shadow
+### hasHover
 
-Sets if card has shadow state (shadow)
-
-- `hasHover` only set shadow on hover
-- `hasShadow` always setShadow
+Sets if card should only display shadow state (shadow) on hover
 
 <KCard
   title="hasHover"
   class="mb-2"
   body="This card only has a shadow on hover"
-  hasHover/>
-
-<KCard
-  title="hasShadow"
-  body="This card always has a shadow"
-  hasShadow/>
+  has-hover />
 
 ```vue
 <KCard
@@ -172,14 +158,25 @@ Sets if card has shadow state (shadow)
   class="mb-2"
   body="This card only has a shadow on hover"
   hasHover/>
+```
+
+### hasShadow
+
+Set so the card always has shadow state (shadow)
 
 <KCard
   title="hasShadow"
   body="This card always has a shadow"
-  hasShadow/>
+  has-shadow />
+
+```vue
+<KCard
+  title="hasShadow"
+  body="This card always has a shadow"
+  has-shadow />
 ```
 
-### Side by side
+## Using flex box
 
 Cards can be arranged with flex box.
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -157,7 +157,7 @@ Sets if card should only display shadow state (shadow) on hover
   title="hasHover"
   class="mb-2"
   body="This card only has a shadow on hover"
-  hasHover/>
+  has-hover/>
 ```
 
 ### hasShadow

--- a/packages/KCard/KCard.vue
+++ b/packages/KCard/KCard.vue
@@ -6,7 +6,7 @@
     :aria-describedby="contentId"
     class="kong-card">
     <div
-      v-if="$scopedSlots.actions || status || $scopedSlots.statusHat"
+      v-if="$scopedSlots.actions || useStatusHatLayout || (!useStatusHatLayout && (title || $scopedSlots.title || $slots.title))"
       :class="{ 'has-status': status || $scopedSlots.statusHat }"
       class="k-card-header d-flex mb-3">
       <div
@@ -16,6 +16,16 @@
         <slot name="statusHat">{{ status }}</slot>
       </div>
 
+      <div
+        v-if="!useStatusHatLayout && (title || $scopedSlots.title || $slots.title)"
+        :id="title ? null : titleId"
+        class="k-card-title mb-3">
+        <h4>
+          <!-- @slot Use this slot to pass title content -->
+          <slot name="title">{{ title }}</slot>
+        </h4>
+      </div>
+
       <div class="k-card-actions">
         <!-- @slot Use this slot to pass actions to right side of header -->
         <slot name="actions"/>
@@ -23,7 +33,7 @@
     </div>
 
     <div
-      v-if="title || $scopedSlots.title || $slots.title"
+      v-if="useStatusHatLayout && (title || $scopedSlots.title || $slots.title)"
       :id="title ? null : titleId"
       class="k-card-title mb-3">
       <h4>
@@ -113,6 +123,12 @@ export default {
     return {
       titleId: !this.testMode ? uuid.v1() : 'test-title-id-1234',
       contentId: !this.testMode ? uuid.v1() : 'test-content-id-1234'
+    }
+  },
+
+  computed: {
+    useStatusHatLayout () {
+      return this.status || this.$scopedSlots.statusHat
     }
   }
 }

--- a/packages/KCard/__snapshots__/KCard.spec.js.snap
+++ b/packages/KCard/__snapshots__/KCard.spec.js.snap
@@ -37,6 +37,7 @@ exports[`KCard renders proper content when using props 1`] = `
 <section aria-label="Card Title" aria-describedby="test-content-id-1234" class="kong-card border">
   <div class="k-card-header d-flex mb-3 has-status">
     <div class="k-card-status-hat">Card Status</div>
+    <!---->
     <div class="k-card-actions"></div>
   </div>
   <div class="k-card-title mb-3">
@@ -53,6 +54,7 @@ exports[`KCard renders slots when passed 1`] = `
 <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card border">
   <div class="k-card-header d-flex mb-3 has-status">
     <div class="k-card-status-hat"><span>Card Status Hat</span></div>
+    <!---->
     <div class="k-card-actions"><span>Card Actions</span></div>
   </div>
   <div id="test-title-id-1234" class="k-card-title mb-3">

--- a/packages/KCatalog/KCatalogItem.vue
+++ b/packages/KCatalog/KCatalogItem.vue
@@ -1,6 +1,6 @@
 <template>
   <KCard
-    :data-testid="item && item.title ? `${item.title.replace(' ', '-')}-catalog-item` : 'catalog-item'"
+    :data-testid="item && item.title ? `${item.title.replace(/[^0-9a-z]/gi, '-')}-catalog-item` : 'catalog-item'"
     :test-mode="testMode"
     class="grid-item d-flex flex-column overflow-hidden k-card-catalog-item"
     has-hover

--- a/packages/KCatalog/KCatalogItem.vue
+++ b/packages/KCatalog/KCatalogItem.vue
@@ -1,6 +1,6 @@
 <template>
   <KCard
-    :data-testid="item ? `${item.title.replace(' ', '-')}-catalog-item` : 'catalog-item'"
+    :data-testid="item && item.title ? `${item.title.replace(' ', '-')}-catalog-item` : 'catalog-item'"
     :test-mode="testMode"
     class="grid-item d-flex flex-column overflow-hidden k-card-catalog-item"
     has-hover

--- a/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
+++ b/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
@@ -336,7 +336,7 @@ exports[`KCatalog general can disable truncation 1`] = `
 <div class="k-card-catalog">
   <!---->
   <div class="k-catalog-page k-card-medium">
-    <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="A-very long item-catalog-item" role="button" tabindex="0">
+    <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="A-very-long-item-catalog-item" role="button" tabindex="0">
       <div class="k-card-header d-flex mb-3">
         <!---->
         <div id="test-title-id-1234" class="k-card-title mb-3">
@@ -422,7 +422,7 @@ exports[`KCatalog general handles truncation 1`] = `
 <div class="k-card-catalog">
   <!---->
   <div class="k-catalog-page k-card-medium">
-    <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="A-very long item-catalog-item" role="button" tabindex="0">
+    <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="A-very-long-item-catalog-item" role="button" tabindex="0">
       <div class="k-card-header d-flex mb-3">
         <!---->
         <div id="test-title-id-1234" class="k-card-title mb-3">

--- a/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
+++ b/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
@@ -5,12 +5,16 @@ exports[`KCatalog general can change card sizes - large 1`] = `
   <!---->
   <div class="k-catalog-page k-card-large">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-0-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 0
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 0
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -21,12 +25,16 @@ exports[`KCatalog general can change card sizes - large 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-1-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 1
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 1
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -37,12 +45,16 @@ exports[`KCatalog general can change card sizes - large 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-2-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 2
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 2
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -53,12 +65,16 @@ exports[`KCatalog general can change card sizes - large 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-3-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 3
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 3
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -69,12 +85,16 @@ exports[`KCatalog general can change card sizes - large 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-4-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 4
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 4
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -151,12 +171,16 @@ exports[`KCatalog general can change card sizes - small 1`] = `
   <!---->
   <div class="k-catalog-page k-card-small">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-0-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 0
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 0
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -167,12 +191,16 @@ exports[`KCatalog general can change card sizes - small 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-1-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 1
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 1
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -183,12 +211,16 @@ exports[`KCatalog general can change card sizes - small 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-2-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 2
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 2
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -199,12 +231,16 @@ exports[`KCatalog general can change card sizes - small 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-3-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 3
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 3
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -215,12 +251,16 @@ exports[`KCatalog general can change card sizes - small 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-4-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 4
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 4
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -297,12 +337,16 @@ exports[`KCatalog general can disable truncation 1`] = `
   <!---->
   <div class="k-catalog-page k-card-medium">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="A-very long item-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          A very long item
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            A very long item
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="">
@@ -379,12 +423,16 @@ exports[`KCatalog general handles truncation 1`] = `
   <!---->
   <div class="k-catalog-page k-card-medium">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="A-very long item-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          A very long item
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            A very long item
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -529,12 +577,16 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
   </div>
   <div class="k-catalog-page k-card-medium">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-0-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 0
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 0
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -545,12 +597,16 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-1-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 1
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 1
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -561,12 +617,16 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-2-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 2
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 2
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -577,12 +637,16 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-3-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 3
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 3
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -593,12 +657,16 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
       </div>
     </section>
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-4-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4>
-          Item 4
-        </h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4>
+            Item 4
+          </h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate">
@@ -755,10 +823,14 @@ exports[`KCatalog general renders slotted cards when passed 1`] = `
   <!---->
   <div class="k-catalog-page k-card-medium">
     <section aria-labelledby="test-title-id-1234" aria-describedby="test-content-id-1234" class="kong-card grid-item d-flex flex-column overflow-hidden k-card-catalog-item catalog-item border hover" data-testid="Item-0-catalog-item" role="button" tabindex="0">
-      <!---->
-      <div id="test-title-id-1234" class="k-card-title mb-3">
-        <h4><span>Look mah!</span></h4>
+      <div class="k-card-header d-flex mb-3">
+        <!---->
+        <div id="test-title-id-1234" class="k-card-title mb-3">
+          <h4><span>Look mah!</span></h4>
+        </div>
+        <div class="k-card-actions"></div>
       </div>
+      <!---->
       <div class="k-card-content d-flex">
         <div id="test-content-id-1234" class="k-card-body">
           <div class="multi-line-truncate"><span>My body</span></div>


### PR DESCRIPTION
### Summary
Fix `KCard` title positioning.

If no `statusHat`, align the `title` with the `actions` content. If there is a `statusHat`, align the `statusHat` with the `actions` content and display the `title` beneath.

No statusHat:

![image](https://user-images.githubusercontent.com/67973710/162482408-e1ae3ff7-b007-4b3a-831e-6aa7a68bed59.png)

With statusHat:

![image](https://user-images.githubusercontent.com/67973710/162482584-22a219a2-e8d2-4274-b69c-201b61f34eb8.png)


#### Changes made:
* Update `KCard`
* Update `snaps`

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
