### PR TITLE
feat(klabel, kooltip): added support for max-width and tooltip-attributes [KHCP-3486]

### DIFF
--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -4,8 +4,6 @@
 
 ## Standard Input
 
-<br />
-
 <KLabel>Input Title</KLabel>
 
 ```vue
@@ -13,8 +11,6 @@
 ```
 
 ## With Help
-
-<br />
 
 <KLabel help="This is an example">Input Title</KLabel>
 
@@ -36,8 +32,6 @@
 
 ## With Info
 
-<br />
-
 <KLabel info="This is an example">Input Title</KLabel>
 
 ```vue
@@ -45,8 +39,6 @@
 ```
 
 ## With for attribute
-
-<br />
 
 <KLabel for="service">Service Name</KLabel>
 <KInput id="service"/>
@@ -58,12 +50,23 @@
 
 ## Sample input with a tooltip
 
-<br />
-
 <KLabel help="A service is an API that you want to offer">Service Name</KLabel>
 <KInput />
 
 ```vue
 <KLabel help="A service is an API that you want to offer">Service Name</KLabel>
 <KInput />
+```
+
+## With tooltipAttributes
+
+<KLabel :tooltip-attributes="{ placement: 'right', 'max-width': '200' }" help="I wonder how it handles long inputs. I wonder how it handles long inputs. I wonder how it handles long inputs. I wonder how it handles long inputs.">With Tooltip Attributes</KLabel>
+
+```vue
+<KLabel
+  :tooltip-attributes="{ placement: 'right', 'max-width': '200' }"
+  help="I wonder how it handles long inputs"
+>
+  With Tooltip Attributes
+</KLabel>
 ```

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -303,6 +303,26 @@ The width of the popover body - by default it is 200px.
 </KPop>
 ```
 
+### maxWidth
+
+The max width of the popover body - by default it is `auto`.
+
+<KPop title="Cool header" width="auto" max-width="500">
+  <KButton>button</KButton>
+  <template v-slot:content>
+    I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide!
+  </template>
+</KPop>
+
+```vue
+<KPop title="Cool header" max-width="500">
+  <KButton>button</KButton>
+  <template v-slot:content>
+    I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide!
+  </template>
+</KPop>
+```
+
 ### popoverClasses
 
 Custom classes that you want to append to the popover - by default it has a `k-popover` class on it.

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -32,7 +32,7 @@ Here you can pass in the text to display in the toolip.
 </KoolTip>
 ```
 
-### position
+### placement
 
 This is where the tooltip will appear - by default it appears on top.
 Here are the different options:
@@ -58,7 +58,7 @@ Here are the different options:
 </div>
 
 ```vue
-<KoolTip position="bottom" label="A label that appears on the bottom">
+<KoolTip placement="bottom" label="A label that appears on the bottom">
   <KButton>Sample Button</KButton>
 </KoolTip>
 ```
