### PR TITLE
fix(kbutton,kicon): fix button icon color [beta]

### DIFF
--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -147,7 +147,7 @@ export default defineComponent({
     const buttonType = computed((): string => props.to ? 'router-link' : 'button')
 
     const iconColor = computed((): string => {
-      if (attrs.disabled !== undefined) {
+      if (attrs.disabled) {
         return 'var(--grey-400)'
       } else if (['primary', 'danger', 'creation'].includes(props.appearance)) {
         return 'white'

--- a/src/components/KIcon/KIcon.vue
+++ b/src/components/KIcon/KIcon.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, onMounted, nextTick } from 'vue'
+import { defineComponent, ref, computed, onMounted, nextTick, watch } from 'vue'
 import * as allIcons from './icons'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -193,6 +193,10 @@ export default defineComponent({
         recursivelyCustomizeIconColors(child)
       })
     }
+
+    watch(() => props.color, () => {
+      recursivelyCustomizeIconColors(svg.value)
+    })
 
     onMounted(async () => {
       await nextTick()


### PR DESCRIPTION
### Summary
Applies https://github.com/Kong/kongponents/pull/622 and https://github.com/Kong/kongponents/pull/623 to the beta branch.

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
