### PR TITLE
fix(ktable): row click handling

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -607,7 +607,7 @@ Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to va
 
 `@row:<event>` - returns the `Event`, the row item, and the type: `row`
 
-To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements (unless they are `disabled`). As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
+To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements (unless they have the `disabled` attribute). As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
 
 <KTable
   :headers="tableOptionsLinkHeaders"

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -601,24 +601,24 @@ export default {
 
 ## Events
 
-Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to
-various parts of the table. We support events on both table rows and cells in addition to click elements inside a row (ie. buttons or hyperlinks) without triggering the a row or cell event. You can also add logic to check for `metakey` to support cmd/ctrl when clicking. Examples highlighted below.
+Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to various parts of the table. We support events on both table rows and cells, but must be careful with clickable content in rows when row click is enabled. You can also add logic to check for `metakey` to support cmd/ctrl when clicking. Examples highlighted below.
 
 ### Rows
 
 `@row:<event>` - returns the `Event`, the row item, and the type: `row`
 
 ```vue
-<KTable @row:click="rowHandler" @row:dblclick="rowHandler">
+<KTable @row:click="rowHandler">
 ```
+
+To avoid firing row clicks by accident, the row click handler ignores events coming from `button`, `input`, and `a` tags. As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
 
 <KTable
   :headers="tableOptionsLinkHeaders"
   :fetcher="tableOptionsLinkFetcher"
   @row:click="handleRowClick">
   <template v-slot:company="{rowValue}">
-    <a v-if="rowValue" @click="linkHander">{{rowValue.label}}</a>
-    <span v-else>{{rowValue}}</span>
+    <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:actions>
     <div class="float-right">
@@ -629,19 +629,23 @@ various parts of the table. We support events on both table rows and cells in ad
       </KButton>
     </div>
   </template>
+  <template v-slot:input>
+    <KInput type="text" placeholder="Need help?" />
+  </template>
 </KTable>
 
-```vue{6,8,15,30-46}
+```html
 <KTable
   :fetcher="fetcher"
   :headers="headers"
   @row:click="handleRowClick">
   <template v-slot:company="{rowValue}">
-    <a v-if="rowValue" @click="linkHander">{{rowValue.label}}</a>
-    <span v-else>{{rowValue}}</span>
+    <!-- .stop not needed on @click because we ignore clicks from anchors -->
+    <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:actions>
     <div class="float-right">
+      <!-- .stop not needed on @click because we ignore clicks from buttons -->
       <KButton
         appearance="secondary"
         @click="buttonHandler">
@@ -649,7 +653,12 @@ various parts of the table. We support events on both table rows and cells in ad
       </KButton>
     </div>
   </template>
+  <template v-slot:input>
+    <!-- no special handling needed because click events on input elements are ignored -->
+    <KInput type="text" placeholder="Need help?" />
+  </template>
 </KTable>
+
 <script>
 export default {
   data() {
@@ -677,6 +686,61 @@ export default {
   }
 }
 </script>
+```
+
+Click events tied to non-ignored elements (not `a`, `button`, `input`) must use the `.stop` keyword to stop propagation firing the row click handler.
+
+Using a `KPop` inside of a clickable row requires some special handling. Non-clickable content must be wrapped in a `div` with the `@click.stop` attribute to prevent the row click handler from firing if a user clicks content inside of the popover. Any handlers on non-ignored elements will need to have `.stop`.
+
+<KTable
+  :headers="tableOptionsLinkHeaders2"
+  :fetcher="tableOptionsLinkFetcher"
+  @row:click="handleRowClick">
+  <template v-slot:company="{rowValue}">
+    <a @click="linkHander">{{rowValue.label}}</a>
+  </template>
+  <template v-slot:wrapped>
+    <div>Row click event? <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+  </template>
+  <template v-slot:other>
+    <div>
+      <KPop title="Cool header">
+        <KButton>Popover!</KButton>
+        <template v-slot:content>
+          <div @click.stop>Clicking me does nothing!</div>
+          <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
+        </template>
+      </KPop>
+    </div>
+  </template>
+</KTable>
+
+```vue
+<KTable
+  :fetcher="fetcher"
+  :headers="headers"
+  @row:click="handleRowClick">
+  <template v-slot:company="{rowValue}">
+    <a @click="linkHander">{{rowValue.label}}</a>
+  </template>
+  <template v-slot:wrapped>
+    <!-- We have a click event on a div, div clicks are not ignored so we need .stop -->
+    <div>Row click event? <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+  </template>
+  <template v-slot:other>
+    <div>
+      <KPop title="Cool header">
+        <KButton>Popover!</KButton>
+        <template v-slot:content>
+          <!-- non-clickable content in a KPop MUST be wrapped in a div with @click.stop to prevent row click firing on content click -->
+          <div @click.stop>Clicking me does nothing!</div>
+          <!-- an example where we want a click event to fire from the popover, requires .stop on the @click -->
+          <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
+        </template>
+      </KPop>
+    </div>
+  </template>
+</KTable>
 ```
 
 ### Cells
@@ -1251,7 +1315,13 @@ export default {
       ],
       tableOptionsLinkHeaders: [
         { label: 'Company', key: 'company' },
-        { key: 'actions', hideLabel: true }
+        { key: 'actions', hideLabel: true },
+        { lable: 'Input', key: 'input' }
+      ],
+      tableOptionsLinkHeaders2: [
+        { label: 'Company', key: 'company' },
+        { label: 'Wrapped', key: 'wrapped' },
+        { label: 'Pop', key: 'other' }
       ],
       tableOptionsCellAttrsHeaders: [
         { label: 'Name', key: 'name' },

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -611,7 +611,7 @@ Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to va
 <KTable @row:click="rowHandler">
 ```
 
-To avoid firing row clicks by accident, the row click handler ignores events coming from `button`, `input`, and `a` tags. As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
+To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements. As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
 
 <KTable
   :headers="tableOptionsLinkHeaders"
@@ -688,7 +688,7 @@ export default {
 </script>
 ```
 
-Click events tied to non-ignored elements (not `a`, `button`, `input`) must use the `.stop` keyword to stop propagation firing the row click handler.
+Click events tied to non-ignored elements (not `a`, `button`, `input`, `select`) must use the `.stop` keyword to stop propagation firing the row click handler.
 
 Using a `KPop` inside of a clickable row requires some special handling. Non-clickable content must be wrapped in a `div` with the `@click.stop` attribute to prevent the row click handler from firing if a user clicks content inside of the popover. Any handlers on non-ignored elements will need to have `.stop`.
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -699,7 +699,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:wrapped>
-    <div>Row click event <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+    <div>Row click event <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
   </template>
   <template v-slot:other>
     <div>
@@ -707,7 +707,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
         <KButton>Popover!</KButton>
         <template v-slot:content>
           <div @click.stop>Clicking me does nothing!</div>
-          <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
+          <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
         </template>
       </KPop>
     </div>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -607,11 +607,7 @@ Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to va
 
 `@row:<event>` - returns the `Event`, the row item, and the type: `row`
 
-```vue
-<KTable @row:click="rowHandler">
-```
-
-To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements. As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
+To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements (unless they are `disabled`). As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
 
 <KTable
   :headers="tableOptionsLinkHeaders"
@@ -631,6 +627,7 @@ To avoid firing row clicks by accident, the row click handler ignores events com
   </template>
   <template v-slot:input>
     <KInput type="text" placeholder="Need help?" />
+    <KInput type="text" placeholder="Row click me" disabled />
   </template>
 </KTable>
 
@@ -656,6 +653,8 @@ To avoid firing row clicks by accident, the row click handler ignores events com
   <template v-slot:input>
     <!-- no special handling needed because click events on input elements are ignored -->
     <KInput type="text" placeholder="Need help?" />
+    <!-- row click is triggered when clicking disabled elements -->
+    <KInput type="text" placeholder="Row click me" disabled />
   </template>
 </KTable>
 
@@ -746,10 +745,6 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
 ### Cells
 
 `@cell:<event>` - returns the `Event`, the cell value, and the type: `cell`
-
-```vue
-<KTable @cell:mouseout="cellHandler" @cell:mousedown="cellHandler">
-```
 
 <template>
   <div>
@@ -1315,8 +1310,8 @@ export default {
       ],
       tableOptionsLinkHeaders: [
         { label: 'Company', key: 'company' },
-        { key: 'actions', hideLabel: true },
-        { lable: 'Input', key: 'input' }
+        { label: 'Input', key: 'input' },
+        { key: 'actions', hideLabel: true }
       ],
       tableOptionsLinkHeaders2: [
         { label: 'Company', key: 'company' },

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -671,9 +671,9 @@ export default {
       const metaKeyPressed = e.metaKey || e.ctrlKey
 
       if (metaKeyPressed) {
-        $toaster.open('MetaKey row click')
+        this.$toaster.open('MetaKey row click')
       } else {
-        $toaster.open('Row click event fired!')
+        this.$toaster.open('Row click event fired!')
       }
     },
     linkHander (e) {
@@ -1287,11 +1287,6 @@ An Example of changing the hover background might look like.
 ```
 
 <script>
-import Vue from 'vue';
-import { ToastManager } from '@kongponents/ktoaster';
-
-Vue.prototype.$toaster = new ToastManager()
-
 export default {
   data() {
     return {

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -621,7 +621,7 @@ To avoid firing row clicks by accident, the row click handler ignores events com
       <KButton
         appearance="secondary"
         @click="buttonHandler">
-        Visit Website
+        Fire Button Handler!
       </KButton>
     </div>
   </template>
@@ -646,7 +646,7 @@ To avoid firing row clicks by accident, the row click handler ignores events com
       <KButton
         appearance="secondary"
         @click="buttonHandler">
-        Visit Website
+        Fire Button Handler!
       </KButton>
     </div>
   </template>
@@ -671,9 +671,9 @@ export default {
       const metaKeyPressed = e.metaKey || e.ctrlKey
 
       if (metaKeyPressed) {
-        return window.open(row.company.href)
+        $toaster.open('MetaKey row click')
       } else {
-        window.location = row.company.href
+        $toaster.open('Row click event fired!')
       }
     },
     linkHander (e) {
@@ -699,7 +699,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:wrapped>
-    <div>Row click event? <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+    <div>Row click event <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
   </template>
   <template v-slot:other>
     <div>
@@ -724,7 +724,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
   </template>
   <template v-slot:wrapped>
     <!-- We have a click event on a div, div clicks are not ignored so we need .stop -->
-    <div>Row click event? <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+    <div>Row click event <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
   </template>
   <template v-slot:other>
     <div>
@@ -1287,6 +1287,11 @@ An Example of changing the hover background might look like.
 ```
 
 <script>
+import Vue from 'vue';
+import { ToastManager } from '@kongponents/ktoaster';
+
+Vue.prototype.$toaster = new ToastManager()
+
 export default {
   data() {
     return {
@@ -1530,12 +1535,10 @@ for (let i = ((page-1)* pageSize); i < limit; i++) {
     handleRowClick(e, row) {
       const metaKeyPressed = e.metaKey || e.ctrlKey
 
-      if (e.target.tagName !== 'BUTTON') {
-        if (metaKeyPressed) {
-          return window.open(row.company.href)
-        } else {
-          window.location = row.company.href
-        }
+      if (metaKeyPressed) {
+        this.$toaster.open('MetaKey row click')
+      } else {
+        this.$toaster.open('Row click event fired!')
       }
     },
     linkHander (e) {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -523,7 +523,7 @@ export default defineComponent({
       return (entity, rowData) => {
         const rowListeners = pluckListeners('row:', ctx.listeners)(rowData, 'row')
         const cellListeners = pluckListeners('cell:', ctx.listeners)(entity, 'cell')
-        const ignoredElements = ['button', 'input', 'a']
+        const ignoredElements = ['a', 'button', 'input', 'select']
 
         if (rowListeners.click) {
           isClickable.value = true

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -523,6 +523,7 @@ export default defineComponent({
       return (entity, rowData) => {
         const rowListeners = pluckListeners('row:', ctx.listeners)(rowData, 'row')
         const cellListeners = pluckListeners('cell:', ctx.listeners)(entity, 'cell')
+        const ignoredElements = ['button', 'input', 'a']
 
         if (rowListeners.click) {
           isClickable.value = true
@@ -532,7 +533,8 @@ export default defineComponent({
           ...rowListeners,
           ...cellListeners,
           click (e) {
-            if (e.target.tagName === 'TD' && (rowListeners.click || cellListeners.click)) {
+            const isPopoverContent = e.target.className.includes('k-popover')
+            if (!ignoredElements.includes(e.target.tagName.toLowerCase()) && !isPopoverContent && (rowListeners.click || cellListeners.click)) {
               if (cellListeners.click) {
                 cellListeners.click(e, entity, 'cell')
               } else {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -534,7 +534,9 @@ export default defineComponent({
           ...cellListeners,
           click (e) {
             const isPopoverContent = e.target.className.includes('k-popover')
-            if (!ignoredElements.includes(e.target.tagName.toLowerCase()) && !isPopoverContent && (rowListeners.click || cellListeners.click)) {
+            // ignore click if it is from the popover, or is a non-disabled ignored element
+            if ((!ignoredElements.includes(e.target.tagName.toLowerCase()) || e.target.hasAttribute('disabled')) &&
+                 !isPopoverContent && (rowListeners.click || cellListeners.click)) {
               if (cellListeners.click) {
                 cellListeners.click(e, entity, 'cell')
               } else {


### PR DESCRIPTION
### Summary
Fix handling of row click events.

#### Changes made:
- Ignore clicks from `a`, `button`, and `input`
- Ignore clicks from popover content
- Update docs

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
