### PR TITLE
fix(docs): code snippet syntax

### DIFF
--- a/cli/template/docs/Template.md
+++ b/cli/template/docs/Template.md
@@ -4,7 +4,7 @@
 
 <{%%KONGPONENT_NAME%%} />
 
-```vue
+```html
 <template>
   <{%%KONGPONENT_NAME%%} />
 </template>
@@ -30,7 +30,7 @@ Actual component using examplePropName
 
 <{%%KONGPONENT_NAME%%} :examplePropName="true" />
 
-```vue
+```html
 <{%%KONGPONENT_NAME%%} examplePropName="variation1" />
 <{%%KONGPONENT_NAME%%} examplePropName="variation2" />
 <{%%KONGPONENT_NAME%%} examplePropName="variation3" />
@@ -41,7 +41,7 @@ Actual component using examplePropName
 - `default` - default slot description
 - `slotName` - slot description
 
-```vue
+```html
 <{%%KONGPONENT_NAME%%}>
   here is some slot content
 </{%%KONGPONENT_NAME%%}>
@@ -68,7 +68,7 @@ like:
   </div>
 </template>
 
-```vue
+```html
 <template>
   <div class="{%%KONGPONENT_NAME%%}-wrapper">
     <{%%KONGPONENT_NAME%%} />

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -4,7 +4,7 @@
 
 <KAlert alert-message="I'm an alert" />
 
-```vue
+```html
 <KAlert alert-message="I'm an alert" />
 ```
 
@@ -16,7 +16,7 @@ You can pass in the alert message (as a `string`) if you are not utilizing the [
 
 <KAlert alert-message="This is the alert message." />
 
-```vue
+```html
 <KAlert alert-message="This is the alert message." />
 ```
 
@@ -39,7 +39,7 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 
 <KAlert appearance="danger" alert-message="Danger alert message" />
 
-```vue
+```html
 <KAlert appearance="info" alert-message="Info alert message" />
 <KAlert appearance="warning" alert-message="Warning alert message" />
 <KAlert appearance="success" alert-message="Success alert message" />
@@ -64,7 +64,7 @@ The display type of the alert.
 
 <KAlert alert-message="I'm a banner type alert" appearance="warning" type="banner" />
 
-```vue
+```html
 <KAlert alert-message="I'm a banner type alert" type="banner" />
 <KAlert alert-message="I'm a banner type alert" appearance="success" type="banner" />
 <KAlert alert-message="I'm a banner type alert" appearance="danger" type="banner" />
@@ -85,7 +85,7 @@ The display type of the alert.
 
 <KAlert alert-message="I'm an alert" dismissType="button" appearance="warning" type="alert" :isShowing="alert4IsOpen" @closed="alert4IsOpen = false" />
 
-```vue
+```html
 <KAlert alert-message="I'm an alert" dismissType="button" type="alert" :isShowing="alert1IsOpen" @closed="alert1IsOpen = false" />
 <KAlert alert-message="I'm an alert" dismissType="button" appearance="success" type="alert" :isShowing="alert2IsOpen" @closed="alert2IsOpen = false" />
 <KAlert alert-message="I'm an alert" dismissType="button" appearance="danger" type="alert" :isShowing="alert3IsOpen" @closed="alert4IsOpen = false" />
@@ -112,7 +112,7 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 
 <KAlert alert-message="Alert with dismiss type as button" type="banner" dismissType="button" :isShowing="dismissTypeBtn" @closed="dismissTypeBtn = false"/>
 
-```vue
+```html
 <KAlert alert-message="Alert that can not be dismissed" type="alert" dismissType="none" />
 <KAlert alert-message="Info alert message that is dismissible" appearance="info" type="alert" dismissType="icon" :isShowing="infoIsOpen" @closed="infoIsOpen = false" />
 <KAlert alert-message="Warning alert message that is dismissible" appearance="warning" type="alert" dismissType="icon" :isShowing="warningIsOpen" @closed="warningIsOpen = false" />
@@ -127,7 +127,7 @@ Set whether or not the alert box is shown.
 
 > Note: By default isShowing is set to true.
 
-```vue
+```html
 <KAlert :is-showing="false" alert-message="isShowing set to false"/>
 ```
 
@@ -137,7 +137,7 @@ Adds border around alert. Used for [KToaster](/components/toaster.html).
 
 <KAlert is-bordered appearance="info" alert-message="Info bordered"/>
 
-```vue
+```html
 <KAlert is-bordered appearance="info" alert-message="Info bordered"/>
 ```
 
@@ -147,7 +147,7 @@ Adds border to the left side. Typically used for alerts that show info that may 
 
 <KAlert has-left-border alert-message="Bordered alert"/>
 
-```vue
+```html
 <KAlert has-left-border alert-message="Bordered alert"/>
 ```
 
@@ -159,7 +159,7 @@ Adds border to the right side. Typically used for alerts that show info that may
 
 <KAlert has-right-border alert-message="Bordered alert"/>
 
-```vue
+```html
 <KAlert has-right-border alert-message="Bordered alert"/>
 ```
 
@@ -169,7 +169,7 @@ Adds border to the top.
 
 <KAlert has-top-border alert-message="Bordered alert"/>
 
-```vue
+```html
 <KAlert has-top-border alert-message="Bordered alert"/>
 ```
 
@@ -179,7 +179,7 @@ Adds border to the bottom.
 
 <KAlert has-bottom-border alert-message="Bordered alert"/>
 
-```vue
+```html
 <KAlert has-bottom-border alert-message="Bordered alert"/>
 ```
 
@@ -191,7 +191,7 @@ Controls size of alert.
 
 <KAlert style="width:250px" size="small" alert-message="Small alert"/>
 
-```vue
+```html
 <KAlert style="width:250px" size="small" alert-message="Small alert"/>
 ```
 
@@ -210,7 +210,7 @@ Controls size of alert.
   </template>
 </KAlert>
 
-```vue
+```html
 <KAlert type="banner" dismissType="button" appearance="warning" icon="support" size="large" :isShowing="extraMsg" @closed="extraMsg = false">
   <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Review</KButton></template>
@@ -231,7 +231,7 @@ Fixes KAlert to the top of the container.
 
 - `is-fixed`
 
-```vue
+```html
 <KAlert is-fixed alert-message="Info bordered"/>
 ```
 
@@ -251,7 +251,7 @@ Fixes KAlert to the top of the container.
   </template>
 </KAlert>
 
-```vue
+```html
 <KAlert type="banner" dismissType="button" appearance="success" :isShowing="extraBtnSlot" @closed="extraBtnSlot = false">
     <template v-slot:alertMessage>
     I'm an alert with action buttons
@@ -279,7 +279,7 @@ Fixes KAlert to the top of the container.
   </template>
 </KAlert>
 
-```vue
+```html
 <KAlert appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
@@ -296,7 +296,7 @@ Fixes KAlert to the top of the container.
   </template>
 </KAlert>
 
-```vue
+```html
 <KAlert appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
@@ -332,7 +332,7 @@ look like.
   <KAlert appearance="success" alert-message="Im Lime" />
 </div>
 
-```vue
+```html
 <template>
   <div class="alert-wrapper">
     <KAlert appearance="success" alert-message="Im Lime" />

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -4,7 +4,7 @@
 
 <KBadge appearance="success">SUCCESS</KBadge>
 
-```vue
+```html
 <KBadge appearance="success">SUCCESS</KBadge>
 ```
 
@@ -27,7 +27,7 @@ The Badge component can take the following appearance values:
 <KBadge appearance="info" class="mr-2">INFO</KBadge>
 <KBadge>DEFAULT</KBadge>
 
-```vue
+```html
 <KBadge appearance="success">SUCCESS</KBadge>
 <KBadge appearance="warning">WARNING</KBadge>
 <KBadge appearance="danger">DANGER</KBadge>
@@ -45,7 +45,7 @@ The Badge has two shapes that can be changed with a `shape` property.
 <KBadge appearance="warning" class="mr-2">Round</KBadge>
 <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 
-```vue
+```html
 <KBadge appearance="warning">Round</KBadge>
 <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 ```
@@ -60,7 +60,7 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
 <KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 
-```vue
+```html
 <KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>
 <KBadge color="var(--red-100)" background-color="var(--red-400)">Badge</KBadge>
 <KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
@@ -74,7 +74,7 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 
 <KBadge appearance="success">SUCCESS</KBadge>
 
-```vue
+```html
 <KBadge appearance="success">SUCCESS</KBadge>
 ```
 
@@ -111,7 +111,7 @@ An example of theming the danger badge:
   <KBadge appearance="danger">DANGER - RADIOACTIVE MATERIAL</KBadge>
 </div>
 
-```vue
+```html
 <template>
   <div class="KBadge-wrapper">
     <KBadge appearance="danger">DANGER - RADIOACTIVE MATERIAL</KBadge>

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -8,7 +8,7 @@
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KBreadcrumbs :items="breadcrumbItems" />
 </template>
@@ -73,7 +73,7 @@ The `to` property can be a Vue route or traditional URL. When using a URL though
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KBreadcrumbs :items="breadcrumbItems" />
 </template>
@@ -114,7 +114,7 @@ Maximum width of each breadcrumb item for truncating to ellipsis.
   </template>
 </KCard>
 
-```vue
+```html
 <KBreadcrumbs :items="longBreadcrumbs" item-max-width="16ch" />
 ```
 

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -5,7 +5,7 @@ and configuration options.
 
 <KButton appearance="primary">I'm a button</KButton>
 
-```vue
+```html
 <KButton appearance="primary">I'm a button</KButton>
 ```
 
@@ -29,7 +29,7 @@ The Button component can take 1 of 6 appearance values:
 <KButton class="mr-2 mb-2" appearance="creation">Creation</KButton>
 <KButton class="mr-2 mb-2" appearance='btn-link'>btn-link</KButton>
 
-```vue
+```html
 <KButton appearance='primary'>Primary</KButton>
 <KButton appearance="secondary">Secondary</KButton>
 <KButton appearance='outline'>Outline</KButton>
@@ -52,7 +52,7 @@ We support `small`, `medium`, and `large` sizes, default to `medium`.
 
 <KButton appearance="secondary" size="large">Large</KButton>
 
-```vue
+```html
 <KButton appearance="secondary" size="small">Small</KButton>
 <KButton appearance="secondary" size="medium">Medium</KButton>
 <KButton appearance="secondary" size="large">Large</KButton>
@@ -68,7 +68,7 @@ KButton can display a dropdown caret to the right hand side. This is useful for 
 
 > The `KComponent` component is used in this example to create state.
 
-```vue
+```html
 <KComponent :data="{ isActive: false }" v-slot="{ data }">
   <KButton appearance="primary" size="medium" :isOpen="data.isActive" @click="data.isActive = !data.isActive">
     I'm a button
@@ -83,7 +83,7 @@ The buttons are rounded by default. This can be disabled by setting `isRounded` 
 <KButton class="mr-2" appearance="primary" :isRounded="false">I'm a button</KButton>
 <KButton appearance="primary" >I'm a button</KButton>
 
-```vue
+```html
 <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
 <KButton appearance="primary" >I'm a button</KButton>
 ```
