### PR TITLE
fix(kprompt): bottom divider

### DIFF
--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -249,7 +249,7 @@ export default {
         }
       }
 
-      .k-modal-body.modal-body .k-prompt-body {
+      .k-modal-body.modal-body .k-prompt-body .k-prompt-body-content {
         font-size: var(--type-md);
         text-align: start;
         color: var(--grey-600);
@@ -258,23 +258,21 @@ export default {
         overflow-y: auto;
         overflow-x: hidden;
         max-height: var(--KPromptMaxHeight, 300px);
+        padding-bottom: var(--spacing-lg);
+        width: 99%;
 
         @media screen and (min-width: 768px) {
           max-height: var(--KPromptMaxHeight, 500px);
         }
 
-        .k-prompt-body-content {
-          padding-bottom: var(--spacing-lg);
-          width: 99%;
+        .k-prompt-confirm-text {
+          margin-top: var(--spacing-lg);
 
-          .k-prompt-confirm-text {
-            margin-top: var(--spacing-lg);
-
-            .k-input {
-              width: 100%;
-            }
+          .k-input {
+            width: 100%;
           }
         }
+
       }
 
       .k-modal-footer.modal-footer {


### PR DESCRIPTION
### Summary
Fix bottom divider display.

Before:

![image](https://user-images.githubusercontent.com/67973710/166965002-1832ad9a-9e44-4384-8fa6-f8b6ef587674.png)

After:

![image](https://user-images.githubusercontent.com/67973710/166965321-2708b904-c384-419e-a761-86e19a08f431.png)


#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
