### PR TITLE
feat(kstyles): multi-line truncation [beta]

### DIFF
--- a/docs/style-guide/utilities.md
+++ b/docs/style-guide/utilities.md
@@ -169,14 +169,14 @@ For each size in our [type definitions](/style-guide/type.html) we include a uti
 
 ## Truncation
 
-We support both single line truncation as well as multi-line. Multi-line truncation is customizable with the following properties:
+We support both single line truncation as well as multi-line. Multi-line truncation is customizable with the following CSS variable:
 
-- `MaxLineLimit` - the maximum number of allowed lines (defaults to `3`)
+- `TMaxLineLimit` - the maximum number of allowed lines (defaults to `3`)
 
-| Class       |Properties
+| Class       |Properties/Variables
 | :---------- |:-------------- |:-----------
 | .truncate | white-space: nowrap;<br>text-overflow: ellipsis;<br>overflow: hidden;
-| .multi-line-truncation | `MaxLineLimit`
+| .multi-line-truncation | `TMaxLineLimit`
 
 <div class="multi-line-truncation" style="width: 425px; height: 84px; border: 1px solid black; padding: 8px;">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer condimentum leo a neque tristique faucibus. Praesent at imperdiet elit, vel tincidunt metus. Praesent elementum mollis libero, et semper diam efficitur tristique. Nam aliquam tortor a leo pretium vestibulum. Proin posuere auctor odio, sit amet elementum massa aliquet in.
@@ -190,7 +190,7 @@ We support both single line truncation as well as multi-line. Multi-line truncat
 
 ```css
 .multi-line-truncation {
-  --MaxLineLimit: 5;
+  --TMaxLineLimit: 5;
 }
 ```
 
@@ -204,7 +204,7 @@ We support both single line truncation as well as multi-line. Multi-line truncat
 - `TPosRight` - css property `right` position of the ellipsis
 - `TPadRight` - the amount of padding on the right side of the container
 
-| Class       |Properties
+| Class       |Variables
 | :---------- |:-------------- |:-----------
 | .truncate-multi | `TLineHeight`, `TMaxLines`, `TFontSize`, `TPosRight`, `TPadRight`
 
@@ -246,6 +246,6 @@ We support both single line truncation as well as multi-line. Multi-line truncat
   }
 }
 .multi-line-truncation {
-  --MaxLineLimit: 5;
+  --TMaxLineLimit: 5;
 }
 </style>

--- a/docs/style-guide/utilities.md
+++ b/docs/style-guide/utilities.md
@@ -171,6 +171,33 @@ For each size in our [type definitions](/style-guide/type.html) we include a uti
 
 We support both single line truncation as well as multi-line. Multi-line truncation is customizable with the following properties:
 
+- `MaxLineLimit` - the maximum number of allowed lines (defaults to `3`)
+
+| Class       |Properties
+| :---------- |:-------------- |:-----------
+| .truncate | white-space: nowrap;<br>text-overflow: ellipsis;<br>overflow: hidden;
+| .multi-line-truncation | `MaxLineLimit`
+
+<div class="multi-line-truncation" style="width: 425px; height: 84px; border: 1px solid black; padding: 8px;">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer condimentum leo a neque tristique faucibus. Praesent at imperdiet elit, vel tincidunt metus. Praesent elementum mollis libero, et semper diam efficitur tristique. Nam aliquam tortor a leo pretium vestibulum. Proin posuere auctor odio, sit amet elementum massa aliquet in.
+</div>
+
+```html
+<div class="multi-line-truncation" style="width: 425px; height: 84px; border: 1px solid black; padding: 8px;">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer condimentum leo a neque tristique faucibus. Praesent at imperdiet elit, vel tincidunt metus. Praesent elementum mollis libero, et semper diam efficitur tristique. Nam aliquam tortor a leo pretium vestibulum. Proin posuere auctor odio, sit amet elementum massa aliquet in.
+</div>
+```
+
+```css
+.multi-line-truncation {
+  --MaxLineLimit: 5;
+}
+```
+
+## Truncation - deprecated
+
+**Deprecated** - Multi-line truncation is customizable with the following properties:
+
 - `TLineHeight` - the height of each line
 - `TMaxLines` - the maximum number of allowed lines
 - `TFontSize` - the size of the font to truncate