@@ -98,7 +98,7 @@ coloring to the icon depending on the `disabled` state of the button.
 <KButton class="mr-2" appearance="primary" icon="spinner">I'm a button</KButton>
 <KButton appearance="primary" icon="spinner" disabled>I'm a button</KButton>
 
-```vue
+```html
 <KButton appearance="primary" icon="spinner">I'm a button</KButton>
 <KButton appearance="primary" icon="spinner" disabled>I'm a button</KButton>
 ```
@@ -110,7 +110,7 @@ KButton can render either a `<a>` or `<router-link>` by simply passing the `to` 
 <KButton :to="{path: '/'}" appearance="btn-link">Router Link!</KButton>
 <KButton to="http://google.com" appearance="btn-link">Anchor Link!</KButton>
 
-```vue
+```html
 <KButton :to="{path: '/'}" appearance="btn-link">Router Link!</KButton>
 <KButton to="http://google.com" appearance="btn-link">Anchor Link!</KButton>
 ```
@@ -122,7 +122,7 @@ KButton also supports the disabled attribute with both Button and Anchor types.
 <KButton appearance="danger" disabled>Disabled Danger</KButton>
 <KButton to="http://google.com" appearance="btn-link" disabled>Disabled Native Anchor Link</KButton>
 
-```vue
+```html
 <KButton appearance="danger" disabled>Disabled Danger</KButton>
 <KButton to="http://google.com" appearance="btn-link" disabled>Disabled Native Anchor Link</KButton>
 ```
@@ -145,7 +145,7 @@ KButton supports using an icon either before the text or without text. If you ar
   </template>
 </KButton>
 
-```vue
+```html
 <KButton appearance="secondary">
   <template v-slot:icon>
     <KIcon icon="externalLink" />
@@ -192,7 +192,7 @@ look like.
 
 <KButton class="purple-button" appearance="primary">PURPLE!</KButton>
 
-```vue
+```html
 <template>
   <KButton class="purple-button" appearance="primary">PURPLE!</KButton>
 </template>
@@ -211,7 +211,7 @@ should not look like buttons.
 
 <KButton class='non-visual-button'>Click Me</KButton>
 
-```vue
+```html
 <KButton class='non-visual-button'>Click Me</KButton>
 ```
 

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -4,7 +4,7 @@
 
 <KCard title="Card Title" body="Body Content"/>
 
-```vue
+```html
 <KCard title="Card Title" body="Body Content"/>
 ```
 
@@ -20,7 +20,7 @@ String to be used in the title slot.
   </template>
 </KCard>
 
-```vue
+```html
 <KCard title="Title">
   <template v-slot:body>
     I am the body.
@@ -36,7 +36,7 @@ If the title is omitted, then KCard acts as a generic Box element.
   </template>
 </KCard>
 
-```vue
+```html
 <KCard>
   <template v-slot:body>
     I am a box. I have padding and a border. Useful for composing other components
@@ -63,7 +63,7 @@ Example composing `KCard` with other Kongponents to make another component:
   </template>
 </KCard>
 
-```vue
+```html
 <KCard :hasHover="true">
   <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
@@ -88,7 +88,7 @@ String to be used in the `statusHat` slot.
 
 <KCard status="My status" title="My title" body="My body" />
 
-```vue
+```html
 <KCard status="My status" title="My title" body="My body" />
 ```
 
@@ -98,7 +98,7 @@ String to be used in the body slot.
 
 <KCard body="I am the body."/>
 
-```vue
+```html
 <KCard body="I am the body."/>
 ```
 
@@ -115,7 +115,7 @@ Sets top border or no border. If neither set default will have border
   <KCard title="Card with top border" body="Body Content" border-variant="borderTop"/>
 </div>
 
-```vue
+```html
 <KCard title="Card without border" body="Body Content" border-variant="noBorder"/>
 
 <KCard title="Card with top border" body="Body Content" border-variant="borderTop"/>
@@ -127,7 +127,7 @@ Set if card should have shadow state (shadow) on hover
 
 <KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" has-hover />
 
-```vue
+```html
 <KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" has-hover />
 ```
 
@@ -137,7 +137,7 @@ Set if the card should always have shadow state (shadow)
 
 <KCard title="hasShadow" body="This card always has a shadow" has-shadow />
 
-```vue
+```html
 <KCard title="hasShadow" body="This card always has a shadow" has-shadow />
 ```
 
@@ -178,7 +178,7 @@ Cards can be arranged with flex box.
   </KCard>
 </div>
 
-```vue
+```html
 <div class="d-flex flex-row">
   <KCard title="Left" class="w-auto" body="This card only has a title" />
   <KCard title="Center" class="w-auto mx-5" body="This card always has a icon button">
@@ -230,7 +230,7 @@ Cards can be arranged with flex box.
   </template>
 </KCard>
 
-```vue
+```html
 <KCard>
   <template v-slot:statusHat>
     <KIcon
@@ -273,7 +273,7 @@ An Example of changing the background might look like.
     hasShadow />
 </div>
 
-```vue
+```html
 <template>
   <KCard
     title="Colorful Title"

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -4,7 +4,7 @@
 
 <KCatalog :fetcher="fetcherXs" />
 
-```vue
+```html
 <KCatalog :fetcher="fetcher" />
 ```
 
@@ -23,7 +23,7 @@ The catalog title.
 
 <KCatalog title="Look Mah!" :fetcher="fetcherXs" />
 
-```vue
+```html
 <KCatalog title="Look Mah!" :fetcher="fetcher" />
 ```
 
@@ -35,7 +35,7 @@ Size of the cards. Supports values `small`, `medium` (default), and `large`.
 <KCatalog title="Medium Cards" :fetcher="fetcherXs" />
 <KCatalog title="Large Cards" :fetcher="fetcherXs" cardSize="large" />
 
-```vue
+```html
 <KCatalog title="Small Cards" :fetcher="fetcher" cardSize="small" />
 <KCatalog title="Medium Cards" :fetcher="fetcher" />
 <KCatalog title="Large Cards" :fetcher="fetcher" cardSize="large" />
@@ -49,7 +49,7 @@ to turn it off.
 <KCatalog title="Truncate me" :fetcher="fetcherLong" />
 <KCatalog title="No truncation allowed!!" :fetcher="fetcherLong" no-truncation />
 
-```vue
+```html
 const longItem = {
   title: "Item long",
   description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas in tempus lorem, et molestie quam. Praesent sapien massa, posuere et volutpat nec, imperdiet a dui. Fusce non leo posuere, molestie neque et, posuere ex. Nullam euismod tortor in est sagittis iaculis. In sodales bibendum nulla nec feugiat."
@@ -121,7 +121,7 @@ will default to the following values:
 The fetcher functionality makes use of [SWRV](https://docs-swrv.netlify.app/) to handle caching of response data. Whenever the cache key is changed the fetcher will automatically
 refire and repopulate the table data.
 
-```vue
+```html
 <template>
   <KCatalog
     :fetcher="fetcher"
@@ -177,7 +177,7 @@ Set this to `true` to limit pagination navigation to `previous` / `next` page on
 
 <KCatalog :fetcher="fetcher" :disablePaginationPageJump="true" :paginationPageSizes="[4, 5, 6]" :initial-fetcher-params="{ pageSize: 4, page: 1 }" />
 
-```vue
+```html
 <template>
   <KCatalog :fetcher="fetcher" :disablePaginationPageJump="true" />
 </template>
@@ -206,7 +206,7 @@ a wrapper around `KCard` to display correctly inside `KCatalog`. You can use the
 
 - `truncate` - a boolean (default to `true`), whether or not to truncate the `description` text.
 
-```vue
+```html
 <KCatalogItem :item="item" :truncate="false" class="catalog-item" />
 ```
 
@@ -215,7 +215,7 @@ a wrapper around `KCard` to display correctly inside `KCatalog`. You can use the
 - `cardTitle` - the title content for the card
 - `cardBody` - the body content for the card
 
-```vue
+```html
 <KCatalogItem>
   <template v-slot:cardTitle>
     <KIcon
@@ -234,7 +234,7 @@ a wrapper around `KCard` to display correctly inside `KCatalog`. You can use the
 
 <KCatalog title="Empty catalog" :fetcher="emptyFetcher" />
 
-```vue
+```html
 <KCatalog title="Empty catalog" :fetcher="emptyFetcher" />
 ```
 
@@ -253,7 +253,7 @@ If using a CTA button, a `KCatalog-empty-state-cta-clicked` event is fired when 
 
 <KCatalog :fetcher="emptyFetcher" title="Customized empty catalog" emptyStateTitle="No Workspaces exist" emptyStateMessage="Adding a new Workspace will populate this catalog." emptyStateActionMessage="Create a Workspace" emptyStateActionRoute="#empty-state-full-example" emptyStateIcon="workspaces" emptyStateIconColor="#5996ff" emptyStateIconSize="35" />
 
-```vue
+```html
 <!-- Using a route string -->
 <KCatalog
   title="Customized empty catalog"
@@ -292,7 +292,7 @@ Set the `hasError` prop to `true` to enable the error state.
 
 <KCatalog title="Catalog with error" :fetcher="fetcherXs" :hasError="true" />
 
-```vue
+```html
 <KCatalog title="Empty catalog" :fetcher="fetcher" :hasError="true" />
 ```
 
@@ -321,7 +321,7 @@ If using a CTA button, a `KCatalog-error-cta-clicked` event is fired when clicke
   errorStateIconSize="35"
 />
 
-```vue
+```html
 <!-- Using a route string -->
 <KCatalog
   title="Catalog with error"
