### PR TITLE
fix(ktable,kcatalog): data-testid additions

### DIFF
--- a/src/components/KCatalog/KCatalog.spec.ts
+++ b/src/components/KCatalog/KCatalog.spec.ts
@@ -331,7 +331,7 @@ describe('KCatalog', () => {
         },
       })
 
-      cy.getTestId('k-pagination-container').should('be.visible')
+      cy.getTestId('k-catalog-pagination').should('be.visible')
     })
 
     it('allows disabling pagination', () => {
@@ -347,7 +347,7 @@ describe('KCatalog', () => {
         },
       })
 
-      cy.getTestId('k-pagination-container').should('not.exist')
+      cy.getTestId('k-catalog-pagination').should('not.exist')
     })
 
     it('does not display pagination when no fetcher', () => {
@@ -359,7 +359,7 @@ describe('KCatalog', () => {
         },
       })
 
-      cy.getTestId('k-pagination-container').should('not.exist')
+      cy.getTestId('k-catalog-pagination').should('not.exist')
     })
   })
 })

--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -3,6 +3,7 @@
     <div
       v-if="title"
       class="k-card-catalog-title"
+      data-testid="k-catalog-title"
     >
       <h3>{{ title }}</h3>
     </div>
@@ -12,6 +13,7 @@
       :card-count="4"
       type="card"
       class="k-skeleton-grid"
+      data-testid="k-catalog-skeleton"
     >
       <template #card-header>
         <KSkeletonBox
@@ -41,7 +43,7 @@
     >
       <slot name="error-state">
         <KEmptyState
-          :is-error="true"
+          is-error
           :cta-is-hidden="!errorStateActionMessage || !errorStateActionRoute"
           :icon="errorStateIcon || ''"
           :icon-color="errorStateIconColor"
@@ -60,6 +62,7 @@
               v-if="errorStateActionMessage"
               :to="errorStateActionRoute ? errorStateActionRoute : undefined"
               appearance="primary"
+              :data-testid="getTestIdString(errorStateActionMessage)"
               @click="$emit('kcatalog-error-cta-clicked')"
             >
               {{ errorStateActionMessage }}
@@ -92,20 +95,11 @@
             <KButton
               v-if="emptyStateActionMessage"
               :to="emptyStateActionRoute ? emptyStateActionRoute : undefined"
+              :icon="emptyStateActionButtonIcon"
               appearance="primary"
+              :data-testid="getTestIdString(errorStateActionMessage)"
               @click="$emit('kcatalog-empty-state-cta-clicked')"
             >
-              <template
-                v-if="emptyStateActionButtonIcon"
-                #icon
-              >
-                <KIcon
-                  :icon="emptyStateActionButtonIcon"
-                  color="white"
-                  view-box="0 0 20 20"
-                  size="16"
-                />
-              </template>
               {{ emptyStateActionMessage }}
             </KButton>
           </template>
@@ -122,10 +116,11 @@
         :data="data"
         name="body"
       >
-        <template v-for="item in data">
+        <template v-for="(item, idx) in data">
           <router-link
             v-if="item.locationParam"
-            :key="item.key ? item.key : null"
+            :key="item.key ? item.key : `k-catalog-item-${idx}`"
+            :data-testid="item.id ? item.id : `k-catalog-item-${idx}`"
           >
             <KCatalogItem
               :item="item"
@@ -156,11 +151,12 @@
 
           <KCatalogItem
             v-else
-            :key="item.key ? item.key : null"
+            :key="item.key ? item.key : `k-catalog-item-${idx}`"
             :item="item"
             :truncate="!noTruncation"
             :test-mode="!!testMode"
             class="catalog-item"
+            :data-testid="item.id ? item.id : `k-catalog-item-${idx}`"
           >
             <template #cardTitle>
               <slot
@@ -186,6 +182,7 @@
       <div
         v-if="!disablePagination && fetcher"
         class="card-pagination"
+        data-testid="k-catalog-pagination"
       >
         <KPagination
           :initial-page-size="pageSize"
@@ -507,6 +504,10 @@ export default defineComponent({
       pageSize.value = newPageSize
     }
 
+    const getTestIdString = (message: string) => {
+      return message.toLowerCase().replace(/[^[a-z0-9]/gi, '-')
+    }
+
     watch(() => props.searchInput, (newValue: string) => {
       search(newValue)
     }, { immediate: true })
@@ -527,6 +528,7 @@ export default defineComponent({
       pageSize,
       pageSizeChangeHandler,
       total,
+      getTestIdString,
     }
   },
 })

--- a/src/components/KTable/KTable.spec.ts
+++ b/src/components/KTable/KTable.spec.ts
@@ -323,7 +323,7 @@ describe('KTable', () => {
         },
       })
 
