### PR TITLE
fix(kbutton): falsy disabled attribute on native link element

### DIFF
--- a/src/components/KButton/KButton.spec.ts
+++ b/src/components/KButton/KButton.spec.ts
@@ -4,7 +4,7 @@
 import { mount } from '@cypress/vue'
 import KButton, { appearances } from '@/components/KButton/KButton.vue'
 
-const rendersCorrectAppearance = (variant) => {
+const rendersCorrectAppearance = (variant: string) => {
   it(`renders kbutton with the ${variant} appearance`, () => {
     mount(KButton, {
       props: {
@@ -103,5 +103,19 @@ describe('KButton', () => {
     })
 
     cy.get('.k-button').should('contain.text', iconText)
+  })
+
+  it('strips falsy disabled attribute on native link', () => {
+    mount(KButton, {
+      props: {
+        to: 'https://google.com',
+        disabled: false,
+      },
+      slots: {
+        default: () => "I'm a native link",
+      },
+    })
+
+    cy.get('.k-button').should('not.have.attr', 'disabled')
   })
 })

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -164,7 +164,10 @@ export default defineComponent({
     })
 
     /**
-     * Strips falsy `disabled` attribute, so it does not fall onto native <a> elements
+     * Strips falsy `disabled` attribute, so it does not fall onto native <a> elements.
+     * Vue 3 no longer removes attribute if the value is boolean false. Instead, it's set as attr="false".
+     * So for <KButton :disabled="false" to="SOME_URL">, the rendered <a> element will have `disabled="false"`,
+     * which is greyed out and cannot be interacted with.
      */
     const strippedAttrs = computed((): typeof attrs => {
       const { disabled, ...restAttrs } = attrs

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -5,7 +5,7 @@
     :href="to"
     :class="[size, {'icon-btn': !hasText && hasIcon, 'rounded': isRounded}, appearance]"
     class="k-button"
-    v-bind="$attrs"
+    v-bind="strippedAttrs"
   >
 
     <slot name="icon">
@@ -37,7 +37,7 @@
     :to="to"
     :class="[size, {'icon-btn': !hasText && hasIcon, 'rounded': isRounded}, appearance, caretClasses]"
     class="k-button"
-    v-bind="$attrs"
+    v-bind="strippedAttrs"
   >
     <slot name="icon">
       <KIcon
@@ -163,12 +163,25 @@ export default defineComponent({
       return ''
     })
 
+    /**
+     * Strips falsy `disabled` attribute, so it does not fall onto native <a> elements
+     */
+    const strippedAttrs = computed((): typeof attrs => {
+      const { disabled, ...restAttrs } = attrs
+      if (disabled) {
+        return attrs
+      } else {
+        return { ...restAttrs }
+      }
+    })
+
     return {
       caretClasses,
       hasText,
       hasIcon,
       buttonType,
       iconColor,
+      strippedAttrs,
     }
   },
 })


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Because of the new [attribute coercion behavior](https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html) in Vue 3, if a `KButton` with `:disabled="false"` renders an `<a>` element, the `disabled` attribute is not removed. As a result, the `<a>` element is greyed out and cannot be interacted with.

Reproduction Link: https://codesandbox.io/s/hungry-jones-cf7k0k?file=/src/App.vue

This PR fixes this by stripping falsy disabled attribute before binding `$attrs`.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [x] **No**, because this PR is already for the `beta` branch, and does not need to backport to the `main` branch

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
