### PR TITLE
fix: add data-testids to action buttons

### DIFF
--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -21,6 +21,7 @@
       v-if="dismissType === 'icon'"
       type="button"
       aria-label="Close"
+      data-testid="k-alert-close-button"
       class="close"
       @click="dismissAlert">
       <KIcon
@@ -38,12 +39,14 @@
         name="actionButtons">
         <KButton
           size="small"
+          data-testid="k-alert-proceed-button"
           @click="proceed"
           @keyup.enter="proceed"/>
       </slot>
       <KButton
         v-if="dismissType === 'button'"
         size="small"
+        data-testid="k-alert-dismiss-button"
         @click="dismissAlert">
         Dismiss
       </KButton>

--- a/packages/KEmptyState/KEmptyState.vue
+++ b/packages/KEmptyState/KEmptyState.vue
@@ -29,6 +29,7 @@
             v-if="!ctaIsHidden"
             appearance="primary"
             size="small"
+            data-testid="k-empty-state-cta-button"
             @click.native="() => handleClick && handleClick()">
             {{ ctaText }}
           </KButton>

--- a/packages/KMenu/KMenu.vue
+++ b/packages/KMenu/KMenu.vue
@@ -24,6 +24,7 @@
       <slot
         name="actionButton">
         <KButton
+          data-testid="k-menu-proceed-button"
           @click="proceed"
           @keyup.enter="proceed"/>
       </slot>

--- a/packages/KMenu/KMenuItem.vue
+++ b/packages/KMenu/KMenuItem.vue
@@ -11,6 +11,7 @@
       :aria-labelledby="menuItemId"
       :is-rounded="false"
       type="button"
+      data-testid="k-menu-item-button"
       class="menu-button non-visual-button"
       @click="toggleMenuItem">
       <span

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -27,6 +27,7 @@
             <slot name="footer-content">
               <KButton
                 :appearance="cancelButtonAppearance"
+                data-testid="k-modal-cancel-button"
                 @click="close"
                 @keyup.esc="close">
                 {{ cancelButtonText }}
@@ -35,6 +36,7 @@
                 <slot name="action-buttons">
                   <KButton
                     :appearance="actionButtonAppearance"
+                    data-testid="k-modal-proceed-button"
                     @click="proceed"
                     @keyup.enter="proceed">
                     {{ actionButtonText }}

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -50,6 +50,7 @@
               <slot name="action-buttons">
                 <KButton
                   :appearance="cancelButtonAppearance"
+                  data-testid="k-modal-fullscreen-cancel-button"
                   class="cancel-button"
                   @click="close"
                 >
@@ -57,6 +58,7 @@
                 </KButton>
                 <KButton
                   :appearance="actionButtonAppearance"
+                  data-testid="k-modal-fullscreen-proceed-button"
                   class="proceed-button"
                   @click="proceed"
                 >

--- a/packages/KMultiselect/KMultiselect.vue
+++ b/packages/KMultiselect/KMultiselect.vue
@@ -14,6 +14,7 @@
       v-bind="buttonAttributes"
       :appearance="buttonAttributes.appearance || 'secondary'"
       :is-open="isOpen"
+      data-testid="k-multiselect-trigger-button"
       class="k-multiselect-trigger has-caret">
       {{ buttonText }}
     </KButton>
@@ -57,6 +58,7 @@
               :disabled="applyDisabled"
               size="small"
               appearance="secondary"
+              data-testid="k-multiselect-apply-button"
               class="k-multiselect-apply"
               @click="handleApply">{{ applyText }}</KButton>
           </div>

--- a/packages/KPrompt/KPrompt.vue
+++ b/packages/KPrompt/KPrompt.vue
@@ -22,6 +22,7 @@
             <KButton
               class="non-visual-button"
               aria-label="Close"
+              data-testid="k-prompt-close-button"
               @click="close">
               <KIcon
                 icon="close"
@@ -59,6 +60,7 @@
         <slot name="action-buttons">
           <KButton
             appearance="outline"
+            data-testid="k-prompt-cancel-button"
             class="k-prompt-cancel mr-2"
             @click="close">
             {{ cancelButtonText }}
@@ -66,6 +68,7 @@
           <KButton
             :appearance="type === 'danger' ? 'danger' : 'primary'"
             :disabled="disableProceedButton"
+            data-testid="k-prompt-proceed-button"
             class="k-prompt-proceed"
             @click="proceed">
             <KIcon

--- a/packages/KSegmentedControl/KSegmentedControl.vue
+++ b/packages/KSegmentedControl/KSegmentedControl.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="segmented-control d-flex" >
     <KButton
-      v-for="item in options"
+      v-for="(item, index) in options"
       :key="label(item)"
       :name="value(item)"
       :disabled="disabled(item)"
       :appearance="appearance(item)"
+      :data-testid="`k-segmented-control-item-${index}`"
       size="small"
       class="justify-content-center"
       v-on="listeners"

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -63,6 +63,7 @@
               :is-rounded="false"
               v-bind="$attrs"
               appearance="btn-link"
+              data-testid="k-select-button"
               @keyup="triggerFocus(isToggled)">{{ selectButtonText }}</KButton>
           </div>
           <div

--- a/packages/KViewSwitcher/KViewSwitcher.vue
+++ b/packages/KViewSwitcher/KViewSwitcher.vue
@@ -5,6 +5,7 @@
     :title="`Toggle to ${view === 'table' ? 'grid' : 'table'} view`"
     size="small"
     appearance="outline"
+    data-testid="k-view-switcher-toggle-button"
     class="view-switch-button non-visual-button"
     @click="toggleView"
   >


### PR DESCRIPTION
### Summary
Adds data-testids to action buttons.

#### Changes made:


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
