### PR TITLE
fix(ktable): add data-testid to empty/error state buttons

### DIFF
--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -665,7 +665,7 @@ export default defineComponent({
     }
 
     const getTestIdString = (message) => {
-      return message.toLowerCase().replaceAll(' ', '-')
+      return message.toLowerCase().replace(/[^[a-z0-9]/gi, '-')
     }
 
     watch(() => props.searchInput, (newValue) => {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -23,6 +23,7 @@
             <KButton
               v-if="errorStateActionMessage"
               :to="errorStateActionRoute ? errorStateActionRoute : null"
+              :data-testid="getTestIdString(errorStateActionMessage)"
               appearance="primary"
               @click="$emit('ktable-error-cta-clicked')"
             >
@@ -49,6 +50,7 @@
             <KButton
               v-if="emptyStateActionMessage"
               :to="emptyStateActionRoute ? emptyStateActionRoute : null"
+              :data-testid="getTestIdString(emptyStateActionMessage)"
               appearance="primary"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
@@ -662,6 +664,10 @@ export default defineComponent({
       }
     }
 
+    const getTestIdString = (message) => {
+      return message.toLowerCase().replaceAll(' ', '-')
+    }
+
     watch(() => props.searchInput, (newValue) => {
       search(newValue)
     }, { immediate: true })
@@ -690,7 +696,8 @@ export default defineComponent({
       tableHeaders,
       tdlisteners,
       total,
-      trlisteners
+      trlisteners,
+      getTestIdString
     }
   }
 })


### PR DESCRIPTION
### Summary
Adds a `data-testid` attribute to empty and error state action buttons using the values passed into the `emptyStateActionMessage` and `errorStateActionMessage` props. The data-testid will reflect the text of the button: if an action button reads "Create New Service", the attribute will be `data-testid="create-new-service"`. This allows the data-testids to be created on the action buttons without needing to manually build out the empty/error states via slots and specify the data-testids by hand.

#### Changes made:
- Add `data-testid` to error state and empty state action buttons.

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
