### PR TITLE
fix(kcatalog): add emptyStateActionButtonIcon prop

### DIFF
--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -274,6 +274,7 @@ Set the following properties to handle empty state:
 - `emptyStateIconSize` - Size for empty state icon
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
+- `emptyStateActionButtonIcon` - Icon for the empty state action button
 
 If using a CTA button, a `KCatalog-empty-state-cta-clicked` event is fired when clicked.
 

--- a/packages/KCatalog/KCatalog.vue
+++ b/packages/KCatalog/KCatalog.vue
@@ -48,6 +48,7 @@
             <KButton
               v-if="errorStateActionMessage"
               :to="errorStateActionRoute ? errorStateActionRoute : null"
+              :data-testid="getTestIdString(errorStateActionMessage)"
               appearance="primary"
               @click="$emit('KCatalog-error-cta-clicked')"
             >
@@ -74,6 +75,8 @@
             <KButton
               v-if="emptyStateActionMessage"
               :to="emptyStateActionRoute ? emptyStateActionRoute : null"
+              :data-testid="getTestIdString(emptyStateActionMessage)"
+              :icon="emptyStateActionButtonIcon ? emptyStateActionButtonIcon : null"
               appearance="primary"
               @click="$emit('KCatalog-empty-state-cta-clicked')"
             >
@@ -237,6 +240,13 @@ export default defineComponent({
      * A prop to pass in a custom empty state action message
      */
     emptyStateActionMessage: {
+      type: String,
+      default: ''
+    },
+    /**
+     * A prop to pass in a custom empty state action message
+     */
+    emptyStateActionButtonIcon: {
       type: String,
       default: ''
     },
@@ -452,6 +462,10 @@ export default defineComponent({
       pageSize.value = newPageSize
     }
 
+    const getTestIdString = (message) => {
+      return message.toLowerCase().replace(/[^[a-z0-9]/gi, '-')
+    }
+
     watch(() => props.searchInput, (newValue) => {
       search(newValue)
     }, { immediate: true })
@@ -471,7 +485,8 @@ export default defineComponent({
       pageSizeChangeHandler,
       pageSize,
       total,
-      isCardLoading
+      isCardLoading,
+      getTestIdString
     }
   }
 })

--- a/packages/KCatalog/KCatalog.vue
+++ b/packages/KCatalog/KCatalog.vue
@@ -33,6 +33,7 @@
 
     <div
       v-else-if="hasError"
+      class="k-catalog-empty-state"
       data-testid="k-card-catalog-error-state">
       <slot name="error-state">
         <KEmptyState
@@ -61,6 +62,7 @@
 
     <div
       v-else-if="!hasError && (!isCardLoading && !isLoading) && (data && !data.length)"
+      class="k-catalog-error-state"
       data-testid="k-card-catalog-empty-state">
       <slot name="empty-state">
         <KEmptyState

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -51,18 +51,10 @@
               v-if="emptyStateActionMessage"
               :to="emptyStateActionRoute ? emptyStateActionRoute : null"
               :data-testid="getTestIdString(emptyStateActionMessage)"
+              :icon="emptyStateActionButtonIcon ? emptyStateActionButtonIcon : null"
               appearance="primary"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
-              <template
-                v-slot:icon
-                v-if="emptyStateActionButtonIcon">
-                <KIcon
-                  :icon="emptyStateActionButtonIcon"
-                  color="white"
-                  view-box="0 0 20 20"
-                  size="16" />
-              </template>
               {{ emptyStateActionMessage }}
             </KButton>
           </template>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -8,6 +8,7 @@
 
     <div
       v-else-if="hasError"
+      class="k-table-error-state"
       data-testid="k-table-error-state">
       <slot name="error-state">
         <KEmptyState
@@ -36,6 +37,7 @@
 
     <div
       v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length)"
+      class="k-table-empty-state"
       data-testid="k-table-empty-state">
       <slot name="empty-state">
         <KEmptyState


### PR DESCRIPTION
### Summary
Add `emptyStateActionButtonIcon` prop to `KCatalog`

#### Changes made:
- add `emptyStateActionButtonIcon` prop to `KCatalog`
- add data-testid's, classes for empty/error state
- use `KButton` `icon` prop

### Vue 3 Upgrade

These changes already exist in `beta` branch, no separate PR needed.

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
