### PR TITLE
fix(kinput): fix manual change to v-model

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -2,7 +2,8 @@
 
 **KInput** provides a wrapper around general `text` input's and provides specific Kong styling and state treatments (error, focus, etc).
 
-<KInput class="w-100"/>
+<KInput class="w-100" />
+
 ```vue
 <KInput class="w-100"/>
 ```
@@ -215,43 +216,58 @@ You can pass any input attribute and it will get properly bound to the element.
 
 KInput works as regular inputs do using v-model for data binding:
 
-<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
-  <div>
-    {{ data.myInput }}
-    <KInput
-      v-model="data.myInput"
-      @blur="e => (data.myInput = 'blurred')" />
-  </div>
-</Komponent>
-
-```vue
-<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+<div>
   {{ myInput }}
-  <KInput v-model="data.myInput" />
-</Komponent>
+  <div class="d-flex">
+    <KInput v-model="myInput" @blur="e => (myInput = 'blurred')" />
+    <KButton class="ml-2" @click="clearIt">Clear</KButton>
+  </div>
+</div>
+
+```html
+<div>
+  {{ myInput }}
+  <KInput v-model="myInput" @blur="e => (myInput = 'blurred')" />
+  <KButton @click="clearIt">Clear</KButton>
+</div>
+
+<script>
+  export default {
+    data() {
+      return {
+        myInput: 'test'
+      }
+    },
+    methods: {
+      clearIt () {
+        this.myInput = ''
+      }
+    }
+  }
+</script>
 ```
 
 ## Events
 
 KInput transparently binds to events:
 
-<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+<Komponent :data="{myInput2: 'hello'}" v-slot="{ data }">
   <div>
     <KInput
-      v-model="data.myInput"
-      @blur="e => (data.myInput = 'blurred')"
-      @focus="e => (data.myInput = 'focused')"
+      v-model="data.myInput2"
+      @blur="e => (data.myInput2 = 'blurred')"
+      @focus="e => (data.myInput2 = 'focused')"
     />
   </div>
 </Komponent>
 
 ```vue
-<Komponent :data="{myInput: 'hello'}" v-slot="{ data }">
+<Komponent :data="{myInput2: 'hello'}" v-slot="{ data }">
   <div>
     <KInput
-      v-model="data.myInput"
-      @blur="e => (data.myInput = 'blurred')"
-      @focus="e => (data.myInput = 'focused')"
+      v-model="data.myInput2"
+      @blur="e => (data.myInput2 = 'blurred')"
+      @focus="e => (data.myInput2 = 'focused')"
     />
   </div>
 </Komponent>
