### PR TITLE
fix(kselect): page jump, caret, and docs

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -266,7 +266,7 @@ export default defineComponent({
 
 You can pass a `width` string for dropdown. By default the `width` is `170px`. This is the width of the input, dropdown, and selected item.
 
-<KSelect width="100" :items="[{
+<KSelect width="350" :items="[{
     label: 'test',
     value: 'test',
     selected: true
@@ -277,7 +277,7 @@ You can pass a `width` string for dropdown. By default the `width` is `170px`. T
 />
 
 ```html
-<KSelect width="100" :items="[{
+<KSelect width="350" :items="[{
     label: 'test',
     value: 'test',
     selected: true
@@ -299,7 +299,7 @@ KSelect works as regular inputs do using v-model for data binding:
 <KComponent :data="{ myVal: 'test' }" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect width="100" v-model="data.myVal" :items="[{
+    <KSelect v-model="data.myVal" :items="[{
         label: 'test',
         value: 'test'
       }, {
@@ -314,7 +314,7 @@ KSelect works as regular inputs do using v-model for data binding:
 <KComponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect width="100" v-model="data.myVal" :items="[{
+    <KSelect v-model="data.myVal" :items="[{
         label: 'test',
         value: 'test'
       }, {

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -341,7 +341,7 @@ export default defineComponent({
       const popperEl = this.$refs.popper
       const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
       theTarget.appendChild(popperEl)
-      theTarget.style.overflow = 'auto'
+      theTarget?.style?.overflow = 'auto'
       await this.$nextTick()
       this.popper = new Popper(this.reference, popperEl, {
         placement,
@@ -398,6 +398,8 @@ export default defineComponent({
     },
     destroy() {
       if (this.popper) {
+        const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
+        theTarget?.style?.removeProperty('overflow')
         this.isOpen = false
         this.popper.destroy()
         this.popper = null

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -341,7 +341,8 @@ export default defineComponent({
       const popperEl = this.$refs.popper
       const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
       theTarget.appendChild(popperEl)
-      theTarget.style.overflow = 'auto'
+      // Hide overflow to prevent page jump
+      theTarget.style.overflow = 'hidden'
       await this.$nextTick()
       this.popper = new Popper(this.reference, popperEl, {
         placement,

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -341,6 +341,7 @@ export default defineComponent({
       const popperEl = this.$refs.popper
       const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
       theTarget.appendChild(popperEl)
+      theTarget.style.overflow = 'auto'
       await this.$nextTick()
       this.popper = new Popper(this.reference, popperEl, {
         placement,

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -342,7 +342,7 @@ export default defineComponent({
       const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
       theTarget.appendChild(popperEl)
       // Hide overflow to prevent page jump
-      theTarget.style.overflow = 'hidden'
+      theTarget.style.overflow = 'auto'
       await this.$nextTick()
       this.popper = new Popper(this.reference, popperEl, {
         placement,
@@ -358,6 +358,8 @@ export default defineComponent({
         },
       })
       await this.$nextTick()
+      // Remove overflow attribute now that rendering is complete
+      theTarget.style.removeProperty('overflow')
       this.popper.update()
     },
     handleClick(e) {
@@ -399,8 +401,6 @@ export default defineComponent({
     },
     destroy() {
       if (this.popper) {
-        const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
-        theTarget.style.removeProperty('overflow')
         this.isOpen = false
         this.popper.destroy()
         this.popper = null

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -341,7 +341,7 @@ export default defineComponent({
       const popperEl = this.$refs.popper
       const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
       theTarget.appendChild(popperEl)
-      theTarget?.style?.overflow = 'auto'
+      theTarget.style.overflow = 'auto'
       await this.$nextTick()
       this.popper = new Popper(this.reference, popperEl, {
         placement,
@@ -399,7 +399,7 @@ export default defineComponent({
     destroy() {
       if (this.popper) {
         const theTarget = this.target === 'body' && !this.isSvg ? document.getElementById(this.targetId) : document.querySelector(this.target)
-        theTarget?.style?.removeProperty('overflow')
+        theTarget.style.removeProperty('overflow')
         this.isOpen = false
         this.popper.destroy()
         this.popper = null

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -433,8 +433,9 @@ export default defineComponent({
 
     :deep(.kong-icon) {
       position: absolute;
-      top: 15px;
+      top: 45%;
       right: 6px;
+      transform: translateY(-50%);
       z-index: 9;
     }
   }

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -273,8 +273,6 @@ export default defineComponent({
       }
     })
 
-    console.log('width', widthValue.value.replace(/px/i, ''))
-
     const createKPopAttributes = computed(() => {
       return {
         ...defaultKPopAttributes,

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -149,6 +149,7 @@ const defaultKPopAttributes = {
   popoverClasses: 'k-select-popover mt-0',
   popoverTimeout: 0,
   placement: 'bottomStart',
+  hideCaret: true,
 }
 
 interface SelectItem {


### PR DESCRIPTION
### Summary

Fixes:

- Prevent page jump when clicking `KPop` element.
- Hide popover caret in `KSelect.vue`
- Fix Select element examples in the docs.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
