### PR TITLE
fix(ktable): add sortHandlerFn prop

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -107,6 +107,131 @@ Set this to `true` to disable ablity to sort.
 **Experimental** - set this prop to `true` to enable client side sorting if using a fetcher that returns unpaginatinated data.
 This functionality may be flaky.
 
+### sortHandlerFn
+
+Use a custom sort handler function to handle sorting table data for specific columns
+
+::: tip Notes
+
+1. In order for a column to use the custom sort handler function, `useSortHandlerFn` must be set to `true` in the [headers](#headers) object
+
+2. Sort handler functions can take four params:
+
+- `key`: the key of the column to be sorted
+- `prevKey`: the key of the column previously sorted
+- `sortColumnOrder`: the order in which to sort the column (`asc` or `desc`)
+- `data`: the data returned from the fetcher function response
+:::
+
+#### sortHandlerFn Example
+
+Here the `last_seen` column is set to use the custom sort handler function via the `useSortHandlerFn` property set in the table header object. The function passed into the `sortHandlerFn` prop sorts and returns the table data. The other columns use the default built-in client side sort function because the `useSortHandlerFn` property is not set in the header objects.
+
+<KTable
+  :fetcher="sortHandlerFnFetcher"
+  :headers="sortHandlerFnHeaders"
+  :sortHandlerFn="sortHandlerFn"
+  enable-client-sort
+/>
+
+```vue
+<template>
+  <KTable
+    :fetcher="fetcher"
+    :headers="headers"
+    :sortHandlerFn="sortHandlerFn"
+    enable-client-sort
+  />
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      headers: [
+        { label: 'Host', key: 'hostname', sortable: true },
+        { label: 'Version', key: 'version', sortable: true },
+        { label: 'Connected', key: 'connected', sortable: true },
+        { label: 'Last Seen', key: 'last_seen', sortable: true, useSortHandlerFn: true }
+      ],
+    }
+  },
+  methods: {
+    sortHandlerFn({ key, prevKey, sortColumnOrder, data}) {
+      return data.sort((a, b) => {
+        if (key === 'last_seen') {
+          if (sortColumnOrder === 'asc') {
+            if (a.last_ping > b.last_ping) {
+              return 1
+            } else if (a.last_ping < b.last_ping) {
+              return -1
+            }
+
+            return 0
+          } else {
+            if (a.last_ping > b.last_ping) {
+              return -1
+            } else if (a.last_ping < b.last_ping) {
+              return 1
+            }
+
+            return 0
+          }
+        }
+      })
+    },
+
+    fetcher() {
+      return {
+        data: [
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.8.0.0-enterprise-edition',
+            hostname: '99e591ae3776',
+            last_ping: 1648855072,
+            connected: 'Disconnected',
+            last_seen: '6 days ago'
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.7.0.0-enterprise-edition',
+            hostname: '19e591ae3776',
+            last_ping: 1649362660,
+            connected: 'Connected',
+            last_seen: '3 hours ago',
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.8.1.0-enterprise-edition',
+            hostname: '79e591ae3776',
+            last_ping: 1649355460,
+            connected: 'Connected',
+            last_seen: '5 hours ago',
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.6.0.0-enterprise-edition',
+            hostname: '89e591ae3776',
+            last_ping: 1648155072,
+            connected: 'Disconnected',
+            last_seen: '14 days ago'
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.8.2.0-enterprise-edition',
+            hostname: '59e591ae3776',
+            last_ping: 1649855072,
+            connected: 'Connected',
+            last_seen: 'Just now'
+          },
+        ]
+      }
+    },
+  }
+}
+</script>
+```
+
 ### fetcher
 
 Use a custom fetcher function to fetch table data and leverage server-side search, sort and pagination.
@@ -292,6 +417,7 @@ Pass in an array of header objects for the table.
 | `label` | string | The label displayed on the table for the column
 | `sortable` | boolean | Enables or disables server-side sorting for the column (`false` by default)
 | `hideLabel`| boolean | Hides or displays the column label (useful for actions columns)
+| `useSortHandlerFn` | boolean | Uses the function passed in the [sortHandlerFn](#sorthandlerfn) prop to sort the column data instead of the default client sorter function
 
 :::tip Note
 `sortable` columns emit a `sort` event when clicked, returns:
@@ -1131,7 +1257,13 @@ export default {
         { label: 'Name', key: 'name' },
         { label: 'Company', key: 'company' },
         { label: 'Description', key: 'description' }
-      ]
+      ],
+      sortHandlerFnHeaders: [
+        { label: 'Host', key: 'hostname', sortable: true },
+        { label: 'Version', key: 'version', sortable: true },
+        { label: 'Connected', key: 'connected', sortable: true },
+        { label: 'Last Seen', key: 'last_seen', sortable: true, useSortHandlerFn: true }
+      ],
     }
   },
   methods: {
@@ -1250,6 +1382,77 @@ for (let i = ((page-1)* pageSize); i < limit; i++) {
             name: 'TensorFlow',
             company: 'Google',
             description: 'TensorFlow is an open source software library for numerical computation using data flow graphs.',
+          },
+        ]
+      }
+    },
+
+    sortHandlerFn({ key, prevKey, sortColumnOrder, data}) {
+      return data.sort((a, b) => {
+        if (key === 'last_seen') {
+          if (sortColumnOrder === 'asc') {
+            if (a.last_ping > b.last_ping) {
+              return 1
+            } else if (a.last_ping < b.last_ping) {
+              return -1
+            }
+
+            return 0
+          } else {
+            if (a.last_ping > b.last_ping) {
+              return -1
+            } else if (a.last_ping < b.last_ping) {
+              return 1
+            }
+
+            return 0
+          }
+        }
+      })
+    },
+
+    sortHandlerFnFetcher() {
+      return {
+        data: [
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.8.0.0-enterprise-edition',
+            hostname: '99e591ae3776',
+            last_ping: 1648855072,
+            connected: 'Disconnected',
+            last_seen: '6 days ago'
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.7.0.0-enterprise-edition',
+            hostname: '19e591ae3776',
+            last_ping: 1649362660,
+            connected: 'Connected',
+            last_seen: '3 hours ago',
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.8.1.0-enterprise-edition',
+            hostname: '79e591ae3776',
+            last_ping: 1649355460,
+            connected: 'Connected',
+            last_seen: '5 hours ago',
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.6.0.0-enterprise-edition',
+            hostname: '89e591ae3776',
+            last_ping: 1648155072,
+            connected: 'Disconnected',
+            last_seen: '14 days ago'
+          },
+          {
+            id: '08cc7d81-a9d8-4ae1-a42f-8d4e5a919d07',
+            version: '2.8.2.0-enterprise-edition',
+            hostname: '59e591ae3776',
+            last_ping: 1649855072,
+            connected: 'Connected',
+            last_seen: 'Just now'
           },
         ]
       }

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1391,17 +1391,17 @@ for (let i = ((page-1)* pageSize); i < limit; i++) {
       return data.sort((a, b) => {
         if (key === 'last_seen') {
           if (sortColumnOrder === 'asc') {
-            if (a.last_ping > b.last_ping) {
+            if (a.last_ping < b.last_ping) {
               return 1
-            } else if (a.last_ping < b.last_ping) {
+            } else if (a.last_ping > b.last_ping) {
               return -1
             }
 
             return 0
           } else {
-            if (a.last_ping > b.last_ping) {
+            if (a.last_ping < b.last_ping) {
               return -1
-            } else if (a.last_ping < b.last_ping) {
+            } else if (a.last_ping > b.last_ping) {
               return 1
             }
 

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -96,7 +96,7 @@
                       sortColumnKey: column.key,
                       sortColumnOrder: sortColumnOrder === 'asc' ? 'desc' : 'asc' // display opposite because sortColumnOrder outdated
                     })
-                    sortClickHandler(column.key)
+                    sortClickHandler(column)
                   }
                 }"
               >
@@ -464,6 +464,10 @@ export default defineComponent({
     testMode: {
       type: String,
       default: ''
+    },
+    sortHandlerFn: {
+      type: Function,
+      default: () => ({})
     }
   },
   data: function () {
@@ -600,7 +604,9 @@ export default defineComponent({
       { revalidateOnFocus: false }
     )
 
-    const sortClickHandler = (key) => {
+    const sortClickHandler = (header) => {
+      const { key, useSortHandlerFn } = header
+
       page.value = 1
       let prevKey = sortColumnKey.value + '' // avoid pass by ref
 
@@ -623,7 +629,16 @@ export default defineComponent({
       // Use deprecated sort function to sort data passed in via
       // the deprecated options.data prop
       if ((props.options && props.options.data) || props.enableClientSort) {
-        defaultSorter(key, prevKey, sortColumnOrder.value, data.value)
+        if (useSortHandlerFn && props.sortHandlerFn) {
+          props.sortHandlerFn({
+            key,
+            prevKey,
+            sortColumnOrder: sortColumnOrder.value,
+            data: data.value
+          })
+        } else {
+          defaultSorter(key, prevKey, sortColumnOrder.value, data.value)
+        }
       } else {
         revalidate()
       }


### PR DESCRIPTION
### Summary
Adds a `sortHandlerFn` prop allowing custom sorting on table columns.

#### Changes made:
* Adds `sortHandlerFn` prop
* Adds `useSortHandlerFn` property to `headers` object
* Updates docs to detail the new prop and provide a usage example

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `next` branch, please add the [`port to next branch`](https://github.com/Kong/kongponents/labels/port%20to%20next%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `next` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