@@ -300,6 +316,21 @@ An Example of changing the error border color of KInput to pink might look like:
 }
 </style>
 ```
+
+<script>
+export default {
+  data() {
+    return {
+      myInput: 'test'
+    }
+  },
+  methods: {
+    clearIt () {
+      this.myInput = ''
+    }
+  }
+}
+</script>
 
 <style lang="scss">
 .custom-input {

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -1,18 +1,19 @@
 # Select
 
 **Select** - Dropdown/Select component
-
-<KSelect label="Pick Something:" :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }, {
-    label: 'TEST 2',
-    value: 'test2'
-  }]"
-/>
+<div>
+  <KSelect label="Pick Something:" :items="[{
+      label: 'test',
+      value: 'test'
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }, {
+      label: 'TEST 2',
+      value: 'test2'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect label="Pick Something:" :items="[{
@@ -35,18 +36,20 @@
 An array of items containing a `label` and `value`. May also specify that a certain item is `selected`
 by default.
 
-<KSelect :items="[{
-    label: 'test me because I am a super long option with text that wraps',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }, {
-    label: 'TEST 2',
-    value: 'test2'
-  }]"
-/>
+<div>
+  <KSelect :items="[{
+      label: 'test me because I am a super long option with text that wraps',
+      value: 'test',
+      selected: true
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }, {
+      label: 'TEST 2',
+      value: 'test2'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect :items="[{
@@ -67,15 +70,17 @@ by default.
 
 The label for the select.
 
-<KSelect label="Cool label" :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+<div>
+  <KSelect label="Cool label" :items="[{
+      label: 'test',
+      value: 'test',
+      selected: true
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect label="Cool label" :items="[{
@@ -93,20 +98,20 @@ The label for the select.
 
 Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label.html) if using the `label` prop.
 
-<KSelect
-  label="Name"
-  :label-attributes="{
-    help: 'I use the KLabel `help` prop',
-    'data-testid': 'test'
-  }"
-  :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+<div>
+  <KSelect label="Name" :label-attributes="{
+      help: 'I use the KLabel `help` prop',
+      'data-testid': 'test'
+    }"
+    :items="[{
+      label: 'test',
+      value: 'test'
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect
@@ -132,15 +137,17 @@ There are three styles of selects, `select` and `dropdown` (default) which are f
 The `dropdown` appearance style has a selected item object. You can deselect the item by clicking
 the Clear icon.
 
-<KSelect :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+<div>
+  <KSelect :items="[{
+      label: 'test',
+      value: 'test',
+      selected: true
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect :items="[{
@@ -157,15 +164,17 @@ the Clear icon.
 The `select` style displays the selected item in the textbox and also displays a chevron. There is no
 way to clear the selection once it is made.
 
-<KSelect appearance='select' :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+<div>
+  <KSelect appearance='select' :items="[{
+      label: 'test',
+      value: 'test',
+      selected: true
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect appearance='select' :items="[{
@@ -181,14 +190,16 @@ way to clear the selection once it is made.
 
 The `button` style triggers the dropdown on click and you cannot filter the entries.
 
-<KSelect appearance='button' :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+<div>
+  <KSelect appearance='button' :items="[{
+      label: 'test',
+      value: 'test'
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect appearance='button' :items="[{
@@ -205,7 +216,9 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 
 You can configure the button text when an item is selected, if `appearance` is type `button`.
 
-<KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
+<div>
+  <KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
+</div>
 
 ```vue
 <KSelect
@@ -244,15 +257,17 @@ export default {
 You can pass a `width` string for dropdown. By default the `width` is `200px`. This is the width
 of the input, dropdown, and selected item.
 
-<KSelect width="250" :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+<div>
+  <KSelect width="250" :items="[{
+      label: 'test',
+      value: 'test',
+      selected: true
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+  />
+</div>
 
 ```vue
 <KSelect width="100" :items="[{
@@ -319,7 +334,9 @@ KSelect works as regular inputs do using v-model for data binding:
 
 You can pass any input attribute and it will get properly bound to the element.
 
-<KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
+<div>
+  <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
+</div>
 
 ```vue
 <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
@@ -329,14 +346,16 @@ You can pass any input attribute and it will get properly bound to the element.
 
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
-<KSelect :items="myItems" width="500" :filterFunc="customFilter">
-  <template v-slot:item-template="{ item }">
-    <div class="select-item-label">{{ item.label }}</div>
-    <div class="select-item-desc">{{ item.description }}</div>
-  </template>
-</KSelect>
+<div>
+  <KSelect :items="myItems" width="500" :filterFunc="customFilter">
+    <template v-slot:item-template="{ item }">
+      <div class="select-item-label">{{ item.label }}</div>
+      <div class="select-item-desc">{{ item.description }}</div>
+    </template>
+  </KSelect>
+</div>
 
-```vue
+```html
 <KSelect :items="myItems" width="500" :filterFunc="customFilter">
   <template v-slot:item-template="{ item }">
     <div class="select-item-label">{{item.label}}</div>

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -190,6 +190,11 @@ export default {
           limitExceeded: newVal
         })
       }
+    },
+    value (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.handleInput({ target: { value: newVal } })
+      }
     }
   },
   methods: {

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -152,6 +152,11 @@ export default {
           limitExceeded: newval
         })
       }
+    },
+    value (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.inputHandler({ target: { value: newVal } })
+      }
     }
   },
   methods: {


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- Fix issue where manipulating `KInput` `v-model` externally was not reflected
- Wrap `KSelect` in `<div>` for broken markdown issue related to tabbing

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
