### PR TITLE
fix(kicon): re-render svg on icon prop change

### DIFF
--- a/packages/KIcon/KIcon.vue
+++ b/packages/KIcon/KIcon.vue
@@ -139,39 +139,17 @@ export default {
       handler () {
         this.recursivelyCustomizeIconColors(this.svg)
       }
+    },
+    icon: {
+      handler () {
+        this.renderIcon()
+      }
     }
   },
 
   mounted () {
     this.$nextTick(function () {
-      // Set svg
-      this.svg = this.$refs.svgWrapper ? this.$refs.svgWrapper.querySelector('svg:not(.slot-content)') : null
-
-      if (this.svg) {
-        // Check for slot content
-        if (this.$slots.svgElements && this.$slots.svgElements.length) {
-          this.addSlotContent()
-        }
-
-        // Bind attributes
-        for (const [attributeName, attributeValue] of Object.entries(this.$attrs)) {
-          this.svg.setAttribute(attributeName, attributeValue)
-        }
-
-        // Add role
-        this.svg.setAttribute('role', 'img')
-
-        // Set size
-        this.svg.setAttribute('width', this.setSize || this.width)
-        this.svg.setAttribute('height', this.setSize || this.height)
-        this.svg.setAttribute('viewBox', this.setViewbox)
-
-        // Set title
-        this.setSvgTitle()
-
-        // Customize icon colors
-        this.recursivelyCustomizeIconColors(this.svg)
-      }
+      this.renderIcon()
     })
   },
 
@@ -231,6 +209,36 @@ export default {
       [].forEach.call(el.children, child => {
         this.recursivelyCustomizeIconColors(child)
       })
+    },
+    renderIcon () {
+      // Set svg
+      this.svg = this.$refs.svgWrapper ? this.$refs.svgWrapper.querySelector('svg:not(.slot-content)') : null
+
+      if (this.svg) {
+        // Check for slot content
+        if (this.$slots.svgElements && this.$slots.svgElements.length) {
+          this.addSlotContent()
+        }
+
+        // Bind attributes
+        for (const [attributeName, attributeValue] of Object.entries(this.$attrs)) {
+          this.svg.setAttribute(attributeName, attributeValue)
+        }
+
+        // Add role
+        this.svg.setAttribute('role', 'img')
+
+        // Set size
+        this.svg.setAttribute('width', this.setSize || this.width)
+        this.svg.setAttribute('height', this.setSize || this.height)
+        this.svg.setAttribute('viewBox', this.setViewbox)
+
+        // Set title
+        this.setSvgTitle()
+
+        // Customize icon colors
+        this.recursivelyCustomizeIconColors(this.svg)
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

When the `icon` prop changes for `KIcon`, we need to re-render the svg itself and recalculate width, height, colors, etc.

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
