### PR TITLE
MA-643: add increase / decrease icons

### DIFF
--- a/packages/KIcon/__snapshots__/KIcon.spec.js.snap
+++ b/packages/KIcon/__snapshots__/KIcon.spec.js.snap
@@ -156,6 +156,14 @@ exports[`KIcon renders dashboard icon 1`] = `
 </span>
 `;
 
+exports[`KIcon renders decrease icon 1`] = `
+<span class="kong-icon kong-icon-decrease"><svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" width="24" height="24">
+  <title>decrease</title>
+  <path d="M8.001 13.197 4 2.804h8L8.001 13.197Z" fill="#A3BBCC"></path>
+</svg>
+</span>
+`;
+
 exports[`KIcon renders devPortal icon 1`] = `
 <span class="kong-icon kong-icon-devPortal"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" width="24" height="24">
   <title>devPortal</title>
@@ -311,6 +319,13 @@ exports[`KIcon renders immunity icon 1`] = `
   <path d="M21 5.3a2 2 0 100-4 2 2 0 000 4zM21 22.3a2 2 0 100-4 2 2 0 000 4zM3 22.3a2 2 0 100-4 2 2 0 000 4z" stroke="#A3BBCC" stroke-width="2" fill="none"></path>
 </svg>
 </span>
+`;
+
+exports[`KIcon renders increase icon 1`] = `
+<span class="kong-icon kong-icon-increase"><svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" width="24" height="24">
+  <title>increase</title>
+  <path d="m8 2.804 4 10.393H4L8 2.804Z" fill="#A3BBCC"></path>
+</svg></span>
 `;
 
 exports[`KIcon renders info icon 1`] = `

--- a/packages/KIcon/icons/icn-decrease.svg
+++ b/packages/KIcon/icons/icn-decrease.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Decrease</title>
+  <path d="M8.001 13.197 4 2.804h8L8.001 13.197Z" fill="#A3BBCC"/>
+</svg>

--- a/packages/KIcon/icons/icn-increase.svg
+++ b/packages/KIcon/icons/icn-increase.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Increase</title>
+  <path d="m8 2.804 4 10.393H4L8 2.804Z" fill="#A3BBCC"/>
+</svg>

--- a/packages/KIcon/icons/index.js
+++ b/packages/KIcon/icons/index.js
@@ -17,6 +17,7 @@ import copy from './icn-copy.svg'
 import dangerCircle from './icn-danger-circle.svg'
 import dangerCircleOutline from './icn-danger-circle-outline.svg'
 import dashboard from './icn-dashboard.svg'
+import decrease from './icn-decrease.svg'
 import devPortal from './icn-dev-portal.svg'
 import disabled from './icn-disabled.svg'
 import document from './icn-document.svg'
@@ -36,6 +37,7 @@ import gearFilled from './icn-gear-filled.svg'
 import grid from './icn-grid.svg'
 import help from './icn-help.svg'
 import immunity from './icn-immunity.svg'
+import increase from './icn-increase.svg'
 import info from './icn-info.svg'
 import kong from './icn-kong.svg'
 import lock from './icn-lock.svg'
@@ -92,6 +94,7 @@ export default {
   dangerCircle,
   dangerCircleOutline,
   dashboard,
+  decrease,
   devPortal,
   disabled,
   document,
@@ -111,6 +114,7 @@ export default {
   grid,
   help,
   immunity,
+  increase,
   info,
   kong,
   list,


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/MA-643

Still need to resolve view box / artboard padding (icons not centered)
<img width="835" alt="Screen Shot 2022-06-09 at 6 29 23 PM" src="https://user-images.githubusercontent.com/103061463/172955855-46d524d0-6d0a-44ed-b464-a03e0e5777ea.png">

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [x] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
