### PR TITLE
fix(kmodalfullscreen): align header [khcp-4021]

### DIFF
--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -267,6 +267,7 @@ $fullscreen-modal-padding: 64px;
 .header-icon {
   margin-right: 6px;
   border-right: 1px solid var(--grey-300);
+  line-height: 24px;
 }
 
 .k-modal-fullscreen-body-header,
@@ -334,5 +335,14 @@ $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-action-buttons {
     margin-left: auto;
+}
+</style>
+
+<style lang="scss">
+.header-icon {
+  .kong-icon.kong-icon-kong {
+    position: relative;
+    top: 1px;
+  }
 }
 </style>

--- a/packages/KModalFullscreen/KModalFullscreen.vue
+++ b/packages/KModalFullscreen/KModalFullscreen.vue
@@ -264,12 +264,6 @@ $fullscreen-modal-padding: 64px;
   }
 }
 
-.header-icon {
-  margin-right: 6px;
-  border-right: 1px solid var(--grey-300);
-  line-height: 24px;
-}
-
 .k-modal-fullscreen-body-header,
 .k-modal-fullscreen-body {
   color: var(--KModalFullscreenColor, var(--black-500, color(black-500)));
@@ -330,11 +324,14 @@ $fullscreen-modal-padding: 64px;
 
 .header-content {
   display: inline-block;
-  margin-top: var(--spacing-xxs, spacing(xxs))
+  margin-top: var(--spacing-xxs, spacing(xxs));
+  padding-left: 6px;
+  border-left: 1px solid var(--grey-300);
+  line-height: 24px;
 }
 
 .k-modal-fullscreen-action-buttons {
-    margin-left: auto;
+  margin-left: auto;
 }
 </style>
 


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- fix alignment of icon and header text / height of divider

Addresses [KHCP-4021](https://konghq.atlassian.net/browse/KHCP-4021)

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: `https://github.com/Kong/kongponents/pull/670`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
