### PR TITLE
fix(ktable,kcatalog): hide pag logic [khcp-3929]

### DIFF
--- a/packages/KCatalog/KCatalog.spec.js
+++ b/packages/KCatalog/KCatalog.spec.js
@@ -386,9 +386,10 @@ describe('KCatalog', () => {
       const wrapper = mount(KCatalog, {
         localVue,
         propsData: {
-          fetcher: () => { return { total: 10 } },
+          fetcher: () => { return { data: getItems(5) } },
           isLoading: false,
           pageSize: 15,
+          paginationPageSizes: [10, 15, 20],
           hidePaginationWhenOptional: true
         }
       })
@@ -398,15 +399,16 @@ describe('KCatalog', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
-    it('does not display pagination when hidePaginationWhenOptional is true and total is equal to pageSize', async () => {
+    it('does not display pagination when hidePaginationWhenOptional is true and total is equal to min pageSize', async () => {
       const wrapper = mount(KCatalog, {
         localVue,
         propsData: {
           fetcher: () => {
-            return { total: 15 }
+            return { data: largeDataSet }
           },
           isLoading: false,
           pageSize: 15,
+          paginationPageSizes: [10, 15, 20],
           hidePaginationWhenOptional: true
         }
       })
@@ -416,15 +418,16 @@ describe('KCatalog', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
-    it('does display pagination when total is greater than pageSize', async () => {
+    it('does display pagination when hidePaginationWhenOptional is true and total is greater than min pageSize', async () => {
       const wrapper = mount(KCatalog, {
         localVue,
         propsData: {
           fetcher: () => {
-            return { total: 25 }
+            return { data: largeDataSet }
           },
           isLoading: false,
           pageSize: 15,
+          paginationPageSizes: [5, 10, 15],
           hidePaginationWhenOptional: true
         }
       })

--- a/packages/KCatalog/KCatalog.vue
+++ b/packages/KCatalog/KCatalog.vue
@@ -149,7 +149,7 @@
         </template>
       </slot>
       <div
-        v-if="!disablePagination && fetcher && !(hidePaginationWhenOptional && total <= pageSize)"
+        v-if="!disablePagination && fetcher && !(hidePaginationWhenOptional && total <= paginationPageSizes[0])"
         class="card-pagination">
         <KPagination
           :total-count="total"

--- a/packages/KTable/KTable.spec.js
+++ b/packages/KTable/KTable.spec.js
@@ -401,7 +401,7 @@ describe('KTable', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
-    it('does not display pagination when hidePaginationWhenOptional is true and total is less than pageSize', async () => {
+    it('does not display pagination when hidePaginationWhenOptional is true and total is less than min pageSize', async () => {
       const wrapper = mount(KTable, {
         localVue,
         propsData: {
@@ -410,6 +410,7 @@ describe('KTable', () => {
           isLoading: false,
           headers: options.headers,
           pageSize: 15,
+          paginationPageSizes: [10, 15, 20],
           hidePaginationWhenOptional: true
         }
       })
@@ -419,17 +420,18 @@ describe('KTable', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
-    it('does not display pagination when hidePaginationWhenOptional is true and total is equal to pageSize', async () => {
+    it('does not display pagination when hidePaginationWhenOptional is true and total is equal to min pageSize', async () => {
       const wrapper = mount(KTable, {
         localVue,
         propsData: {
           testMode: 'true',
           fetcher: () => {
-            return { total: 15 }
+            return { data: largeDataSet }
           },
           isLoading: false,
           headers: options.headers,
           pageSize: 15,
+          paginationPageSizes: [12, 15, 20],
           hidePaginationWhenOptional: true
         }
       })
@@ -439,17 +441,18 @@ describe('KTable', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
-    it('does display pagination when total is greater than pageSize', async () => {
+    it('does display pagination when total is greater than min pageSize', async () => {
       const wrapper = mount(KTable, {
         localVue,
         propsData: {
           testMode: 'true',
           fetcher: () => {
-            return { total: 25 }
+            return { data: largeDataSet }
           },
           isLoading: false,
           headers: options.headers,
           pageSize: 15,
+          paginationPageSizes: [10, 15, 20],
           hidePaginationWhenOptional: true
         }
       })
@@ -459,7 +462,7 @@ describe('KTable', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(true)
     })
 
-    it('does not display offset-based pagination when hidePaginationWhenOptional is true and total is less than pageSize', async () => {
+    it('does not display offset-based pagination when hidePaginationWhenOptional is true and total is less than min pageSize', async () => {
       const wrapper = mount(KTable, {
         localVue,
         propsData: {
@@ -468,6 +471,7 @@ describe('KTable', () => {
           isLoading: false,
           headers: options.headers,
           pageSize: 15,
+          paginationPageSizes: [10, 15, 20],
           hidePaginationWhenOptional: true,
           initialFetcherParams: { offset: null },
           paginationType: 'offset'
@@ -479,18 +483,19 @@ describe('KTable', () => {
       expect(wrapper.find('[data-testid="k-pagination-container"]').exists()).toBe(false)
     })
 
-    it('does display offset-based pagination when total is greater than pageSize', async () => {
+    it('does display offset-based pagination when total is greater than min pageSize', async () => {
       const wrapper = mount(KTable, {
         localVue,
         propsData: {
           testMode: 'true',
           fetcher: () => {
-            return { data: options.data, offset: 'abc' }
+            return { data: largeDataSet, offset: 'abc' }
           },
           isLoading: false,
           initialFetcherParams: { offset: 'abc' },
           headers: options.headers,
           pageSize: 15,
+          paginationPageSizes: [10, 15, 20],
           hidePaginationWhenOptional: true,
           paginationType: 'offset'
         }

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -758,12 +758,14 @@ export default defineComponent({
     }
 
     // fetcher must be defined, disablePagination must be false
-    // if using standard pagination with hidePaginationWhenOptional - hide if total <= pagesize
-    // if using offset-based pagination with hidePaginationWhenOptional - hide if neither previous/next offset exists
+    // if using standard pagination with hidePaginationWhenOptional
+    //  - hide if total <= min pagesize
+    // if using offset-based pagination with hidePaginationWhenOptional
+    //  - hide if neither previous/next offset exists and current data set count is <= min pagesize
     const shouldShowPagination = computed(() => {
       return props.fetcher && !props.disablePagination &&
-        !(props.paginationType !== 'offset' && props.hidePaginationWhenOptional && total.value <= pageSize.value) &&
-        !(props.paginationType === 'offset' && props.hidePaginationWhenOptional && !previousOffset.value && !offset.value)
+        !(props.paginationType !== 'offset' && props.hidePaginationWhenOptional && total.value <= props.paginationPageSizes[0]) &&
+        !(props.paginationType === 'offset' && props.hidePaginationWhenOptional && !previousOffset.value && !offset.value && data.value.length <= props.paginationPageSizes[0])
     })
 
     watch(() => props.searchInput, (newValue) => {


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Hide pagination bar if less than minimum pagesize, not current pagesize.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
