### PR TITLE
fix(kcard): title positioning 

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -110,35 +110,38 @@ Sets top border or no border. If neither set default will have border
 - `noBorder`
 
 <div class="borderless-cards">
-  <KCard title="Card without border" body="Body Content" borderVariant="noBorder"/>
+  <KCard title="Card without border" body="Body Content" border-variant="noBorder"/>
 
-  <KCard title="Card with top border" body="Body Content" borderVariant="borderTop"/>
+  <KCard title="Card with top border" body="Body Content" border-variant="borderTop"/>
 </div>
 
 ```vue
-<KCard title="Card without border" body="Body Content" borderVariant="noBorder"/>
+<KCard title="Card without border" body="Body Content" border-variant="noBorder"/>
 
-<KCard title="Card with top border" body="Body Content" borderVariant="borderTop"/>
+<KCard title="Card with top border" body="Body Content" border-variant="borderTop"/>
 ```
 
-### hasHover, hasShadow
+### hasHover
 
-Sets if card has shadow state (shadow)
+Set if card should have shadow state (shadow) on hover
 
-- `hasHover` only set shadow on hover
-- `hasShadow` always setShadow
-
-<KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" hasHover />
-
-<KCard title="hasShadow" body="This card always has a shadow" hasShadow />
+<KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" has-hover />
 
 ```vue
-<KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" hasHover />
-
-<KCard title="hasShadow" body="This card always has a shadow" hasShadow />
+<KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" has-hover />
 ```
 
-## Side by side
+### hasShadow
+
+Set if the card should always have shadow state (shadow)
+
+<KCard title="hasShadow" body="This card always has a shadow" has-shadow />
+
+```vue
+<KCard title="hasShadow" body="This card always has a shadow" has-shadow />
+```
+
+## Using flex box
 
 Cards can be arranged with flex box.
 

--- a/src/components/KCard/KCard.vue
+++ b/src/components/KCard/KCard.vue
@@ -136,7 +136,7 @@ export default defineComponent({
     const titleId = computed((): string => props.testMode ? uuidv1() : 'test-title-id-1234')
     const contentId = computed((): string => props.testMode ? uuidv1() : 'test-content-id-1234')
     const useStatusHatLayout = computed((): boolean => {
-      return !!(props.status || slots.statusHat)
+      return !!(props.status || !!slots.statusHat)
     })
 
     return {

--- a/src/components/KCard/KCard.vue
+++ b/src/components/KCard/KCard.vue
@@ -142,7 +142,7 @@ export default defineComponent({
     return {
       titleId,
       contentId,
-      useStatusHatLayout
+      useStatusHatLayout,
     }
   },
 })

--- a/src/components/KCard/KCard.vue
+++ b/src/components/KCard/KCard.vue
@@ -7,7 +7,7 @@
     class="kong-card"
   >
     <div
-      v-if="$slots.actions || status || $slots.statusHat"
+      v-if="$slots.actions || useStatusHatLayout || (!useStatusHatLayout && (title || $slots.title))"
       :class="{ 'has-status': status || $slots.statusHat }"
       class="k-card-header d-flex mb-3"
     >
@@ -21,6 +21,16 @@
         </slot>
       </div>
 
+      <div
+        v-if="!useStatusHatLayout && (title || $slots.title)"
+        :id="title ? null : titleId"
+        class="k-card-title mb-3">
+        <h4>
+          <!-- @slot Use this slot to pass title content -->
+          <slot name="title">{{ title }}</slot>
+        </h4>
+      </div>
+
       <div class="k-card-actions">
         <!-- @slot Use this slot to pass actions to right side of header -->
         <slot name="actions" />
@@ -28,7 +38,7 @@
     </div>
 
     <div
-      v-if="title || $slots.title || $slots.title"
+      v-if="useStatusHatLayout && (title || $slots.title)"
       :id="title ? null : titleId"
       class="k-card-title mb-3"
     >
@@ -122,13 +132,17 @@ export default defineComponent({
     },
   },
 
-  setup(props) {
+  setup(props, { slots }) {
     const titleId = computed((): string => props.testMode ? uuidv1() : 'test-title-id-1234')
     const contentId = computed((): string => props.testMode ? uuidv1() : 'test-content-id-1234')
+    const useStatusHatLayout = computed((): boolean => {
+      return !!(props.status || slots.statusHat)
+    })
 
     return {
       titleId,
       contentId,
+      useStatusHatLayout
     }
   },
 })


### PR DESCRIPTION
### Summary
Fix KCard title positioning.

If no statusHat, align the title with the actions content. If there is a statusHat, align the statusHat with the actions content and display the title beneath.

#### Changes made:
* Update KCard
* Update snaps

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
