### PR TITLE
docs(ktable): fix tables with no fetcher

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -989,7 +989,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
 
 <KCard class="my-2">
   <template v-slot:body>
-    <KTable />
+    <KTable :fetcher="() => { return { data: [] } }" />
   </template>
 </KCard>
 
@@ -1010,6 +1010,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
 <KCard class="my-2">
   <template v-slot:body>
     <KTable
+      :fetcher="() => { return { data: [] } }"
       emptyStateTitle="No Workspaces exist"
       emptyStateMessage="Adding a new Workspace will populate this table."
       emptyStateActionMessage="Create a Workspace"
@@ -1085,7 +1086,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 <KCard class="my-2">
   <template v-slot:body>
-    <KTable :hasError="true" />
+    <KTable :fetcher="() => { return { data: [] } }" :hasError="true" />
   </template>
 </KCard>
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1171,6 +1171,7 @@ Set the `isLoading` prop to `true` to enable the loading state.
 <KCard class="pb-0 mt-2">
   <template v-slot:body>
     <KTable
+      :fetcher="() => { return { data: [] } }"
       :isLoading="true"
       class="my-0" />
   </template>


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Fix KTable examples with no fetcher

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
