### PR TITLE
fix(kbutton): account for when disabled is false

### DIFF
--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -152,7 +152,7 @@ export default {
     },
 
     iconColor () {
-      if (this.$attrs.disabled !== undefined && this.$attrs.disabled !== false) {
+      if (this.$attrs.disabled) {
         return 'var(--grey-400)'
       } else if (['primary', 'danger', 'creation'].includes(this.appearance)) {
         return 'white'

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -152,7 +152,7 @@ export default {
     },
 
     iconColor () {
-      if (this.$attrs.disabled !== undefined) {
+      if (this.$attrs.disabled !== undefined && this.$attrs.disabled !== false) {
         return 'var(--grey-400)'
       } else if (['primary', 'danger', 'creation'].includes(this.appearance)) {
         return 'white'


### PR DESCRIPTION
### Summary
This is part one of a two part fix that resolves an issue where the icon color within a KButton was not being updated when the `disabled` attribute on the KButton was toggled.

Sometimes `this.$attrs.disabled` can be passed in as `false` and in these cases we want to ensure the button icon color gets updated.

Part two of this fix is here: https://github.com/Kong/kongponents/pull/623

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
