### PR TITLE
feat(kselect): filterfunc support

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -334,15 +334,18 @@ You can use the `item-template` slot to customize the look and feel of your item
   </template>
 </KSelect>
 
-```vue
+```html
 <KSelect :items="myItems" width="500" :filterFunc="customFilter">
   <template v-slot:item-template="{ item }">
     <div class="select-item-label">{{item.label}}</div>
     <div class="select-item-desc">{{item.description}}</div>
   </template>
 </KSelect>
-<script>
-export default {
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
   data() {
     return {
       myItems: this.getItems(5),
@@ -367,7 +370,7 @@ export default {
       })
     }
   }
-}
+})
 </script>
 ```
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -204,30 +204,6 @@ You can configure the button text when an item is selected, if `appearance` is t
 
 <KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
 
-<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  data() {
-    return {
-      mySelect: '',
-      items: [{
-        label: '25',
-        value: '25'
-      }, {
-        label: '50',
-        value: '50'
-      }]
-    }
-  },
-  methods: {
-    handleItemSelect (item) {
-      this.mySelect = item.label
-    }
-  }
-})
-</script>
-
 ```html
 <KSelect
   appearance='button'
@@ -264,7 +240,7 @@ export default defineComponent({
 
 ### width
 
-You can pass a `width` string for dropdown. By default the `width` is `170px`. This is the width of the input, dropdown, and selected item.
+You can pass a `width` string for dropdown. By default the `width` is `200px`. This is the width of the input, dropdown, and selected item.
 
 <KSelect width="350" :items="[{
     label: 'test',
@@ -291,6 +267,17 @@ You can pass a `width` string for dropdown. By default the `width` is `170px`. T
 ### positionFixed
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `true`. See [`KPop` docs](popover.html#positionfixed) for more information.
+
+### filterFunc
+
+Use this prop to override the default filter function if you want to do something like filter on an attribute other than `label`. Your filter function
+should take as parameter a JSON object containing the items to filter on (`items`) and the query string (`query`) and return the filtered items. See [Slots](#slots) for an example.
+
+```js
+myCustomFilter ({ items, query }) {
+  return items.filter(anItem => anItem.label.includes(query))
+}
+```
 
 ### v-model
 
@@ -336,6 +323,54 @@ You can pass any input attribute and it will get properly bound to the element.
 <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
 ```
 
+## Slots
+
+You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
+
+<KSelect :items="myItems" width="500" :filterFunc="customFilter">
+  <template v-slot:item-template="{ item }">
+    <div class="select-item-label">{{ item.label }}</div>
+    <div class="select-item-desc">{{ item.description }}</div>
+  </template>
+</KSelect>
+
+```vue
+<KSelect :items="myItems" width="500" :filterFunc="customFilter">
+  <template v-slot:item-template="{ item }">
+    <div class="select-item-label">{{item.label}}</div>
+    <div class="select-item-desc">{{item.description}}</div>
+  </template>
+</KSelect>
+<script>
+export default {
+  data() {
+    return {
+      myItems: this.getItems(5),
+    }
+  },
+  methods: {
+    getItems(count) {
+      let myItems = []
+        for (let i = 0; i < count; i++) {
+          myItems.push({
+            label: "Item " + i,
+            value: "item_" + i,
+            description: "The item's description for number " + i
+          })
+        }
+      return myItems
+    },
+    customFilter (items, queryStr) {
+      return items.filter(item => {
+        return item.label.toLowerCase().includes(queryStr.toLowerCase()) ||
+          item.description.toLowerCase().includes(queryStr.toLowerCase())
+      })
+    }
+  }
+}
+</script>
+```
+
 ## Events
 
 | Event     | returns             |
@@ -343,3 +378,54 @@ You can pass any input attribute and it will get properly bound to the element.
 | `selected` | `selectedItem` Object |
 | `input` | `selectedItem` Object or null |
 | `change` | `selectedItem` Object or null |
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+function getItems(count) {
+  let myItems = []
+    for (let i = 0; i < count; i++) {
+      myItems.push({
+        label: "Item " + i,
+        value: "item_" + i,
+        description: "The item's description for number " + i
+      })
+    }
+  return myItems
+}
+
+export default defineComponent({
+  data() {
+    return {
+      myItems: getItems(5),
+      mySelect: '',
+      items: [{
+        label: '25',
+        value: '25'
+      }, {
+        label: '50',
+        value: '50'
+      }]
+    }
+  },
+  methods: {
+    handleItemSelect (item) {
+      this.mySelect = item.label
+    },
+    customFilter ({items, query}) {
+      return items.filter(item => item.label.toLowerCase().includes(query.toLowerCase()) || item.description.toLowerCase().includes(query.toLowerCase()))
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+  .select-item-label {
+    color: blue;
+    font-weight: bold;
+  }
+
+  .select-item-desc {
+    color: red;
+  }
+</style>

--- a/src/components/KSelect/KSelect.spec.ts
+++ b/src/components/KSelect/KSelect.spec.ts
@@ -2,6 +2,7 @@
 /// <reference types="../../cypress/support" />
 
 import { mount } from '@cypress/vue'
+import { h } from 'vue'
 import KSelect from '@/components/KSelect/KSelect.vue'
 
 /**
@@ -169,5 +170,27 @@ describe('KSelect', () => {
 
     cy.getTestId(`k-select-item-${vals[0]}`).click({ multiple: true, force: true })
     cy.get('.selected-item-label').should('contain.text', labels[0])
+  })
+
+  it('allows slotting content into the items', async () => {
+    const itemSlotContent = 'I am slotted baby!'
+    const itemLabel = 'Label 1'
+    const itemValue = 'label1'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        appearance: 'button',
+        items: [{
+          label: itemLabel,
+          value: itemValue,
+        }],
+      },
+      slots: {
+        'item-template': h('span', {}, itemSlotContent),
+      },
+    })
+
+    cy.getTestId(`k-select-item-${itemValue}`).should('contain.text', itemSlotContent)
   })
 })

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -2,7 +2,7 @@
   <li
     :key="item.key"
     :data-testid="`k-select-item-${item.value}`"
-    class="k-select-item"
+    class="k-select-item mx-4"
     @click="handleClick"
   >
     <div
@@ -14,7 +14,7 @@
         :value="item.value"
       >
         <span class="k-select-item-label mr-2">
-          <slot>{{ item.label }}</slot>
+          <slot name="content">{{ item.label }}</slot>
         </span>
         <span class="k-select-selected-icon-container">
           <KIcon


### PR DESCRIPTION
### Summary
Add support for `filterFunc` and slots example

![image](https://user-images.githubusercontent.com/67973710/164257369-8b129182-12d8-462f-b47f-270bcb005ca8.png)


#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
