### PR TITLE
style(kselect): update for new UI [khcp-4158]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -401,6 +401,8 @@ You can pass any input attribute and it will get properly bound to the element.
 
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
+If you use the `select-item-label` and `select-item-desc` classes within the slot as shown in the example below, the dropdown items will inherit preconfigured styles for two-level select items which you're then free to customize.
+
 <div>
   <KSelect appearance='select' :items="myItems" width="100%" :filterFunc="customFilter">
     <template v-slot:item-template="{ item }">

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -495,10 +495,9 @@ export default {
 </script>
 
 <style lang="scss">
-.select-item-label {
-  color: blue;
-  font-weight: bold;
-}
+  .select-item-label {
+    color: blue;
+  }
 
 .select-item-desc {
   color: red;

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -358,7 +358,7 @@ KSelect works as regular inputs do using v-model for data binding:
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect width="100" v-model="data.myVal" :items="[{
+    <KSelect v-model="data.myVal" :items="[{
         label: 'test',
         value: 'test'
       }, {
@@ -373,7 +373,7 @@ KSelect works as regular inputs do using v-model for data binding:
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect width="100" v-model="data.myVal" :items="[{
+    <KSelect v-model="data.myVal" :items="[{
         label: 'test',
         value: 'test'
       }, {
@@ -402,7 +402,7 @@ You can pass any input attribute and it will get properly bound to the element.
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
 <div>
-  <KSelect :items="myItems" width="100%" :filterFunc="customFilter">
+  <KSelect appearance='select' :items="myItems" width="100%" :filterFunc="customFilter">
     <template v-slot:item-template="{ item }">
       <div class="select-item-label">{{ item.label }}</div>
       <div class="select-item-desc">{{ item.description }}</div>
@@ -411,7 +411,7 @@ You can use the `item-template` slot to customize the look and feel of your item
 </div>
 
 ```html
-<KSelect :items="myItems" width="100%" :filterFunc="customFilter">
+<KSelect appearance='select' :items="myItems" width="100%" :filterFunc="customFilter">
   <template v-slot:item-template="{ item }">
     <div class="select-item-label">{{item.label}}</div>
     <div class="select-item-desc">{{item.description}}</div>
@@ -493,13 +493,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss">
-  .select-item-label {
-    color: blue;
-  }
-
-.select-item-desc {
-  color: red;
-}
-</style>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -1,5 +1,7 @@
 # Select
 
+<div v-if="hasMounted">
+
 **Select** - Dropdown/Select component
 <div>
   <KSelect label="Pick Something:" :items="[{
@@ -458,6 +460,8 @@ export default {
 | `input` | `selectedItem` Object or null |
 | `change` | `selectedItem` Object or null |
 
+</div>
+
 <script>
 function getItems(count) {
   let myItems = []
@@ -474,6 +478,7 @@ function getItems(count) {
 export default {
   data() {
     return {
+      hasMounted: false,
       myItems: getItems(5),
       mySelect: '',
       items: [{
@@ -484,6 +489,9 @@ export default {
         value: '50'
       }]
     }
+  },
+  mounted() {
+    this.hasMounted = true
   },
   methods: {
     handleItemSelect (item) {

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -403,10 +403,10 @@ You can pass any input attribute and it will get properly bound to the element.
 
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
-If you use the `select-item-label` and `select-item-desc` classes within the slot as shown in the example below, the dropdown items will inherit preconfigured styles for two-level select items which you're then free to customize.
+If you use the `.select-item-label` and `.select-item-desc` classes within the slot as shown in the example below, the dropdown items will inherit preconfigured styles for two-level select items which you're then free to customize.
 
 <div>
-  <KSelect appearance='select' :items="myItems" width="100%" :filterFunc="customFilter">
+  <KSelect :items="myItems" width="100%" :filterFunc="customFilter">
     <template v-slot:item-template="{ item }">
       <div class="select-item-label">{{ item.label }}</div>
       <div class="select-item-desc">{{ item.description }}</div>
@@ -415,7 +415,7 @@ If you use the `select-item-label` and `select-item-desc` classes within the slo
 </div>
 
 ```html
-<KSelect appearance='select' :items="myItems" width="100%" :filterFunc="customFilter">
+<KSelect :items="myItems" width="100%" :filterFunc="customFilter">
   <template v-slot:item-template="{ item }">
     <div class="select-item-label">{{item.label}}</div>
     <div class="select-item-desc">{{item.description}}</div>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -276,7 +276,7 @@ Because we are controlling the widths of multiple elements, we recommend using t
 </div>
 
 ```vue
-<KSelect width="100" :items="[{
+<KSelect width="250" :items="[{
     label: 'test',
     value: 'test',
     selected: true

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -343,25 +343,25 @@ export default {
 
       if (theTarget) {
         theTarget.appendChild(popperEl)
-
-        await this.$nextTick()
-        this.popper = new Popper(this.reference, popperEl, {
-          placement,
-          // Use positionFixed to avoid popover content being cut off by parent boundaries
-          positionFixed: this.positionFixed,
-          removeOnDestroy: true,
-          modifiers: {
-          // Ensures element does not ovflow outside of boundary
-            preventOverflow: {
-              enabled: true,
-              boundariesElement: 'viewport'
-            }
-          }
-        })
-
-        await this.$nextTick()
-        this.popper.update()
       }
+
+      await this.$nextTick()
+      this.popper = new Popper(this.reference, popperEl, {
+        placement,
+        // Use positionFixed to avoid popover content being cut off by parent boundaries
+        positionFixed: this.positionFixed,
+        removeOnDestroy: true,
+        modifiers: {
+          // Ensures element does not ovflow outside of boundary
+          preventOverflow: {
+            enabled: true,
+            boundariesElement: 'viewport'
+          }
+        }
+      })
+
+      await this.$nextTick()
+      this.popper.update()
     },
 
     handleClick (e) {

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -343,25 +343,25 @@ export default {
 
       if (theTarget) {
         theTarget.appendChild(popperEl)
-      }
 
-      await this.$nextTick()
-      this.popper = new Popper(this.reference, popperEl, {
-        placement,
-        // Use positionFixed to avoid popover content being cut off by parent boundaries
-        positionFixed: this.positionFixed,
-        removeOnDestroy: true,
-        modifiers: {
+        await this.$nextTick()
+        this.popper = new Popper(this.reference, popperEl, {
+          placement,
+          // Use positionFixed to avoid popover content being cut off by parent boundaries
+          positionFixed: this.positionFixed,
+          removeOnDestroy: true,
+          modifiers: {
           // Ensures element does not ovflow outside of boundary
-          preventOverflow: {
-            enabled: true,
-            boundariesElement: 'viewport'
+            preventOverflow: {
+              enabled: true,
+              boundariesElement: 'viewport'
+            }
           }
-        }
-      })
+        })
 
-      await this.$nextTick()
-      this.popper.update()
+        await this.$nextTick()
+        this.popper.update()
+      }
     },
 
     handleClick (e) {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -74,7 +74,7 @@
             role="listbox">
             <KIcon
               v-if="appearance === 'select'"
-              icon="chevronDown"
+              :icon="isToggled ? 'chevronUp' : 'chevronDown'"
               color="var(--grey-500)"
               size="15" />
             <KInput
@@ -104,6 +104,7 @@
                     <slot
                       :item="item"
                       name="item-template"
+                      class="select-item-label select-item-desc"
                     />
                   </template>
                 </KSelectItem>
@@ -399,7 +400,7 @@ export default {
 
     .selected-item-label {
       align-self: center;
-      font-size: var(--type-xs);
+      font-size: 14px;
       line-height: 16px;
     }
 
@@ -481,8 +482,8 @@ export default {
     }
 
     &.k-select-pop-dropdown {
-      --KPopPaddingY: var(--spacing-md);
-      --KPopPaddingX: var(--spacing-xxs);
+      --KPopPaddingY: 7px;
+      --KPopPaddingX: 7px;
       border: 1px solid var(--blue-200);
     }
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -475,21 +475,21 @@ export default {
     border-radius: 0 0 4px 4px;
 
     &.k-select-pop-button {
-      --KPopPaddingY: var(--spacing-md);
-      --KPopPaddingX: var(--spacing-xxs);
+      --KPopPaddingY: var(--spacing-xs);
+      --KPopPaddingX: var(--spacing-xs);
       border-radius: 4px;
       border: 1px solid var(--blue-200);
     }
 
     &.k-select-pop-dropdown {
-      --KPopPaddingY: 7px;
-      --KPopPaddingX: 7px;
-      border: 1px solid var(--blue-200);
+      --KPopPaddingY: var(--spacing-xs);
+      --KPopPaddingX: var(--spacing-xs);
+      border: 1px solid var(--grey-300);
     }
 
     &.k-select-pop-select {
-      --KPopPaddingY: var(--spacing-md);
-      --KPopPaddingX: var(--spacing-xxs);
+      --KPopPaddingY: var(--spacing-xs);
+      --KPopPaddingX: var(--spacing-xs);
       border: 1px solid var(--black-10);
     }
 

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -55,7 +55,7 @@ export default {
 @import '~@kongponents/styles/variables';
 
 .k-select-item {
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   list-style: none !important;
 
   button {
@@ -81,6 +81,19 @@ export default {
     .k-select-item-label {
       width: auto;
       line-height: 16px;
+      font-weight: 500;
+      font-size: 14px;
+      padding: 8px;
+
+      .select-item-label {
+        font-weight: 600;
+        font-size: 14px;
+      }
+
+      .select-item-desc {
+        font-weight: 400;
+        font-size: 14px;
+      }
     }
 
     .kong-icon:not(.selected-item-icon) {

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -81,16 +81,20 @@ export default {
     .k-select-item-label {
       width: auto;
       line-height: 16px;
+      color: var(--grey-600);
       font-weight: 500;
       font-size: 14px;
       padding: 8px;
+      margin-bottom: 4px;
 
       .select-item-label {
+        color: var(--grey-600);
         font-weight: 600;
         font-size: 14px;
       }
 
       .select-item-desc {
+        color: var(--grey-500);
         font-weight: 400;
         font-size: 14px;
       }

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -91,6 +91,7 @@ export default {
         color: var(--grey-600);
         font-weight: 600;
         font-size: 14px;
+        margin-bottom: 4px;
       }
 
       .select-item-desc {

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -106,7 +106,7 @@
       display: none;
     }
   }
-
+}
   /**
    * KSelect should ignore read-only styles
    */
@@ -124,6 +124,7 @@
    * Note: this style-block MUST come AFTER the read-only block. Disabled state
    *  takes precedence over read-only state.
    */
+   
   .k-input,
   .form-control {
     &:not([type="checkbox"]),
@@ -141,7 +142,6 @@
         box-shadow: none;
       }
     }
-  }
 
   &[type="search"] {
     padding-left: 36px;

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -106,7 +106,7 @@
       display: none;
     }
   }
-}
+
   /**
    * KSelect should ignore read-only styles
    */
@@ -119,6 +119,7 @@
       }
     }
   }
+}
   /**
    * But KSelect still wants disabled/invalid styles applied
    * Note: this style-block MUST come AFTER the read-only block. Disabled state


### PR DESCRIPTION
# Summary
Addresses: 
[https://konghq.atlassian.net/browse/KHCP-4158](https://konghq.atlassian.net/browse/KHCP-4158)
<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
**KSelect (general rules)**
- Updates `minimum font size`
- Adds `margin` and `padding` for dropdown items
- `Caret` should switch direction on open/close of dropdown

**KSelect (default, no slots)**
- Updates `font-size` and `font-weight` of dropdown items

**KSelect (slotted content)**
- Support `.select-item-label` by default, and sets` font weight` and `font-size`
- Support `.select-item-description` by default, and sets` font weight` and `font-size`

I have added the label `port to beta branch`. Once this is approved, I will port the changes.
## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [x] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
