### PR TITLE
fix(ktable): emit event on cell and row click

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -606,6 +606,7 @@ Bind any DOM [events](https://developer.mozilla.org/en-US/docs/Web/Events) to va
 ### Rows
 
 `@row:<event>` - returns the `Event`, the row item, and the type: `row`
+`row-click` - Event is emitted whenever a row is clicked and the row handler is fired, returns the row `data`
 
 To avoid firing row clicks by accident, the row click handler ignores events coming from `a`, `button`, `input`, and `select` elements (unless they have the `disabled` attribute). As such click handlers attached to these element types do not require stopping propagation via `@click.stop`.
 
@@ -761,6 +762,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
 ### Cells
 
 `@cell:<event>` - returns the `Event`, the cell value, and the type: `cell`
+`cell-click` - Event is emitted whenever a cell is clicked and the cell handler is fired, returns the row `data`
 
 <template>
   <div>

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -555,10 +555,10 @@ export default defineComponent({
             if ((!isIgnored || e.target.hasAttribute('disabled')) &&
                  !isPopoverContent && (rowListeners.click || cellListeners.click)) {
               if (cellListeners.click) {
-                ctx.emit('cell-click', entity)
+                ctx.emit('cell-click', { data: entity })
                 cellListeners.click(e, entity, 'cell')
               } else {
-                ctx.emit('row-click', rowData)
+                ctx.emit('row-click', { data: rowData })
                 rowListeners.click(e, rowData, 'row')
               }
             }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -555,8 +555,10 @@ export default defineComponent({
             if ((!isIgnored || e.target.hasAttribute('disabled')) &&
                  !isPopoverContent && (rowListeners.click || cellListeners.click)) {
               if (cellListeners.click) {
+                ctx.emit('cell-click', entity)
                 cellListeners.click(e, entity, 'cell')
               } else {
+                ctx.emit('row-click', rowData)
                 rowListeners.click(e, rowData, 'row')
               }
             }


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Emit event on row/cell click

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
