### PR TITLE
fix(kcheckbox): readonly styles

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -33,7 +33,7 @@ An array of items containing a `label` and `value`. You may also specify that a 
   }, {
     label: 'Bunnies',
     value: 'bunnies'
-  }]""
+  }]"
 />
 ```
 
@@ -104,21 +104,21 @@ The `dropdown` appearance style has a selected item object. You can deselect the
 The `select` style displays the selected item in the textbox and also displays a chevron. There is no way to clear the selection once it is made.
 
 <div>
-  <KSelect appearance='select' :items="deepClone(defaultItems)" />
+  <KSelect appearance="select" :items="deepClone(defaultItems)" />
 </div>
 
 ```html
-<KSelect appearance='select' :items="items" />
+<KSelect appearance="select" :items="items" />
 ```
 
 The `button` style triggers the dropdown on click and you cannot filter the entries.
 
 <div>
-  <KSelect appearance='button' :items="deepClone(defaultItems)" />
+  <KSelect appearance="button" :items="deepClone(defaultItems)" />
 </div>
 
 ```html
-<KSelect appearance='button' :items="items" />
+<KSelect appearance="button" :items="items" />
 ```
 
 ### buttonText
@@ -126,12 +126,12 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 You can configure the button text when an item is selected, if `appearance` is type `button`.
 
 <div>
-  <KSelect appearance='button' width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
+  <KSelect appearance="button" width="225" @selected="item => handleItemSelect(item)" :buttonText="`Show ${mySelect} per page`" :items="items" />
 </div>
 
 ```html
 <KSelect
-  appearance='button'
+  appearance="button"
   width="225"
   @selected="item => handleItemSelect(item)"
   :buttonText="`Show ${mySelect} per page`"

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -49,8 +49,7 @@
 
 .k-input,
 .form-control {
-  &:not([type="checkbox"]),
-  &:not([type="radio"]) {
+  &:not([type="checkbox"]):not([type="radio"]) {
     display: block;
     padding: 10px var(--spacing-md, spacing(md));
     color: var(--KInputColor, var(--black-70, color(black-70)));

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -95,7 +95,7 @@
       }
     }
 
-    &:not(.k-select-input):read-only {
+    &:not([type="checkbox"]):not([type="radio"]):not(.k-select-input):read-only {
       background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
       box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
     }


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- Fix KCheckbox,KRadio styles
- KSelect docs cleanup

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
