### PR TITLE
fix(kselect): disabled and readonly states

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -56,6 +56,7 @@ Enable this prop to overlay the label on the input element's border for `select`
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" />
 <KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+<KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
 
 ```html
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="items" />

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -62,6 +62,7 @@ Enable this prop to overlay the label on the input element's border for `select`
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="items" />
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="items" />
 <KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="items" />
+<KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="items" />
 ```
 
 ### labelAttributes

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -10,7 +10,7 @@
         <label
           :for="inputId"
           v-bind="labelAttributes"
-          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled }">
+          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled, readonly: isReadonly }">
           <span>{{ label }}</span>
         </label>
         <input
@@ -171,6 +171,9 @@ export default {
     isDisabled () {
       return this.$attrs.hasOwnProperty('disabled')
     },
+    isReadonly () {
+      return this.$attrs.hasOwnProperty('readonly')
+    },
     listeners () {
       const listeners = { ...this.$listeners }
 
@@ -256,8 +259,8 @@ export default {
     margin-top: 2px;
   }
 
-  .text-on-input label.hovered,
-  .text-on-input label:hover {
+  .text-on-input label:not(.disabled):not(.readonly).hovered,
+  .text-on-input label:not(.disabled):not(.readonly):hover {
     color: var(--KInputHover, var(--blue-500));
   }
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -280,7 +280,7 @@ export default {
         width: String(this.inputWidth),
         maxWidth: String(this.inputWidth),
         // We have to check here if the property exists since it evals to an empty string
-        disabled: this.$attrs.hasOwnProperty('disabled') || this.$attrs.hasOwnProperty('readonly')
+        disabled: (this.$attrs.disabled !== undefined && String(this.$attrs.disabled) !== 'false') || (this.$attrs.readonly !== undefined && String(this.$attrs.readonly) !== 'false')
       }
     },
     listeners () {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -94,13 +94,13 @@
               :id="selectTextId"
               v-bind="$attrs"
               v-model="filterStr"
-              :readonly="!filterIsEnabled"
               :is-open="isToggled"
               :label="label && overlayLabel ? label : null"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' ? selectedItem.label : placeholderText"
-              :class="{ 'cursor-default': !filterIsEnabled }"
+              :class="{ 'cursor-default prevent-pointer-events': !filterIsEnabled }"
               class="k-select-input"
+              @keypress="onInputKeypress"
               @keyup="!$attrs.disabled ? triggerFocus(isToggled) : null"
             />
           </div>
@@ -270,8 +270,8 @@ export default {
   },
 
   computed: {
-    boundKPopAttributes: function () {
-      let theClasses = `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses} k-select-pop-${this.appearance}`
+    boundKPopAttributes () {
+      const theClasses = `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses} k-select-pop-${this.appearance}`
 
       return {
         ...defaultKPopAttributes,
@@ -279,7 +279,8 @@ export default {
         popoverClasses: theClasses,
         width: String(this.inputWidth),
         maxWidth: String(this.inputWidth),
-        disabled: this.$attrs.disabled
+        // We have to check here if the property exists since it evals to an empty string
+        disabled: this.$attrs.hasOwnProperty('disabled') || this.$attrs.hasOwnProperty('readonly')
       }
     },
     listeners () {
@@ -403,6 +404,11 @@ export default {
       if (!isToggled && inputElem) { // simulate click to trigger dropdown open
         inputElem.click()
       }
+    },
+    onInputKeypress (event) {
+      if (!this.filterIsEnabled) {
+        event.preventDefault()
+      }
     }
   }
 }
@@ -457,8 +463,16 @@ export default {
     width: 100%;
 
     &.cursor-default {
+      cursor: pointer;
+
       input.k-input {
         cursor: default;
+      }
+    }
+
+    &.prevent-pointer-events {
+      input.k-input {
+        pointer-events: none;
       }
     }
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -406,8 +406,11 @@ export default {
       }
     },
     onInputKeypress (event) {
+      // If filters are not enabled, ignore any keypresses
       if (!this.filterIsEnabled) {
         event.preventDefault()
+
+        return false
       }
     }
   }

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -3,23 +3,23 @@
 .k-input-wrapper .text-on-input {
   position: relative;
 
-  .hovered {
+  .hovered:not(.readonly) {
     color: var(--KInputHover, var(--blue-500));
     transition: color 0.1s ease;
   }
 
-  .focused {
+  .focused:not(.readonly) {
     color: var(--KInputFocus, var(--blue-500));
     transition: color 0.1s ease;
   }
 
   label {
-    &.hovered {
+    &.hovered:not(.readonly) {
       color: var(--KInputHover, var(--blue-500));
       transition: color 0.1s ease;
     }
 
-    &.focused {
+    &.focused:not(.readonly) {
       color: var(--KInputFocus, var(--blue-500));
       transition: color 0.1s ease;
     }

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -95,6 +95,11 @@
       }
     }
 
+    &:read-only {
+      background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
+      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
+    }
+
     &:disabled,
     .disabled {
       cursor: not-allowed;
@@ -107,11 +112,6 @@
     &:-moz-submit-invalid,
     &:-moz-ui-invalid {
       box-shadow: none;
-    }
-
-    &:read-only {
-      background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
-      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
     }
 
     /* Browser Overrides */

--- a/packages/styles/forms/_inputs.scss
+++ b/packages/styles/forms/_inputs.scss
@@ -95,6 +95,25 @@
       }
     }
 
+    &:disabled,
+    .disabled {
+      cursor: not-allowed;
+      font-style: italic;
+      background-color: var(--KInputDisabledBackground, var(--grey-100, color(grey-100)));
+      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
+    }
+
+    &:invalid,
+    &:-moz-submit-invalid,
+    &:-moz-ui-invalid {
+      box-shadow: none;
+    }
+
+    &:read-only {
+      background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
+      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
+    }
+
     /* Browser Overrides */
     &::placeholder {
       color: var(--KInputPlaceholderColor, var(--black-45, color(black-45)));
@@ -120,43 +139,6 @@
       width: 16px;
       background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2012%2012%27%20fill%3D%27none%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%0A%3Cpath%20d%3D%27M9.60005%202.40021L1.80005%2010.2002%27%20stroke%3D%27%233C4557%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%2F%3E%0A%3Cpath%20d%3D%27M9.60005%2010.2002L1.80005%202.40021%27%20stroke%3D%27%233C4557%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27%2F%3E%0A%3C%2Fsvg%3E");
       background-size: 16px 16px;
-    }
-  }
-}
-
-/**
- * KSelect should ignore read-only styles
- */
-.k-input-wrapper:not(.k-select-input) {
-  .k-input,
-  .form-control {
-    &:not([type="checkbox"]):not([type="radio"]):not(.k-select-input):read-only {
-      background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
-      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
-    }
-  }
-}
-
-/**
- * But KSelect still wants disabled/invalid styles applied
- * Note: this style-block MUST come AFTER the read-only block. Disabled state
- *  takes precedence over read-only state.
- */
-.k-input,
-.form-control {
-  &:not([type="checkbox"]),
-  &:not([type="radio"]) {
-    &:disabled {
-      cursor: not-allowed;
-      font-style: italic;
-      background-color: var(--KInputDisabledBackground, var(--grey-100, color(grey-100)));
-      box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
-    }
-
-    &:invalid,
-    &:-moz-submit-invalid,
-    &:-moz-ui-invalid {
-      box-shadow: none;
     }
   }
 }


### PR DESCRIPTION
# Summary

- Fixes `.k-input` `disabled` and `readonly` styles so that they are supported both on the component and if a user only utilizes the CSS classes
- Updates `KSelect` `disabled` and `readonly` logic to both be styled correctly given these attributes, but also to respond to or ignore the filter and text input accordingly.
    - Adds a `readonly` KSelect to the `overviewLabel` docs just to display a readonly example

![image](https://user-images.githubusercontent.com/2229946/179636051-268885f1-4535-4016-85cf-b03ca9aa33df.png)


![image](https://user-images.githubusercontent.com/2229946/179636035-24458c0b-1d36-42cf-8d13-e711555e4cdf.png)

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: https://github.com/Kong/kongponents/pull/707
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `insert reason`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
