### PR TITLE
fix(kselect): input border radius and dropdown spacing

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -31,7 +31,7 @@ table {
       content: '/'
       align-items: center;
       background: linear-gradient(-225deg, #d5dbe4, #f8f8f8);
-      border-radius: 3px;
+      border-radius: 4px;
       box-shadow: inset 0 -2px 0 0 #cdcde6, inset 0 0 1px 1px #fff, 0 1px 2px 1px rgba(30,35,90,0.4);
       color: #969faf;
       display: flex;

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -342,7 +342,7 @@ An Example of changing the background might look like.
 .borderless-cards {
   padding: 1rem;
   background: rgba(27,31,35,0.05);
-  border-radius: 3px;
+  border-radius: 4px;
   .kong-card {
     background: #fff;
   }

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -4,31 +4,11 @@
 
 **Select** - Dropdown/Select component
 <div>
-  <KSelect label="Pick Something:" :items="[{
-      label: 'test',
-      value: 'test'
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }, {
-      label: 'TEST 2',
-      value: 'test2'
-    }]"
-  />
+  <KSelect label="Pick Something:" :items="deepClone(defaultItemsUnselect)" />
 </div>
 
-```vue
-<KSelect label="Pick Something:" :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }, {
-    label: 'TEST 2',
-    value: 'test2'
-  }]"
-/>
+```html
+<KSelect label="Pick Something:" :items="items" />
 ```
 
 ## Props
@@ -39,31 +19,20 @@ An array of items containing a `label` and `value`. May also specify that a cert
 by default.
 
 <div>
-  <KSelect :items="[{
-      label: 'test me because I am a super long option with text that wraps',
-      value: 'test',
-      selected: true
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }, {
-      label: 'TEST 2',
-      value: 'test2'
-    }]"
-  />
+  <KSelect :items="deepClone(defaultItems)" />
 </div>
 
-```vue
+```html
 <KSelect :items="[{
-    label: 'test',
-    value: 'test',
+    label: 'Cats',
+    value: 'cats',
     selected: true
   }, {
-    label: 'Test 1',
-    value: 'test1'
+    label: 'Dogs',
+    value: 'dogs'
   }, {
-    label: 'TEST 2',
-    value: 'test2'
+    label: 'Bunnies',
+    value: 'bunnies'
   }]"
 />
 ```
@@ -73,27 +42,25 @@ by default.
 The label for the select.
 
 <div>
-  <KSelect label="Cool label" :items="[{
-      label: 'test',
-      value: 'test',
-      selected: true
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-  />
+  <KSelect label="Cool label" :items="deepClone(defaultItemsUnselect)" />
 </div>
 
-```vue
-<KSelect label="Cool label" :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
+```html
+<KSelect label="Cool label" :items="items"
 />
+```
+
+### overlayLabel
+
+Enable this prop to overlay the label on the input element's border for `select` and `dropdown` appearances. Defaults to `false`.
+<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" />
+<KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+
+```html
+<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="items" />
+<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="items" />
+<KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="items" />
 ```
 
 ### labelAttributes
@@ -105,30 +72,18 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
       help: 'I use the KLabel `help` prop',
       'data-testid': 'test'
     }"
-    :items="[{
-      label: 'test',
-      value: 'test'
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
+    :items="deepClone(defaultItemsUnselect)"
   />
 </div>
 
-```vue
+```html
 <KSelect
   label="Name"
   :label-attributes="{
     help: 'I use the KLabel `help` prop',
     'data-testid': 'test'
   }"
-  :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
+  :items="items"
 />
 ```
 
@@ -140,78 +95,32 @@ The `dropdown` appearance style has a selected item object. You can deselect the
 the Clear icon.
 
 <div>
-  <KSelect :items="[{
-      label: 'test',
-      value: 'test',
-      selected: true
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-  />
+  <KSelect :items="deepClone(defaultItems)" />
 </div>
 
-```vue
-<KSelect :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+```html
+<KSelect :items="items" />
 ```
 
 The `select` style displays the selected item in the textbox and also displays a chevron. There is no
 way to clear the selection once it is made.
 
 <div>
-  <KSelect appearance='select' :items="[{
-      label: 'test',
-      value: 'test',
-      selected: true
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-  />
+  <KSelect appearance='select' :items="deepClone(defaultItems)" />
 </div>
 
-```vue
-<KSelect appearance='select' :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+```html
+<KSelect appearance='select' :items="items" />
 ```
 
 The `button` style triggers the dropdown on click and you cannot filter the entries.
 
 <div>
-  <KSelect appearance='button' :items="[{
-      label: 'test',
-      value: 'test'
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-  />
+  <KSelect appearance='button' :items="deepClone(defaultItems)" />
 </div>
 
-```vue
-<KSelect appearance='button' :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+```html
+<KSelect appearance='button' :items="items" />
 ```
 
 ### buttonText
@@ -222,7 +131,7 @@ You can configure the button text when an item is selected, if `appearance` is t
   <KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
 </div>
 
-```vue
+```html
 <KSelect
   appearance='button'
   width="225"
@@ -264,27 +173,11 @@ Because we are controlling the widths of multiple elements, we recommend using t
 :::
 
 <div>
-  <KSelect width="250" :items="[{
-      label: 'test',
-      value: 'test',
-      selected: true
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-  />
+  <KSelect width="250" :items="deepClone(defaultItemsUnselect)" />
 </div>
 
-```vue
-<KSelect width="250" :items="[{
-    label: 'test',
-    value: 'test',
-    selected: true
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-/>
+```html
+<KSelect width="250" :items="items" />
 ```
 
 ### positionFixed
@@ -296,50 +189,13 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
 Use this prop to control whether or not the `KSelect` component with an `appearance` prop set to a value of `select` or `dropdown` allows filtering. By default, filtering is enabled for `dropdown` appearance and is disabled for `select` appearance. `button` style `appearance` does not have filter support because it is a button.
 
 <div>
-  <KSelect :items="[{
-      label: 'test',
-      value: 'test'
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-    :enable-filtering="false"
-    class="mb-2"
-  />
-
-  <KSelect :items="[{
-      label: 'test',
-      value: 'test'
-    }, {
-      label: 'Test 1',
-      value: 'test1'
-    }]"
-    appearance="select"
-    :enable-filtering="true"
-  />
+  <KSelect :items="deepClone(defaultItemsUnselect)" :enable-filtering="false" class="mb-2" />
+  <KSelect :items="deepClone(defaultItemsUnselect)" appearance="select" :enable-filtering="true" />
 </div>
 
 ```html
-<KSelect :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-  :enable-filtering="false"
-/>
-
-<KSelect :items="[{
-    label: 'test',
-    value: 'test'
-  }, {
-    label: 'Test 1',
-    value: 'test1'
-  }]"
-  appearance="select"
-  :enable-filtering="true"
-/>
+<KSelect :items="items" :enable-filtering="false" />
+<KSelect :items="items" appearance="select" :enable-filtering="true" />
 ```
 
 ### filterFunc
