### PR TITLE
fix(typography): docs display

### DIFF
--- a/docs/style-guide/type.md
+++ b/docs/style-guide/type.md
@@ -69,27 +69,27 @@ import { defineComponent } from 'vue'
 
 export default defineComponent({
   beforeMount() {
-    const styles = Array.from(document.styleSheets)
-      .filter(sheet => sheet.href === null || sheet.href.startsWith(window.location.origin))
-      .reduce((acc, sheet) => {
-        const rules = Array.from(sheet.cssRules).filter((rule) => {
-          return rule.selectorText && rule.selectorText.startsWith('.style-') && rule.selectorText.indexOf(',') === -1
-        }, [])
+    const styles = [
+      // heading
+      'style-heading-1',
+      'style-heading-2',
+      'style-heading-3',
+      'style-heading-4',
+      // body
+      'style-body-lg-bold',
+      'style-body-lg',
+      'style-body-md-bold',
+      'style-body-md',
+      'style-body-sm-bold',
+      'style-body-sm',
+      'style-body-link',
+      'style-body-bc',
+      'style-body-code',
+      'style-body-tiny',
+    ]
 
-        if (rules.length) {
-          acc = [
-            ...acc,
-            ...rules.reduce((acc, rule) => {
-              return [ ...acc, rule.selectorText.substring(1, rule.selectorText.length) ]
-            }, [])
-          ]
-        }
-
-        return acc
-      }, [])
-
-    this.$page.headingStyles = styles.length ? styles.filter(i => i.includes('heading') && !i.includes('data-v')) : []
-    this.$page.bodyStyles = styles.length ? styles.filter(i => i.includes('body') && !i.includes('data-v')) : []
+    this.$page.headingStyles = styles.filter(i => i.includes('heading'))
+    this.$page.bodyStyles = styles.filter(i => i.includes('body'))
   }
 })
 </script>


### PR DESCRIPTION
### Summary
Fix typography docs

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
