### PR TITLE
test(kselect): update height [pdux-624]

### DIFF
--- a/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
+++ b/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
@@ -137,21 +137,21 @@ exports[`KCatalog general can change card sizes - large 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -303,21 +303,21 @@ exports[`KCatalog general can change card sizes - small 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -389,21 +389,21 @@ exports[`KCatalog general can disable truncation 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -475,21 +475,21 @@ exports[`KCatalog general handles truncation 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -541,21 +541,21 @@ exports[`KCatalog general matches snapshot 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -709,21 +709,21 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -789,21 +789,21 @@ exports[`KCatalog general renders slots when passed 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -871,21 +871,21 @@ exports[`KCatalog general renders slotted cards when passed 1`] = `
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>
@@ -937,21 +937,21 @@ exports[`KCatalog states displays a loading skeletion when the "isLoading" prop 
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
-              <div data-testid="k-select-item-15" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-30" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-50" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-75" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
-              <div data-testid="k-select-item-100" class="k-select-item mx-4">
-                <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-              </div>
+              <li data-testid="k-select-item-15" class="k-select-item">
+                <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-30" class="k-select-item">
+                <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-50" class="k-select-item">
+                <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-75" class="k-select-item">
+                <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
+              <li data-testid="k-select-item-100" class="k-select-item">
+                <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+              </li>
               <!---->
             </ul>
           </div>

--- a/packages/KPagination/__snapshots__/KPagination.spec.js.snap
+++ b/packages/KPagination/__snapshots__/KPagination.spec.js.snap
@@ -45,15 +45,15 @@ exports[`KPagination correctly renders props 1`] = `
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">
-        <div data-testid="k-select-item-2" class="k-select-item mx-4">
-          <li role="option" class="d-block"><button value="2" class=""><span class="k-select-item-label mr-2">2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-        </div>
-        <div data-testid="k-select-item-4" class="k-select-item mx-4">
-          <li role="option" class="d-block"><button value="4" class=""><span class="k-select-item-label mr-2">4</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-        </div>
-        <div data-testid="k-select-item-6" class="k-select-item mx-4">
-          <li role="option" class="d-block"><button value="6" class=""><span class="k-select-item-label mr-2">6</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-        </div>
+        <li data-testid="k-select-item-2" class="k-select-item">
+          <div role="option" class="d-block"><button value="2" class=""><span class="k-select-item-label mr-2">2</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+        </li>
+        <li data-testid="k-select-item-4" class="k-select-item">
+          <div role="option" class="d-block"><button value="4" class=""><span class="k-select-item-label mr-2">4</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+        </li>
+        <li data-testid="k-select-item-6" class="k-select-item">
+          <div role="option" class="d-block"><button value="6" class=""><span class="k-select-item-label mr-2">6</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+        </li>
         <!---->
       </ul>
     </div>
@@ -120,15 +120,15 @@ exports[`KPagination matches snapshot 1`] = `
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">
-        <div data-testid="k-select-item-10" class="k-select-item mx-4">
-          <li role="option" class="d-block"><button value="10" class=""><span class="k-select-item-label mr-2">10</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-        </div>
-        <div data-testid="k-select-item-20" class="k-select-item mx-4">
-          <li role="option" class="d-block"><button value="20" class=""><span class="k-select-item-label mr-2">20</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-        </div>
-        <div data-testid="k-select-item-30" class="k-select-item mx-4">
-          <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-        </div>
+        <li data-testid="k-select-item-10" class="k-select-item">
+          <div role="option" class="d-block"><button value="10" class=""><span class="k-select-item-label mr-2">10</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+        </li>
+        <li data-testid="k-select-item-20" class="k-select-item">
+          <div role="option" class="d-block"><button value="20" class=""><span class="k-select-item-label mr-2">20</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+        </li>
+        <li data-testid="k-select-item-30" class="k-select-item">
+          <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+        </li>
         <!---->
       </ul>
     </div>

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -393,7 +393,7 @@ export default {
     position: relative;
     display: inline-block;
     width: 100%;
-    height: 32px;
+    height: 44px;
 
     input.k-input {
       padding: var(--spacing-xs);
@@ -406,10 +406,6 @@ export default {
       top: 15px;
       right: 6px;
       z-index: 9;
-    }
-
-    .kong-icon-chevronDown {
-      top: 10px;
     }
   }
 

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -1,10 +1,10 @@
 <template>
-  <div
+  <li
     :key="item.key"
     :data-testid="`k-select-item-${item.value}`"
-    class="k-select-item mx-4"
+    class="k-select-item"
     @click="handleClick">
-    <li
+    <div
       role="option"
       class="d-block">
       <button
@@ -21,8 +21,8 @@
             color="var(--blue-200)" />
         </span>
       </button>
-    </li>
-  </div>
+    </div>
+  </li>
 </template>
 
 <script>
@@ -71,6 +71,11 @@ export default {
     border-radius: 4px;
     text-align: left;
     font-weight: 200;
+
+    &:not(:disabled),
+    &:not(.disabled) {
+      cursor: pointer;
+    }
 
     .k-select-item-label {
       width: auto;

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -17,9 +17,9 @@ exports[`KSelect matches snapshot 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div data-testid="k-select-item-label1" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
+            <li data-testid="k-select-item-label1" class="k-select-item">
+              <div role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
             <!---->
           </ul>
         </div>
@@ -47,15 +47,15 @@ exports[`KSelect renders props when passed 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div data-testid="k-select-item-label1" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-label2" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="label2" class=""><span class="k-select-item-label mr-2">Label 2</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-label3" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="label3" class=""><span class="k-select-item-label mr-2">Label 3</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
+            <li data-testid="k-select-item-label1" class="k-select-item">
+              <div role="option" class="d-block"><button value="label1" class=""><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-label2" class="k-select-item">
+              <div role="option" class="d-block"><button value="label2" class=""><span class="k-select-item-label mr-2">Label 2</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-label3" class="k-select-item">
+              <div role="option" class="d-block"><button value="label3" class=""><span class="k-select-item-label mr-2">Label 3</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
             <!---->
           </ul>
         </div>
@@ -90,12 +90,12 @@ exports[`KSelect renders with selected item 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div data-testid="k-select-item-label1" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="label1" class="selected"><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><span class="kong-icon selected-item-icon kong-icon-check"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <li data-testid="k-select-item-label1" class="k-select-item">
+              <div role="option" class="d-block"><button value="label1" class="selected"><span class="k-select-item-label mr-2">Label 1</span> <span class="k-select-selected-icon-container"><span class="kong-icon selected-item-icon kong-icon-check"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="m14 7-6 6-3-3" fill="none" stroke="#A3BBCC" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
-</span></span></button></li>
-            </div>
+</span></span></button></div>
+            </li>
             <!---->
           </ul>
         </div>

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -80,21 +80,21 @@ exports[`KTable default has hover class when passed 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div data-testid="k-select-item-15" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-30" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-50" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-75" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-100" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
+            <li data-testid="k-select-item-15" class="k-select-item">
+              <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-30" class="k-select-item">
+              <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-50" class="k-select-item">
+              <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-75" class="k-select-item">
+              <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-100" class="k-select-item">
+              <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
             <!---->
           </ul>
         </div>
@@ -238,21 +238,21 @@ exports[`KTable sorting should allow disabling sorting 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div data-testid="k-select-item-15" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-30" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-50" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-75" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-100" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
+            <li data-testid="k-select-item-15" class="k-select-item">
+              <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-30" class="k-select-item">
+              <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-50" class="k-select-item">
+              <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-75" class="k-select-item">
+              <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-100" class="k-select-item">
+              <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
             <!---->
           </ul>
         </div>
@@ -346,21 +346,21 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
-            <div data-testid="k-select-item-15" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-30" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-50" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-75" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
-            <div data-testid="k-select-item-100" class="k-select-item mx-4">
-              <li role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></li>
-            </div>
+            <li data-testid="k-select-item-15" class="k-select-item">
+              <div role="option" class="d-block"><button value="15" class=""><span class="k-select-item-label mr-2">15</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-30" class="k-select-item">
+              <div role="option" class="d-block"><button value="30" class=""><span class="k-select-item-label mr-2">30</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-50" class="k-select-item">
+              <div role="option" class="d-block"><button value="50" class=""><span class="k-select-item-label mr-2">50</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-75" class="k-select-item">
+              <div role="option" class="d-block"><button value="75" class=""><span class="k-select-item-label mr-2">75</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
+            <li data-testid="k-select-item-100" class="k-select-item">
+              <div role="option" class="d-block"><button value="100" class=""><span class="k-select-item-label mr-2">100</span> <span class="k-select-selected-icon-container"><!----></span></button></div>
+            </li>
             <!---->
           </ul>
         </div>


### PR DESCRIPTION
### Summary
Dropdown form fields do not match other fields (are much shorter height-wise).
[https://konghq.atlassian.net/browse/PDUX-624](https://konghq.atlassian.net/browse/PDUX-624)

#### Changes made:

-  `.k-select-input` height changed from 32px to `44px`
- Removed the `top` css style for .`kong-icon-chevronDown` to align the icon based on new height

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
