### PR TITLE
fix(kbadge): doc issues [khcp-3409]

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -21,10 +21,10 @@ The Badge component can take the following appearance values:
 - `default`
 - `custom`
 
-<KBadge appearance="success">SUCCESS</KBadge>
-<KBadge appearance="warning">WARNING</KBadge>
-<KBadge appearance="danger">DANGER</KBadge>
-<KBadge appearance="info">INFO</KBadge>
+<KBadge appearance="success" class="mr-2">SUCCESS</KBadge>
+<KBadge appearance="warning" class="mr-2">WARNING</KBadge>
+<KBadge appearance="danger" class="mr-2">DANGER</KBadge>
+<KBadge appearance="info" class="mr-2">INFO</KBadge>
 <KBadge>DEFAULT</KBadge>
 
 ```vue
@@ -42,7 +42,7 @@ The Badge has two shapes that can be changed with a `shape` property.
 - `rounded` - Default
 - `rectangular`
 
-<KBadge appearance="warning">Round</KBadge>
+<KBadge appearance="warning" class="mr-2">Round</KBadge>
 <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 
 ```vue
@@ -54,10 +54,10 @@ The Badge has two shapes that can be changed with a `shape` property.
 
 Using the `custom` appearance in conjunction with `color` and `background-color`:
 
-<KBadge color="var(--yellow-500)" background-color="var(--yellow-200)">Custom</KBadge>
-<KBadge color="var(--red-100)" background-color="var(--red-400)">Badge</KBadge>
-<KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
-<KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
+<KBadge color="var(--yellow-500)" background-color="var(--yellow-200)" class="mr-2">Custom</KBadge>
+<KBadge color="var(--red-100)" background-color="var(--red-400)" class="mr-2">Badge</KBadge>
+<KBadge color="var(--blue-200)" background-color="var(--blue-500)" class="mr-2">Hello</KBadge>
+<KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
 <KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 
 ```vue
@@ -71,6 +71,8 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 ## Slots
 
 - `default` - innerHTML inside badge
+
+<KBadge appearance="success">SUCCESS</KBadge>
 
 ```vue
 <KBadge appearance="success">SUCCESS</KBadge>


### PR DESCRIPTION
### Summary
Docs clean up.

https://konghq.atlassian.net/browse/KHCP-3409

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
