### PR TITLE
fix(ktable,kcatalog): fix issues - beta

### DIFF
--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -202,7 +202,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref, onMounted, watch } from 'vue'
+import { defineComponent, PropType, ref, computed, onMounted, watch } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import KButton from '@/components/KButton/KButton.vue'
 import KEmptyState from '@/components/KEmptyState/KEmptyState.vue'
@@ -478,20 +478,19 @@ export default defineComponent({
       pageSize.value = fetcherParams.pageSize
       filterQuery.value = fetcherParams.query
       hasInitialized.value = true
-
-      // get data
-      if (props.fetcher) {
-        await fetchData()
-      }
-
-      if (props.isLoading === false) {
-        isCardLoading.value = false
-      }
     }
 
+    // once `initData()` finishes fetch data
+    const catalogFetcherCacheKey = computed(() => {
+      if (!props.fetcher || !hasInitialized.value) {
+        return ''
+      }
+
+      return `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}` as string
+    })
     const { query, search } = useDebounce('', 350)
     const { revalidate } = useRequest(
-      () => (props.fetcher && hasInitialized.value && `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`) as string,
+      () => catalogFetcherCacheKey.value,
       () => fetchData(),
       { revalidateOnFocus: false },
     )

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -137,7 +137,7 @@
             :key="`k-table-${tableId}-row-${rowIndex}`"
             :tabindex="isClickable ? 0 : null"
             :role="isClickable ? 'link' : null"
-            v-on="hasSideBorder ? tdlisteners(row[value.key]) : null"
+            v-on="hasSideBorder ? tdlisteners(row, row) : null"
           >
             <td
               v-for="(value, index) in tableHeaders"


### PR DESCRIPTION
### Summary
Fix miscellaneous issues with `KTable` and `KCatalog`.

#### Changes made:
- remove code causing duplicate fetch on initial load
- fix row/cell click handling for Vue3
- trigger row clicks on the `td` instead of the `tr`

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
