### PR TITLE
fix(ktable): hide pagination based on row numbers

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -99,6 +99,10 @@ Set this to `true` to limit pagination navigation to `previous` / `next` page on
 
 Set this to `true` to remove the pagination bar when using a fetcher.
 
+### hidePaginationWhenOptional
+
+Set this to `true` to remove the pagination bar. For cases, when the table record in Konnect is less than or equal to 15.
+
 ### disableSorting
 
 Set this to `true` to disable ablity to sort.
@@ -331,6 +335,7 @@ object these features should be explicitly disabled.
       { label: 'Enabled', key: 'enabled', sortable: false }
     ]"
     disablePagination
+    hidePaginationWhenOptional
     :enableClientSort="true"
   />
 </template>
@@ -369,6 +374,7 @@ object these features should be explicitly disabled.
       { label: 'Enabled', key: 'enabled', sortable: false }
     ]"
     disablePagination
+    hidePaginationWhenOptional
     :enableClientSort="true"
   />
 </template>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -101,7 +101,7 @@ Set this to `true` to remove the pagination bar when using a fetcher.
 
 ### hidePaginationWhenOptional
 
-Set this to `true` to remove the pagination bar. For cases, when the table record in Konnect is less than or equal to 15.
+Set this to `true` to hide the pagination UI when the table record count is less than or equal to the `pageSize`.
 
 ### disableSorting
 

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -436,7 +436,7 @@ describe('KTable', () => {
 
       await tick(wrapper.vm, 1)
 
-      expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
     it('does display pagination when total is greater than pageSize', async () => {
@@ -449,7 +449,8 @@ describe('KTable', () => {
           },
           isLoading: false,
           headers: options.headers,
-          pageSize: 15
+          pageSize: 15,
+          hidePaginationWhenOptional: true
         }
       })
 

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -401,6 +401,63 @@ describe('KTable', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
+    it('does not display pagination when hidePaginationWhenOptional is true and total is less than pageSize', async () => {
+      const wrapper = mount(KTable, {
+        localVue,
+        propsData: {
+          testMode: 'true',
+          fetcher: () => { return { data: options.data } },
+          isLoading: false,
+          headers: options.headers,
+          pageSize: 15,
+          hidePaginationWhenOptional: true
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+
+      expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
+    })
+
+    it('does not display pagination when hidePaginationWhenOptional is true and total is equal to pageSize', async () => {
+      const wrapper = mount(KTable, {
+        localVue,
+        propsData: {
+          testMode: 'true',
+          fetcher: () => {
+            return { total: 15 }
+          },
+          isLoading: false,
+          headers: options.headers,
+          pageSize: 15,
+          hidePaginationWhenOptional: true
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+
+      expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(true)
+    })
+
+    it('does display pagination when total is greater than pageSize', async () => {
+      const wrapper = mount(KTable, {
+        localVue,
+        propsData: {
+          testMode: 'true',
+          fetcher: () => {
+            return { total: 25 }
+          },
+          isLoading: false,
+          headers: options.headers,
+          pageSize: 15
+        }
+      })
+
+      await tick(wrapper.vm, 1)
+
+      expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(true)
+    })
+
     it('does not display pagination when no fetcher', async () => {
       const wrapper = mount(KTable, {
         localVue,

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -144,7 +144,7 @@
         </tbody>
       </table>
       <KPagination
-        v-if="fetcher && !disablePagination && !hidePaginationWhenOptional"
+        v-if="fetcher && !disablePagination && !(hidePaginationWhenOptional && total < pageSize)"
         :total-count="total"
         :current-page="page"
         :neighbors="paginationNeighbors"

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -144,7 +144,7 @@
         </tbody>
       </table>
       <KPagination
-        v-if="fetcher && !disablePagination && !(hidePaginationWhenOptional && total < pageSize)"
+        v-if="fetcher && !disablePagination && !(hidePaginationWhenOptional && total <= pageSize)"
         :total-count="total"
         :current-page="page"
         :neighbors="paginationNeighbors"

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -144,7 +144,7 @@
         </tbody>
       </table>
       <KPagination
-        v-if="fetcher && !disablePagination"
+        v-if="fetcher && !disablePagination && !hidePaginationWhenOptional"
         :total-count="total"
         :current-page="page"
         :neighbors="paginationNeighbors"
@@ -453,6 +453,13 @@ export default defineComponent({
       default: false
     },
     disablePagination: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * A prop to pass to hide pagination for table records less than or equal to 15 records
+     */
+    hidePaginationWhenOptional: {
       type: Boolean,
       default: false
     },

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -457,7 +457,7 @@ export default defineComponent({
       default: false
     },
     /**
-     * A prop to pass to hide pagination for table records less than or equal to 15 records
+     * A prop to pass to hide pagination for total table records is less than or equal to pagesize
      */
     hidePaginationWhenOptional: {
       type: Boolean,


### PR DESCRIPTION
# Summary
Addresses one of the solutions from this ticket:
[https://konghq.atlassian.net/browse/PDUX-741](https://konghq.atlassian.net/browse/PDUX-741)
<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Adds new `prop` for KTable `hidePaginationWhenOptional` to display record navigation only when there are more than 15 records in a `KTable`. Otherwise the control should be hidden.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [x] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