@@ -362,7 +362,7 @@ Set the `isLoading` prop to `true` to enable the loading state.
 
 <KCatalog title="Loading catalog" :fetcher="fetcherXs" :isLoading="true" />
 
-```vue
+```html
 <KCatalog title="Loading catalog" :fetcher="fetcher" :isLoading="true" />
 ```
 
@@ -385,7 +385,7 @@ If used in conjuction with a `fetcher` you have the option of using the returned
   </template>
 </KCatalog>
 
-```vue
+```html
 <KCatalog :fetcher="fetcher" title="Customized body">
   <template v-slot:body="{ data }">
     <div v-for="item in data">
@@ -411,7 +411,7 @@ Use the `cardTitle` and `cardBody` slots to access `item` specific data.
   </template>
 </KCatalog>
 
-```vue
+```html
 <KCatalog :fetcher="fetcher" title="Customized cards">
   <template v-slot:cardTitle="{ item }">
     <div class="color-blue-500">
@@ -449,7 +449,7 @@ the section above or completely slot in your own content.
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KCatalog :fetcher="() => { return { data: [] } }">
     <template v-slot:empty-state>
@@ -491,7 +491,7 @@ Example URL
 https://kongponents.dev/api/components?_page=1&_limit=10
 ```
 
-```vue
+```html
 <!-- Example Component Usage -->
 
 <KCard>

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -8,7 +8,7 @@
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KCheckbox
     v-model="checked"
@@ -49,7 +49,7 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
   </template>
 </KCard>
 
-```vue
+```html
 <KCheckbox v-model="checked">
   {{ checked ? 'Checked!' : 'Unchecked' }}
 </KCheckbox>
@@ -59,7 +59,7 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/api/composition-api-setup.html#setup-context).
 
-```vue
+```html
 <KCheckbox v-model="checked" disabled />
 ```
 
@@ -74,7 +74,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 - `default` - Anything passed in to the default slot will replace the label prop text
 
-```vue
+```html
 <KCheckbox v-model="checkbox1">
   Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}
 </KCheckbox>
@@ -123,7 +123,7 @@ An Example of changing the background color of KCheckbox to `blueviolet` might l
   <KCheckbox v-model="themeChecked"/>
 </div>
 
-```vue
+```html
 <template>
   <div class="KCheckbox-wrapper">
     <KCheckbox v-model="checked"/>

--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -7,7 +7,7 @@
   <template v-slot:message>Message</template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState cta-text="CTA Button">
   <template v-slot:title>EmptyState Title</template>
   <template v-slot:message>EmptyState Message</template>
@@ -25,7 +25,7 @@ Boolean value used to hide the call to action button.
   <template v-slot:message>You do not have any content here 😉️</template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState cta-is-hidden>
   <template v-slot:title>No Content</template>
   <template v-slot:message>You do not have any content here 😉️</template>
@@ -39,7 +39,7 @@ You can also use this to move your call to action into the message text.
   <template v-slot:message><router-link to="/">Add a Service</router-link> to begin proxying traffic.</template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState cta-is-hidden>
   <template v-slot:title>No Services</template>
   <template v-slot:message><router-link>Add a Service</router-link> to begin proxying traffic</template>
@@ -55,7 +55,7 @@ A string to be used as the text content of the call to action button.
   <template v-slot:message>You do not have any content here 😉️</template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState cta-text="button text">
   <template v-slot:title>No Content</template>
   <template v-slot:message>You do not have any content here 😉️</template>
@@ -71,7 +71,7 @@ A function that is passed as the click handler for the call to action button
   <template v-slot:message>You do not have any content here 😉️</template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState cta-text="Click Me!" :handle-click="clickFunction">
   <template v-slot:title>No Content</template>
   <template v-slot:message>You do not have any content here 😉️</template>
@@ -106,7 +106,7 @@ A flag denoting whether or not the message is an error message. If so, a warning
   </template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState :cta-is-hidden="true" :is-error="true">
   <template v-slot:message>
     <h3>
@@ -128,7 +128,7 @@ A string for the `KIcon` name to be displayed directly above the title. Specifyi
   </template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState :cta-is-hidden="true" icon="support">
   <template v-slot:message>
     <h3>
@@ -150,7 +150,7 @@ A number denoting the size of the icon to be displayed above the empty state mes
   </template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState :cta-is-hidden="true" :is-error="true" icon-size="40">
   <template v-slot:message>
     <h3>
@@ -174,7 +174,7 @@ A string denoting the color of the icon to be displayed above the empty state me
   </template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState :cta-is-hidden="true" :is-error="true" icon-size="40" icon-color="#5996ff">
   <template v-slot:title>No users exist</template>
   <template v-slot:message>
@@ -198,7 +198,7 @@ A string denoting the color of the icon to be displayed above the empty state me
   </template>
 </KEmptyState>
 
-```vue
+```html
 <KEmptyState icon="kong">
   <template v-slot:cta>
   <template v-slot:title>Look Mah!</template>
@@ -225,7 +225,7 @@ An Example of what using theming might look like.
   </KEmptyState>
 </div>
 
-```vue
+```html
 <div class="custom-empty-state">
   <KEmptyState cta-text="CTA Button">
     <template v-slot:title>EmptyState Title</template>

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -4,7 +4,7 @@
 
 <KIcon icon="dashboard" />
 
-```vue
+```html
 <KIcon icon="dashboard" />
 ```
 
@@ -43,7 +43,7 @@ This prop takes a string that will replace the SVG default height and width. If 
 
 <KIcon icon="gear" size="50" />
 
-```vue
+```html
 <KIcon icon="gear" size="50" />
 ```
 
@@ -53,7 +53,7 @@ Overrides the default svg color.
 
 <KIcon icon="list" color="red" />
 
-```vue
+```html
 <KIcon icon="list" color="red" />
 ```
 
@@ -63,7 +63,7 @@ Overrides the secondary svg color (if one exists).
 
 <KIcon icon="warning" color="var(--black-70)" secondaryColor="var(--yellow-400)" />
 
-```vue
+```html
 <KIcon icon="warning" color="var(--black-70)" secondaryColor="var(--yellow-400)" />
 ```
 
@@ -83,7 +83,7 @@ The title to be announced by screenreaders and displayed on hover. If not provid
 <KIcon icon="warning" class="mr-2"/>
 <KIcon icon="warning" title="Custom Title" />
 
-```vue
+```html
 <KIcon icon="warning" />
 <KIcon icon="warning" title="Custom Title" />
 ```
@@ -102,7 +102,7 @@ You can read more about the viewBox attribute
 
 <KIcon icon="cogwheel" viewBox="0 0 16 16" />
 
-```vue
+```html
 <KIcon icon="cogwheel" viewBox="0 0 16 16" />
 ```
 
@@ -146,7 +146,7 @@ You can read more about the viewBox attribute
   </template>
 </KIcon>
 
-```vue
+```html
 <KIcon icon="check" size="50" color="url('#linear-gradient')">
   <template v-slot:svgElements>
     <defs>

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -8,7 +8,7 @@
 
 > The `KComponent` component is used in this example to create state.
 
-```vue
+```html
 <KComponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
   <KInlineEdit>
     <h3>{{ data.inlineText }}</h3>
@@ -28,7 +28,7 @@ If true, will not set the value of the input when enabled/clicked. This is usefu
 
 > The `KComponent` component is used in this example to create state.
 
-```vue
+```html
 <KComponent :data="{ inlineText: '' }" v-slot="{ data }">
   <KInlineEdit
     :ignore-value="data.inlineText.length === 0"
@@ -48,7 +48,7 @@ Styles to set when the input is active. Useful when styling the default state di
 
 > The `KComponent` component is used in this example to create state.
 
-```vue
+```html
 <KComponent :data="{ inlineText: '' }" v-slot="{ data }">
   <KInlineEdit
     :ignore-value="data.inlineText.length === 0"
@@ -88,7 +88,7 @@ While the component itself does not protect against returning empty an empty val
 
 > The `KComponent` component is used in this example to create state.
 
-```vue
+```html
 <KComponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
   <div>
     Updated: {{ data.inlineText }}
@@ -106,7 +106,7 @@ While the component itself does not protect against returning empty an empty val
 :::warning
 An HTML element must be passed in the slot. An error will be thrown if not passed.
 
-```vue
+```html
 <!-- good -->
 <KInlineEdit>
   <p>Some text</p>
@@ -128,7 +128,7 @@ An HTML element must be passed in the slot. An error will be thrown if not passe
   <KInlineEdit class="w-50" @changed="newVal => data.inlineText = newVal"><h3>{{ data.inlineText }}</h3></KInlineEdit>
 </KComponent>
 
-```vue
+```html
 <KInlineEdit
   class="w-50"
   @changed="newVal => text = newVal">

--- a/docs/components/input-switch.md
+++ b/docs/components/input-switch.md
@@ -4,7 +4,7 @@
 
 <KInputSwitch v-model="defaultChecked" @change="handleToggle" />
 
-```vue
+```html
 <template>
   <KInputSwitch v-model="defaultChecked" @change="handleToggle" />
 </template>
@@ -35,7 +35,7 @@ export default defineComponent({
 
 Use `v-model` to bind to the `checked` state of the underlying `<input />`. The `v-model` binds to the `value` prop of the component and sets current checked state of toggle switch. You can read more about passing values via `v-model` [here](https://vuejs.org/guide/components/events.html#usage-with-v-model).
 
-```vue
+```html
 <KInputSwitch v-model="isChecked" />
 ```
 