@@ -360,29 +216,15 @@ KSelect works as regular inputs do using v-model for data binding:
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect v-model="data.myVal" :items="[{
-        label: 'test',
-        value: 'test'
-      }, {
-        label: 'Test 1',
-        value: 'test1'
-      }]"
-    />
+    <KSelect width="100" v-model="data.myVal" :items="deepClone(defaultItemsUnselect)" />
   </div>
 </Komponent>
 
-```vue
+```html
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect v-model="data.myVal" :items="[{
-        label: 'test',
-        value: 'test'
-      }, {
-        label: 'Test 1',
-        value: 'test1'
-      }]"
-    />
+    <KSelect width="100" v-model="data.myVal" :items="items" />
   </div>
 </Komponent>
 ```
@@ -395,7 +237,7 @@ You can pass any input attribute and it will get properly bound to the element.
   <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
 </div>
 
-```vue
+```html
 <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
 ```
 
@@ -417,8 +259,8 @@ If you use the `.select-item-label` and `.select-item-desc` classes within the s
 ```html
 <KSelect :items="myItems" width="100%" :filterFunc="customFilter">
   <template v-slot:item-template="{ item }">
-    <div class="select-item-label">{{item.label}}</div>
-    <div class="select-item-desc">{{item.description}}</div>
+    <div class="select-item-label">{{ item.label }}</div>
+    <div class="select-item-desc">{{ item.description }}</div>
   </template>
 </KSelect>
 
@@ -434,9 +276,9 @@ export default {
       let myItems = []
         for (let i = 0; i < count; i++) {
           myItems.push({
-            label: "Item " + i,
-            value: "item_" + i,
-            description: "The item's description for number " + i
+            label: `Item ${i}`,
+            value: `item_${i}`,
+            description: `${i} - The item's description for number ${i}`
           })
         }
       return myItems
