### PR TITLE
fix(kcatalog,ktables): docs and classes [beta]

### DIFF
--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -256,6 +256,7 @@ Set the following properties to handle empty state:
 - `emptyStateIconSize` - Size for empty state icon
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
+- `emptyStateActionButtonIcon` - Icon for the empty state action button
 
 If using a CTA button, a `KCatalog-empty-state-cta-clicked` event is fired when clicked.
 

--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -39,6 +39,7 @@
 
     <div
       v-else-if="hasError"
+      class="k-catalog-error-state"
       data-testid="k-card-catalog-error-state"
     >
       <slot name="error-state">
@@ -74,6 +75,7 @@
 
     <div
       v-else-if="!hasError && (!isCardLoading && !isLoading) && (data && !data.length)"
+      class="k-catalog-empty-state"
       data-testid="k-card-catalog-empty-state"
     >
       <slot name="empty-state">

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -8,6 +8,7 @@
 
     <div
       v-else-if="hasError"
+      class="k-table-error-state"
       data-testid="k-table-error-state"
     >
       <slot name="error-state">
@@ -43,6 +44,7 @@
 
     <div
       v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length)"
+      class="k-table-empty-state"
       data-testid="k-table-empty-state"
     >
       <slot name="empty-state">


### PR DESCRIPTION
### Summary
- Update docs with missing prop
- Add empty/error state classes

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
