### PR TITLE
fix(kpagination): disable buttons when necessary

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1344,7 +1344,7 @@ export default {
       row: null,
       eventType: '',
       offsetPaginationPageSize: 15,
-      offsetPaginationData: [],
+      offsetPaginationData: {},
       headers: [
         { label: 'Title', key: 'title', sortable: true },
         { label: 'Description', key: 'description', sortable: true },
@@ -1383,9 +1383,9 @@ export default {
         { label: 'Last Seen', key: 'last_seen', sortable: true, useSortHandlerFn: true }
       ],
       offsetPaginationHeaders: [
-        { label: 'Host', key: 'hostname', sortable: true },
-        { label: 'Version', key: 'version', sortable: true },
-        { label: 'Connected', key: 'connected', sortable: true },
+        { label: 'Host', key: 'hostname', sortable: false },
+        { label: 'Version', key: 'version', sortable: false },
+        { label: 'Connected', key: 'connected', sortable: false },
         { label: 'Last Seen', key: 'last_seen', sortable: false }
       ]
     }
@@ -1454,11 +1454,9 @@ for (let i = ((page-1)* pageSize); i < limit; i++) {
         this.generateOffsetPaginationTableData()
       }
 
-      if (!offset) {
-        return Object.values(this.offsetPaginationData)[0]
-      }
-
-      return this.offsetPaginationData[offset]
+      return offset
+        ? this.offsetPaginationData[offset]
+        : Object.values(this.offsetPaginationData)[0]
     },
 
     async fetcher(payload) {

--- a/packages/KPagination/PaginationOffset.vue
+++ b/packages/KPagination/PaginationOffset.vue
@@ -1,38 +1,38 @@
 <template>
-  <ul class="pagination-button-container mb-0 pa-0">
-    <li
+  <div class="pagination-button-container mb-0 pa-0">
+    <KButton
       :class="{ disabled: prevButtonDisabled }"
       class="pagination-button"
-      data-testid="prev-btn">
-      <a
-        href="#"
-        aria-label="Go to the previous page"
-        @click.prevent="getPrevOffset">
+      data-testid="prev-btn"
+      aria-label="Go to the previous page"
+      @click.prevent="getPrevOffset"
+    >
+      <template v-slot:icon>
         <KIcon
           :color="prevButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
           icon="arrowLeft"
           size="16"
-          view-box="0 0 16 14"
+          view-box="0 0 16 16"
         />
-      </a>
-    </li>
-    <li
+      </template>
+    </KButton>
+    <KButton
       :class="{ disabled: nextButtonDisabled }"
       class="pagination-button"
-      data-testid="next-btn">
-      <a
-        href="#"
-        aria-label="Go to the next page"
-        @click.prevent="getNextOffset">
+      data-testid="next-btn"
+      aria-label="Go to the next page"
+      @click.prevent="getNextOffset"
+    >
+      <template v-slot:icon>
         <KIcon
           :color="nextButtonDisabled ? 'var(--grey-500)' : 'var(--blue-400)'"
           icon="arrowRight"
           size="16"
-          view-box="0 0 16 14"
+          view-box="0 0 16 16"
         />
-      </a>
-    </li>
-  </ul>
+      </template>
+    </KButton>
+  </div>
 </template>
 
 <script>
@@ -76,32 +76,16 @@ export default {
 @import '~@kongponents/styles/variables';
 .pagination-button-container {
   display: flex;
-  list-style: none;
-  text-align: center;
-
-  a {
-    text-decoration: none !important;
-    font-weight: initial;
-    display: block;
-  }
 
   .pagination-button {
-    align-self: center;
-    width: 32px;
-    height: 32px;
-    line-height: 20px;
-    font-size: 12px;
-    font-weight: initial;
+    width: 34px;
+    height: 34px;
     color: var(--grey-500);
     border: 1px solid var(--grey-300);
     background-color: white;
     border-radius: 4px;
     margin: 0 6px;
-    cursor: pointer;
-
-    a, div {
-      padding: 6px;
-    }
+    padding: 6px;
 
     &:focus,
     &:hover {
@@ -114,6 +98,8 @@ export default {
     &.disabled:hover {
       color: var(--black-45);
       border-color: var(--grey-200);
+      box-shadow: none;
+      cursor: default;
     }
 
     &.active {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -504,6 +504,7 @@ export default defineComponent({
     const offsets = ref([])
     const isClickable = ref(false)
     const hasInitialized = ref(false)
+    const nextPageClicked = ref(false)
 
     /**
      * Grabs listeners from this.$listeners matching a prefix to attach the
@@ -598,6 +599,12 @@ export default defineComponent({
       if (props.paginationType === 'offset') {
         if (!res.pagination || !res.pagination.offset) {
           offset.value = null
+
+          // reset to first page if no pagiantion data is returned unless the "next page" button was clicked
+          // this will ensure buttons display the correct state for cases like search
+          if (!nextPageClicked.value) {
+            page.value = 1
+          }
         } else {
           offset.value = res.pagination.offset
 
@@ -617,6 +624,7 @@ export default defineComponent({
       }
 
       isTableLoading.value = false
+      nextPageClicked.value = false
 
       return res
     }
@@ -732,6 +740,7 @@ export default defineComponent({
 
     const getNextOffsetHandler = () => {
       page.value++
+      nextPageClicked.value = true
     }
 
     const getPrevOffsetHandler = () => {

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -702,8 +702,6 @@ export default defineComponent({
         } else {
           defaultSorter(key, prevKey, sortColumnOrder.value, data.value)
         }
-      } else {
-        revalidate()
       }
     }
 


### PR DESCRIPTION
# Summary

This fix adds more cases for disabled state handling for the prev/next page buttons.

It's possible that when the data returned is either less than the page size or the last page of data, no pagination data will be returned in the response (i.e. a `next` URL or an `offset` value). This is our current use case, and this fix should now handle these cases.

Cases tested:
1. When the data loaded on initial page load is less than the page size
3. When the data loaded after clicking the "next" page button is less than the page size (i.e. the last page of results)
4. When the current page is not the first page, data is refetched (i.e. a search)

Note about cbdaf702a97eaaa1d6adcfe29c4aaace08833f83:
I included this change because I found the following bug:
1. `enable-client-sort` is disabled on a KTable instance
2. `sort: true` is set for one or more of the headers for that table
3. Clicking a sortable header would trigger the `revalidate()` call. When used in combination with `pagination-type="offset"`, clicking a sortable header would trigger the `revalidate()` call, fetching the next page of results

Are there cases where we would want to revalidate after clicking a sortable header?

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
