### PR TITLE
style(kselect): update readonly, disabled style

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -216,7 +216,7 @@ KSelect works as regular inputs do using v-model for data binding:
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect width="100" v-model="data.myVal" :items="deepClone(defaultItemsUnselect)" />
+    <KSelect v-model="data.myVal" :items="deepClone(defaultItemsUnselect)" />
   </div>
 </Komponent>
 
@@ -224,7 +224,7 @@ KSelect works as regular inputs do using v-model for data binding:
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
     <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect width="100" v-model="data.myVal" :items="items" />
+    <KSelect v-model="data.myVal" :items="items" />
   </div>
 </Komponent>
 ```

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -107,10 +107,27 @@
     }
   }
 
+  &[type="search"] {
+    padding-left: 36px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23000' fill-opacity='.45' fill-rule='evenodd' d='M6 12c-3.3137085 0-6-2.6862915-6-6s2.6862915-6 6-6 6 2.6862915 6 6c0 1.29583043-.410791 2.49571549-1.1092521 3.47653436l1.2305724 1.23057244 2.8232632 2.8338633c.3897175.3911808.3947266 1.0192147.005164 1.4087774-.3868655.3868655-1.014825.3873148-1.4087774-.005164l-2.8338633-2.8232632-1.23057244-1.2305724C8.49571549 11.589209 7.29583043 12 6 12zm4-6c0-2.209139-1.790861-4-4-4S2 3.790861 2 6s1.790861 4 4 4 4-1.790861 4-4z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: 12px 50%;
+
+    /* Browser Overrides */
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      height: 16px;
+      width: 16px;
+      background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2012%2012%27%20fill%3D%27none%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0A%3Cpath%20d%3D%27M9.60005%202.40021L1.80005%2010.2002%27%20stroke%3D%27%233C4557%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%2F%3E%0A%3Cpath%20d%3D%27M9.60005%2010.2002L1.80005%202.40021%27%20stroke%3D%27%233C4557%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%2F%3E%0A%3C%2Fsvg%3E");
+      background-size: 16px 16px;
+    }
+  }
+}
+
   /**
    * KSelect should ignore read-only styles
    */
-  :not(.k-select-input) {
+   .k-input-wrapper:not(.k-select-input) {
     .k-input,
     .form-control {
       &:not([type="checkbox"]),
@@ -145,24 +162,7 @@
       }
     }
   }
-
-  &[type="search"] {
-    padding-left: 36px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23000' fill-opacity='.45' fill-rule='evenodd' d='M6 12c-3.3137085 0-6-2.6862915-6-6s2.6862915-6 6-6 6 2.6862915 6 6c0 1.29583043-.410791 2.49571549-1.1092521 3.47653436l1.2305724 1.23057244 2.8232632 2.8338633c.3897175.3911808.3947266 1.0192147.005164 1.4087774-.3868655.3868655-1.014825.3873148-1.4087774-.005164l-2.8338633-2.8232632-1.23057244-1.2305724C8.49571549 11.589209 7.29583043 12 6 12zm4-6c0-2.209139-1.790861-4-4-4S2 3.790861 2 6s1.790861 4 4 4 4-1.790861 4-4z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: 12px 50%;
-
-    /* Browser Overrides */
-    &::-webkit-search-cancel-button {
-      -webkit-appearance: none;
-      height: 16px;
-      width: 16px;
-      background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2012%2012%27%20fill%3D%27none%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0A%3Cpath%20d%3D%27M9.60005%202.40021L1.80005%2010.2002%27%20stroke%3D%27%233C4557%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%2F%3E%0A%3Cpath%20d%3D%27M9.60005%2010.2002L1.80005%202.40021%27%20stroke%3D%27%233C4557%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%2F%3E%0A%3C%2Fsvg%3E");
-      background-size: 16px 16px;
-    }
-  }
-}
-
+  
 .k-input-wrapper textarea.form-control {
   resize: none;
   padding: 17px 0 0 22px;


### PR DESCRIPTION
# Summary
Fixes the` read-only`, `disabled` styles for KInput, KSelect.

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
