### PR TITLE
fix(ktable): fix row click handling [beta]

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -537,49 +537,58 @@ export default {
 
 ## Events
 
-Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to various parts of the table. We support events on both table rows and cells in addition to click elements inside a row (ie. buttons or hyperlinks) without triggering the a row or cell event. You can also add logic to check for `metakey` to support cmd/ctrl when clicking. Examples highlighted below.
+Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to various parts of the table. We support events on both table rows and cells, but must be careful with clickable content in rows when row click is enabled. You can also add logic to check for `metakey` to support cmd/ctrl when clicking. Examples highlighted below.
 
 ### Rows
 
 `@row:{event}` - returns the `Event`, the row item, and the type: `row`
 
-```vue
-  <KTable @row:click="rowHandler" @row:dblclick="rowHandler" />
-```
+To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements (unless they have the `disabled` attribute). As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
 
 <KTable :headers="tableOptionsLinkHeaders" :fetcher="tableOptionsLinkFetcher" @row:click="handleRowClick">
   <template v-slot:company="{ rowValue }">
-    <a v-if="rowValue" @click="linkHander">{{ rowValue.label }}</a>
-    <span v-else>{{ rowValue }}</span>
+    <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:actions>
     <div class="float-right">
       <KButton appearance="secondary" @click="buttonHandler">
-        Visit Website
+        Fire Button Handler!
       </KButton>
     </div>
   </template>
+  <template v-slot:input>
+    <KInput type="text" placeholder="Need help?" />
+    <KInput type="text" placeholder="Row click me" disabled />
+  </template>
 </KTable>
 
-```vue
+```html
 <KTable
   :fetcher="fetcher"
   :headers="headers"
   @row:click="handleRowClick">
   <template v-slot:company="{rowValue}">
-    <a v-if="rowValue" @click="linkHander">{{rowValue.label}}</a>
-    <span v-else>{{rowValue}}</span>
+    <!-- .stop not needed on @click because we ignore clicks from anchors -->
+    <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:actions>
     <div class="float-right">
+      <!-- .stop not needed on @click because we ignore clicks from buttons -->
       <KButton
         appearance="secondary"
         @click="buttonHandler">
-        Visit Website
+        Fire Button Handler!
       </KButton>
     </div>
   </template>
+  <template v-slot:input>
+    <!-- no special handling needed because click events on input elements are ignored -->
+    <KInput type="text" placeholder="Need help?" />
+    <!-- row click is triggered when clicking disabled elements -->
+    <KInput type="text" placeholder="Row click me" disabled />
+  </template>
 </KTable>
+
 <script>
 export default {
   data() {
@@ -593,9 +602,9 @@ export default {
       const metaKeyPressed = e.metaKey || e.ctrlKey
 
       if (metaKeyPressed) {
-        return window.open(row.company.href)
+        this.$toaster.open('MetaKey row click')
       } else {
-        window.location = row.company.href
+        this.$toaster.open('Row click event fired!')
       }
     },
     linkHander (e) {
@@ -609,13 +618,61 @@ export default {
 </script>
 ```
 
+Click events tied to non-ignored elements (not `a`, `button`, `input`, `select`) must use the `.stop` keyword to stop propagation firing the row click handler.
+
+Using a `KPop` inside of a clickable row requires some special handling. Non-clickable content must be wrapped in a `div` with the `@click.stop` attribute to prevent the row click handler from firing if a user clicks content inside of the popover. Any handlers on non-ignored elements will need to have `.stop`.
+
+<KTable :headers="tableOptionsLinkHeaders2" :fetcher="tableOptionsLinkFetcher" @row:click="handleRowClick">
+  <template v-slot:company="{rowValue}">
+    <a @click="linkHander">{{rowValue.label}}</a>
+  </template>
+  <template v-slot:wrapped>
+    <div>Row click event <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+  </template>
+  <template v-slot:other>
+    <div>
+      <KPop title="Cool header">
+        <KButton>Popover!</KButton>
+        <template v-slot:content>
+          <div @click.stop>Clicking me does nothing!</div>
+          <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
+        </template>
+      </KPop>
+    </div>
+  </template>
+</KTable>
+
+```vue
+<KTable
+  :fetcher="fetcher"
+  :headers="headers"
+  @row:click="handleRowClick">
+  <template v-slot:company="{rowValue}">
+    <a @click="linkHander">{{rowValue.label}}</a>
+  </template>
+  <template v-slot:wrapped>
+    <!-- We have a click event on a div, div clicks are not ignored so we need .stop -->
+    <div>Row click event <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+  </template>
+  <template v-slot:other>
+    <div>
+      <KPop title="Cool header">
+        <KButton>Popover!</KButton>
+        <template v-slot:content>
+          <!-- non-clickable content in a KPop MUST be wrapped in a div with @click.stop to prevent row click firing on content click -->
+          <div @click.stop>Clicking me does nothing!</div>
+          <!-- an example where we want a click event to fire from the popover, requires .stop on the @click -->
+          <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
+        </template>
+      </KPop>
+    </div>
+  </template>
+</KTable>
+```
+
 ### Cells
 
 `@cell:{event}` - returns the `Event`, the cell value, and the type: `cell`
-
-```vue
-<KTable @cell:mouseout="cellHandler" @cell:mousedown="cellHandler" />
-```
 
 <template>
   <div>
@@ -1149,7 +1206,13 @@ export default defineComponent({
       ],
       tableOptionsLinkHeaders: [
         { label: 'Company', key: 'company' },
+        { label: 'Input', key: 'input' },
         { key: 'actions', hideLabel: true }
+      ],
+      tableOptionsLinkHeaders2: [
+        { label: 'Company', key: 'company' },
+        { label: 'Wrapped', key: 'wrapped' },
+        { label: 'Pop', key: 'other' }
       ],
       tableOptionsCellAttrsHeaders: [
         { label: 'Name', key: 'name' },
@@ -1363,12 +1426,10 @@ export default defineComponent({
     handleRowClick(e, row) {
       const metaKeyPressed = e.metaKey || e.ctrlKey
 
-      if (e.target.tagName !== 'BUTTON') {
-        if (metaKeyPressed) {
-          return window.open(row.company.href)
-        } else {
-          window.location = row.company.href
-        }
+      if (metaKeyPressed) {
+        this.$toaster.open('MetaKey row click')
+      } else {
+        this.$toaster.open('Row click event fired!')
       }
     },
     linkHander (e) {

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -544,6 +544,7 @@ export default defineComponent({
       return (entity: any, rowData: any) => {
         const rowListeners = pluckListeners('onRow:', attrs)(rowData, 'row')
         const cellListeners = pluckListeners('onCell:', attrs)(entity, 'cell')
+        const ignoredElements = ['a', 'button', 'input', 'select']
 
         if (rowListeners.click) {
           isClickable.value = true
@@ -553,7 +554,10 @@ export default defineComponent({
           ...rowListeners,
           ...cellListeners,
           click(e: any) {
-            if (rowListeners.click || cellListeners.click) {
+            const isPopoverContent = e.target.className.includes('k-popover')
+            // ignore click if it is from the popover, or is a non-disabled ignored element
+            if ((!ignoredElements.includes(e.target.tagName.toLowerCase()) || e.target.hasAttribute('disabled')) &&
+                 !isPopoverContent && (rowListeners.click || cellListeners.click)) {
               if (cellListeners.click) {
                 cellListeners.click(e, entity, 'cell')
               } else {


### PR DESCRIPTION
### Summary
Fix handling of row click events.

#### Changes made:
- Ignore clicks from `a`, `button`, and `input`
- Ignore clicks from popover content
- Update docs

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
