### PR TITLE
feat(kinput): add character limit to kinput [KHCP-3687]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,29 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+  },
+  "editor.formatOnPaste": true,
+  "editor.trimAutoWhitespace": true,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.detectIndentation": false,
+  "eslint.codeActionsOnSave.mode": "problems",
+  "eslint.packageManager": "yarn",
+  "eslint.format.enable": true,
+  "eslint.validate": [
+    "typescript",
+    "javascript",
+    "javascriptreact",
+    "vue"
+  ],
+  "files.associations": {
+    ".env.*": "ini",
+    "*.vue": "vue"
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "markdownlint.ignore": [
+    "docs/**/*.md"
+  ]
+}

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -40,12 +40,7 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 <KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' }" />
 
 ```vue
-<KInput
-  label="Name"
-  :label-attributes="{
-    help: 'I use the KLabel `help` prop'
-  }"
-/>
+<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 ```
 
 ### overlayLabel
@@ -74,6 +69,31 @@ You can specify `small`, `medium` (default), or `large` for the size.
 <KInput label="Medium" class="mb-2" />
 <KInput label="Large" size="large" />
 ```
+
+### characterLimit
+
+Use this prop to specify a character limit for the input.
+
+<KInput value="This field has too many characters" :character-limit="10" class="w-100" placeholder="Placeholder text" />
+
+```vue
+<KInput value="This field has too many characters" :character-limit="10" class="w-100" placeholder="Placeholder text" />
+```
+
+The character counter will only display below the input if the `characterLimit` is exceeded.
+
+If the `characterLimit` is exceeded, the character counter below the `KInput` will override the display of a provided `errorMessage` until the character count is within the acceptable range.
+
+:::tip
+You may also specify a native `maxlength` attribute on the `KInput` to actually limit the number of characters the user is allowed to type in the field. This will prevent the user from exceeding the character limit so the error state will not be shown.
+
+<KInput :character-limit="10" maxlength="10" placeholder="Type..."/>
+
+```vue
+<KInput :character-limit="10" maxlength="10" placeholder="Type..."/>
+```
+
+:::
 
 ### help
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -75,10 +75,10 @@ You can specify `rows`, `cols` for the textarea size.
 
 Use this prop to specify a character limit for the textarea, defaults to `2048`.
 
-<KTextArea :characterLimit="500" />
+<KTextArea :characterLimit="20" />
 
 ```vue
