### PR TITLE
MA-606: add "no data" icon for vitals

### DIFF
--- a/packages/KIcon/__snapshots__/KIcon.spec.js.snap
+++ b/packages/KIcon/__snapshots__/KIcon.spec.js.snap
@@ -365,6 +365,13 @@ exports[`KIcon renders more icon 1`] = `
 </span>
 `;
 
+exports[`KIcon renders noData icon 1`] = `
+<span class="kong-icon kong-icon-noData"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" role="img" width="24" height="24">
+  <title>noData</title>
+  <path d="M3.1 9.1C2.5 9.1 2 8.6 2 8c0-.6.5-1.1 1.1-1.1h9.7c.7 0 1.2.5 1.2 1.1 0 .6-.5 1.1-1.1 1.1H3.1z" fill="#A3BBCC"></path>
+</svg></span>
+`;
+
 exports[`KIcon renders notificationBell icon 1`] = `
 <span class="kong-icon kong-icon-notificationBell"><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" width="24" height="24">
   <title>notificationBell</title>

--- a/packages/KIcon/icons/icn-no-data.svg
+++ b/packages/KIcon/icons/icn-no-data.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <title>No Data</title>
+  <path d="M3.1 9.1C2.5 9.1 2 8.6 2 8c0-.6.5-1.1 1.1-1.1h9.7c.7 0 1.2.5 1.2 1.1 0 .6-.5 1.1-1.1 1.1H3.1z" fill="#A3BBCC"/>
+</svg>

--- a/packages/KIcon/icons/index.js
+++ b/packages/KIcon/icons/index.js
@@ -41,6 +41,7 @@ import kong from './icn-kong.svg'
 import lock from './icn-lock.svg'
 import list from './icn-list.svg'
 import more from './icn-more.svg'
+import noData from './icn-no-data.svg'
 import notificationBell from './icn-notification-bell.svg'
 import notificationInbox from './icn-notification-inbox.svg'
 import organization from './icn-organization.svg'
@@ -115,6 +116,7 @@ export default {
   list,
   lock,
   more,
+  noData,
   notificationBell,
   notificationInbox,
   organization,


### PR DESCRIPTION
https://konghq.atlassian.net/browse/MA-606

# Summary
Added a new dashed line KIcon (grabbed it from Figma).

<img width="657" alt="Screen Shot 2022-05-25 at 10 35 47 AM" src="https://user-images.githubusercontent.com/103061463/170328058-a1aa3f57-3f95-4ff9-b595-34f5c758c604.png">

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [x] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
