### PR TITLE
feat(kselect): misc fixes [beta]

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -157,7 +157,7 @@ export default defineUserConfig({
 
   plugins: [
     searchPlugin({
-      hotKeys: ['s', '/'],
+      hotKeys: ['/'],
       locales: {
         '/': {
           placeholder: 'Search...',

--- a/docs/components/menu.md
+++ b/docs/components/menu.md
@@ -70,7 +70,7 @@ export default defineComponent({
 
 ### width
 
-You can pass a `width` string for **KMenu**. Either the string `auto` or a string width, like `120`.
+You can pass a `width` string for **KMenu**. Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
 
 By default the `width` is set to `284px`.
 

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -284,7 +284,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
 
 ### width
 
-The width of the popover body - by default it is 200px.
+The width of the popover body - by default it is 200px. Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
 
 <KPop title="Cool header" width="300">
   <KButton>button</KButton>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -255,6 +255,11 @@ export default defineComponent({
 ### width
 
 You can pass a `width` string for dropdown. By default the `width` is `200px`. This is the width of the input, dropdown, and selected item.
+Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
+
+:::tip Note
+Because we are controlling the widths of multiple elements, we recommend using this prop instead of classes or explicit styles to control the width.
+:::
 
 <div>
   <KSelect width="350" :items="[{
@@ -346,7 +351,7 @@ You can pass any input attribute and it will get properly bound to the element.
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
 <div>
-  <KSelect :items="myItems" width="500" :filterFunc="customFilter">
+  <KSelect :items="myItems" width="100%" :filterFunc="customFilter">
     <template v-slot:item-template="{ item }">
       <div class="select-item-label">{{ item.label }}</div>
       <div class="select-item-desc">{{ item.description }}</div>
@@ -355,7 +360,7 @@ You can use the `item-template` slot to customize the look and feel of your item
 </div>
 
 ```html
-<KSelect :items="myItems" width="500" :filterFunc="customFilter">
+<KSelect :items="myItems" width="100%" :filterFunc="customFilter">
   <template v-slot:item-template="{ item }">
     <div class="select-item-label">{{item.label}}</div>
     <div class="select-item-desc">{{item.description}}</div>
@@ -443,12 +448,12 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-  .select-item-label {
-    color: blue;
-    font-weight: bold;
-  }
+.select-item-label {
+  color: blue;
+  font-weight: bold;
+}
 
-  .select-item-desc {
-    color: red;
-  }
+.select-item-desc {
+  color: red;
+}
 </style>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -289,6 +289,57 @@ Because we are controlling the widths of multiple elements, we recommend using t
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `true`. See [`KPop` docs](popover.html#positionfixed) for more information.
 
+### enableFiltering
+
+Use this prop to control whether or not `KSelect` with `appearance` `select` or `dropdown` allows filtering. By default, filtering is enabled for `dropdown` appearance and disabled for `select` appearance. `button` style `appearance` does not have filter support because it is a button.
+
+<div>
+  <KSelect :items="[{
+      label: 'test',
+      value: 'test'
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+    :enable-filtering="false"
+    class="mb-2"
+  />
+
+  <KSelect :items="[{
+      label: 'test',
+      value: 'test'
+    }, {
+      label: 'Test 1',
+      value: 'test1'
+    }]"
+    appearance="select"
+    :enable-filtering="true"
+  />
+</div>
+
+```html
+<KSelect :items="[{
+    label: 'test',
+    value: 'test'
+  }, {
+    label: 'Test 1',
+    value: 'test1'
+  }]"
+  :enable-filtering="false"
+/>
+
+<KSelect :items="[{
+    label: 'test',
+    value: 'test'
+  }, {
+    label: 'Test 1',
+    value: 'test1'
+  }]"
+  appearance="select"
+  :enable-filtering="true"
+/>
+```
+
 ### filterFunc
 
 Use this prop to override the default filter function if you want to do something like filter on an attribute other than `label`. Your filter function

--- a/src/components/KMenu/KMenu.vue
+++ b/src/components/KMenu/KMenu.vue
@@ -75,7 +75,7 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const widthStyle = computed((): Record<string, string> => {
       return {
-        width: props.width === 'auto' || props.width.includes('px') ? props.width : props.width + 'px',
+        width: props.width === 'auto' || props.width.endsWith('%') || props.width.endsWith('px') ? props.width : props.width + 'px',
       }
     })
 

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -28,7 +28,7 @@
           :id="popoverId"
           ref="popper"
           :style="popoverStyle"
-          :class="[popoverClasses, {'hide-caret': hideCaret }, { 'pb-0': $slots.actions }]"
+          :class="popoverClassObj"
           role="region"
           class="k-popover"
         >
@@ -72,7 +72,7 @@
         :id="popoverId"
         ref="popper"
         :style="popoverStyle"
-        :class="[popoverClasses, {'hide-caret': hideCaret }, { 'pb-0': $slots.actions }]"
+        :class="popoverClassObj"
         role="region"
         class="k-popover"
       >
@@ -288,9 +288,12 @@ export default defineComponent({
   computed: {
     popoverStyle: function() {
       return {
-        width: this.width === 'auto' ? this.width : this.width + 'px',
-        'max-width': this.maxWidth === 'auto' ? this.maxWidth : this.maxWidth + 'px',
+        width: this.width === 'auto' || this.width.endsWith('%') || this.width.endsWith('px') ? this.width : this.width + 'px',
+        'max-width': this.maxWidth === 'auto' || this.maxWidth.endsWith('%') || this.maxWidth.endsWith('px') ? this.maxWidth : this.maxWidth + 'px',
       }
+    },
+    popoverClassObj: function() {
+      return [this.popoverClasses, { 'hide-caret': this.hideCaret }, { 'pb-0': this.$slots.actions }]
     },
   },
   watch: {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -140,7 +140,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, computed, onBeforeMount, PropType } from 'vue'
+import { defineComponent, ref, Ref, computed, onBeforeMount, onMounted, PropType } from 'vue'
 import { v1 as uuidv1 } from 'uuid'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -273,16 +273,21 @@ export default defineComponent({
     const selectItems: Ref<SelectItem[]> = ref([])
 
     const widthValue = computed(() => {
-      let w
+      let w = ''
       if (!props.width) {
-        w = 205
+        w = '205'
         if (props.appearance === 'button') {
-          w = 230
+          w = '230'
         }
       } else {
         w = props.width
       }
-      return w === 'auto' ? w : w + 'px'
+
+      if (w !== 'auto' && !w.endsWith('%') && !w.endsWith('px')) {
+        w += 'px'
+      }
+
+      return w
     })
 
     const widthStyle = computed(() => {
@@ -296,7 +301,8 @@ export default defineComponent({
         ...defaultKPopAttributes,
         ...props.kpopAttributes,
         popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-select-pop-${props.appearance}`,
-        width: String(widthValue.value.replace(/px/i, '')),
+        width: String(inputWidth.value),
+        maxWidth: String(inputWidth.value),
         disabled: typeof attrs.disabled === 'boolean' ? attrs.disabled : false,
       }
     })
@@ -388,6 +394,15 @@ export default defineComponent({
       }
     })
 
+    const inputWidth = ref(0)
+    onMounted(() => {
+      const inputElem = document.getElementById(selectInputId.value)
+
+      if (inputElem) {
+        inputWidth.value = inputElem.offsetWidth
+      }
+    })
+
     return {
       filterStr,
       selectedItem,
@@ -404,6 +419,7 @@ export default defineComponent({
       handleItemSelect,
       clearSelection,
       triggerFocus,
+      inputWidth,
     }
   },
 })

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -99,8 +99,10 @@
               :is-open="isToggled.value"
               :placeholder="placeholderText"
               class="k-select-input"
+              :class="{ 'cursor-default': !filterIsEnabled }"
               autocomplete="off"
               autocapitalize="off"
+              :readonly="!filterIsEnabled"
               @keyup="evt => triggerFocus(evt, isToggled)"
             />
           </div>
@@ -255,6 +257,10 @@ export default defineComponent({
       type: Function,
       default: (params: SelectFilterFnParams) => params.items.filter((item: SelectItem) => item.label.toLowerCase().includes(params.query.toLowerCase())),
     },
+    enableFiltering: {
+      type: Boolean,
+      default: null,
+    },
     /**
      * Test mode - for testing only, strips out generated ids
      */
@@ -271,6 +277,18 @@ export default defineComponent({
     const selectInputId = computed((): string => props.testMode ? 'test-select-input-id-1234' : uuidv1())
     const selectTextId = computed((): string => props.testMode ? 'test-select-text-id-1234' : uuidv1())
     const selectItems: Ref<SelectItem[]> = ref([])
+    const filterIsEnabled = computed((): boolean => {
+      if (props.enableFiltering !== null) {
+        // filtering not allowed for `button` appearance
+        return props.appearance === 'button' ? false : props.enableFiltering
+      }
+
+      if (props.appearance === 'dropdown') {
+        return true
+      }
+
+      return false
+    })
 
     const widthValue = computed(() => {
       let w = ''
@@ -318,7 +336,7 @@ export default defineComponent({
       } else if (attrs.placeholder) {
         return attrs.placeholder as string
       }
-      if (props.appearance === 'button') {
+      if (props.appearance === 'button' || !filterIsEnabled.value) {
         return 'Select an item'
       }
       return 'Filter...'
@@ -420,6 +438,7 @@ export default defineComponent({
       clearSelection,
       triggerFocus,
       inputWidth,
+      filterIsEnabled,
     }
   },
 })
@@ -452,45 +471,7 @@ export default defineComponent({
       margin-bottom: auto;
       padding: 0;
       height: 24px;
-
-      :deep(.kong-icon) {
-        margin-left: auto;
-      }
     }
-  }
-
-  .k-select-input {
-    position: relative;
-    display: inline-block;
-    width: 100%;
-
-    :deep(input.k-input) {
-      padding: var(--spacing-xs);
-      height: 100%;
-      border-radius: 4px 4px 0 0;
-    }
-
-    :deep(.kong-icon) {
-      position: absolute;
-      top: 60%;
-      right: 6px;
-      transform: translateY(-50%);
-      z-index: 9;
-    }
-  }
-
-  .k-select-button .has-caret :deep(.kong-icon) {
-    margin-left: auto;
-  }
-
-  .k-select-button {
-    :deep(.k-button.btn-link):hover {
-      text-decoration: none;
-    }
-  }
-
-  :deep(.k-input) {      // need this so input takes the
-    width: 100%;  // k-input-wrapper's width which uses this.width prop
   }
 
   .k-select-trigger:after {
@@ -504,8 +485,61 @@ export default defineComponent({
     border-right: 0.325em solid transparent;
     border-left: 0.325em solid transparent;
   }
+}
+</style>
 
-  :deep(.k-select-popover) {
+<style lang="scss">
+@import '@/styles/variables';
+@import '@/styles/functions';
+
+.k-select {
+  .k-select-item-selection {
+    .clear-selection-icon {
+      .kong-icon {
+        margin-left: auto;
+      }
+    }
+  }
+
+  .k-select-input {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+
+    &.cursor-default {
+      cursor: default;
+    }
+
+    &input.k-input {
+      padding: var(--spacing-xs);
+      height: 100%;
+      border-radius: 4px 4px 0 0;
+    }
+
+    .kong-icon {
+      position: absolute;
+      top: 60%;
+      right: 6px;
+      transform: translateY(-50%);
+      z-index: 9;
+    }
+  }
+
+  .k-select-button .has-caret .kong-icon {
+    margin-left: auto;
+  }
+
+  .k-select-button {
+    &.k-button.btn-link:hover {
+      text-decoration: none;
+    }
+  }
+
+  &.k-input {
+    width: 100%;  // need this so input takes the k-input-wrapper's width which uses this.width prop
+  }
+
+  .k-select-popover {
     box-sizing: border-box;
     // width: 100%;
     border-radius: 0 0 4px 4px;

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -257,6 +257,9 @@ export default defineComponent({
       type: Function,
       default: (params: SelectFilterFnParams) => params.items.filter((item: SelectItem) => item.label.toLowerCase().includes(params.query.toLowerCase())),
     },
+    /**
+     * Control whether the input for `select` and `dropdown` appearances supports filtering.
+     */
     enableFiltering: {
       type: Boolean,
       default: null,

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -95,7 +95,7 @@
       }
     }
 
-    &:read-only {
+    &:not(.k-select-input):read-only {
       background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
       box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
     }


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- Fix `width` prop handling to ensure selected item, input, and dropdown are the same size
- Add support for `%` for `width` props
- Add `enableFilter` prop to control filter support on `KSelect` input
- Break out unscoped styles because `:deep()` wasn't correctly applying all styles

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