@@ -43,7 +43,7 @@ Use `v-model` to bind to the `checked` state of the underlying `<input />`. The 
 
 Will place label text to the right of the switch. Can also be [slotted](#slots).
 
-```vue
+```html
 <KInputSwitch v-model="checked" :label="checked ? 'on' : 'off'" />
 ```
 
@@ -58,7 +58,7 @@ Position the label to the left or right of the switch, default to `right`.
 <br>
 <KInputSwitch v-model="labelPropChecked" label="Label on the left" labelPosition="left" />
 
-```vue
+```html
 <KInputSwitch label="Label on the right" />
 <KInputSwitch label="Label on the left" label-position="left" />
 ```
@@ -67,7 +67,7 @@ Position the label to the left or right of the switch, default to `right`.
 
 You can add `disabled` to the input to disallow interactivity.
 
-```vue
+```html
 <KInputSwitch v-model="checked" label="disabled" disabled />
 ```
 
@@ -77,7 +77,7 @@ You can add `disabled` to the input to disallow interactivity.
 
 You can specify tooltip text to be displayed when the switch is disabled.
 
-```vue
+```html
 <KInputSwitch v-model="checked" label="disabled" disabled disabledTooltipText="I'm disabled!" />
 ```
 
@@ -92,7 +92,7 @@ You can specify tooltip text to be displayed when the switch is disabled.
 
 Display a check icon when switch is enabled
 
-```vue
+```html
 <KInputSwitch v-model="enabledIconChecked" :label="enabledIconChecked ? 'Enabled' : 'Disabled'" enabled-icon />
 ```
 
@@ -112,7 +112,7 @@ Display a check icon when switch is enabled
   </template>
 </KInputSwitch>
 
-```vue
+```html
 <template>
   <KInputSwitch v-model="checked">
     <template v-slot:label>
@@ -152,7 +152,7 @@ To listen for changes to the `KInputSwitch` value, you can bind to the `@input`,
   </div>
 </KComponent>
 
-```vue
+```html
 <template>
   <KInputSwitch
     :model-value="false"
@@ -171,7 +171,7 @@ To listen for changes to the `KInputSwitch` value, you can bind to the `@input`,
   </div>
 </KComponent>
 
-```vue
+```html
 <template>
   <div>
     <KInputSwitch v-model="eventsSwitchEnabled2" @change="e => (changeCount++)" label="Toggle Me" />
@@ -197,7 +197,7 @@ An Example of changing the success KInputSwitch on color to pink instead of Kong
   <KInputSwitch v-model="themeChecked" />
 </div>
 
-```vue
+```html
 <template>
   <div class="switch-wrapper">
     <KInputSwitch v-model="checked" />

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -4,7 +4,7 @@
 
 <KInput class="w-100" placeholder="Placeholder text" />
 
-```vue
+```html
 <KInput class="w-100" placeholder="Placeholder text" />
 ```
 
@@ -16,7 +16,7 @@ To set the value of the input element without using `v-model`, you can set the `
 
 <KInput model-value="This is the input value" placeholder="Placeholder text" />
 
-```vue
+```html
 <KInput model-value="This is the input value" placeholder="Placeholder text" />
 ```
 
@@ -27,7 +27,7 @@ String to be used as the input label.
 <KInput label="Name" placeholder="I'm labelled!" class="mb-2" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" />
 
-```vue
+```html
 <KInput label="Name" placeholder="I'm labelled!" class="mb-2" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" />
 ```
@@ -37,7 +37,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 <KLabel for="my-input">Label</KLabel>
 <KInput id="my-input" type="text" placeholder="I have a label" />
 
-```vue
+```html
 <KLabel for="my-input">Label</KLabel>
 <KInput id="my-input" type="text" placeholder="I have a label" />
 ```
@@ -48,7 +48,7 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 
 <KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' }"/>
 
-```vue
+```html
 <KInput label="Name" :label-attributes="{   help: 'I use the KLabel `help` prop' }" />
 ```
 ### overlayLabel
@@ -59,7 +59,7 @@ Make sure that if you are using the built in label you specify the `--KInputBack
 <KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" />
 
-```vue
+```html
 <KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" />
 ```
@@ -72,7 +72,7 @@ You can specify `small`, `medium` (default), or `large` for the size.
 <KInput label="Medium" class="mb-2" />
 <KInput label="Large" size="large" />
 
-```vue
+```html
 <KInput label="Small" size="small" class="mb-2" />
 <KInput label="Medium" class="mb-2" />
 <KInput label="Large" size="large" />
@@ -84,7 +84,7 @@ String to be displayed as help text.
 
 <KInput help="I can help with that" placeholder="Need help?" />
 
-```vue
+```html
 <KInput help="I can help with that" placeholder="Need help?" />
 ```
 
@@ -93,7 +93,7 @@ You also have the option of using the `.help` utility class. This is meant to be
 <KInput type="text" placeholder="Need help?" />
 <p class="help">I can help with that</p>
 
-```vue
+```html
 <template>
   <KInput type="text" placeholder="Need help?" />
   <p class="help">I can help with that</p>
@@ -106,7 +106,7 @@ Use this prop to specify a character limit for the input. See the [`@char-limit-
 
 <KInput model-value="This field has too many characters" :character-limit="10" class="w-100" placeholder="Placeholder text" />
 
-```vue
+```html
 <KInput model-value="This field has too many characters" :character-limit="10" class="w-100" placeholder="Placeholder text" />
 ```
 
@@ -119,7 +119,7 @@ You may also specify a native `maxlength` attribute on the `KInput` to actually 
 
 <KInput :character-limit="10" maxlength="10" placeholder="Type..."/>
 
-```vue
+```html
 <KInput :character-limit="10" maxlength="10" placeholder="Type..."/>
 ```
 
@@ -135,7 +135,7 @@ String to be displayed as error message if `hasError` prop is `true`.
 
 <KInput class="w-100" hasError errorMessage="Service name should not contain '_'" />
 
-```vue
+```html
 <KInput class="w-100" hasError errorMessage="Service name should not contain '_'"/>
 ```
 
@@ -143,7 +143,7 @@ String to be displayed as error message if `hasError` prop is `true`.
 <KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" />
 
-```vue
+```html
 <KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain '_'" />
 <KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" />
@@ -153,7 +153,7 @@ String to be displayed as error message if `hasError` prop is `true`.
 <KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 
-```vue
+```html
 <KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 <KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
@@ -174,7 +174,7 @@ You can pass any input attribute and it will get properly bound to the element.
 
 > Note: Add the `input-error` class to add custom error styling
 
-```vue
+```html
 <KInput placeholder="placeholder" />
 <KInput type="password" model-value="123" />
 <KInput type="number" model-value="1"/>
@@ -230,14 +230,14 @@ To listen for changes to the `KInput` value, you can bind to the `@input` or `@u
 <KLabel>{{ inputText }}</KLabel>
 <KInput model-value="This is the input value" @update:modelValue="newValue => inputText = newValue" />
 
-```vue
+```html
 <KLabel>{{ inputText }}</KLabel>
 <KInput model-value="This is the input value" @update:modelValue="newValue => inputText = newValue" />
 ```
 
 ### `char-limit-exceeded`
 
-```vue
+```html
 <KInput @char-limit-exceeded="exampleFunction" />
 ```
 
@@ -260,7 +260,7 @@ Fired when the text starts or stops exceeding the limit, returns an object:
   </div>
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{myInput2: 'hello'}" v-slot="{ data }">
   <div>
     <KInput
@@ -289,7 +289,7 @@ An Example of changing the error border color of KInput to pink might look like:
 
 <KInput class="custom-input" has-error type="email" model-value="error" />
 
-```vue
+```html
 <template>
   <KInput class="custom-input" has-error type="email" model-value="error" />
 </template>

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -4,7 +4,7 @@
 
 <KLabel>Input Title</KLabel>
 
-```vue
+```html
 <KLabel>Input Title</KLabel>
 ```
 
@@ -16,13 +16,13 @@ Use the `help` prop to display helper tooltip text.
 
 <KLabel help="This is an example">Input Title</KLabel>
 
-```vue
+```html
 <KLabel help="This is an example">Input Title</KLabel>
 ```
 
 <KLabel help="This is a really long tooltip. Hopefully we won't have anything this long but we might. I wonder how it handles long inputs">Long Input Title</KLabel>
 
-```vue
+```html
 <KLabel help="This is a really long tooltip. Hopefully we won't have anything this long but we might. I wonder how it handles long inputs">
   Long Input Title
 </KLabel>
@@ -34,7 +34,7 @@ Use the `info` prop to display information help text.
 
 <KLabel info="This is an example">Input Title</KLabel>
 
-```vue
+```html
 <KLabel info="This is an example">Input Title</KLabel>
 ```
 
@@ -44,7 +44,7 @@ Use the `tooltipAttributes` prop to configure the **KTooltip's** [props](/compon
 
 <KLabel :tooltip-attributes="{ placement: 'right', 'max-width': '200' }" help="This is a really long tooltip. Hopefully we won't have anything this long but we might. I wonder how it handles long inputs">With Tooltip Attributes</KLabel>
 
-```vue
+```html
 <KLabel
   :tooltip-attributes="{ placement: 'right', 'max-width': '200' }"
   help="This is a really long tooltip. Hopefully we won't have anything this long but we might. I wonder how it handles long inputs"
@@ -62,7 +62,7 @@ Use the `for` attribute to bind a label to an input element for accessibility.
 <KLabel for="service">Service Name</KLabel>
 <KInput id="service"/>
 
-```vue
+```html
 <KLabel for="service" help="A service is an API that you want to offer">Service Name</KLabel>
 <KInput id="service"/>
 ```

--- a/docs/components/menu.md
+++ b/docs/components/menu.md
@@ -4,7 +4,7 @@
 
 <KMenu :items="getMenuItems(5)" />
 
-```vue
+```html
 <KMenu :items="items" />
 ```
 
@@ -37,7 +37,7 @@ Properties:
 
 <KMenu :items="getMenuItems(6)" />
 
-```vue
+```html
 <template>
   <KMenu :items="getMenuItems(6)" />
 </template>
@@ -76,7 +76,7 @@ By default the `width` is set to `284px`.
 
 <KMenu :items="getMenuItems(3)" width="735" />
 
-```vue
+```html
 <KMenu :items="getMenuItems(3)" width="735" />
 ```
 
@@ -101,7 +101,7 @@ By default the `width` is set to `284px`.
 - `expandable` - boolean of whether or not this item is expandable
 - `lastMenuItem` - boolean of whether or not this is the last item in the menu (for styling)
 
-```vue
+```html
   <KMenuItem :item="{ title: 'some title', description: 'some description' }" :expandable="true" type="string" />
 ```
 
@@ -110,7 +110,7 @@ By default the `width` is set to `284px`.
 - `itemTitle` - the title content for the menu item
 - `itemBody` - the body content for the menu item
 
-```vue
+```html
 <KMenuItem>
   <template v-slot:itemTitle>
     Custom Title!
@@ -153,7 +153,7 @@ By default the `width` is set to `284px`.
   </template>
 </KMenu>
 
-```vue
+```html
 <KMenu>
   <template v-slot:body>
     <KMenuItem v-for="item in getMenuItems(3)" :item="item" />

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -13,7 +13,7 @@ The **KModalFullscreen** component is used to show content in a full screen moda
   <p>Cras porttitor malesuada lorem vel malesuada. Fusce at hendrerit enim. Suspendisse potenti. Nullam interdum maximus dolor, et commodo urna imperdiet condimentum. Nunc hendrerit arcu eu libero sodales, sed auctor nibh sodales. Nunc mattis tortor eleifend, rutrum justo non, malesuada massa. Integer aliquet accumsan ex, et consequat urna egestas pretium.</p>
 </KModalFullscreen>
 
-```vue
+```html
 <KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
 
 <KModalFullscreen
@@ -81,7 +81,7 @@ Change the [appearance](/components/button.html#props) of the save/proceed butto
   <p>Nunc ante orci, tempus a fringilla quis, interdum et nisi. Nulla a dui ut leo scelerisque rhoncus. Suspendisse iaculis, orci quis congue sollicitudin, orci ligula tempus nisl, consequat elementum urna elit sit amet orci. Pellentesque in feugiat massa, ac dapibus nunc. Etiam dapibus vehicula elit, a sollicitudin nulla fringilla in. Pellentesque lobortis arcu lectus, sit amet fringilla quam pretium sit amet. Sed mi turpis, bibendum quis tincidunt vel, mattis finibus lorem. Ut imperdiet ultrices libero in dictum. Duis elementum imperdiet erat in feugiat. Nam tempor interdum tellus non auctor. Quisque sed sodales purus. Nunc eu est ac elit aliquet euismod. Fusce pellentesque, lorem sed elementum placerat, dolor felis scelerisque quam, ut placerat elit dolor sit amet dui.</p>
 </KModalFullscreen>
 
-```vue
+```html
 <KButton appearance="primary" @click="contentIsOpen = true">Open Modal</KButton>
 
 <KModalFullscreen
@@ -133,7 +133,7 @@ There are 6 designated slots you can use to display content in the fullscreen mo
   <KCatalog :fetcher="() => getItems(16)" />
 </KModalFullscreen>
 
-```vue
+```html
 <KButton appearance="primary" @click="exampleIsOpen = true">Open Fullscreen Modal</KButton>
 
 <KModalFullscreen
@@ -219,7 +219,7 @@ There are 6 designated slots you can use to display content in the fullscreen mo
   </div>
 </KModalFullscreen>
 
-```vue
+```html
 <KButton appearance="primary" @click="sampleIsOpen = true">Open Form Modal</KButton>
 
 <KModalFullscreen
@@ -320,7 +320,7 @@ An Example of changing the the colors of KModalFullscreen might look like.
   </KModalFullscreen>
 </div>
 
-```vue
+```html
 
 <KButton appearance="primary" @click="themeIsOpen = true">Open Modal</KButton>
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -6,7 +6,7 @@ The **KModal** component is used to show content on top of existing UI. Typicall
 
 <KModal title="Look Mah!" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris accumsan tincidunt velit ac vulputate. Aliquam turpis odio, elementum a hendrerit id, pellentesque quis ligula. Nulla ultricies sit amet nisi vitae congue. Quisque vitae ullamcorper leo, id pretium mi. Nam sed odio dapibus, dapibus augue at, pulvinar est." :isVisible="defaultIsOpen" @proceed="defaultIsOpen = false" @canceled="defaultIsOpen = false" />
 
-```vue
+```html
 <template>
   <div>
     <KModal
@@ -102,7 +102,7 @@ Notice that even though we are using the `header-content` slot we still specify 
   </template>
 </KModal>
 
-```vue
+```html
 <template>
   <KModal
     :isVisible="isVisible"
@@ -150,7 +150,7 @@ An Example of changing the the colors of KModal might look like.
     @canceled="themeIsOpen = false" />
 </div>
 
-```vue
+```html
 <template>
   <div class="modal-wrapper">
     <KModal

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -10,7 +10,7 @@
 
 A total number of items inside the paginated data source. This prop is **required**.
 
-```vue
+```html
 <KPagination :totalCount="50"/>
 ```
 
@@ -24,7 +24,7 @@ You can provide custom page sizes. The first one in the array will be the initia
 
 <KPagination :totalCount="100" :pageSizes="[10, 20, 30, 40]"/>
 
-```vue
+```html
 <KPagination :totalCount="100" :pageSizes="[10, 20, 30, 40]"/>
 ```
 
@@ -36,7 +36,7 @@ Prop is a Number. If the value is not set, the first one of the available pageSi
 
 <KPagination :totalCount="100" :pageSizes="[10, 20, 30, 40]" :initialPageSize="20"/>
 
-```vue
+```html
 <KPagination :totalCount="100" :pageSizes="[10, 20, 30, 40]" :initialPageSize="20"/>
 ```
 
@@ -56,7 +56,7 @@ Optional array of items that can be provided for easy pagination. Slice of this 
   </div>
 </KComponent>
 
-```vue
+```html
 <template>
   <div>
     <span><b>Visible letters: </b></span>
@@ -92,7 +92,7 @@ A number that sets the neighboring pages visible to the left and right of the ce
 
 <KPagination :totalCount="1000" :neighbors="2"/>
 
-```vue
+```html
 <KPagination :totalCount="1000" :pageSize="15" neighbors="2"/>
 ```
 
@@ -108,7 +108,7 @@ Restrict navigation to only `previous` / `next` page. Defaults to `false`.
   </div>
 </KComponent>
 
-```vue
+```html
 <template>
   <div>
     <span><b>Visible letters: </b></span>
@@ -156,7 +156,7 @@ Manually control the current page instead of using native handling. If using thi
   </div>
 </KComponent>
 
-```vue
+```html
 <template>
   <div>
     <span><b>Visible letters: </b></span>
@@ -245,7 +245,7 @@ Pass in a boolean value for whether or not the offset-based Next button should b
   </div>
 </KComponent>
 
-```vue
+```html
 <template>
   <div>
     <KCard title="Cool names list">
@@ -305,7 +305,7 @@ An Example of changing the border color of KPagination to lime might look like:
   <KPagination :totalCount="100" :pageSizes="[10, 20, 30, 40]"/>
 </div>
 
-```vue
+```html
 <template>
   <div class="KPagination-wrapper">
     <KPagination :totalCount="100" :pageSizes="[10, 20, 30, 40]"/>

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -11,7 +11,7 @@ For example a button:
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -33,7 +33,7 @@ the default slot.
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" buttonText="Click Me!">
   <template v-slot:content>
     You clicked me!
@@ -53,7 +53,7 @@ This is the target `element` that the <code>popover</code> is appended to. By de
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -67,7 +67,7 @@ This is the target `element` that the <code>popover</code> is appended to. By de
 
 This is the tag that the popover is wrapped around. By default its the div tag.
 
-```vue
+```html
 <KPop title="Cool header" tag="details">
   <KButton>button</KButton>
   <template v-slot:content>I am inside a &lt;details/&gt; block!</template>
@@ -92,7 +92,7 @@ This is the Title of the popover. Either this or the title slot needs to be fill
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="I am a new sample header">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -111,7 +111,7 @@ or alternatively, via the slot:
   <template v-slot:content>I am some sample text!</template>
 </KPop>
 
-```vue
+```html
 <KPop>
   <template>
     <KButton>button</KButton>
@@ -137,7 +137,7 @@ Here are the different options:
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" trigger="hover">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -175,7 +175,7 @@ Here are the different options:
   </template>
 </KPop>
 
-```vue
+```html
 <template>
 <select v-model="selectedPosition">
   <option
@@ -237,7 +237,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
   </KPop>
 </div>
 
-```vue
+```html
 <div style="width: 300px; height: 125px; position: relative; overflow: hidden; z-index: 1; background-color: var(--red-100);">
   <KPop
     title="Look Mah!"
@@ -266,7 +266,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
   </KPop>
 </div>
 
-```vue
+```html
 <div style="width: 300px; height: 125px; position: relative; overflow: hidden; z-index: 1; background-color: var(--blue-100);">
   <KPop
     title="Look Mah!"
@@ -293,7 +293,7 @@ The width of the popover body - by default it is `200px`. Currently we support n
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" width="300">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -313,7 +313,7 @@ The max width of the popover body - by default it is `auto`.
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" max-width="500">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -326,7 +326,7 @@ The max width of the popover body - by default it is `auto`.
 
 Custom classes that you want to append to the popover - by default it has a `k-popover` class on it.
 
-```vue
+```html
 <KPop title="Cool header" popoverClasses="my-class">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -339,7 +339,7 @@ Custom classes that you want to append to the popover - by default it has a `k-p
 
 Custom transitions that you want the popover to have - by default it uses a `fade` transition.
 
-```vue
+```html
 <KPop title="Cool header" popoverTransitions="slide">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -359,7 +359,7 @@ Custom timeout setting that you want the popover to have - by default it is set 
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" :popover-timeout="1000">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -372,7 +372,7 @@ Custom timeout setting that you want the popover to have - by default it is set 
 
 You can pass in an optional flag to trigger the popover to hide - useful for external events like zooming or panning - by default it is set to `false`.
 
-```vue
+```html
 <KPop title="Cool header" hidePopover="zoom()">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -385,7 +385,7 @@ You can pass in an optional flag to trigger the popover to hide - useful for ext
 
 You can pass in an optional flag to disable the popover - by default it is set to `false`.
 
-```vue
+```html
 <KPop title="Cool header" disabled="true">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -405,7 +405,7 @@ You can pass in an optional flag to not show the caret on the edge of the popove
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" hide-caret placement="right">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -428,7 +428,7 @@ The callback function can optionally return a boolean, which will show or hide t
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
   <template v-slot:content>
@@ -467,7 +467,7 @@ To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` pro
   </KPop>
 </svg>
 
-```vue
+```html
 <svg v-for="light in ['red', 'yellow', 'green']">
   <KPop trigger="hover" title="Light" :is-svg="true" tag="g" :popover-timeout="10">
     <template v-slot:content>
@@ -482,7 +482,7 @@ To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` pro
 
 - `default` There is a main slot that takes in the element you want the popover to be triggered over.
 
-```vue
+```html
 <KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
@@ -493,7 +493,7 @@ To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` pro
 
 There is an optional title slot that can take in an element for the title. The title could alternatively be populated via the prop.
 
-```vue
+```html
 <KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
@@ -508,7 +508,7 @@ There is an optional title slot that can take in an element for the title. The t
 
 An optional slot for an actions button in the upper right corner of the popover.
 
-```vue
+```html
 <KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
@@ -523,7 +523,7 @@ An optional slot for an actions button in the upper right corner of the popover.
 
 This is the slot that takes in the content of the popover.
 
-```vue
+```html
 <KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
@@ -539,7 +539,7 @@ This is the slot that takes in the content of the popover.
 This is an optional slot that takes in content for the footer bar. This typically is an actionable element like
 a button or link.
 
-```vue
+```html
 <KPop title="Cool header">
   <!-- Your element goes here -->
   <KButton>button</KButton>
@@ -568,7 +568,7 @@ Example:
   </template>
 </KPop>
 
-```vue
+```html
 <KPop title="Notifications" :on-popover-click="toggle" width="500">
   <KButton>Fire!</KButton>
   <template v-slot:title>
@@ -674,7 +674,7 @@ export default defineComponent({
 })
 </script>
 
-```vue
+```html
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <template v-slot:content>

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -11,7 +11,7 @@ The **KPrompt** component is used to display a dialog that prompts a user to tak
   @proceed="defaultIsOpen = false"
 />
 
-```vue
+```html
 <KButton appearance="primary" @click="defaultIsOpen = true">Prompt</KButton>
 
 <KPrompt :is-visible="defaultIsOpen" message="Hello, World?" @canceled="defaultIsOpen = false" @proceed="defaultIsOpen = false" />
@@ -55,7 +55,7 @@ Text to display in body section if not using slot.
   @proceed="contentIsOpen = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="contentIsOpen" title="Look Mah!" message="I'm prompting you" @canceled="contentIsOpen = false" @proceed="contentIsOpen = false" />
 ```
 
@@ -78,7 +78,7 @@ Change the text content of the close/cancel button.
   @proceed="buttonsIsOpen = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="contentIsOpen" actionButtonText="Let's do it!" cancelButtonText="Abort" @canceled="buttonsIsOpen = false" @proceed="buttonsIsOpen = false" />
 ```
 
@@ -96,7 +96,7 @@ This boolean indicates if an action is being taken on the dialog and we should d
   @proceed="pendingIsOpen = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="pendingIsOpen" message="Click Cancel to close me" :action-pending="true" @canceled="pendingIsOpen = false" @proceed="pendingIsOpen = false" />
 ```
 
@@ -117,7 +117,7 @@ Use the `info` prompt type to notify the user about general information associat
   @proceed="infoIsOpen = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="infoIsOpen" message="You have been informed 🕵🏻‍♂️" @canceled="infoIsOpen = false" @proceed="infoIsOpen = false" />
 ```
 
@@ -129,7 +129,7 @@ Use the `warning` prompt type if the user needs to be notified that there is a r
 
 <KPrompt :is-visible="warningIsOpen" title="Pay attention" message="I'm warning you 🤔" type="warning" @canceled="warningIsOpen = false" @proceed="warningIsOpen = false" />
 
-```vue
+```html
 <KPrompt :is-visible="warningIsOpen" message="I'm warning you 🤔" type="warning" @canceled="warningIsOpen = false" @proceed="warningIsOpen = false" />
 ```
 
@@ -147,7 +147,7 @@ Use the `danger` prompt type if the user is taking an irreversible action, like 
   @proceed="dangerIsOpen = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="dangerIsOpen" type="danger" message="This is dangerous ☠️" @canceled="dangerIsOpen = false" @proceed="dangerIsOpen = false" />
 ```
 
@@ -166,7 +166,7 @@ Provide a string the user must type before the action button becomes enabled
   @proceed="dangerConfirmIsOpen = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="dangerConfirmIsOpen" type="danger" message="This is dangerous ☠️" confirmationText="I Agree" @canceled="dangerConfirmIsOpen = false" @proceed="dangerConfirmIsOpen = false" />
 ```
 
@@ -185,7 +185,7 @@ If you don't want to `emit` the `proceed` event upon pressing the `Enter` key, y
   @proceed="preventProceed = false"
 />
 
-```vue
+```html
 <KPrompt :is-visible="preventProceed" type="danger" message="I don't care if you press Enter" prevent-proceed-on-enter @canceled="preventProceed = false" @proceed="preventProceed = false" />
 ```
 
@@ -212,7 +212,7 @@ There are 3 designated slots you can use to display content in the modal.
   </template>
 </KPrompt>
 
-```vue
+```html
 <KPrompt :is-visible="slotsIsOpen" @canceled="slotsIsOpen = false" @proceed="slotsIsOpen = false">
   <template v-slot:header-content>
     <KIcon icon="immunity" color="#7F01FE" class="mr-2" size="20" />

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -14,7 +14,7 @@
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KRadio name="test" :selected-value="true" v-model="radio">Boolean</KRadio>
   <KRadio name="test" selected-value="string" v-model="radio">String</KRadio>
@@ -56,7 +56,7 @@ The value of the `KRadio` option that will be emitted by the `change` and `updat
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/api/composition-api-setup.html#setup-context).
 
-```vue
+```html
 <KRadio v-model="checked" :selected-value="true" disabled>Disabled radio</KRadio>
 ```
 
@@ -80,7 +80,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
   </template>
 </KCard>
 
-```vue
+```html
 <KRadio v-model="selected" :selected-value="true">
   Label goes here. The radio is {{ selected ? 'selected' : 'not selected' }}
 </KRadio>
@@ -108,7 +108,7 @@ An Example of changing the background color of KRadio to lime might look like:
   <KRadio v-model="radioState" :selected-value="true" />
 </div>
 
-```vue
+```html
 <template>
   <div class="KRadio-wrapper">
     <KRadio v-model="selected" :selected-value="true" />

--- a/docs/components/renderless/clipboard-provider.md
+++ b/docs/components/renderless/clipboard-provider.md
@@ -13,7 +13,7 @@
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KInput :model-value="dataToCopy" @input="newValue => dataToCopy = newValue" type="text" class="mb-2 w-100" />
   <KClipboardProvider v-slot="{ copyToClipboard }">

--- a/docs/components/renderless/k-component.md
+++ b/docs/components/renderless/k-component.md
@@ -15,7 +15,7 @@ e.g.
   </div>
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{ count: 0 }" v-slot="{ data }">
   <div>
     <KButton size="small" appearance="outline" :isRounded="false" @click="data.count = data.count - 1">-</KButton>
@@ -68,7 +68,7 @@ them and placing them inside `KComponent`'s default slot.
   </template>
 </KCard>
 
-```vue
+```html
 <KCard class="mt-2" style="min-height: 100px;">
   <template v-slot:body>
     <KComponent :data="{ selected: '' }" v-slot="{ data }">

--- a/docs/components/renderless/toggle.md
+++ b/docs/components/renderless/toggle.md
@@ -18,7 +18,7 @@ e.g.
   </template>
 </KCard>
 
-```vue
+```html
 <KToggle v-slot="{isToggled, toggle}">
   <KButton @click="toggle">
     {{ isToggled.value ? 'toggled' : 'not toggled' }}
@@ -62,7 +62,7 @@ For instance, here we are toggling the state on `mouseover` and toggling back on
   </template>
 </KCard>
 
-```vue
+```html
 <KToggle v-slot="{isToggled, toggle}" :toggled="true">
   <div :style="{color: isToggled.value ? 'green' : 'red'}" @mouseover="toggle" @mouseout="toggle">
     {{ isToggled.value ? 'yes' : 'no' }}
@@ -84,7 +84,7 @@ For instance, here we are toggling the state on `mouseover` and toggling back on
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KToggle v-slot="{ toggle }" @toggled="sayHello">
     <KButton @click="toggle">keep clicking me</KButton>
@@ -131,7 +131,7 @@ them and placing them inside `KToggle`'s default slot.
   </template>
 </KCard>
 
-```vue
+```html
 <KToggle v-slot="{ isToggled, toggle }">
   <div>
     <KButton @click="toggle">
@@ -160,7 +160,7 @@ them and placing them inside `KToggle`'s default slot.
   </template>
 </KCard>
 
-```vue
+```html
 <KToggle v-slot="{isToggled, toggle}">
   <div>
     <KButton @click="toggle">
@@ -191,7 +191,7 @@ them and placing them inside `KToggle`'s default slot.
   </template>
 </KCard>
 
-```vue
+```html
 <KToggle v-slot="{isToggled, toggle}">
       <div>
         <KButton @click="toggle">

--- a/docs/components/segmented-control.md
+++ b/docs/components/segmented-control.md
@@ -6,7 +6,7 @@
   <KSegmentedControl :options="['Like it?','Love it!']" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{ selected: 'Like it?' }" v-slot="{ data }">
   <KSegmentedControl :options="['Like it?','Love it!']" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
@@ -40,7 +40,7 @@ export interface SegmentedControlOption {
   <KSegmentedControl :options="[{label:'Left',value:'left'},{label:'Middle',value:'middle'},{label:'Right',value:'right'}]" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{ selected: 'left' }" v-slot="{ data }">
   <KSegmentedControl :options="[{label:'Left',value:'left'},{label:'Right',value:'right'}]" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
@@ -54,7 +54,7 @@ The value of the currently selected option.
   <KSegmentedControl :options="['5m','30m','1h','6h','24h','all']" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{ selected: '1h' }" v-slot="{ data }">
   <KSegmentedControl :options="['5m','30m','1h','6h','24h','all']" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
@@ -66,7 +66,7 @@ You can pass in an optional flag to disable the control or an individual button 
 
 <KSegmentedControl :options="['On','Off']" selected="On" :isDisabled="true" />
 
-```vue
+```html
 <KSegmentedControl :options="['On','Off']" selected="On" :isDisabled="true" />
 ```
 
@@ -74,7 +74,7 @@ You can pass in an optional flag to disable the control or an individual button 
   <KSegmentedControl :options="[{label:'pick me',value:'1'},{label:'disabled',value:'2',disabled: true},{label:'or me',value:'3'}]" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{ selected: '1' }" v-slot="{ data }">
   <KSegmentedControl :options="[{label:'pick me',value:'1'},{label:'disabled',value:'2',disabled: true},{label:'or me',value:'3'}]" v-model="data.selected" @click="x => data.selected = x" />
 </KComponent>
@@ -100,7 +100,7 @@ export default defineComponent({
 })
 </script>
 
-```vue
+```html
 <KComponent :data="{ selected: 'On' }" v-slot="{ data }">
   <KSegmentedControl :options="['On','Off']" v-model="data.selected" @click="state => sayHello(state, data)" />
 </KComponent>

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -12,7 +12,7 @@ There are 5 different types of loading states that KSkeleton supports: Card, Tab
 
 <KSkeleton type="form" />
 
-```vue
+```html
 <KSkeleton type="form" />
 ```
 
@@ -30,7 +30,7 @@ The number of milliseconds to wait before showing the skeleton state. Defaults t
   </div>
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{ isLoading: false }" v-slot="{ data }">
   <div>
     <KButton class="mb-2" @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</KButton>
@@ -48,7 +48,7 @@ By default, **KSkeleton** will load a generic loading state. There are no props 
 
 <KSkeleton />
 
-```vue
+```html
 <KSkeleton />
 ```
 
@@ -58,7 +58,7 @@ This loading state is using for card type components, like **KCard** or similar.
 
 <KSkeleton type="card" />
 
-```vue
+```html
 <KSkeleton type="card" />
 ```
 
@@ -68,7 +68,7 @@ Used for displaying the number of cards in this loading state. Defaults to 1. Th
 
 <KSkeleton type="card" :card-count="3" />
 
-```vue
+```html
 <KSkeleton type="card" :card-count="3" />
 ```
 
@@ -78,7 +78,7 @@ This loading state is used for form type components. There are no props for this
 
 <KSkeleton type="form" />
 
-```vue
+```html
 <KSkeleton type="form" />
 ```
 
@@ -88,7 +88,7 @@ This loading state is used for table type components.
 
 <KSkeleton type="table" />
 
-```vue
+```html
 <KSkeleton type="table" />
 ```
 
@@ -98,7 +98,7 @@ Used for displaying the number of rows in this loading state. Defaults to 6. The
 
 <KSkeleton type="table" :table-rows="3" />
 
-```vue
+```html
 <KSkeleton type="table" :table-rows="3" />
 ```
 
@@ -108,7 +108,7 @@ Used for displaying the number of columns in this loading state. Defaults to 6. 
 
 <KSkeleton type="table" :table-columns="3" />
 
-```vue
+```html
 <KSkeleton type="table" :table-columns="3" />
 ```
 
@@ -118,7 +118,7 @@ This loading state is used for a spinner, which can be used for a wide variety o
 
 <KSkeleton type="spinner" />
 
-```vue
+```html
 <KSkeleton type="spinner" />
 ```
 
@@ -140,7 +140,7 @@ The full screen loading state is used to display a full screen loader typically 
     :delay-milliseconds="0" />
 </div>
 
-```vue
+```html
   <KButton @click="clicked()">click for default progress behavior</KButton>
   <KSkeleton v-if="loading" type="fullscreen-kong" :delay-milliseconds="0" />
 ```
@@ -162,7 +162,7 @@ KSkeleton package uses a component to render the placeholder content `<KSkeleton
 <KSkeletonBox width="50" height="1"/>
 <KSkeletonBox width="100" height="2"/>
 
-```vue
+```html
 <KSkeletonBox />
 <KSkeletonBox width="2" height="2"/>
 <KSkeletonBox width="5" height="2"/>
@@ -193,7 +193,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
   </template>
 </KSkeleton>
 
-```vue
+```html
 <KSkeleton type="card" :card-count="3">
   <template v-slot:card-header>
     <div class="w-100">
@@ -239,7 +239,7 @@ And another example:
   </template>
 </KSkeleton>
 
-```vue
+```html
 <template>
   <KSkeleton type="card">
     <template v-slot:card-header>
@@ -284,7 +284,7 @@ To reveal the header on this docs page during full page loader, click the button
   <KSkeleton v-if="loadingTheming" type="fullscreen-kong" :delay-milliseconds="0" />
 </div>
 
-```vue
+```html
 <div class="mt-4 k-skeleton-full-screen-margin">
   <KButton @click="clickedTheming()">themed full screen loader</KButton>
   <KSkeleton v-if="loadingTheming" type="fullscreen-kong" :delay-milliseconds="0" />

--- a/docs/components/slideout.md
+++ b/docs/components/slideout.md
@@ -30,7 +30,7 @@ Below we demonstrate wrapping `KSlideout` in the [`KToggle`](/components/renderl
   </div>
 </KToggle>
 
-```vue
+```html
 <KToggle v-slot="{ isToggled, toggle }">
   <div>
     <KButton @click="toggle">Toggle Panel</KButton>
@@ -68,7 +68,7 @@ Tells the component whether or not to render the open panel.
 
 There is one default slot which is used to place content into the slideout panel.
 
-```vue
+```html
 <KSlideout :is-visible="isToggled" @close="toggle">
   <div>
     <h1>Default Slot</h1>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -5,7 +5,7 @@ pageClass: table-docs
 
 Pass a fetcher function to build a slot-able table.
 
-```vue
+```html
   <KTable :fetcher="fetcher" :headers="headers" />
 ```
 
@@ -22,7 +22,7 @@ Highlight the table row on hover. By default this is set to `true`. In the examp
 
 <KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" :hasHover="false" />
 
-```vue
+```html
   <KTable :fetcher="fetcher" :headers="headers" :hasHover="false" />
 ```
 
@@ -34,7 +34,7 @@ The below example demonstrates the disabled state:
 
 <KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" :hasSideBorder="true" />
 
-```vue
+```html
   <KTable :fetcher="fetcher" :headers="headers" :hasSideBorder="true" />
 ```
 
@@ -52,7 +52,7 @@ Set this to `true` to limit pagination navigation to `previous` / `next` page on
 
 <KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" :disablePaginationPageJump="true" />
 
-```vue
+```html
   <KTable :fetcher="fetcher" :headers="headers" :disablePaginationPageJump="true" />
 ```
 
@@ -95,7 +95,7 @@ Here the `last_seen` column is set to use the custom sort handler function via t
 
 <KTable :fetcher="sortHandlerFnFetcher" :headers="sortHandlerFnHeaders" :sortHandlerFn="sortHandlerFn" enable-client-sort />
 
-```vue
+```html
 <template>
   <KTable
     :fetcher="fetcher"
@@ -286,7 +286,7 @@ Remember that the `fetcher` function is responsible for managing pagination/sort
   :enableClientSort="true"
 />
 
-```vue
+```html
 <template>
   <KTable
     :fetcher="() => {
@@ -329,7 +329,7 @@ Remember that the `fetcher` function is responsible for managing pagination/sort
 
 The fetcher functionality makes use of [SWRV](https://docs-swrv.netlify.app/) to handle caching of response data. Whenever the cache key is changed the fetcher will automatically refire and repopulate the table data.
 
-```vue
+```html
 <template>
   <KTable :fetcher="fetcher" :headers="headers" :fetcherCacheKey="cacheKey" />
 </template>
@@ -382,7 +382,7 @@ Pass in an array of header objects for the table.
 
 Example headers array:
 
-```vue
+```html
 <script>
   export default {
     data() {
@@ -440,7 +440,7 @@ Pass in the type of pagination to be used. Options are `default` (page/pageSize)
   :initial-fetcher-params="{ pageSize: offsetPaginationPageSize }"
   pagination-type="offset" />
 
-```vue
+```html
 <template>
   <KTable
     :fetcher="fetcher"
@@ -458,7 +458,7 @@ A prop to add custom properties to individual rows. The row object is passed as 
 
 <KTable :fetcher="tableOptionsRowAttrsFetcher" :headers="tableOptionsRowAttrsHeaders" :rowAttrs="rowAttrsFn" />
 
-```vue
+```html
 <template>
   <KTable :fetcher="fetcher" :headers="headers" :rowAttrs="rowAttrsFn" />
 </template>
@@ -507,7 +507,7 @@ A prop to add custom properties to individual table cells or groups of cells. Th
 
 <KTable :headers="tableOptionsCellAttrsHeaders" :fetcher="tableOptionsCellAttrsFetcher" :cellAttrs="cellAttrsFn" />
 
-```vue
+```html
 <template>
   <KTable :fetcher="fetcher" :headers="headers" :cellAttrs="cellAttrsFn" />
 </template>
@@ -694,7 +694,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
   </template>
 </KTable>
 
-```vue
+```html
 <KTable
   :fetcher="fetcher"
   :headers="headers"
@@ -752,7 +752,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
 
 #### Example
 
-```vue
+```html
 <template>
   <div>
     <div v-if="eventType">
@@ -819,7 +819,7 @@ Both column cells & header cells are slottable in KTable. Use slots to gain acce
   </template>
 </KTable>
 
-```vue
+```html
 <template>
   <KTable :fetcher="fetcher" :headers="headers">
     <!-- Slot column header "name" -->
@@ -854,7 +854,7 @@ export default {
   <template v-slot:actions><KButton appearance="btn-link">Edit</KButton></template>
 </KTable>
 
-```vue
+```html
 <template>
   <KTable :fetcher="fetcher" :headers="headers">
     <!-- Slot each "enabled" cell in each row & add icon if matching value -->
@@ -907,7 +907,7 @@ the section below or completely slot in your own content.
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KTable :fetcher="() => { return { data: [] } }" :headers="headers">
     <template v-slot:empty-state>
@@ -947,7 +947,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KCard>
     <template v-slot:body>
@@ -974,7 +974,7 @@ If using a CTA button, a `ktable-empty-state-cta-clicked` event is fired when cl
   </template>
 </KCard>
 
-```vue
+```html
 <!-- Using a route string -->
 <template>
   <KCard>
@@ -1042,7 +1042,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
   </template>
 </KCard>
 
-```vue
+```html
 <template>
   <KCard>
     <template v-slot:body>
@@ -1069,7 +1069,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
   </template>
 </KCard>
 
-```vue
+```html
 <!-- Using a route string -->
 <template>
   <KCard>
@@ -1127,7 +1127,7 @@ Set the `isLoading` prop to `true` to enable the loading state.
   </template>
 </KCard>
 
-```vue
+```html
 <template>
 <KCard>
   <template v-slot:body>
@@ -1156,7 +1156,7 @@ Example URL
 https://kongponents.dev/api/components?_page=1&_limit=10&_sort=name&_order=desc
 ```
 
-```vue
+```html
 <!-- Example Component Usage -->
 
 <KCard>
@@ -1235,7 +1235,7 @@ An Example of changing the hover background might look like.
   <KTable :headers="tableOptionsHeaders" :fetcher="tableOptionsFetcher" hasHover />
 </div>
 
-```vue
+```html
 <template>
   <KTable :fetcher="fetcher" :headers="headers" hasHover />
 </template>

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -11,7 +11,7 @@
   </template>
 </KTabs>
 
-```vue
+```html
 <KTabs :tabs="tabs">
   <template v-slot:tab1>
     <p>Tab 1 content</p>
@@ -58,7 +58,7 @@ export interface Tab {
 }
 ```
 
-```vue
+```html
 <template>
   <KTabs :tabs="tabs" />
 </template>
@@ -95,7 +95,7 @@ By default the `KTabs` will set the first tab in the array as active. You can ov
   </template>
 </KTabs>
 
-```vue
+```html
 <KTabs v-model="#tab2" :tabs="tabs">
   <template v-slot:tab1>Tab 1 content</template>
   <template v-slot:tab2>Tab 2 content</template>
@@ -118,7 +118,7 @@ If you want to keep your `v-model` in sync so that you can programatically chang
 <KButton @click="defaultProgrammaticTab = '#tab1'" class="mr-2">Activate Tab 1</KButton>
 <KButton @click="defaultProgrammaticTab = '#tab2'">Activate Tab 2</KButton>
 
-```vue
+```html
 <KTabs v-model="defaultTab" :tabs="tabs" @changed="hash => defaultTab = hash">
   <template v-slot:tab1>
     <p>Tab 1 content</p>
@@ -148,7 +148,7 @@ In order to actually see your tabbed content you must slot it using the tab hash
   </template>
 </KTabs>
 
-```vue
+```html
 <template>
   <KTabs :tabs="tabs">
     <template v-slot:pictures>Wow look Pictures!</template>
@@ -186,7 +186,7 @@ export default defineComponent({
 
 `KTabs` emits a `changed` event with the new tab hash when clicked. You can use this to set the router or window hash and in turn use that with [`v-model`](#v-model).
 
-```vue
+```html
 <template>
   <KTabs
     :tabs="tabs"
@@ -243,7 +243,7 @@ look like.
   </KTabs>
 </div>
 
-```vue
+```html
 <template>
   <div class="KTabs-wrapper">
     <KTabs :tabs="tabs">

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -4,7 +4,7 @@
 
 <KTextArea />
 
-```vue
+```html
 <KTextArea />
 ```
 
@@ -16,7 +16,7 @@ String to be used as the textarea label.
 
 <KTextArea label="Name" placeholder="I'm labelled!" />
 
-```vue
+```html
 <KTextArea label="Name" placeholder="I'm labelled!" />
 ```
 
@@ -25,7 +25,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 <KLabel>Label</KLabel>
 <KTextArea placeholder="I have a label" />
 
-```vue
+```html
 <KLabel>Label</KLabel>
 <KTextArea placeholder="I have a label" />
 ```
@@ -36,7 +36,7 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 
 <KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 
-```vue
+```html
 <KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 ```
 
@@ -46,7 +46,7 @@ Enable this prop to overlay the label on the input element's border. Defaults to
 
 <KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 
-```vue
+```html
 <KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 ```
 
@@ -58,7 +58,7 @@ You can specify `rows`, `cols` for the textarea size.
 <br>
 <KTextArea :rows="8" :cols="25" placeholder="rows:8, cols:25" />
 
-```vue
+```html
 <template>
   <KTextArea label="Size" :rows="3" :cols="20" placeholder="I'm labelled and customized!" />
   <br>
@@ -72,7 +72,7 @@ Use this prop to specify a character limit for the textarea, defaults to `2048`.
 
 <KTextArea :characterLimit="20" />
 
-```vue
+```html
 <KTextArea :characterLimit="20" />
 ```
 
@@ -82,7 +82,7 @@ Use this prop to remove the character limit on the textarea. Defaults to `false`
 
 <KTextArea disable-character-limit />
 
-```vue
+```html
 <KTextArea disable-character-limit />
 ```
 
@@ -92,7 +92,7 @@ Boolean value to indicate whether the element has an error and should apply erro
 
 <KTextArea has-error />
 
-```vue
+```html
 <KTextArea has-error />
 ```
 
@@ -107,7 +107,7 @@ Boolean value to indicate whether the element has an error and should apply erro
   </div>
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
   {{ myInput }}
   <KTextArea v-model="data.myInput" />
@@ -142,7 +142,7 @@ Boolean value to indicate whether the element has an error and should apply erro
   </div>
 </KComponent>
 
-```vue
+```html
 <KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
   <div>
     <KTextArea
@@ -171,7 +171,7 @@ An Example of changing the error border color of KInput to pink might look like:
 
 <KTextArea class="custom-input" has-error type="email" />
 
-```vue
+```html
 <template>
   <KTextArea class="custom-input" has-error type="email" />
 </template>

--- a/docs/components/toaster.md
+++ b/docs/components/toaster.md
@@ -32,13 +32,13 @@ Once `ToastManager` is added as a global property, you can access it's methods v
 
 <KButton @click="$toaster.open('Basic Notification')">Open Toaster</KButton>
 
-```vue
+```html
 <KButton @click="$toaster.open('Basic Toaster')">Open Toaster</KButton>
 ```
 
 or within the `setup()` function in your component
 
-```vue
+```html
 <script lang="ts">
 import { defineComponent, getCurrentInstance } from 'vue'
 
@@ -70,7 +70,7 @@ The default argument passed to the toaster is the message.
 
 <KButton @click="$toaster.open('Default message here')">Open Toaster</KButton>
 
-```vue
+```html
 <KButton @click="$toaster.open('Default message here')">Open Toaster</KButton>
 ```
 
@@ -83,7 +83,7 @@ The Toaster uses the same appearance values as [KAlert](/components/alert) and a
 <KButton class="mr-2" appearance="danger" @click="openNotification({'appearance': 'danger', 'message':'This toaster has danger appearance'})">Open Toaster</KButton>
 <KButton class="warning mr-2" appearance="primary" @click="openNotification({'appearance': 'warning', 'message':'This toaster has warning appearance'})">Open Toaster</KButton>
 
-```vue
+```html
 <template>
   <KButton @click="openNotification(toasterOptions)">Open Toaster</KButton>
 </template>
@@ -117,7 +117,7 @@ The default timeout, in milliseconds, is `5000` (5 seconds) however you can chan
 
 <KButton :disabled="timeLeft <= 3" @click="openNotificationElapse({timeoutMilliseconds: 3000, 'appearance': 'success', 'message': `This toaster has a 3 second timeout`})">{{timeLeft > 3 ? 'Open Toaster' : `Closing in ${timeLeft} seconds` }}</KButton>
 
-```vue
+```html
 <template>
   <KButton @click="openNotification(toasterOptions)">Open Toaster</KButton>
 </template>
@@ -158,7 +158,7 @@ You can view the current state of active toasters by calling `this.$toaster.toas
 </code>
 </pre>
 
-```vue
+```html
 <template>
   <KButton class="success" appearance="primary" @click="openNotification({timeoutMilliseconds: 10000, message: 'Success Notification', appearance: 'success'})">Open Toaster</KButton>
   <KButton appearance="danger" @click="openNotification({'appearance': 'danger', 'message': 'Danger Notification'})">Open Toaster</KButton>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -6,7 +6,7 @@
   <KButton>&nbsp;🎮</KButton>
 </KTooltip>
 
-```vue
+```html
 <KTooltip label="Video Games">
   <KButton>&nbsp;🎮</KButton>
 </KTooltip>
@@ -24,7 +24,7 @@ Here you can pass in the text to display in the toolip.
   <KButton>Sample Button</KButton>
 </KTooltip>
 
-```vue
+```html
 <KTooltip label="I am a new sample label">
   <KButton>Sample Button</KButton>
 </KTooltip>
@@ -55,7 +55,7 @@ Here are the different options:
   </KTooltip>
 </div>
 
-```vue
+```html
 <KTooltip placement="bottom" label="A label that appears on the bottom">
   <KButton>Sample Button</KButton>
 </KTooltip>
@@ -73,7 +73,7 @@ You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWid
   <KButton>bottom</KButton>
 </KTooltip>
 
-```vue
+```html
 <KTooltip placement="bottom" max-width="300" label="A label that appears on the bottom. A label that appears on the bottom">
   <KButton>button</KButton>
 </KTooltip>
@@ -83,7 +83,7 @@ You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWid
 
 - `Default` There is a main slot that takes in the element you want the popover to be triggered over.
 
-```vue
+```html
 <KTooltip label="a cool label">
   <!-- Your element goes here -->
   <KButton>button</KButton>
@@ -99,7 +99,7 @@ You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWid
   </template>
 </KTooltip>
 
-```vue
+```html
 <KTooltip>
   <KButton>&nbsp;✌🏻</KButton>
   <template v-slot:content>
@@ -121,7 +121,7 @@ Example:
   <KButton>themed tooltip</KButton>
 </KTooltip>
 
-```vue
+```html
 <template>
   <KTooltip class="tooltip-blue" label="Video Games">
     <KButton class="primary">themed tooltip</KButton>

--- a/docs/components/view-switcher.md
+++ b/docs/components/view-switcher.md
@@ -37,7 +37,7 @@ The current view of your UI, one of `table` or `grid`. The button will show icon
 
 > The `KComponent` component is used in this example to create state.
 
-```vue
+```html
 <KComponent :data="{ currentView: 'grid' }" v-slot="{ data }">
   <div>
     <KCard class="mb-4">

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -32,7 +32,7 @@ Add the `input-error` class to add error styling
 
 <KInput id="theme-page-kinput" class="input-error w-50" type="email" value="error" label="This input has a custom error border color" />
 
-```vue
+```html
 <template>
   <KInput type="email" value="error" class="input-error"/>
 </template>
@@ -54,7 +54,7 @@ Add the `input-error` class to add error styling
 
 You can also scope the CSS variable to a single component by providing a parent selector. Here's an Example of changing the color of KPopover text
 
-```vue
+```html
 <template>
   <div class="custom-class-name">
     <KPop title="email">


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Code snippets should use `html` highlighting, since `vue` is not a supported language.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
