### PR TITLE
fix(kinput): deepclone value prop

### DIFF
--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -199,9 +199,12 @@ export default {
   },
   methods: {
     handleInput ($event) {
-      this.currValue = $event.target.value
+      // avoid pass by ref
+      const val = JSON.parse(JSON.stringify($event?.target?.value))
+
+      this.currValue = val
       this.modelValueChanged = true
-      this.$emit('input', $event.target.value)
+      this.$emit('input', val)
     }
   }
 }

--- a/packages/KTextArea/KTextArea.vue
+++ b/packages/KTextArea/KTextArea.vue
@@ -161,9 +161,12 @@ export default {
   },
   methods: {
     inputHandler (e) {
+      // avoid pass by ref
+      const val = JSON.parse(JSON.stringify(e?.target?.value))
+
       // this 'input' event must be emitted for v-model binding to work properly
-      this.$emit('input', e.target.value)
-      this.currValue = e.target.value
+      this.$emit('input', val)
+      this.currValue = val
     }
   }
 }


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
We are watching the `value` and then re-assigning it to another var that is editable - clone the value before doing this.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
