### PR TITLE
fix(kmodalfullscreen): backport spacing

### DIFF
--- a/src/components/KModalFullscreen/KModalFullscreen.vue
+++ b/src/components/KModalFullscreen/KModalFullscreen.vue
@@ -316,7 +316,7 @@ $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-body-header {
   margin-top: $fullscreen-modal-padding;
-  margin-bottom: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
 
   .body-header {
     font-size: 32px;


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Backport https://github.com/Kong/kongponents/pull/682

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
