### PR TITLE
fix(ktable): more row click fix

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -704,7 +704,15 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
   <template v-slot:other>
     <div>
       <KPop title="Cool header">
-        <KButton>Popover!</KButton>
+        <KButton>
+          <template #icon>
+            <KIcon
+              icon="more"
+              color="var(--black-400)"
+              size="16"
+            />
+          </template>
+        </KButton>
         <template v-slot:content>
           <div @click.stop>Clicking me does nothing!</div>
           <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -737,7 +737,15 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
   <template v-slot:other>
     <div>
       <KPop title="Cool header">
-        <KButton>Popover!</KButton>
+        <KButton>
+          <template #icon>
+            <KIcon
+              icon="more"
+              color="var(--black-400)"
+              size="16"
+            />
+          </template>
+        </KButton>
         <template v-slot:content>
           <!-- non-clickable content in a KPop MUST be wrapped in a div with @click.stop to prevent row click firing on content click -->
           <div @click.stop>Clicking me does nothing!</div>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -533,9 +533,32 @@ export default defineComponent({
           ...rowListeners,
           ...cellListeners,
           click (e) {
-            const isPopoverContent = e.target.className.includes('k-popover')
+            const targetClasses = e.target.className
+            let isIgnored = ignoredElements.includes(e.target.tagName.toLowerCase())
+            let isPopoverContent = false
+
+            // check for popover class
+            if (typeof targetClasses === 'string' || Array.isArray(targetClasses)) {
+              isPopoverContent = targetClasses.includes('k-popover')
+            } else if (typeof targetClasses === 'object') {
+              isPopoverContent = Object.keys(targetClasses).includes('k-popover')
+            }
+
+            // check parent for popover class
+            if (e.target.closest('.k-popover-content') !== null) {
+              isPopoverContent = true
+            }
+
+            // check parent of target is not an ignored elem
+            for (let i = 0; i < ignoredElements.length; i++) {
+              if (e.target.closest(ignoredElements[i]) !== null) {
+                isIgnored = true
+                break
+              }
+            }
+
             // ignore click if it is from the popover, or is a non-disabled ignored element
-            if ((!ignoredElements.includes(e.target.tagName.toLowerCase()) || e.target.hasAttribute('disabled')) &&
+            if ((!isIgnored || e.target.hasAttribute('disabled')) &&
                  !isPopoverContent && (rowListeners.click || cellListeners.click)) {
               if (cellListeners.click) {
                 cellListeners.click(e, entity, 'cell')


### PR DESCRIPTION
### Summary
Fix an issue where clicking a popover triggered from a button containing only an icon throwing an error on click.

![image](https://user-images.githubusercontent.com/67973710/167158447-54d4a578-9055-4a77-9980-88625aab2b88.png)

#### Changes made:
- Fix handling of `className` when an object
- Extend row click logic to query parents
- Docs example update

### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
