### PR TITLE
fix(ktextarea): docs cleanup

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -86,6 +86,16 @@ Use this prop to remove the character limit on the textarea. Defaults to `false`
 <KTextArea disable-character-limit />
 ```
 
+### hasError
+
+Boolean value to indicate whether the element has an error and should apply error styling. By default this is `false`.
+
+<KTextArea has-error />
+
+```vue
+<KTextArea has-error />
+```
+
 ## v-model
 
 `KTextArea` works as regular texarea do using v-model for data binding:
@@ -93,9 +103,7 @@ Use this prop to remove the character limit on the textarea. Defaults to `false`
 <KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
   <div>
     {{ data.myInput }}
-    <KTextArea
-      v-model="data.myInput"
-      @blur="e => (data.myInput = 'blurred')" />
+    <KTextArea v-model="data.myInput" />
   </div>
 </KComponent>
 
@@ -124,12 +132,12 @@ Use this prop to remove the character limit on the textarea. Defaults to `false`
 
 `KTextArea` also transparently binds to events:
 
-<KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
+<KComponent :data="{myInput2: 'hello'}" v-slot="{ data }">
   <div>
     <KTextArea
-      v-model="data.myInput"
-      @blur="e => (data.myInput = 'blurred')"
-      @focus="e => (data.myInput = 'focused')"
+      v-model="data.myInput2"
+      @blur="e => (data.myInput2 = 'blurred')"
+      @focus="e => (data.myInput2 = 'focused')"
     />
   </div>
 </KComponent>
@@ -161,11 +169,11 @@ Use this prop to remove the character limit on the textarea. Defaults to `false`
 
 An Example of changing the error border color of KInput to pink might look like:
 
-<KTextArea class="custom-input input-error" type="email" value="error" />
+<KTextArea class="custom-input" has-error type="email" />
 
 ```vue
 <template>
-  <KTextArea class="custom-input input-error" type="email" value="error" />
+  <KTextArea class="custom-input" has-error type="email" />
 </template>
 
 <style>

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="k-input-wrapper mb-2">
+  <div
+    :class="{'input-error' : hasError || charLimitExceeded}"
+    class="k-input-wrapper mb-2"
+  >
     <textarea
       v-if="!label"
       v-bind="$attrs"
@@ -28,6 +31,7 @@
           :value="currValue ? currValue : modelValue"
           :rows="rows"
           :cols="cols"
+          :aria-invalid="hasError ? hasError : 'false'"
           class="form-control k-input style-body-lg"
           @input="inputHandler"
           @mouseenter="() => isHovered = true"
@@ -54,6 +58,7 @@
         :value="currValue ? currValue : modelValue"
         :rows="rows"
         :cols="cols"
+        :aria-invalid="hasError ? hasError : 'false'"
         class="form-control k-input style-body-lg"
         @input="inputHandler"
         @mouseenter="() => isHovered = true"
@@ -116,6 +121,10 @@ export default defineComponent({
     cols: {
       type: Number,
       default: 52,
+    },
+    hasError: {
+      type: Boolean,
+      default: false,
     },
     /**
      * Test mode - for testing only, strips out generated ids
@@ -203,6 +212,11 @@ export default defineComponent({
 
   .over-char-limit {
     color: var(--red-600);
+  }
+
+  .text-on-input label.hovered,
+  .text-on-input label:hover {
+    color: var(--KInputHover, var(--blue-500));
   }
 }
 </style>


### PR DESCRIPTION
### Summary
Add `has-error` prop

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