-      cy.getTestId('k-pagination-container').should('be.visible')
+      cy.getTestId('k-table-pagination').should('be.visible')
     })
 
     it('does not display pagination when pagination disabled', () => {
@@ -340,7 +340,7 @@ describe('KTable', () => {
         },
       })
 
-      cy.getTestId('k-pagination-container').should('not.exist')
+      cy.getTestId('k-table-pagination').should('not.exist')
     })
 
     it('does not display pagination when no fetcher', () => {
@@ -352,7 +352,7 @@ describe('KTable', () => {
         },
       })
 
-      cy.getTestId('k-pagination-container').should('not.exist')
+      cy.getTestId('k-table-pagination').should('not.exist')
     })
   })
 })

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -3,6 +3,7 @@
     <KSkeleton
       v-if="(!testMode || testMode === 'loading') && (isTableLoading || isLoading) && !hasError"
       type="table"
+      data-testid="k-table-skeleton"
     />
 
     <div
@@ -11,23 +12,26 @@
     >
       <slot name="error-state">
         <KEmptyState
+          is-error
           :cta-is-hidden="!errorStateActionMessage || !errorStateActionRoute"
           :icon="errorStateIcon || ''"
-          :is-error="true"
           :icon-color="errorStateIconColor"
           :icon-size="errorStateIconSize"
         >
           <template #title>
             {{ errorStateTitle }}
           </template>
+
           <template #message>
             {{ errorStateMessage }}
           </template>
+
           <template #cta>
             <KButton
               v-if="errorStateActionMessage"
               :to="errorStateActionRoute ? errorStateActionRoute : undefined"
               appearance="primary"
+              :data-testid="getTestIdString(errorStateActionMessage)"
               @click="$emit('ktable-error-cta-clicked')"
             >
               {{ errorStateActionMessage }}
@@ -51,27 +55,20 @@
           <template #title>
             {{ emptyStateTitle }}
           </template>
+
           <template #message>
             {{ emptyStateMessage }}
           </template>
+
           <template #cta>
             <KButton
               v-if="emptyStateActionMessage"
               :to="emptyStateActionRoute ? emptyStateActionRoute : undefined"
+              :icon="emptyStateActionButtonIcon"
               appearance="primary"
+              :data-testid="getTestIdString(errorStateActionMessage)"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
-              <template
-                v-if="emptyStateActionButtonIcon"
-                #icon
-              >
-                <KIcon
-                  :icon="emptyStateActionButtonIcon"
-                  color="white"
-                  view-box="0 0 20 20"
-                  size="16"
-                />
-              </template>
               {{ emptyStateActionMessage }}
             </KButton>
           </template>
@@ -86,8 +83,8 @@
     >
       <table
         :class="{'has-hover': hasHover, 'is-clickable': isClickable, 'side-border': hasSideBorder}"
-        :data-tableid="tableId"
         class="k-table"
+        :data-tableid="tableId"
       >
         <thead :class="{ 'is-scrolled': isScrolled }">
           <tr :class="{ 'is-scrolled': isScrolled }">
@@ -116,36 +113,36 @@
                   :name="`column-${column.key}`"
                   :column="column"
                 >
-                  <span
-                    :class="{'sr-only': column.hideLabel}"
-                  >
+                  <span :class="{'sr-only': column.hideLabel}">
                     {{ column.label ? column.label : column.key }}
                   </span>
                 </slot>
+
                 <KIcon
                   v-if="!disableSorting && !column.hideLabel && column.sortable"
-                  class="caret ml-2"
+                  icon="chevronDown"
                   color="var(--KTableColor, var(--black-70, color(black-70)))"
                   size="12"
-                  icon="chevronDown"
+                  class="caret ml-2"
                 />
               </span>
             </th>
           </tr>
         </thead>
+
         <tbody>
           <tr
             v-for="(row, rowIndex) in data"
+            v-bind="rowAttrs(row)"
             :key="`k-table-${tableId}-row-${rowIndex}`"
             :tabindex="isClickable ? 0 : null"
             :role="isClickable ? 'link' : null"
-            v-bind="rowAttrs(row)"
             v-on="trlisteners(row, 'row')"
           >
             <td
               v-for="(value, index) in tableHeaders"
-              :key="`k-table-${tableId}-cell-${index}`"
               v-bind="cellAttrs({ headerKey: value.key, row, rowIndex, colIndex: index })"
+              :key="`k-table-${tableId}-cell-${index}`"
               v-on="tdlisteners(row[value.key], 'cell')"
             >
               <slot
@@ -160,6 +157,7 @@
           </tr>
         </tbody>
       </table>
+
       <KPagination
         v-if="fetcher && !disablePagination"
         :total-count="total"
@@ -170,6 +168,7 @@
         :disable-page-jump="disablePaginationPageJump"
         :test-mode="testMode ? true : false"
         class="pa-1"
+        data-testid="k-table-pagination"
         @page-changed="pageChangeHandler"
         @page-size-changed="pageSizeChangeHandler"
       />
@@ -667,6 +666,10 @@ export default defineComponent({
       }
     }
 
+    const getTestIdString = (message: string) => {
+      return message.toLowerCase().replace(/[^[a-z0-9]/gi, '-')
+    }
+
     watch(() => props.searchInput, (newValue) => {
       search(newValue)
     }, { immediate: true })
@@ -697,6 +700,7 @@ export default defineComponent({
       total,
       trlisteners,
       tableId,
+      getTestIdString,
     }
   },
 })


### PR DESCRIPTION
### Summary
Port https://github.com/Kong/kongponents/pull/603 to beta

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