@@ -179,55 +206,23 @@ We support both single line truncation as well as multi-line. Multi-line truncat
 
 | Class       |Properties
 | :---------- |:-------------- |:-----------
-| .truncate | white-space: nowrap;<br>text-overflow: ellipsis;<br>overflow: hidden;
 | .truncate-multi | `TLineHeight`, `TMaxLines`, `TFontSize`, `TPosRight`, `TPadRight`
 
-### Example
+```html
+<div class="truncate-multi" style="width: 425px; height: 84px; border: 1px solid black; padding: 8px;">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer condimentum leo a neque tristique faucibus. Praesent at imperdiet elit, vel tincidunt metus. Praesent elementum mollis libero, et semper diam efficitur tristique. Nam aliquam tortor a leo pretium vestibulum. Proin posuere auctor odio, sit amet elementum massa aliquet in.
+</div>
+```
 
-  ```html
-  <div class="truncate-multi" style="width: 425px; border: 1px solid black; padding: 8px;">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer condimentum leo a neque tristique faucibus. Praesent at imperdiet elit, vel tincidunt metus. Praesent elementum mollis libero, et semper diam efficitur tristique. Nam aliquam tortor a leo pretium vestibulum. Proin posuere auctor odio, sit amet elementum massa aliquet in.
-  </div>
-  ```
-
-  ```css
-  .truncate-multi {
-    --TLineHeight: 24px;
-    --TMaxLines: 5;
-    --TPosRight: 12px;
-    --TPadRight: 8px;
-    --TFontSize: 16px;
-  }
-  ```
-
-  <style type='text/css'>
-    .truncate-multi {
-      --line-height: 24px;
-      --max-lines: 5;
-      --ellipsis-pos: 12px;
-      --pad-right: 8px;
-      --font-size: 16px;
-      line-height: var(--line-height);
-      font-size: var(--font-size);
-      position: relative;
-      max-height: calc(var(--line-height) *var(--max-lines));
-      overflow: hidden;
-      padding-right: calc(var(--ellipsis-pos) + var(--pad-right) + 4px) !important;
-    }
-    .truncate-multi::before {
-      --line-height: 24px;
-      --max-lines: 5;
-      --ellipsis-pos: 12px;
-      --font-size: 16px;
-      position: absolute;
-      content: "...";
-      top: calc(var(--line-height)* (var(--max-lines) - 1) + var(--font-size) * .5);
-      right: var(--ellipsis-pos);
-    }
-  </style>
-  <div class="truncate-multi" style="width: 425px; border: 1px solid black; padding: 8px;">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer condimentum leo a neque tristique faucibus. Praesent at imperdiet elit, vel tincidunt metus. Praesent elementum mollis libero, et semper diam efficitur tristique. Nam aliquam tortor a leo pretium vestibulum. Proin posuere auctor odio, sit amet elementum massa aliquet in.
-  </div>
+```css
+.truncate-multi {
+  --TLineHeight: 24px;
+  --TMaxLines: 5;
+  --TPosRight: 12px;
+  --TPadRight: 8px;
+  --TFontSize: 16px;
+}
+```
 
 ## General Helpers
 
@@ -249,5 +244,8 @@ We support both single line truncation as well as multi-line. Multi-line truncat
     &:first-of-type { color: #6b46c1; }
     &:last-of-type { color: var(--blue-700); }
   }
+}
+.multi-line-truncation {
+  --MaxLineLimit: 5;
 }
 </style>

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -156,7 +156,7 @@ $sides: (top, right, bottom, left);
 }
 .multi-line-truncation {
   display: -webkit-box;
-  -webkit-line-clamp: var(--MaxLineLimit, 3);
+  -webkit-line-clamp: var(--TMaxLineLimit, 3);
   -webkit-box-orient: vertical;
   overflow: hidden;
 }

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -154,7 +154,12 @@ $sides: (top, right, bottom, left);
   text-overflow: ellipsis;
   overflow: hidden;
 }
-
+.multi-line-truncation {
+  display: -webkit-box;
+  -webkit-line-clamp: var(--MaxLineLimit, 3);
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
 .truncate-multi {
   line-height: var(--TLineHeight, 24px);
   font-size: var(--TFontSize, 16px);


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- Add support for `.multi-line-truncation`
- Deprecate `.truncate-multi`

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
