### PR TITLE
ci: update get changed files action

### DIFF
--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -1,0 +1,62 @@
+name: Get Changed files
+
+on:
+  workflow_call:
+    outputs:
+      changed-files:
+        description: Get list of all changes
+        value: ${{ jobs.get-changed-files.outputs.changed-files }}
+      component-files-changed:
+        description: Check if component (`src` directory) files have changed
+        value: ${{ jobs.get-changed-files.outputs.component-files-changed }}
+      docs-files-changed:
+        description: Check if docs (`docs` directory) files have changed
+        value: ${{ jobs.get-changed-files.outputs.docs-files-changed }}
+      src-or-docs-files-changed:
+        description: Check if src or docs (`src` or `docs` directories) files have changed
+        value: ${{ jobs.get-changed-files.outputs.src-or-docs-files-changed }}
+
+
+jobs:
+  get-changed-files:
+    name: Check changed files
+    runs-on: ubuntu-20.04
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+      component-files-changed: ${{ steps.component-files-changed.outputs.only_modified }}
+      docs-files-changed: ${{ steps.docs-files-changed.outputs.only_modified }}
+      src-or-docs-files-changed: ${{ steps.src-or-docs-files-changed.outputs.only_modified }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Get list of all changes
+        uses: tj-actions/changed-files@v18
+        id: changed-files
+
+      - name: Check if component (`src` directory) files have changed
+        uses: tj-actions/changed-files@v18
+        id: component-files-changed
+        # Return 'true' for any directories listed here that changed
+        with:
+          files: |
+            src
+
+      - name: Check if docs (`docs` directory) files have changed
+        uses: tj-actions/changed-files@v18
+        id: docs-files-changed
+        # Return 'true' for any directories listed here that changed
+        with:
+          files: |
+            docs
+
+      - name: Check if src or docs (`src` or `docs` directories) files have changed
+        uses: tj-actions/changed-files@v18
+        id: src-or-docs-files-changed
+        # Return 'true' for any directories listed here that changed
+        with:
+          files: |
+            src
+            docs

--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -16,7 +16,6 @@ on:
         description: Check if src or docs (`src` or `docs` directories) files have changed
         value: ${{ jobs.get-changed-files.outputs.src-or-docs-files-changed }}
 
-
 jobs:
   get-changed-files:
     name: Check changed files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,11 @@ on:
 jobs:
   get-changed-files:
     name: Get Changed Files
-    # Update `@beta` branch to `@main` once 6.x branch is created
-    uses: Kong/kongponents/.github/workflows/get-changed-files.yml@beta
+    uses: ./.github/workflows/get-changed-files.yml
 
   run-tests:
     name: Tests
-    # Update `@beta` branch to `@main` once 6.x branch is created
-    uses: Kong/kongponents/.github/workflows/test.yml@beta
+    uses: ./.github/workflows/test.yml
     # Must pass in secrets here so that the calling workflow can pass in the NPM_TOKEN needed to install private packages.
     secrets:
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,11 @@ on:
       - beta
 
 jobs:
+  get-changed-files:
+    name: Get Changed Files
+    # Update `@beta` branch to `@main` once 6.x branch is created
+    uses: Kong/kongponents/.github/workflows/get-changed-files.yml@beta
+
   run-tests:
     name: Tests
     # Update `@beta` branch to `@main` once 6.x branch is created
@@ -13,27 +18,6 @@ jobs:
     # Must pass in secrets here so that the calling workflow can pass in the NPM_TOKEN needed to install private packages.
     secrets:
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-
-  get-changed-files:
-    name: Check for component changes
-    runs-on: ubuntu-20.04
-    outputs:
-      changed-files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
-      component-files-changed: ${{ steps.component-files-changed.outputs.only_modified }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Get list of all changes
-        uses: tj-actions/changed-files@v18
-        id: changed-files
-      - name: Check if component (`src` directory) files have changed
-        uses: tj-actions/changed-files@v18
-        id: component-files-changed
-        # Return 'true' for any directories listed here that changed
-        with:
-          files: |
-            src
 
   publish:
       name: Build and Publish Kongponents
@@ -81,3 +65,13 @@ jobs:
           env:
              # Since branch protections are on (pushing commits) you need to use a bot PAT
             GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
+
+  no-publish-required:
+    name: No Components Changed - Skipping New Release
+    needs:
+      - get-changed-files
+    if: needs.get-changed-files.outputs.component-files-changed == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip new release
+        run: echo "No files changed in the `src/` directory, so no new release is required."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   get-changed-files:
     name: Get Changed Files
-    # Update `@beta` branch to `@main` once 6.x branch is created
-    uses: Kong/kongponents/.github/workflows/get-changed-files.yml@beta
+    uses: ./.github/workflows/get-changed-files.yml
 
   test:
     name: Run Component Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  get-changed-files:
+    name: Get Changed Files
+    # Update `@beta` branch to `@main` once 6.x branch is created
+    uses: Kong/kongponents/.github/workflows/get-changed-files.yml@beta
+
   test:
     name: Run Component Tests
+    needs:
+      - get-changed-files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,6 +64,8 @@ jobs:
 
       # Percy - disabled on `beta` branch for now
       # - name: Percy visual regression test for docs
+      #   # Only test with Percy if files in the /src/ or /docs/ directory changed.
+      #   if: needs.get-changed-files.outputs.src-or-docs-files-changed == 'true'
       #   run: |
       #     npx percy snapshot docs/.vuepress/dist/ --ignore-files "**/404.html"
       #   env:


### PR DESCRIPTION
### Summary

Moves `get-changed-files` CI workflow action into it's own file.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