@@ -467,9 +309,9 @@ function getItems(count) {
   let myItems = []
     for (let i = 0; i < count; i++) {
       myItems.push({
-        label: "Item " + i,
-        value: "item_" + i,
-        description: "The item's description for number " + i
+        label: `Item ${i}`,
+        value: `item_${i}`,
+        description: `${i} - The item's description for number ${i}`
       })
     }
   return myItems
@@ -481,6 +323,27 @@ export default {
       hasMounted: false,
       myItems: getItems(5),
       mySelect: '',
+       defaultItems: [{
+        label: 'Cats',
+        value: 'cats',
+        selected: true
+      }, {
+        label: 'Dogs',
+        value: 'dogs'
+      }, {
+        label: 'Bunnies',
+        value: 'bunnies'
+      }],
+      defaultItemsUnselect: [{
+        label: 'Cats',
+        value: 'cats'
+      }, {
+        label: 'Dogs',
+        value: 'dogs'
+      }, {
+        label: 'Bunnies',
+        value: 'bunnies'
+      }],
       items: [{
         label: '25',
         value: '25'
@@ -499,6 +362,9 @@ export default {
     },
     customFilter ({items, query}) {
       return items.filter(item => item.label.toLowerCase().includes(query.toLowerCase()) || item.description.toLowerCase().includes(query.toLowerCase()))
+    },
+    deepClone(obj) {
+      return JSON.parse(JSON.stringify(obj))
     }
   }
 }

--- a/packages/KAlert/CHANGELOG.md
+++ b/packages/KAlert/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KAlert/package.json
+++ b/packages/KAlert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kalert",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Alert component",
   "main": "dist/KAlert.umd.min.js",
   "componentName": "KAlert",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KBadge/CHANGELOG.md
+++ b/packages/KBadge/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KBadge/package.json
+++ b/packages/KBadge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbadge",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Badges, pills, lozenges, or whatever you wanna call them.",
   "main": "dist/KBadge.umd.min.js",
   "componentName": "KBadge",
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KButton/CHANGELOG.md
+++ b/packages/KButton/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kbutton",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Button component",
   "main": "dist/KButton.umd.min.js",
   "componentName": "KButton",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KCard/CHANGELOG.md
+++ b/packages/KCard/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KCard/package.json
+++ b/packages/KCard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcard",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Card component",
   "main": "dist/KCard.umd.min.js",
   "componentName": "KCard",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20",
+    "@kongponents/styles": "^6.33.0",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KCatalog/CHANGELOG.md
+++ b/packages/KCatalog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
+++ b/packages/KCatalog/__snapshots__/KCatalog.spec.js.snap
@@ -127,7 +127,9 @@ exports[`KCatalog general can change card sizes - large 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -293,7 +295,9 @@ exports[`KCatalog general can change card sizes - small 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -379,7 +383,9 @@ exports[`KCatalog general can disable truncation 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -465,7 +471,9 @@ exports[`KCatalog general handles truncation 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -531,7 +539,9 @@ exports[`KCatalog general matches snapshot 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -699,7 +709,9 @@ exports[`KCatalog general renders proper cards when using props 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -779,7 +791,9 @@ exports[`KCatalog general renders slots when passed 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -861,7 +875,9 @@ exports[`KCatalog general renders slotted cards when passed 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -927,7 +943,9 @@ exports[`KCatalog states displays a loading skeletion when the "isLoading" prop 
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+          </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>

--- a/packages/KCatalog/package.json
+++ b/packages/KCatalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcatalog",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "A grid view of KCards",
   "main": "dist/KCatalog.umd.min.js",
   "componentName": "KCatalog",
@@ -24,13 +24,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kcard": "^6.32.20",
-    "@kongponents/kemptystate": "^6.32.20",
-    "@kongponents/kpagination": "^6.32.20",
-    "@kongponents/kskeleton": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
-    "@kongponents/utils": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kcard": "^6.33.0",
+    "@kongponents/kemptystate": "^6.33.0",
+    "@kongponents/kpagination": "^6.33.0",
+    "@kongponents/kskeleton": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
+    "@kongponents/utils": "^6.33.0"
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.2.4"

--- a/packages/KCheckbox/CHANGELOG.md
+++ b/packages/KCheckbox/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KCheckbox/package.json
+++ b/packages/KCheckbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kcheckbox",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Checkbox input component",
   "main": "dist/KCheckbox.umd.min.js",
   "componentName": "KCheckbox",
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KClipboardProvider/CHANGELOG.md
+++ b/packages/KClipboardProvider/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KClipboardProvider/package.json
+++ b/packages/KClipboardProvider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kclipboardprovider",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Provide clipboard copy capabilities to any component",
   "main": "dist/KClipboardProvider.umd.min.js",
   "componentName": "KClipboardProvider",

--- a/packages/KEmptyState/CHANGELOG.md
+++ b/packages/KEmptyState/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KEmptyState/package.json
+++ b/packages/KEmptyState/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kemptystate",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Empty state component",
   "main": "dist/KEmptyState.umd.min.js",
   "componentName": "KEmptyState",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KIcon/CHANGELOG.md
+++ b/packages/KIcon/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KIcon/package.json
+++ b/packages/KIcon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kicon",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Icon component.",
   "main": "dist/KIcon.umd.min.js",
   "componentName": "KIcon",

--- a/packages/KInlineEdit/CHANGELOG.md
+++ b/packages/KInlineEdit/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KInlineEdit/KInlineEdit.vue
+++ b/packages/KInlineEdit/KInlineEdit.vue
@@ -127,7 +127,7 @@ Example usage:
     > * {
       width: 100%;
       border: 1px solid transparent;
-      border-radius: 3px;
+      border-radius: 4px;
       padding: var(--padding);
       margin-left: calc(-1 * var(--spacing-xs)); // align the left side of content
       line-height: 1.25;

--- a/packages/KInlineEdit/package.json
+++ b/packages/KInlineEdit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinlineedit",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Inline editable field.",
   "main": "dist/KInlineEdit.umd.min.js",
   "componentName": "KInlineEdit",
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KInput/CHANGELOG.md
+++ b/packages/KInput/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KInput/package.json
+++ b/packages/KInput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinput",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Input component",
   "main": "dist/KInput.umd.min.js",
   "componentName": "KInput",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/klabel": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
+    "@kongponents/klabel": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KInputSwitch/CHANGELOG.md
+++ b/packages/KInputSwitch/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KInputSwitch/package.json
+++ b/packages/KInputSwitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kinputswitch",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "KInputSwitch description here.",
   "main": "dist/KInputSwitch.umd.min.js",
   "componentName": "KInputSwitch",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/kooltip": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/kooltip": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KLabel/CHANGELOG.md
+++ b/packages/KLabel/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KLabel/package.json
+++ b/packages/KLabel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/klabel",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Form input label",
   "main": "dist/KLabel.umd.min.js",
   "componentName": "KLabel",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/kooltip": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/kooltip": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KMenu/CHANGELOG.md
+++ b/packages/KMenu/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KMenu/package.json
+++ b/packages/KMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmenu",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "<Menu component>",
   "main": "dist/KMenu.umd.min.js",
   "componentName": "KMenu",
@@ -24,9 +24,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KModal/CHANGELOG.md
+++ b/packages/KModal/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -187,7 +187,7 @@ export default {
   max-width: var(--KModalMaxWidth, 500px);
   margin: 50px auto;
   padding: var(--spacing-xl, spacing(xl));
-  border-radius: 3px;
+  border-radius: 4px;
   border: var(--KModalBorder);
   box-shadow: 0px 0px 12px 0px var(--black-10, color(black-10));
   background: #fff;

--- a/packages/KModal/package.json
+++ b/packages/KModal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmodal",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Modal component",
   "main": "dist/KModal.umd.min.js",
   "componentName": "KModal",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KModalFullscreen/CHANGELOG.md
+++ b/packages/KModalFullscreen/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KModalFullscreen/package.json
+++ b/packages/KModalFullscreen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmodalfullscreen",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "A full screen Modal",
   "main": "dist/KModalFullscreen.umd.min.js",
   "componentName": "KModalFullscreen",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KMultiselect/CHANGELOG.md
+++ b/packages/KMultiselect/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KMultiselect/package.json
+++ b/packages/KMultiselect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kmultiselect",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Multiselect dropdown component",
   "main": "dist/KMultiselect.umd.min.js",
   "componentName": "KMultiselect",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kpop": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kpop": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KPagination/CHANGELOG.md
+++ b/packages/KPagination/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KPagination/__snapshots__/KPagination.spec.js.snap
+++ b/packages/KPagination/__snapshots__/KPagination.spec.js.snap
@@ -35,7 +35,9 @@ exports[`KPagination correctly renders props 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 2 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            2 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -110,7 +112,9 @@ exports[`KPagination matches snapshot 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="#A3BBCC" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 10 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            10 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>

--- a/packages/KPagination/package.json
+++ b/packages/KPagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kpagination",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Pagination component",
   "main": "dist/KPagination.umd.min.js",
   "componentName": "KPagination",
@@ -24,8 +24,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/kselect": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/kselect": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KPop/CHANGELOG.md
+++ b/packages/KPop/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -427,7 +427,7 @@ export default {
   color: var(--KPopColor, var(--black-400, color(black-400)));
   background-color: var(--KPopBackground, var(--white, color(white)));
   border: 1px solid var(--KPopBorder, var(--black-10, color(black-10)));
-  border-radius: 3px;
+  border-radius: 4px;
   -webkit-box-shadow: 0px 4px 20px var(--black-10);
   box-shadow: 0px 4px 20px var(--black-10);
   padding: var(--KPopPaddingY, 28px) var(--KPopPaddingX, var(--spacing-md, spacing(md)));

--- a/packages/KPop/package.json
+++ b/packages/KPop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kpop",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "A Popover component",
   "main": "dist/KPop.umd.min.js",
   "componentName": "KPop",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
     "popper.js": "^1.15.0",
     "vue-uuid": "^2.0.2"
   }

--- a/packages/KPrompt/CHANGELOG.md
+++ b/packages/KPrompt/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KPrompt/package.json
+++ b/packages/KPrompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kprompt",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "A dialog that prompts a user to take an action",
   "main": "dist/KPrompt.umd.min.js",
   "componentName": "KPrompt",
@@ -23,10 +23,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/kinput": "^6.32.20",
-    "@kongponents/kmodal": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/kinput": "^6.33.0",
+    "@kongponents/kmodal": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KRadio/CHANGELOG.md
+++ b/packages/KRadio/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KRadio/package.json
+++ b/packages/KRadio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kradio",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Radio input component",
   "main": "dist/KRadio.umd.min.js",
   "componentName": "KRadio",
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KSegmentedControl/CHANGELOG.md
+++ b/packages/KSegmentedControl/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KSegmentedControl/KSegmentedControl.vue
+++ b/packages/KSegmentedControl/KSegmentedControl.vue
@@ -98,14 +98,14 @@ export default {
     box-shadow: 0 0 0 2px var(--white), 0 0 0 4px var(--blue-500);
   }
   &:first-child {
-    border-radius: 3px 0 0 3px;
+    border-radius: 4px 0 0 4px;
     margin-left: 0;
   }
   &:last-child {
-    border-radius: 0 3px 3px 0;
+    border-radius: 0 4px 4px 0;
   }
   &:only-child {
-    border-radius: 3px;
+    border-radius: 4px;
     margin-left: 0;
   }
   &:disabled {

--- a/packages/KSegmentedControl/package.json
+++ b/packages/KSegmentedControl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ksegmentedcontrol",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Segmented Control component.",
   "main": "dist/KSegmentedControl.umd.min.js",
   "componentName": "KSegmentedControl",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KSelect/CHANGELOG.md
+++ b/packages/KSelect/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -465,7 +465,6 @@ export default {
 
     input.k-input {
       padding: var(--spacing-xs);
-      height: 100%;
       height: 44px;
     }
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -471,6 +471,12 @@ export default {
   .k-select-popover {
     box-sizing: border-box;
     width: 100%;
+    margin-top: 2px !important;
+
+    &[x-placement^="top"] {
+      margin-top: 0 !important;
+      margin-bottom: 2px !important;
+    }
 
     &.k-select-pop-button {
       --KPopPaddingY: var(--spacing-xs);

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -4,22 +4,28 @@
     class="k-select"
   >
     <KLabel
-      v-if="label"
+      v-if="label && !overlayLabel"
       :for="selectId"
       v-bind="labelAttributes"
-      data-testid="k-select-label">{{ label }}</KLabel>
+      data-testid="k-select-label"
+    >
+      {{ label }}
+    </KLabel>
     <div
       :id="selectId"
-      data-testid="k-select-selected-item">
+      data-testid="k-select-selected-item"
+    >
       <div
         v-if="selectedItem && appearance === 'dropdown'"
-        class="k-select-item-selection px-3 py-1">
-        <div
-          class="selected-item-label">{{ selectedItem.label }}</div>
+        :class="{ 'overlay-label-item-selection': overlayLabel }"
+        class="k-select-item-selection px-3 py-1"
+      >
+        <div class="selected-item-label">{{ selectedItem.label }}</div>
         <button
           class="clear-selection-icon cursor-pointer non-visual-button"
           @click="clearSelection"
-          @keyup.enter="clearSelection">
+          @keyup.enter="clearSelection"
+        >
           <KIcon
             color="var(--blue-200)"
             icon="clear"
@@ -55,7 +61,8 @@
             class="k-select-button"
             data-testid="k-select-input"
             style="position: relative;"
-            role="listbox">
+            role="listbox"
+          >
             <KButton
               :style="widthStyle"
               :id="selectTextId"
@@ -63,7 +70,10 @@
               :is-rounded="false"
               v-bind="$attrs"
               appearance="btn-link"
-              @keyup="triggerFocus(isToggled)">{{ selectButtonText }}</KButton>
+              @keyup="triggerFocus(isToggled)"
+            >
+              {{ selectButtonText }}
+            </KButton>
           </div>
           <div
             v-else
@@ -71,22 +81,28 @@
             :class="{ 'k-select-input': appearance === 'select'}"
             data-testid="k-select-input"
             style="position: relative;"
-            role="listbox">
+            role="listbox"
+          >
             <KIcon
               v-if="appearance === 'select'"
+              :class="{ 'overlay-label-chevron': overlayLabel }"
               :icon="isToggled ? 'chevronUp' : 'chevronDown'"
               color="var(--grey-500)"
-              size="15" />
+              size="15"
+            />
             <KInput
               :id="selectTextId"
               v-bind="$attrs"
               v-model="filterStr"
               :readonly="!filterIsEnabled"
               :is-open="isToggled"
+              :label="label && overlayLabel ? label : null"
+              :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' ? selectedItem.label : placeholderText"
               :class="{ 'cursor-default': !filterIsEnabled }"
               class="k-select-input"
-              @keyup="!$attrs.disabled ? triggerFocus(isToggled) : null" />
+              @keyup="!$attrs.disabled ? triggerFocus(isToggled) : null"
+            />
           </div>
           <template v-slot:content>
             <ul class="k-select-list ma-0 pa-0">
@@ -99,7 +115,8 @@
                   v-for="item in filteredItems"
                   :key="item.key"
                   :item="item"
-                  @selected="handleItemSelect">
+                  @selected="handleItemSelect"
+                >
                   <template v-slot:content>
                     <slot
                       :item="item"
@@ -112,7 +129,8 @@
                   v-if="!filteredItems.length"
                   key="k-select-empty-state"
                   :item="{ label: 'No results', value: 'no_results' }"
-                  class="k-select-empty-item"/>
+                  class="k-select-empty-item"
+                />
               </slot>
             </ul>
           </template>
@@ -157,6 +175,10 @@ export default {
     label: {
       type: String,
       default: ''
+    },
+    overlayLabel: {
+      type: Boolean,
+      default: false
     },
     labelAttributes: {
       type: Object,
@@ -249,10 +271,12 @@ export default {
 
   computed: {
     boundKPopAttributes: function () {
+      let theClasses = `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses} k-select-pop-${this.appearance}`
+
       return {
         ...defaultKPopAttributes,
         ...this.kpopAttributes,
-        popoverClasses: `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses} k-select-pop-${this.appearance}`,
+        popoverClasses: theClasses,
         width: String(this.inputWidth),
         maxWidth: String(this.inputWidth),
         disabled: this.$attrs.disabled
@@ -398,6 +422,11 @@ export default {
     border-radius: 4px;
     margin-bottom: 6px;
 
+    &.overlay-label-item-selection {
+      position: relative;
+      top: 15px;
+    }
+
     .selected-item-label {
       align-self: center;
       font-size: 14px;
@@ -427,7 +456,6 @@ export default {
     position: relative;
     display: inline-block;
     width: 100%;
-    height: 44px;
 
     &.cursor-default {
       input.k-input {
@@ -438,6 +466,7 @@ export default {
     input.k-input {
       padding: var(--spacing-xs);
       height: 100%;
+      height: 44px;
     }
 
     .kong-icon {
@@ -445,6 +474,10 @@ export default {
       top: 15px;
       right: 6px;
       z-index: 9;
+
+      &.overlay-label-chevron {
+        top: 55%;
+      }
     }
   }
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -438,7 +438,6 @@ export default {
     input.k-input {
       padding: var(--spacing-xs);
       height: 100%;
-      border-radius: 4px 4px 0 0;
     }
 
     .kong-icon {
@@ -472,12 +471,10 @@ export default {
   .k-select-popover {
     box-sizing: border-box;
     width: 100%;
-    border-radius: 0 0 4px 4px;
 
     &.k-select-pop-button {
       --KPopPaddingY: var(--spacing-xs);
       --KPopPaddingX: var(--spacing-xs);
-      border-radius: 4px;
       border: 1px solid var(--grey-300);
     }
 

--- a/packages/KSelect/package.json
+++ b/packages/KSelect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kselect",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Dropdown/Select component",
   "main": "dist/KSelect.umd.min.js",
   "componentName": "KSelect",
@@ -24,13 +24,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/kinput": "^6.32.20",
-    "@kongponents/klabel": "^6.32.20",
-    "@kongponents/kpop": "^6.32.20",
-    "@kongponents/ktoggle": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/kinput": "^6.33.0",
+    "@kongponents/klabel": "^6.33.0",
+    "@kongponents/kpop": "^6.33.0",
+    "@kongponents/ktoggle": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KSkeleton/CHANGELOG.md
+++ b/packages/KSkeleton/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KSkeleton/CardSkeleton.vue
+++ b/packages/KSkeleton/CardSkeleton.vue
@@ -67,7 +67,7 @@ $borderColor: #e6e6e6;
   flex-direction: column;
   height: 324px;
   padding: 1rem;
-  border-radius: 3px;
+  border-radius: 4px;
   border: 1px solid $borderColor;
   overflow: hidden;
   .skeleton-card-header {

--- a/packages/KSkeleton/KSkeletonBox.vue
+++ b/packages/KSkeleton/KSkeletonBox.vue
@@ -30,7 +30,7 @@ export default {
 <style lang="scss" scoped>
 .box {
   display: inline-flex;
-  border-radius: 3px;
+  border-radius: 4px;
   background: linear-gradient(
       -70deg,
       #f2f2f2 0%,

--- a/packages/KSkeleton/package.json
+++ b/packages/KSkeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kskeleton",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Loading/Skeleton state component.",
   "main": "dist/KSkeleton.umd.min.js",
   "componentName": "KSkeleton",
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KSlideout/CHANGELOG.md
+++ b/packages/KSlideout/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KSlideout/package.json
+++ b/packages/KSlideout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kslideout",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "KSlideout description here.",
   "main": "dist/KSlideout.umd.min.js",
   "componentName": "KSlideout",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kcard": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kcard": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KTable/CHANGELOG.md
+++ b/packages/KTable/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KTable/__snapshots__/KTable.spec.js.snap
+++ b/packages/KTable/__snapshots__/KTable.spec.js.snap
@@ -70,7 +70,9 @@ exports[`KTable default has hover class when passed 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -228,7 +230,9 @@ exports[`KTable sorting should allow disabling sorting 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
@@ -336,7 +340,9 @@ exports[`KTable sorting should have sortable class when passed 1`] = `
   <path d="M3 8.75h9.17M8.42 5l3.75 3.75-3.75 3.75" fill="none" stroke="var(--grey-500)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
 </span></a></li>
-        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 15 items per page <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
+        </ul> <span data-testid="page-size-dropdown" class="page-size-select"><div class="k-select" style="width: 200px;"><!----> <div id="test-select-id-1234" data-testid="k-select-selected-item"><!----> <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button"><div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="k-select-button" style="position: relative;"><button type="button" class="k-button medium btn-link has-caret" id="test-select-text-id-1234" style="width: 200px;"><!----> 
+            15 items per page
+           <span class="kong-icon kong-icon-chevronDown caret has-caret"><svg viewBox="2 2 15 15" fill="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" xmlns="http://www.w3.org/2000/svg" role="img" width="16" height="16">
   <title>Expand</title>
   <path d="m4.6 7 5.2 5L15 7" fill="none" stroke="var(--KButtonBtnLink, var(--blue-500, color(blue-500)))" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>

--- a/packages/KTable/package.json
+++ b/packages/KTable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktable",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Table component",
   "main": "dist/KTable.umd.min.js",
   "componentName": "KTable",
@@ -23,13 +23,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/kemptystate": "^6.32.20",
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/kpagination": "^6.32.20",
-    "@kongponents/kskeleton": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
-    "@kongponents/utils": "^6.32.20",
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/kemptystate": "^6.33.0",
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/kpagination": "^6.33.0",
+    "@kongponents/kskeleton": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
+    "@kongponents/utils": "^6.33.0",
     "vue-uuid": "^2.0.2"
   },
   "peerDependencies": {

--- a/packages/KTableLegacy/CHANGELOG.md
+++ b/packages/KTableLegacy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KTableLegacy/package.json
+++ b/packages/KTableLegacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktablelegacy",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Legacy version of KTable prior to fetcher support",
   "main": "dist/KTableLegacy.umd.min.js",
   "componentName": "KTableLegacy",
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KTabs/CHANGELOG.md
+++ b/packages/KTabs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KTabs/package.json
+++ b/packages/KTabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktabs",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Tabs component.",
   "main": "dist/KTabs.umd.min.js",
   "componentName": "KTabs",
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KTextArea/CHANGELOG.md
+++ b/packages/KTextArea/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KTextArea/package.json
+++ b/packages/KTextArea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktextarea",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Text area component",
   "main": "dist/KTextArea.umd.min.js",
   "componentName": "KTextArea",
@@ -23,8 +23,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/klabel": "^6.32.20",
-    "@kongponents/styles": "^6.32.20",
+    "@kongponents/klabel": "^6.33.0",
+    "@kongponents/styles": "^6.33.0",
     "vue-uuid": "^2.0.2"
   }
 }

--- a/packages/KToaster/CHANGELOG.md
+++ b/packages/KToaster/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KToaster/package.json
+++ b/packages/KToaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktoaster",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Toaster component.",
   "main": "dist/KToaster.umd.min.js",
   "componentName": "KToaster",
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kalert": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kalert": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/KToggle/CHANGELOG.md
+++ b/packages/KToggle/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KToggle/package.json
+++ b/packages/KToggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/ktoggle",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Provide toggle functionality to components.",
   "main": "dist/KToggle.umd.min.js",
   "componentName": "KToggle",

--- a/packages/KViewSwitcher/CHANGELOG.md
+++ b/packages/KViewSwitcher/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KViewSwitcher/package.json
+++ b/packages/KViewSwitcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kviewswitcher",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "KViewSwitcher description here.",
   "main": "dist/KViewSwitcher.umd.min.js",
   "componentName": "KViewSwitcher",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kbutton": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/Komponent/CHANGELOG.md
+++ b/packages/Komponent/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/Komponent/package.json
+++ b/packages/Komponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/komponent",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Expose reactive state to components.",
   "main": "dist/Komponent.umd.min.js",
   "componentName": "Komponent",

--- a/packages/KoolTip/CHANGELOG.md
+++ b/packages/KoolTip/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/KoolTip/package.json
+++ b/packages/KoolTip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kooltip",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "A tooltip component",
   "main": "dist/KoolTip.umd.min.js",
   "componentName": "KoolTip",
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kpop": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kpop": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/Krumbs/CHANGELOG.md
+++ b/packages/Krumbs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/Krumbs/package.json
+++ b/packages/Krumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/krumbs",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Breadcrumbs component",
   "main": "dist/Krumbs.umd.min.js",
   "componentName": "Krumbs",
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@kongponents/kicon": "^6.32.20",
-    "@kongponents/styles": "^6.32.20"
+    "@kongponents/kicon": "^6.33.0",
+    "@kongponents/styles": "^6.33.0"
   }
 }

--- a/packages/styles/CHANGELOG.md
+++ b/packages/styles/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/styles/forms/_checkbox-radio.scss
+++ b/packages/styles/forms/_checkbox-radio.scss
@@ -16,12 +16,12 @@ input.form-control {
     box-sizing: border-box;
     // Override browser defaults
     -webkit-appearance: none;
-       -moz-appearance: none;
-            appearance: none;
+    -moz-appearance: none;
+    appearance: none;
     -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
     -webkit-print-color-adjust: exact;
 
     &:disabled {
@@ -37,7 +37,7 @@ input.form-control {
     width: 20px;
     color: $primaryCheckboxColor;
     border: none;
-    border-radius: 3px;
+    border-radius: 4px;
     margin: 0 6px 0 0;
     outline: none;
 

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -42,7 +42,7 @@
     color: var(--KInputBorder, var(--grey-600));
     background-color: var(--KInputBackground, var(--white));
     display: inline-block;
-    margin-bottom: .5rem;
+    margin-bottom: 0.5rem;
     transition: color 0.1s ease;
   }
 }
@@ -58,7 +58,7 @@
     font-weight: 400;
     line-height: 24px;
     border: none;
-    border-radius: 3px;
+    border-radius: 4px;
     background-color: var(--KInputBackground, var(--white, color(white)));
     box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
     box-sizing: border-box;
@@ -120,29 +120,29 @@
     }
   }
 }
-  /**
+/**
    * But KSelect still wants disabled/invalid styles applied
    * Note: this style-block MUST come AFTER the read-only block. Disabled state
    *  takes precedence over read-only state.
    */
-   
-  .k-input,
-  .form-control {
-    &:not([type="checkbox"]),
-    &:not([type="radio"]) {
-      &:disabled {
-        cursor: not-allowed;
-        font-style: italic;
-        background-color: var(--KInputDisabledBackground, var(--grey-100, color(grey-100)));
-        box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
-      }
 
-      &:invalid,
-      &:-moz-submit-invalid,
-      &:-moz-ui-invalid {
-        box-shadow: none;
-      }
+.k-input,
+.form-control {
+  &:not([type="checkbox"]),
+  &:not([type="radio"]) {
+    &:disabled {
+      cursor: not-allowed;
+      font-style: italic;
+      background-color: var(--KInputDisabledBackground, var(--grey-100, color(grey-100)));
+      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
     }
+
+    &:invalid,
+    &:-moz-submit-invalid,
+    &:-moz-ui-invalid {
+      box-shadow: none;
+    }
+  }
 
   &[type="search"] {
     padding-left: 36px;

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/styles",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Kong colors & CSS utilities",
   "main": "styles.css",
   "repository": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 6.33.0 (2022-07-15)
+
+
+### Features
+
+* **kselect:** add overlayLabel [khcp-4187] ([#697](https://github.com/Kong/kongponents/issues/697)) ([2efbfbb](https://github.com/Kong/kongponents/commit/2efbfbbd9054138477eeea73ab86fa747f9c0787))
+
+
+
+
+
 ## 6.32.20 (2022-07-15)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/utils",
-  "version": "6.32.20",
+  "version": "6.33.0",
   "description": "Kongponent utilities",
   "main": "dist/utils.umd.min.js",
   "repository": {


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Update KSelect input border radius and popover spacing from input

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: https://github.com/Kong/kongponents/pull/700
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
