### PR TITLE
fix(kprompt): docs fixes [khcp-3438]

### DIFF
--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -172,7 +172,7 @@ export default defineComponent({
         if (e.keyCode === 27) { // 'esc' key
           close()
         } else if (e.keyCode === 13) { // 'enter' key
-          if (props.preventProceedOnEnter) {
+          if (!props.preventProceedOnEnter) {
             proceed(e)
           }
         }

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -83,7 +83,7 @@
                 v-if="actionPending"
                 icon="spinner"
                 size="16"
-                color="var(--white)"
+                color="var(--grey-400)"
               />
             </template>
             {{ actionButtonText }}


### PR DESCRIPTION
### Summary
Fix `proceedOnEnterLogic` and color of `spinner` icon for `actionPending` state.

https://konghq.atlassian.net/browse/KHCP-3438

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
