### PR TITLE
fix(kpop): default maxwidth should be > default width

### DIFF
--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -178,7 +178,7 @@ export default {
     },
     maxWidth: {
       type: String,
-      default: '150'
+      default: '350'
     },
     /**
      * Custom classes that will be applied to the popover


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