-<KTextArea :characterLimit="500" />
+<KTextArea :characterLimit="20" />
 ```
 
 ### disableCharacterLimit

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -20,10 +20,7 @@
           :class="`k-input-${size}`"
           :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
           class="form-control k-input"
-          @input="e => {
-            $emit('input', e.target.value),
-            currValue = e.target.value
-          }"
+          @input="handleInput"
           @mouseenter="() => isHovered = true"
           @mouseleave="() => isHovered = false"
           @focus="() => isFocused = true"
@@ -52,9 +49,7 @@
         :class="`k-input-${size}`"
         :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
         class="form-control k-input"
-        @input="e => {
-          $emit('input', e.target.value)
-        }"
+        @input="handleInput"
         v-on="listeners">
       <p
         v-if="charLimitExceeded || hasError"
@@ -70,9 +65,7 @@
       :class="`k-input-${size}`"
       :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
       class="form-control k-input"
-      @input="e => {
-        $emit('input', e.target.value)
-      }"
+      @input="handleInput"
       v-on="listeners">
 
     <p
@@ -159,6 +152,16 @@ export default {
     inputId () {
       return this.$attrs.id ? this.$attrs.id : !this.testMode ? uuid.v1() : 'test-input-id-1234'
     },
+    charLimitExceeded () {
+      return !!this.characterLimit && (this.currValue.toString().length || (!this.modelValueChanged && this.value.toString().length)) > this.characterLimit
+    },
+    charLimitExceededError () {
+      if (!this.charLimitExceeded) {
+        return ''
+      }
+
+      return this.modelValueChanged ? `${this.currValue.toString().length} / ${this.characterLimit}` : `${this.value.toString().length} / ${this.characterLimit}`
+    },
     isDisabled () {
       return this.$attrs.hasOwnProperty('disabled')
     },
@@ -169,6 +172,25 @@ export default {
       delete listeners['input']
 
       return listeners
+    }
+  },
+  watch: {
+    charLimitExceeded (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.$emit('char-limit-exceeded', {
+          value: this.currValue,
+          length: this.currValue.toString().length,
+          characterLimit: this.characterLimit,
+          limitExceeded: newVal
+        })
+      }
+    }
+  },
+  methods: {
+    handleInput ($event) {
+      this.currValue = $event.target.value
+      this.modelValueChanged = true
+      this.$emit('input', $event.target.value)
     }
   }
 }
@@ -199,6 +221,26 @@ export default {
     -webkit-appearance: none;
   }
 
+  &.w-auto .k-input {
+    width: auto;
+  }
+
+  &.w-100 .k-input {
+    width: 100%;
+  }
+
+  &.w-75 .k-input {
+    width: 75%;
+  }
+
+  &.w-50 .k-input {
+    width: 50%;
+  }
+
+  &.w-25 .k-input {
+    width: 25%;
+  }
+
   & .k-input-label-wrapper-large .has-error,
   & .k-input-large + .has-error {
     font-size: 12px;
@@ -218,6 +260,18 @@ export default {
     font-size: 9px;
     line-height: 11px;
     margin-top: 2px;
+  }
+
+  .text-on-input label.hovered,
+  .text-on-input label:hover {
+    color: var(--KInputHover, var(--blue-500));
+  }
+
+  &.input-error {
+    .text-on-input label.hovered,
+    .text-on-input label:hover {
+      color: var(--red-500);
+    }
   }
 }
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,35 +1,21 @@
-### Summary
+# Summary
 
+<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
 
-#### Changes made:
+## Vue 3
 
+**Did you create a corresponding PR to add this change to the `beta` branch? (required)**
 
-### Vue 3 Upgrade
-
-**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**
-
-<!--
-We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:
-
-- The component feature/fix, updated for Vue 3 and the Composition API.
-- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
-- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).
-
--->
+- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
+- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
+- [ ] **No**, because `[type your reasons]`
 
 If you have questions, tag `@adamdehaven` or `@kaiarrowood`.
 
-<!--
+---
 
-**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**
+## PR Checklist
 
-  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
-    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
-  - [ ] **No**, the component does not yet exist on `next` branch.
-
--->
-
-### PR Checklist
 - [ ] Does not introduce dependencies
 - [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
 - [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>


### PR DESCRIPTION
### Summary

Add `characterLimit` to `KInput`


### Vue 3 Upgrade

**If your PR contains code that needs to be ported to the `beta` branch, please add the [`port to beta branch`](https://github.com/Kong/kongponents/labels/port%20to%20beta%20branch) label to your PR.**

<!--
We are currently in the process of upgrading Kongponents to Vue 3. If changes are made to a component or doc file on the `main` branch, a corresponding PR needs to be made into the `beta` branch that includes:

- The component feature/fix, updated for Vue 3 and the Composition API.
- Documentation updates for the component changes, as well as updating examples and usage to Vue 3 and the Composition API.
- Updates to the corresponding `.spec.ts` test file(s) to utilize [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction).

-->

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

<!--

**Does your PR modify a component [that already exists on the `next` branch](https://github.com/Kong/kongponents/tree/next/src/components)?**

  - [ ] **Yes**, and there is a corresponding PR to update the component on the `next` branch
    - `LINK_TO_PR_ON_NEXT_BRANCH` (**required**)
  - [ ] **No**, the component does not yet exist on `next` branch.

-->

### PR Checklist
- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