@@ -66,6 +66,20 @@ Here are the different options:
 ### positionFixed
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `false`. See [`KPop` docs](popover.html#positionfixed) for more information.
+
+### maxWidth
+
+You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWidth` defaults to `auto`.
+
+<KoolTip placement="bottom" max-width="300" label="A label that appears on the bottom. A label that appears on the bottom">
+  <KButton>bottom</KButton>
+</KoolTip>
+
+```vue
+<KoolTip placement="bottom" max-width="300" label="A label that appears on the bottom. A label that appears on the bottom">
+  <KButton>button</KButton>
+</KoolTip>
+```
 
 ## Slots
 

--- a/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
+++ b/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
@@ -133,7 +133,7 @@ exports[`KCatalog general can change card sizes - large 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -299,7 +299,7 @@ exports[`KCatalog general can change card sizes - small 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -385,7 +385,7 @@ exports[`KCatalog general can disable truncation 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -471,7 +471,7 @@ exports[`KCatalog general handles truncation 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -537,7 +537,7 @@ exports[`KCatalog general matches snapshot 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -705,7 +705,7 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -785,7 +785,7 @@ exports[`KCatalog general renders slots when passed 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -867,7 +867,7 @@ exports[`KCatalog general renders slotted cards when passed 1`] = `
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">
@@ -933,7 +933,7 @@ exports[`KCatalog states displays a loading skeletion when the "isLoading" prop 
 </svg>
 </span></button>
         </div>
-        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+        <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
           <!---->
           <div class="k-popover-content">
             <ul class="k-select-list ma-0 pa-0">

--- a/packages/KLabel/KLabel.vue
+++ b/packages/KLabel/KLabel.vue
@@ -3,6 +3,7 @@
     class="k-input-label">
     <KoolTip
       v-if="help"
+      v-bind="tooltipAttributes"
       :label="help"
       :test-mode="testMode"
       class="label-tooltip"
@@ -15,6 +16,7 @@
     </Kooltip>
     <KoolTip
       v-else-if="info"
+      v-bind="tooltipAttributes"
       :label="info"
       :test-mode="testMode"
       class="label-tooltip"
@@ -48,6 +50,10 @@ export default {
     info: {
       type: String,
       default: undefined
+    },
+    tooltipAttributes: {
+      type: Object,
+      default: () => ({})
     },
     /**
      * Test mode - for testing only, strips out generated ids

--- a/packages/KLabel/__snapshots__/KLabel.spec.js.snap
+++ b/packages/KLabel/__snapshots__/KLabel.spec.js.snap
@@ -9,7 +9,7 @@ exports[`KLabel renders a tooltip when \`help\` is provided 1`] = `
   <path d="M12 2a10.01 10.01 0 0 1 0 20 10 10 0 0 1 0-20Zm-.18 12h.79c.23 0 .35-.1.4-.32.05-.21.1-.42.18-.62.15-.32.43-.5.72-.68 1.18-.74 1.87-1.75 1.7-3.2-.12-.91-.55-1.61-1.32-2.1a4.98 4.98 0 0 0-3.91-.3c-1.07.4-1.72 1.13-1.8 2.31-.01.21.1.37.32.38.52.01 1.04.03 1.57.03.25 0 .42-.14.5-.38.14-.51.51-.72 1.01-.77.57-.04 1.08.3 1.2.8.2.75.03 1.42-.56 1.94-.35.31-.73.58-1.1.87-.49.4-.83.9-.87 1.56-.02.31.1.48.42.48h.75Zm-.02 1.56h-.67c-.3 0-.52.22-.52.53v.8c0 .35.22.57.56.57h1.27c.32 0 .53-.2.55-.53a8.8 8.8 0 0 0 0-.85c-.02-.33-.23-.52-.57-.53h-.62Z" fill="#A3BBCC"></path>
 </svg>
 </span>
-    <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
       <!---->
       <div class="k-popover-content">
         <div role="tooltip">This is a tooltip</div>
@@ -27,7 +27,7 @@ exports[`KLabel renders a tooltip when \`info\` is provided 1`] = `
   <path fill="#A3BBCC" fill-rule="evenodd" d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"></path>
 </svg>
 </span>
-    <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
+    <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
       <!---->
       <div class="k-popover-content">
         <div role="tooltip">This is a tooltip</div>

--- a/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
+++ b/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
@@ -9,7 +9,7 @@ exports[`KMultiselect matches snapshot 1`] = `
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover k-multiselect mt-0 mb-0 hide-caret" style="width: auto; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover k-multiselect mt-0 mb-0 hide-caret" style="width: auto; max-width: 150px; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <div class="k-multiselect-dropdown">

--- a/packages/KPagination/__snapshots__/KPagination.spec.js.snap
+++ b/packages/KPagination/__snapshots__/KPagination.spec.js.snap
@@ -41,7 +41,7 @@ exports[`KPagination correctly renders props 1`] = `
 </svg>
 </span></button>
   </div>
-  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">
@@ -116,7 +116,7 @@ exports[`KPagination matches snapshot 1`] = `
 </svg>
 </span></button>
   </div>
-  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <ul class="k-select-list ma-0 pa-0">

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -176,6 +176,10 @@ export default {
       type: String,
       default: '200'
     },
+    maxWidth: {
+      type: String,
+      default: '150'
+    },
     /**
      * Custom classes that will be applied to the popover
      */
@@ -261,7 +265,8 @@ export default {
   computed: {
     popoverStyle: function () {
       return {
-        width: this.width === 'auto' ? this.width : this.width + 'px'
+        width: this.width === 'auto' ? this.width : this.width + 'px',
+        'max-width': this.maxWidth === 'auto' ? this.maxWidth : this.maxWidth + 'px'
       }
     }
   },

--- a/packages/KPop/__snapshots__/KPop.spec.js.snap
+++ b/packages/KPop/__snapshots__/KPop.spec.js.snap
@@ -5,7 +5,7 @@ exports[`KPop renders props when passed 1`] = `
     <!---->
     Click Me!
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover" style="width: 200px; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover" style="width: 200px; max-width: 150px; display: none;" name="fade">
     <div class="k-popover-header d-flex">
       <div class="k-popover-title">Cool Beans!</div>
       <!---->
@@ -21,7 +21,7 @@ exports[`KPop renders slots when passed 1`] = `
     <!---->
     OK
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover pb-0" style="width: 200px; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover pb-0" style="width: 200px; max-width: 150px; display: none;" name="fade">
     <div class="k-popover-header d-flex">
       <div class="k-popover-title"><span>Look Mah!</span></div>
       <div class="k-popover-actions"><span>Pop Actions</span></div>

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -13,7 +13,7 @@ exports[`KSelect matches snapshot 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="max-width: 150px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -43,7 +43,7 @@ exports[`KSelect renders props when passed 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="max-width: 150px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -86,7 +86,7 @@ exports[`KSelect renders with selected item 1`] = `
           <!---->
         </div>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0  k-select-pop-dropdown hide-caret" style="max-width: 150px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -76,7 +76,7 @@ exports[`KTable default has hover class when passed 1`] = `
 </svg>
 </span></button>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -234,7 +234,7 @@ exports[`KTable sorting should allow disabling sorting 1`] = `
 </svg>
 </span></button>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">
@@ -342,7 +342,7 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
 </svg>
 </span></button>
       </div>
-      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover k-select-popover mt-0 undefined k-select-pop-button hide-caret" style="width: 200px; max-width: 150px; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <ul class="k-select-list ma-0 pa-0">

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -4,6 +4,7 @@
     :popover-classes="`kooltip ${computedClass} ${className}`"
     :position-fixed="positionFixed"
     :test-mode="testMode"
+    :max-width="maxWidth"
     trigger="hover"
     width="auto"
     hide-caret>
@@ -58,6 +59,10 @@ export default {
       type: Boolean,
       default: false
     },
+    maxWidth: {
+      type: String,
+      default: 'auto'
+    },
     /**
      * Test mode - for testing only, strips out generated ids
      */
@@ -83,6 +88,7 @@ export default {
   },
   mounted () {
     this.className = this.$el && this.$el.className
+    // this.maxWidth = this.maxWidth === 'auto' ? this.maxWidth : this.maxWidth + 'px'
   }
 }
 </script>

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -88,7 +88,6 @@ export default {
   },
   mounted () {
     this.className = this.$el && this.$el.className
-    // this.maxWidth = this.maxWidth === 'auto' ? this.maxWidth : this.maxWidth + 'px'
   }
 }
 </script>

--- a/packages/KoolTip/__snapshots__/KoolTip.spec.js.snap
+++ b/packages/KoolTip/__snapshots__/KoolTip.spec.js.snap
@@ -5,7 +5,7 @@ exports[`KoolTip matches snapshot 1`] = `
     <!---->
     OK
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <div role="tooltip">I'm inside the tooltip!</div>
@@ -20,7 +20,7 @@ exports[`KoolTip renders tooltip to the bottom side 1`] = `
     <!---->
     OK
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <div role="tooltip">I'm on the bottom side!</div>
@@ -35,7 +35,7 @@ exports[`KoolTip renders tooltip to the left side 1`] = `
     <!---->
     OK
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mr-2  hide-caret" style="width: auto; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mr-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <div role="tooltip">I'm on the left side!</div>
@@ -50,7 +50,7 @@ exports[`KoolTip renders tooltip to the right side 1`] = `
     <!---->
     OK
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover kooltip ml-2  hide-caret" style="width: auto; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover kooltip ml-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <div role="tooltip">I'm on the right side!</div>
@@ -65,7 +65,7 @@ exports[`KoolTip renders tooltip to the top side 1`] = `
     <!---->
     OK
     <!----></button>
-  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mb-2  hide-caret" style="width: auto; display: none;" name="fade">
+  <div id="test-popover-id-1234" role="region" class="k-popover kooltip mb-2  hide-caret" style="width: auto; max-width: auto; display: none;" name="fade">
     <!---->
     <div class="k-popover-content">
       <div role="tooltip">I'm on the top side!</div>


### PR DESCRIPTION
# Summary
Task in Jira: https://konghq.atlassian.net/browse/KHCP-3486

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
