### PR TITLE
fix(typography): text display [khcp-3407]

### DIFF
--- a/docs/style-guide/type.md
+++ b/docs/style-guide/type.md
@@ -88,8 +88,8 @@ export default defineComponent({
         return acc
       }, [])
 
-    this.$page.headingStyles = styles.length ? styles.filter(i => i.includes('heading')) : []
-    this.$page.bodyStyles = styles.length ? styles.filter(i => i.includes('body')) : []
+    this.$page.headingStyles = styles.length ? styles.filter(i => i.includes('heading') && !i.includes('data-v')) : []
+    this.$page.bodyStyles = styles.length ? styles.filter(i => i.includes('body') && !i.includes('data-v')) : []
   }
 })
 </script>


### PR DESCRIPTION
### Summary
Fix docs display.

https://konghq.atlassian.net/browse/KHCP-3407

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
