### PR TITLE
feat(kpagination/ktable): support offset-based pagination

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -188,6 +188,18 @@ export default defineComponent({
 </script>
 ```
 
+### paginationType
+
+Pass in the type of pagination to be used. Options are `default` (page/pageSize) or `offset` (offset/pageSize)
+
+### offsetPrevButtonDisabled
+
+Pass in a boolean value for whether or not the offset-based Previous button should be disabled
+
+### offsetNextButtonDisabled
+
+Pass in a boolean value for whether or not the offset-based Next button should be disabled
+
 ## Usage
 
 ### Events

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1256,7 +1256,7 @@ export default defineComponent({
       eventType: '',
       enableRowClick: true,
       offsetPaginationPageSize: 15,
-      offsetPaginationData: [],
+      offsetPaginationData: {},
       headers: [
         { label: 'Title', key: 'title', sortable: true },
         { label: 'Description', key: 'description', sortable: true },
@@ -1295,9 +1295,9 @@ export default defineComponent({
         { label: 'Last Seen', key: 'last_seen', sortable: true, useSortHandlerFn: true }
       ],
       offsetPaginationHeaders: [
-        { label: 'Host', key: 'hostname', sortable: true },
-        { label: 'Version', key: 'version', sortable: true },
-        { label: 'Connected', key: 'connected', sortable: true },
+        { label: 'Host', key: 'hostname', sortable: false },
+        { label: 'Version', key: 'version', sortable: false },
+        { label: 'Connected', key: 'connected', sortable: false },
         { label: 'Last Seen', key: 'last_seen', sortable: false }
       ]
     }
@@ -1596,11 +1596,9 @@ export default defineComponent({
         this.generateOffsetPaginationTableData()
       }
 
-      if (!offset) {
-        return Object.values(this.offsetPaginationData)[0]
-      }
-
-      return this.offsetPaginationData[offset]
+      return offset
+        ? this.offsetPaginationData[offset]
+        : Object.values(this.offsetPaginationData)[0]
     },
   },
   mounted() {

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -197,6 +197,7 @@ object supporting the following properties:
 - Pagination support:
   - `page`: the currently visible page - starts at `1`
   - `pageSize`: the number of items to display per page
+  - `offset`: the value of the offset for offset-based pagination. `offset` **MUST** be included in the fetcher params for offset-based pagination to work properly.
 - Sort support:
   - `sortColumnKey`: the column to sort by's `key` defined in the `headers` prop
   - `sortColumnOrder`: can be 'asc' or 'desc'
@@ -424,6 +425,10 @@ Pass in an array of page sizes for the page size dropdown. If not provided will 
 ```js
 [15, 30, 50, 75, 100]
 ```
+
+### paginationType
+
+Pass in the type of pagination to be used. Options are `default` (page/pageSize) or `offset` (offset/pageSize)
 
 ## Row Attributes
 

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -175,7 +175,7 @@ export default defineComponent({
     paginationType: {
       type: String as PropType<'default' | 'offset'>,
       default: 'default',
-      validator: (value: string) => ['default', 'offset'].includes(value)
+      validator: (value: string) => ['default', 'offset'].includes(value),
     },
     offsetPrevButtonDisabled: {
       type: Boolean,

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -365,32 +365,36 @@ export default defineComponent({
   justify-content: space-between;
   margin-top: 4px;
 }
-  
-  .pagination-text {
-    font-size: 14px;
-    color: var(--grey-500);
-    min-width: 115px;
-    font-weight: 500;
-    
-    &-pages {
-      color: black;
+
+.pagination-text {
+  font-size: 14px;
+  color: var(--grey-500);
+  min-width: 115px;
+  font-weight: 500;
+
+  &-pages {
+    color: black;
   }
 }
+
 .page-size-select {
   --KButtonFontSize: var(--type-sm);
   color: var(--blue-400);
   font-weight: 500;
   line-height: 20px;
 }
+
 .pagination-button-container {
   display: flex;
   list-style: none;
   text-align: center;
+
   a {
     text-decoration: none !important;
     font-weight: initial;
     display: block;
   }
+
   .pagination-button {
     align-self: center;
     width: 32px;
@@ -404,26 +408,32 @@ export default defineComponent({
     border-radius: 4px;
     margin: 0 6px;
     cursor: pointer;
+
     a, div {
       padding: 6px;
     }
+
     &.square {
       border: none;
     }
+
     &.placeholder {
       cursor: initial;
     }
+
     &:focus:not(.placeholder),
     &:hover:not(.placeholder) {
       color: var(--blue-500);
       border-color: var(--blue-500);
       border-radius: 4px;
     }
+
     &.disabled:focus:not(.placeholder),
     &.disabled:hover:not(.placeholder) {
       color: var(--black-45);
       border-color: var(--grey-200);
     }
+
     &.active {
       outline: none;
       color: var(--blue-500);

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -4,7 +4,7 @@
     data-testid="k-pagination-container"
   >
     <div class="card-pagination-bar">
-      <div v-if="paginationType === 'default'">
+      <template v-if="paginationType === 'default'">
         <span
           class="pagination-text"
           data-testid="visible-items"
@@ -98,7 +98,7 @@
             </a>
           </li>
         </ul>
-      </div>
+      </template>
       <PaginationOffset
         v-else
         :prev-button-disabled="offsetPrevButtonDisabled"
@@ -129,7 +129,7 @@
 import { defineComponent, ref, Ref, computed, watch, PropType } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KSelect from '@/components/KSelect/KSelect.vue'
-import PaginationOffset from '@/components/KPagination/PaginationOffset.vue'
+import PaginationOffset from './PaginationOffset.vue'
 
 export default defineComponent({
   name: 'KPagination',
@@ -175,6 +175,7 @@ export default defineComponent({
     paginationType: {
       type: String as PropType<'default' | 'offset'>,
       default: 'default',
+      validator: (value: string) => ['default', 'offset'].includes(value)
     },
     offsetPrevButtonDisabled: {
       type: Boolean,
@@ -363,6 +364,7 @@ export default defineComponent({
   align-items: center;
   justify-content: space-between;
   margin-top: 4px;
+}
   
   .pagination-text {
     font-size: 14px;
@@ -372,69 +374,71 @@ export default defineComponent({
     
     &-pages {
       color: black;
-    }
   }
-  .page-size-select {
-    --KButtonFontSize: var(--type-sm);
-    color: var(--blue-400);
-    font-weight: 500;
+}
+.page-size-select {
+  --KButtonFontSize: var(--type-sm);
+  color: var(--blue-400);
+  font-weight: 500;
+  line-height: 20px;
+}
+.pagination-button-container {
+  display: flex;
+  list-style: none;
+  text-align: center;
+  a {
+    text-decoration: none !important;
+    font-weight: initial;
+    display: block;
+  }
+  .pagination-button {
+    align-self: center;
+    width: 32px;
+    height: 32px;
     line-height: 20px;
-  }
-  .pagination-button-container {
-    display: flex;
-    list-style: none;
-    text-align: center;
-    a {
-      text-decoration: none !important;
-      font-weight: initial;
-      display: block;
+    font-size: 12px;
+    font-weight: initial;
+    color: var(--grey-500);
+    border: 1px solid var(--grey-300);
+    background-color: white;
+    border-radius: 4px;
+    margin: 0 6px;
+    cursor: pointer;
+    a, div {
+      padding: 6px;
     }
-    .pagination-button {
-      align-self: center;
-      width: 32px;
-      height: 32px;
-      line-height: 20px;
-      font-size: 12px;
-      font-weight: initial;
-      color: var(--grey-500);
-      border: 1px solid var(--grey-300);
-      background-color: white;
+    &.square {
+      border: none;
+    }
+    &.placeholder {
+      cursor: initial;
+    }
+    &:focus:not(.placeholder),
+    &:hover:not(.placeholder) {
+      color: var(--blue-500);
+      border-color: var(--blue-500);
       border-radius: 4px;
-      margin: 0 6px;
-      cursor: pointer;
-      a, div {
-        padding: 6px;
-      }
-      &.square {
-        border: none;
-      }
-      &.placeholder {
-        cursor: initial;
-      }
-      &:focus:not(.placeholder),
-      &:hover:not(.placeholder) {
-        color: var(--blue-500);
-        border-color: var(--blue-500);
-        border-radius: 4px;
-      }
-      &.disabled:focus:not(.placeholder),
-      &.disabled:hover:not(.placeholder) {
-        color: var(--black-45);
-        border-color: var(--grey-200);
-      }
-      &.active {
-        outline: none;
-        color: var(--blue-500);
-        border-color: var(--blue-200);
-        border-radius: 4px;
-        background-color: var(--blue-100);
-      }
+    }
+    &.disabled:focus:not(.placeholder),
+    &.disabled:hover:not(.placeholder) {
+      color: var(--black-45);
+      border-color: var(--grey-200);
+    }
+    &.active {
+      outline: none;
+      color: var(--blue-500);
+      border-color: var(--blue-200);
+      border-radius: 4px;
+      background-color: var(--blue-100);
     }
   }
-  .page-size-select {
-    .k-select-pop-button[x-placement^="top"] {
-      margin-bottom: 2px;
-    }
+}
+</style>
+
+<style lang="scss">
+.page-size-select {
+  .k-select-pop-button[x-placement^="top"] {
+    margin-bottom: 2px;
   }
 }
 </style>

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -4,99 +4,108 @@
     data-testid="k-pagination-container"
   >
     <div class="card-pagination-bar">
-      <span
-        class="pagination-text"
-        data-testid="visible-items"
-      >
-        <span class="pagination-text-pages">{{ pagesString }}</span>
-        {{ pageCountString }}
-      </span>
-      <ul class="pagination-button-container">
-        <li
-          :class="{ disabled: backDisabled }"
-          class="pagination-button square"
-          data-testid="prev-btn"
+      <div v-if="paginationType === 'default'">
+        <span
+          class="pagination-text"
+          data-testid="visible-items"
         >
-          <a
-            href="#"
-            aria-label="Go to the previous page"
-            @click.prevent="pageBack"
+          <span class="pagination-text-pages">{{ pagesString }}</span>
+          {{ pageCountString }}
+        </span>
+        <ul class="pagination-button-container">
+          <li
+            :class="{ disabled: backDisabled }"
+            class="pagination-button square"
+            data-testid="prev-btn"
           >
-            <KIcon
-              :color="backDisabled ? 'var(--KPaginationDisabledColor, var(--grey-500))' : 'var(--KPaginationColor, var(--blue-400))'"
-              icon="arrowLeft"
-              size="16"
-              view-box="0 0 16 14"
-            />
-          </a>
-        </li>
-        <li
-          v-if="!disablePageJump && firstDetached"
-          class="pagination-button"
-          data-testid="page-1-btn"
-        >
-          <a
-            href="#"
-            aria-label="Go to the first page"
-            @click.prevent="changePage(1)"
-          >1</a>
-        </li>
-        <li
-          v-if="!disablePageJump && firstDetached"
-          class="pagination-button placeholder"
-        >
-          ...
-        </li>
-        <li
-          v-for="page in pagesVisible"
-          :key="page"
-          :class="{ active: page == currentlySelectedPage }"
-          :data-testid="`page-${ page }-btn`"
-          class="pagination-button"
-        >
-          <a
-            :aria-label="`Go to page ${ page }`"
-            :aria-current="page == currentlySelectedPage && 'page'"
-            href="#"
-            @click.prevent="changePage(page)"
-          >{{ page }}</a>
-        </li>
-        <li
-          v-if="!disablePageJump && lastDetached"
-          class="pagination-button placeholder"
-        >
-          ...
-        </li>
-        <li
-          v-if="!disablePageJump && lastDetached"
-          class="pagination-button"
-        >
-          <a
-            href="#"
-            aria-label="Go to the last page"
-            data-testid="last-btn"
-            @click.prevent="changePage(pageCount)"
-          >{{ pageCount }}</a>
-        </li>
-        <li
-          :class="{ disabled: forwardDisabled }"
-          class="pagination-button square"
-          data-testid="next-btn"
-        >
-          <a
-            href="#"
-            aria-label="Go to the next page"
-            @click.prevent="pageForward"
+            <a
+              href="#"
+              aria-label="Go to the previous page"
+              @click.prevent="pageBack"
+            >
+              <KIcon
+                :color="backDisabled ? 'var(--KPaginationDisabledColor, var(--grey-500))' : 'var(--KPaginationColor, var(--blue-400))'"
+                icon="arrowLeft"
+                size="16"
+                view-box="0 0 16 14"
+              />
+            </a>
+          </li>
+          <li
+            v-if="!disablePageJump && firstDetached"
+            class="pagination-button"
+            data-testid="page-1-btn"
           >
-            <KIcon
-              :color="forwardDisabled ? 'var(--KPaginationDisabledColor, var(--grey-500))' : 'var(--KPaginationColor, var(--blue-400))'"
-              icon="arrowRight"
-              size="16"
-              view-box="0 0 16 14"
-            />
-          </a>
-        </li>
-      </ul>
+            <a
+              href="#"
+              aria-label="Go to the first page"
+              @click.prevent="changePage(1)"
+            >1</a>
+          </li>
+          <li
+            v-if="!disablePageJump && firstDetached"
+            class="pagination-button placeholder"
+          >
+            ...
+          </li>
+          <li
+            v-for="page in pagesVisible"
+            :key="page"
+            :class="{ active: page == currentlySelectedPage }"
+            :data-testid="`page-${ page }-btn`"
+            class="pagination-button"
+          >
+            <a
+              :aria-label="`Go to page ${ page }`"
+              :aria-current="page == currentlySelectedPage && 'page'"
+              href="#"
+              @click.prevent="changePage(page)"
+            >{{ page }}</a>
+          </li>
+          <li
+            v-if="!disablePageJump && lastDetached"
+            class="pagination-button placeholder"
+          >
+            ...
+          </li>
+          <li
+            v-if="!disablePageJump && lastDetached"
+            class="pagination-button"
+          >
+            <a
+              href="#"
+              aria-label="Go to the last page"
+              data-testid="last-btn"
+              @click.prevent="changePage(pageCount)"
+            >{{ pageCount }}</a>
+          </li>
+          <li
+            :class="{ disabled: forwardDisabled }"
+            class="pagination-button square"
+            data-testid="next-btn"
+          >
+            <a
+              href="#"
+              aria-label="Go to the next page"
+              @click.prevent="pageForward"
+            >
+              <KIcon
+                :color="forwardDisabled ? 'var(--KPaginationDisabledColor, var(--grey-500))' : 'var(--KPaginationColor, var(--blue-400))'"
+                icon="arrowRight"
+                size="16"
+                view-box="0 0 16 14"
+              />
+            </a>
+          </li>
+        </ul>
+      </div>
+      <PaginationOffset
+        v-else
+        :prev-button-disabled="offsetPrevButtonDisabled"
+        :next-button-disabled="offsetNextButtonDisabled"
+        @getPrevOffset="getPrevOffset"
+        @getNextOffset="getNextOffset"
+      />
       <span
         class="page-size-select"
         data-testid="page-size-dropdown"
@@ -120,12 +129,14 @@
 import { defineComponent, ref, Ref, computed, watch, PropType } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KSelect from '@/components/KSelect/KSelect.vue'
+import PaginationOffset from '@/components/KPagination/PaginationOffset.vue'
 
 export default defineComponent({
   name: 'KPagination',
   components: {
     KIcon,
     KSelect,
+    PaginationOffset,
   },
   props: {
     items: {
@@ -161,6 +172,18 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    paginationType: {
+      type: String as PropType<'default' | 'offset'>,
+      default: 'default'
+    },
+    offsetPrevButtonDisabled: {
+      type: Boolean,
+      default: false
+    },
+    offsetNextButtonDisabled: {
+      type: Boolean,
+      default: false
+    },
     /**
      * Test mode - for testing only, strips out generated ids
      */
@@ -169,7 +192,7 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ['pageChanged', 'pageSizeChanged'],
+  emits: ['pageChanged', 'pageSizeChanged', 'getNextOffset', 'getPrevOffset'],
   setup(props, { emit }) {
     const currPage: Ref<number> = ref(props.currentPage ? props.currentPage : 1)
     const currentPageSize: Ref<number> = ref(props.initialPageSize ? props.initialPageSize : props.pageSizes[0])
@@ -287,6 +310,14 @@ export default defineComponent({
       }
     }
 
+    const getNextOffset = (): void => {
+      emit('getNextOffset')
+    }
+
+    const getPrevOffset = (): void => {
+      emit('getPrevOffset')
+    }
+
     watch(() => props.currentPage, (newVal, oldVal) => {
       if (newVal !== oldVal) {
         changePage(newVal)
@@ -316,6 +347,8 @@ export default defineComponent({
       changePage,
       updatePage,
       updatePageSize,
+      getNextOffset,
+      getPrevOffset,
     }
   },
 })
@@ -329,113 +362,79 @@ export default defineComponent({
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-.pagination-text {
-  font-size: 14px;
-  color: var(--grey-500);
-  min-width: 115px;
-  font-weight: 500;
-
-  &-pages {
-    color: black;
+  margin-top: 4px;
+  
+  .pagination-text {
+    font-size: 14px;
+    color: var(--grey-500);
+    min-width: 115px;
+    font-weight: 500;
+    
+    &-pages {
+      color: black;
+    }
   }
-}
-
-.page-size-select {
-  --KButtonBtnLink: var(--KPaginationPageSizeColor, var(--blue-400));
-  --KButtonOutlineBorder: var(--KPaginationPageSizeColor, var(--blue-400));
-  --KButtonFontSize: var(--type-sm);
-  font-weight: 500;
-  line-height: 20px;
-}
-
-.pagination-button-container {
-  display: flex;
-  list-style: none;
-  text-align: center;
-
-  a {
-    text-decoration: none !important;
-    font-weight: initial;
-    display: block;
-  }
-
-  .pagination-button {
-    align-self: center;
-    width: 32px;
-    height: 32px;
+  .page-size-select {
+    --KButtonFontSize: var(--type-sm);
+    color: var(--blue-400);
+    font-weight: 500;
     line-height: 20px;
-    font-size: 12px;
-    font-weight: initial;
-    color: var(--KPaginationColor, var(--grey-500));
-    border: 1px solid var(--KPaginationBorderColor, var(--grey-300));
-    border-radius: 4px;
-    margin: 0 6px;
-    cursor: pointer;
-
-    &:not(.square) {
-      background-color: var(--KPaginationBackgroundColor, white);
-    }
-
+  }
+  .pagination-button-container {
+    display: flex;
+    list-style: none;
+    text-align: center;
     a {
-      padding: 6px;
+      text-decoration: none !important;
+      font-weight: initial;
+      display: block;
     }
-
-    &:not(.active) a {
-      color: var(--KPaginationColor, var(--grey-500));
-    }
-
-    &.square {
-      border: none;
-    }
-
-    &.placeholder {
-      color: var(--KPaginationColor, var(--grey-500));
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      cursor: initial;
-    }
-
-    &:focus:not(.placeholder),
-    &:hover:not(.placeholder) {
-      color: var(--KPaginationActiveColor, var(--blue-500));
-      border-color: var(--KPaginationActiveColor, var(--blue-500));
+    .pagination-button {
+      align-self: center;
+      width: 32px;
+      height: 32px;
+      line-height: 20px;
+      font-size: 12px;
+      font-weight: initial;
+      color: var(--grey-500);
+      border: 1px solid var(--grey-300);
+      background-color: white;
       border-radius: 4px;
-    }
-
-    &.disabled {
-      a {
-        cursor: not-allowed !important;
+      margin: 0 6px;
+      cursor: pointer;
+      a, div {
+        padding: 6px;
       }
-    }
-
-    &.disabled:focus:not(.placeholder),
-    &.disabled:hover:not(.placeholder) {
-      color: var(--black-45);
-      border-color: var(--grey-200);
-    }
-
-    &.active {
-      outline: none;
-      color: var(--KPaginationActiveColor, var(--blue-500));
-      border-color: var(--KPaginationActiveBorderColor, var(--blue-200));
-      background-color: var(--KPaginationActiveBackgroundColor, var(--blue-100));
-      border-radius: 4px;
-
-      a {
-        color: var(--KPaginationActiveColor, var(--blue-500));
+      &.square {
+        border: none;
+      }
+      &.placeholder {
+        cursor: initial;
+      }
+      &:focus:not(.placeholder),
+      &:hover:not(.placeholder) {
+        color: var(--blue-500);
+        border-color: var(--blue-500);
+        border-radius: 4px;
+      }
+      &.disabled:focus:not(.placeholder),
+      &.disabled:hover:not(.placeholder) {
+        color: var(--black-45);
+        border-color: var(--grey-200);
+      }
+      &.active {
+        outline: none;
+        color: var(--blue-500);
+        border-color: var(--blue-200);
+        border-radius: 4px;
+        background-color: var(--blue-100);
       }
     }
   }
-}
-</style>
-
-<style lang="scss">
-.page-size-select {
-  .k-select-pop-button[x-placement^="top"] {
-    margin-bottom: 2px;
+  .page-size-select {
+    .k-select-pop-button[x-placement^="top"] {
+      margin-bottom: 2px;
+    }
   }
 }
 </style>

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -174,15 +174,15 @@ export default defineComponent({
     },
     paginationType: {
       type: String as PropType<'default' | 'offset'>,
-      default: 'default'
+      default: 'default',
     },
     offsetPrevButtonDisabled: {
       type: Boolean,
-      default: false
+      default: false,
     },
     offsetNextButtonDisabled: {
       type: Boolean,
-      default: false
+      default: false,
     },
     /**
      * Test mode - for testing only, strips out generated ids

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -378,6 +378,8 @@ export default defineComponent({
 }
 
 .page-size-select {
+  --KButtonBtnLink: var(--KPaginationPageSizeColor, var(--blue-400));
+  --KButtonOutlineBorder: var(--KPaginationPageSizeColor, var(--blue-400));
   --KButtonFontSize: var(--type-sm);
   color: var(--blue-400);
   font-weight: 500;
@@ -402,12 +404,16 @@ export default defineComponent({
     line-height: 20px;
     font-size: 12px;
     font-weight: initial;
-    color: var(--grey-500);
-    border: 1px solid var(--grey-300);
+    color: var(--KPaginationColor, var(--grey-500));
+    border: 1px solid var(--KPaginationBorderColor, var(--grey-300));
     background-color: white;
     border-radius: 4px;
     margin: 0 6px;
     cursor: pointer;
+
+     &:not(.square) {
+      background-color: var(--KPaginationBackgroundColor, white);
+    }
 
     a, div {
       padding: 6px;
@@ -418,13 +424,17 @@ export default defineComponent({
     }
 
     &.placeholder {
+      color: var(--KPaginationColor, var(--grey-500));
+      display: flex;
+      justify-content: center;
+      align-items: center;
       cursor: initial;
     }
 
     &:focus:not(.placeholder),
     &:hover:not(.placeholder) {
-      color: var(--blue-500);
-      border-color: var(--blue-500);
+      color: var(--KPaginationActiveColor, var(--blue-500));
+      border-color: var(--KPaginationActiveColor, var(--blue-500));
       border-radius: 4px;
     }
 
@@ -434,12 +444,23 @@ export default defineComponent({
       border-color: var(--grey-200);
     }
 
+    &.disabled {
+      a {
+        cursor: not-allowed !important;
+      }
+    }
+
     &.active {
       outline: none;
-      color: var(--blue-500);
-      border-color: var(--blue-200);
+      color: var(--KPaginationActiveColor, var(--blue-500));
+      border-color: var(--KPaginationActiveBorderColor, var(--blue-200));
+      background-color: var(--KPaginationActiveBackgroundColor, var(--blue-100));
       border-radius: 4px;
       background-color: var(--blue-100);
+
+      a {
+        color: var(--KPaginationActiveColor, var(--blue-500));
+      }
     }
   }
 }

--- a/src/components/KPagination/PaginationOffset.vue
+++ b/src/components/KPagination/PaginationOffset.vue
@@ -3,11 +3,13 @@
     <li
       :class="{ disabled: prevButtonDisabled }"
       class="pagination-button"
-      data-testid="prev-btn">
+      data-testid="prev-btn"
+    >
       <a
         href="#"
         aria-label="Go to the previous page"
-        @click.prevent="getPrevOffset">
+        @click.prevent="getPrevOffset"
+      >
         <KIcon
           :color="prevButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
           icon="arrowLeft"
@@ -19,11 +21,13 @@
     <li
       :class="{ disabled: nextButtonDisabled }"
       class="pagination-button"
-      data-testid="next-btn">
+      data-testid="next-btn"
+    >
       <a
         href="#"
         aria-label="Go to the next page"
-        @click.prevent="getNextOffset">
+        @click.prevent="getNextOffset"
+      >
         <KIcon
           :color="nextButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
           icon="arrowRight"
@@ -38,30 +42,28 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
-import KSelect from '@/components/KSelect/KSelect.vue'
 
 export default defineComponent({
   name: 'PaginationOffset',
   components: {
     KIcon,
-    KSelect
   },
   props: {
     prevButtonDisabled: {
       type: Boolean,
-      default: false
+      default: false,
     },
     nextButtonDisabled: {
       type: Boolean,
-      default: false
+      default: false,
     },
     /**
      * Test mode - for testing only, strips out generated ids
      */
     testMode: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   emits: ['getPrevOffset', 'getNextOffset'],
   setup(props, { emit }) {
@@ -85,6 +87,6 @@ export default defineComponent({
       getPrevOffset,
       getNextOffset,
     }
-  }
+  },
 })
 </script>

--- a/src/components/KPagination/PaginationOffset.vue
+++ b/src/components/KPagination/PaginationOffset.vue
@@ -90,3 +90,52 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss" scoped>
+@import '@/styles/variables';
+.pagination-button-container {
+  display: flex;
+  list-style: none;
+  text-align: center;
+  a {
+    text-decoration: none !important;
+    font-weight: initial;
+    display: block;
+  }
+  .pagination-button {
+    align-self: center;
+    width: 32px;
+    height: 32px;
+    line-height: 20px;
+    font-size: 12px;
+    font-weight: initial;
+    color: var(--grey-500);
+    border: 1px solid var(--grey-300);
+    background-color: white;
+    border-radius: 4px;
+    margin: 0 6px;
+    cursor: pointer;
+    a, div {
+      padding: 6px;
+    }
+    &:focus,
+    &:hover {
+      color: var(--blue-500);
+      border-color: var(--blue-500);
+      border-radius: 4px;
+    }
+    &.disabled:focus,
+    &.disabled:hover {
+      color: var(--black-45);
+      border-color: var(--grey-200);
+    }
+    &.active {
+      outline: none;
+      color: var(--blue-500);
+      border-color: var(--blue-200);
+      border-radius: 4px;
+      background-color: var(--blue-100);
+    }
+  }
+}
+</style>

--- a/src/components/KPagination/PaginationOffset.vue
+++ b/src/components/KPagination/PaginationOffset.vue
@@ -1,42 +1,38 @@
 <template>
-  <ul class="pagination-button-container mb-0 pa-0">
-    <li
+  <div class="pagination-offset-button-container mb-0 pa-0">
+    <KButton
       :class="{ disabled: prevButtonDisabled }"
       class="pagination-button"
       data-testid="prev-btn"
+      aria-label="Go to the previous page"
+      @click.prevent="getPrevOffset"
     >
-      <a
-        href="#"
-        aria-label="Go to the previous page"
-        @click.prevent="getPrevOffset"
-      >
+      <template #icon>
         <KIcon
           :color="prevButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
           icon="arrowLeft"
           size="16"
-          view-box="0 0 16 14"
+          view-box="0 0 16 16"
         />
-      </a>
-    </li>
-    <li
+      </template>
+    </KButton>
+    <KButton
       :class="{ disabled: nextButtonDisabled }"
       class="pagination-button"
       data-testid="next-btn"
+      aria-label="Go to the next page"
+      @click.prevent="getNextOffset"
     >
-      <a
-        href="#"
-        aria-label="Go to the next page"
-        @click.prevent="getNextOffset"
-      >
+      <template #icon>
         <KIcon
           :color="nextButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
           icon="arrowRight"
           size="16"
-          view-box="0 0 16 14"
+          view-box="0 0 16 16"
         />
-      </a>
-    </li>
-  </ul>
+      </template>
+    </KButton>
+  </div>
 </template>
 
 <script lang="ts">
@@ -93,31 +89,17 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
-.pagination-button-container {
+.pagination-offset-button-container {
   display: flex;
-  list-style: none;
-  text-align: center;
-  a {
-    text-decoration: none !important;
-    font-weight: initial;
-    display: block;
-  }
-  .pagination-button {
-    align-self: center;
-    width: 32px;
-    height: 32px;
-    line-height: 20px;
-    font-size: 12px;
-    font-weight: initial;
+  .pagination-button.k-button {
+    width: 34px;
+    height: 34px;
     color: var(--grey-500);
     border: 1px solid var(--grey-300);
     background-color: white;
     border-radius: 4px;
     margin: 0 6px;
-    cursor: pointer;
-    a, div {
-      padding: 6px;
-    }
+    padding: 6px;
     &:focus,
     &:hover {
       color: var(--blue-500);
@@ -128,6 +110,8 @@ export default defineComponent({
     &.disabled:hover {
       color: var(--black-45);
       border-color: var(--grey-200);
+      box-shadow: none;
+      cursor: default;
     }
     &.active {
       outline: none;

--- a/src/components/KPagination/PaginationOffset.vue
+++ b/src/components/KPagination/PaginationOffset.vue
@@ -91,6 +91,7 @@ export default defineComponent({
 @import '@/styles/variables';
 .pagination-offset-button-container {
   display: flex;
+
   .pagination-button.k-button {
     width: 34px;
     height: 34px;
@@ -100,19 +101,22 @@ export default defineComponent({
     border-radius: 4px;
     margin: 0 6px;
     padding: 6px;
+
     &:focus,
     &:hover {
       color: var(--blue-500);
       border-color: var(--blue-500);
       border-radius: 4px;
     }
+
     &.disabled:focus,
     &.disabled:hover {
       color: var(--black-45);
       border-color: var(--grey-200);
       box-shadow: none;
-      cursor: default;
+      cursor: not-allowed;
     }
+
     &.active {
       outline: none;
       color: var(--blue-500);

--- a/src/components/KPagination/PaginationOffset.vue
+++ b/src/components/KPagination/PaginationOffset.vue
@@ -1,0 +1,90 @@
+<template>
+  <ul class="pagination-button-container mb-0 pa-0">
+    <li
+      :class="{ disabled: prevButtonDisabled }"
+      class="pagination-button"
+      data-testid="prev-btn">
+      <a
+        href="#"
+        aria-label="Go to the previous page"
+        @click.prevent="getPrevOffset">
+        <KIcon
+          :color="prevButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
+          icon="arrowLeft"
+          size="16"
+          view-box="0 0 16 14"
+        />
+      </a>
+    </li>
+    <li
+      :class="{ disabled: nextButtonDisabled }"
+      class="pagination-button"
+      data-testid="next-btn">
+      <a
+        href="#"
+        aria-label="Go to the next page"
+        @click.prevent="getNextOffset">
+        <KIcon
+          :color="nextButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
+          icon="arrowRight"
+          size="16"
+          view-box="0 0 16 14"
+        />
+      </a>
+    </li>
+  </ul>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import KIcon from '@/components/KIcon/KIcon.vue'
+import KSelect from '@/components/KSelect/KSelect.vue'
+
+export default defineComponent({
+  name: 'PaginationOffset',
+  components: {
+    KIcon,
+    KSelect
+  },
+  props: {
+    prevButtonDisabled: {
+      type: Boolean,
+      default: false
+    },
+    nextButtonDisabled: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Test mode - for testing only, strips out generated ids
+     */
+    testMode: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['getPrevOffset', 'getNextOffset'],
+  setup(props, { emit }) {
+    const getNextOffset = (): void => {
+      if (props.nextButtonDisabled) {
+        return
+      }
+
+      emit('getNextOffset')
+    }
+
+    const getPrevOffset = (): void => {
+      if (props.prevButtonDisabled) {
+        return
+      }
+
+      emit('getPrevOffset')
+    }
+
+    return {
+      getPrevOffset,
+      getNextOffset,
+    }
+  }
+})
+</script>

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -526,6 +526,7 @@ export default defineComponent({
     const offsets: Ref<Array<any>> = ref([])
     const isClickable = ref(false)
     const hasInitialized = ref(false)
+    const nextPageClicked = ref(false)
     /**
      * Grabs listeners from attrs matching a prefix to attach the
      * event that is dynamic. e.g. `v-on:cell:click`, `@row:focus` etc.
@@ -654,6 +655,12 @@ export default defineComponent({
       if (props.paginationType === 'offset') {
         if (!res.pagination?.offset) {
           offset.value = null
+
+          // reset to first page if no pagiantion data is returned unless the "next page" button was clicked
+          // this will ensure buttons display the correct state for cases like search
+          if (!nextPageClicked.value) {
+            page.value = 1
+          }
         } else {
           offset.value = res.pagination.offset
 
@@ -676,6 +683,7 @@ export default defineComponent({
       }
 
       isTableLoading.value = false
+      nextPageClicked.value = false
 
       return res
     }
@@ -760,7 +768,7 @@ export default defineComponent({
           // @ts-ignore
           defaultSorter(key, prevKey, sortColumnOrder.value, data.value)
         }
-      } else {
+      } else if (props.paginationType !== 'offset') {
         revalidate()
       }
     }
@@ -785,6 +793,7 @@ export default defineComponent({
 
     const getNextOffsetHandler = (): void => {
       page.value++
+      nextPageClicked.value = true
     }
     const getPrevOffsetHandler = (): void => {
       page.value--

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -487,7 +487,7 @@ export default defineComponent({
     },
     paginationType: {
       type: String as PropType<'default' | 'offset'>,
-      default: 'default'
+      default: 'default',
     },
     /**
      * for testing only, strips out generated ids and avoid loading state in tests.
@@ -509,7 +509,7 @@ export default defineComponent({
       query: '',
       sortColumnKey: '',
       sortColumnOrder: 'desc',
-      offset: null
+      offset: null,
     }
     const data = ref([])
     const tableHeaders: Ref<TableHeader[]> = ref([])
@@ -828,7 +828,7 @@ export default defineComponent({
       getNextOffsetHandler,
       getPrevOffsetHandler,
       previousOffset,
-      offset
+      offset,
     }
   },
 })

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -488,7 +488,7 @@ export default defineComponent({
     paginationType: {
       type: String as PropType<'default' | 'offset'>,
       default: 'default',
-      validator: (value: string) => ['default', 'offset'].includes(value)
+      validator: (value: string) => ['default', 'offset'].includes(value),
     },
     /**
      * for testing only, strips out generated ids and avoid loading state in tests.

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -488,6 +488,7 @@ export default defineComponent({
     paginationType: {
       type: String as PropType<'default' | 'offset'>,
       default: 'default',
+      validator: (value: string) => ['default', 'offset'].includes(value)
     },
     /**
      * for testing only, strips out generated ids and avoid loading state in tests.
@@ -767,9 +768,10 @@ export default defineComponent({
       page.value = newPage
     }
     const pageSizeChangeHandler = ({ pageSize: newPageSize }: Record<string, number>) => {
-      pageSize.value = newPageSize
       offsets.value = [null]
       offset.value = null
+      pageSize.value = newPageSize
+      page.value = 1
     }
     const scrollHandler = (event: any) => {
       if (event && event.target && event.target.scrollTop) {
@@ -783,12 +785,10 @@ export default defineComponent({
 
     const getNextOffsetHandler = (): void => {
       page.value++
-      revalidate()
     }
     const getPrevOffsetHandler = (): void => {
       page.value--
       offset.value = previousOffset.value
-      revalidate()
     }
 
     const getTestIdString = (message: string) => {


### PR DESCRIPTION
# Summary
Adds support for offset-based pagination.

In practice, the following would need to be done in order to enable offset-based pagination:
1. Use the new `paginationType` prop for KTable: `<KTable :pagination-type="offset" />`
2. Use the new `offset` param in the fetcher function passed to KTable: `fetcher ({ offset }) {}`

**Assumptions:**
This implementation assumes that the API endpoint used in the fetcher function returns the next offset value in the response. Here is an example of the assumed format:
```json
{
  "data": [{}],
  "pagination": {
    "offset": "cGFnZS1udW1iZXI6Mg"
  },
}
```

This implementation also assumes that the API endpoint used in the fetcher function properly handles offset usage. Here's an example:
`GET /api/runtime_groups/6e30594e-9a90-4e0f-94f8-90b923696c83/services?size=100&offset=cGFnZS1udW1iZXI6Mg`

## Screenshot:
<img width="1201" alt="Screen Shot 2022-06-22 at 9 24 15 AM" src="https://user-images.githubusercontent.com/2080476/175080994-79a2f5d8-d5d1-4a5d-b866-834feea76a86.png">

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
