### PR TITLE
fix(ktable,kcatalog): fix issues

### DIFF
--- a/packages/KCatalog/KCatalog.vue
+++ b/packages/KCatalog/KCatalog.vue
@@ -164,7 +164,7 @@
 </template>
 
 <script>
-import { defineComponent, ref, onMounted, watch } from '@vue/composition-api'
+import { defineComponent, computed, ref, onMounted, watch } from '@vue/composition-api'
 import KButton from '@kongponents/kbutton/KButton.vue'
 import KEmptyState from '@kongponents/kemptystate/KEmptyState.vue'
 import KSkeleton from '@kongponents/kskeleton/KSkeleton.vue'
@@ -426,20 +426,20 @@ export default defineComponent({
       page.value = fetcherParams.page
       pageSize.value = fetcherParams.pageSize
       hasInitialized.value = true
-
-      // get data
-      if (props.fetcher) {
-        await fetchData()
-      }
-
-      if (props.isLoading === false) {
-        isCardLoading.value = false
-      }
     }
+
+    // once `initData()` finishes fetch data
+    const catalogFetcherCacheKey = computed(() => {
+      if (!props.fetcher || !hasInitialized.value) {
+        return ''
+      }
+
+      return `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`
+    })
 
     const { query, search } = useDebounce('', 350)
     const { revalidate } = useRequest(
-      () => props.fetcher && hasInitialized.value && `catalog-item_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
+      () => catalogFetcherCacheKey.value,
       () => fetchData(),
       { revalidateOnFocus: false }
     )

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -209,16 +209,16 @@ describe('KTable', () => {
           fetcher: () => { return { data: options.data } }
         },
         listeners: {
-          [`row:mouseover`]: evtTrigger
+          [`row:click`]: evtTrigger
         }
       })
 
       await tick(wrapper.vm, 1)
 
-      const bodyRow = wrapper.find('.k-table tbody tr')
+      const bodyRow = wrapper.find('.k-table tbody tr td')
 
-      bodyRow.trigger('mouseover')
-      expect(evtTrigger).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: 'mouseover' }), options.data[0], 'row')
+      bodyRow.trigger('click')
+      expect(evtTrigger).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: 'click' }), options.data[0], 'row')
     })
 
     it('@cell:event', async () => {
@@ -334,7 +334,6 @@ describe('KTable', () => {
       })
 
       await tick(wrapper.vm, 1)
-      console.log(wrapper.html())
 
       expect(wrapper.find('[data-testid="k-table-error-state"]').html()).toEqual(expect.stringContaining(errorSlotContent))
       expect(wrapper.html()).toMatchSnapshot()

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -131,7 +131,6 @@
             :tabindex="isClickable ? 0 : null"
             :role="isClickable ? 'link' : null"
             v-bind="rowAttrs(row)"
-            v-on="hasSideBorder ? tdlisteners(row, row) : null"
           >
             <template>
               <td

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -131,14 +131,14 @@
             :tabindex="isClickable ? 0 : null"
             :role="isClickable ? 'link' : null"
             v-bind="rowAttrs(row)"
-            v-on="trlisteners(row, 'row')"
+            v-on="hasSideBorder ? tdlisteners(row, row) : null"
           >
             <template>
               <td
                 v-for="(value, index) in tableHeaders"
                 :key="`k-table-${tableId}-cell-${index}`"
                 v-bind="cellAttrs({ headerKey: value.key, row, rowIndex, colIndex: index })"
-                v-on="tdlisteners(row[value.key], 'cell')"
+                v-on="tdlisteners(row[value.key], row)"
               >
                 <slot
                   :name="value.key"
@@ -520,23 +520,25 @@ export default defineComponent({
         }, {})
     }
 
-    const tdlisteners = computed(() => { // TODO: can we replace with something else??
-      return pluckListeners('cell:', ctx.listeners)
-    })
+    const tdlisteners = computed(() => {
+      return (entity, rowData) => {
+        const rowListeners = pluckListeners('row:', ctx.listeners)(rowData, 'row')
+        const cellListeners = pluckListeners('cell:', ctx.listeners)(entity, 'cell')
 
-    const trlisteners = computed(() => {
-      return (entity, type) => {
-        const pluckedListeners = pluckListeners('row:', ctx.listeners)(entity, type)
-
-        if (pluckedListeners.click) {
+        if (rowListeners.click) {
           isClickable.value = true
         }
 
         return {
-          ...pluckedListeners,
+          ...rowListeners,
+          ...cellListeners,
           click (e) {
-            if (e.target.tagName === 'TD' && pluckedListeners['click']) {
-              pluckedListeners['click'](e, entity, type)
+            if (e.target.tagName === 'TD' && (rowListeners.click || cellListeners.click)) {
+              if (cellListeners.click) {
+                cellListeners.click(e, entity, 'cell')
+              } else {
+                rowListeners.click(e, rowData, 'row')
+              }
             }
           }
         }
@@ -556,6 +558,16 @@ export default defineComponent({
 
       data.value = res.data
       total.value = props.paginationTotalItems || res.total || res.data.length
+
+      if (props.fetcher) {
+        if (props.enableClientSort && sortColumnKey.value && sortColumnOrder.value) {
+          defaultSorter(sortColumnKey.value, '', sortColumnOrder.value, data.value)
+        }
+      } else if (props.options && props.options.data && props.options.data.length) {
+        data.value = props.options.data
+        total.value = props.options.data.length
+      }
+
       isTableLoading.value = false
 
       return res
@@ -573,19 +585,6 @@ export default defineComponent({
       filterQuery.value = fetcherParams.query
       sortColumnKey.value = fetcherParams.sortColumnKey
       sortColumnOrder.value = fetcherParams.sortColumnOrder
-      hasInitialized.value = true
-
-      // get data
-      if (props.fetcher) {
-        await fetchData()
-
-        if (props.enableClientSort && fetcherParams.sortColumnKey && fetcherParams.sortColumnOrder) {
-          defaultSorter(fetcherParams.sortColumnKey, '', fetcherParams.sortColumnOrder, data.value)
-        }
-      } else if (props.options && props.options.data && props.options.data.length) {
-        data.value = props.options.data
-        total.value = props.options.data.length
-      }
 
       // get table headers
       if (props.headers && props.headers.length) {
@@ -594,23 +593,30 @@ export default defineComponent({
         tableHeaders.value = props.options.headers
       }
 
-      if (props.isLoading === false) {
-        isTableLoading.value = false
-      }
+      hasInitialized.value = true
     }
+
+    // once `initData()` finishes fetch data
+    const tableFetcherCacheKey = computed(() => {
+      if (!props.fetcher || !hasInitialized.value) {
+        return ''
+      }
+
+      return `k-table_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`
+    })
 
     const { query, search } = useDebounce('', 350)
     const { revalidate } = useRequest(
-      () => props.fetcher && hasInitialized.value && `k-table_${Math.floor(Math.random() * 1000)}_${props.fetcherCacheKey}`,
+      () => tableFetcherCacheKey.value,
       () => fetchData(),
       { revalidateOnFocus: false }
     )
 
     const sortClickHandler = (header) => {
       const { key, useSortHandlerFn } = header
+      let prevKey = sortColumnKey.value + '' // avoid pass by ref
 
       page.value = 1
-      let prevKey = sortColumnKey.value + '' // avoid pass by ref
 
       if (sortColumnKey.value) {
         if (key === sortColumnKey.value) {
@@ -696,7 +702,6 @@ export default defineComponent({
       tableHeaders,
       tdlisteners,
       total,
-      trlisteners,
       getTestIdString
     }
   }


### PR DESCRIPTION
### Summary
Fix miscellaneous issues with `KTable` and `KCatalog`.

#### Changes made:
- remove code causing duplicate fetch on initial load
- fix row/cell click handling for Vue3
- trigger row clicks on the `td` instead of the `tr`

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
