### PR TITLE
fix(kselect): disabled and readonly states [beta]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -56,11 +56,13 @@ Enable this prop to overlay the label on the input element's border for `select`
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" />
 <KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+<KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
 
 ```html
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="items" />
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="items" />
 <KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="items" />
+<KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="items" />
 ```
 
 ### labelAttributes

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -12,7 +12,7 @@
         <label
           :for="inputId"
           v-bind="labelAttributes"
-          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled }"
+          :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled, readonly: isReadonly }"
         >
           <span>{{ label }}</span>
         </label>
@@ -157,11 +157,13 @@ export default defineComponent({
   emits: ['input', 'update:modelValue', 'char-limit-exceeded'],
 
   setup(props, { attrs, emit }) {
+    console.log('attrs', attrs)
     const currValue = ref('') // We need this so that we don't lose the updated value on hover/blur event with label
     const modelValueChanged = ref(false) // Determine if the original value was modified by the user
     const isFocused = ref(false)
     const isHovered = ref(false)
-    const isDisabled = computed((): boolean => !!attrs?.disabled)
+    const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
+    const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
     const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-input-id-1234' : uuidv1())
     // we need this so we can create a watcher for programmatic changes to the modelValue
     const value = computed({
@@ -231,6 +233,7 @@ export default defineComponent({
       isFocused,
       isHovered,
       isDisabled,
+      isReadonly,
       inputId,
       charLimitExceeded,
       charLimitExceededError,
@@ -288,8 +291,8 @@ export default defineComponent({
     margin-top: 2px;
   }
 
-  .text-on-input label.hovered,
-  .text-on-input label:hover {
+  .text-on-input label:not(.disabled):not(.readonly).hovered,
+  .text-on-input label:not(.disabled):not(.readonly):hover {
     color: var(--KInputHover, var(--blue-500));
   }
 

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -157,7 +157,6 @@ export default defineComponent({
   emits: ['input', 'update:modelValue', 'char-limit-exceeded'],
 
   setup(props, { attrs, emit }) {
-    console.log('attrs', attrs)
     const currValue = ref('') // We need this so that we don't lose the updated value on hover/blur event with label
     const modelValueChanged = ref(false) // Determine if the original value was modified by the user
     const isFocused = ref(false)

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -87,7 +87,7 @@
             style="position: relative;"
             role="listbox"
             @click="evt => {
-              if ($attrs.disabled !== undefined && $attrs.disabled !== false) {
+              if ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false') {
                 evt.stopPropagation()
               }
             }"
@@ -339,7 +339,7 @@ export default defineComponent({
         popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-select-pop-${props.appearance}`,
         width: String(inputWidth.value),
         maxWidth: String(inputWidth.value),
-        disabled: attrs.disabled !== undefined || attrs.readonly !== undefined,
+        disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
       }
     })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -103,15 +103,15 @@
               :id="selectTextId"
               v-bind="$attrs"
               v-model="filterStr"
-              :readonly="!filterIsEnabled"
               :is-open="isToggled.value"
               :label="label && overlayLabel ? label : undefined"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' && !filterIsEnabled ? selectedItem.label : placeholderText"
               autocomplete="off"
               autocapitalize="off"
-              :class="{ 'cursor-default': !filterIsEnabled }"
+              :class="{ 'cursor-default prevent-pointer-events': !filterIsEnabled }"
               class="k-select-input"
+              @keypress="onInputKeypress"
               @keyup="evt => triggerFocus(evt, isToggled)"
             />
           </div>
@@ -332,13 +332,14 @@ export default defineComponent({
     })
 
     const createKPopAttributes = computed(() => {
+      console.log('attrs', attrs)
       return {
         ...defaultKPopAttributes,
         ...props.kpopAttributes,
         popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-select-pop-${props.appearance}`,
         width: String(inputWidth.value),
         maxWidth: String(inputWidth.value),
-        disabled: typeof attrs.disabled === 'boolean' ? attrs.disabled : false,
+        disabled: attrs.disabled !== undefined || attrs.readonly !== undefined,
       }
     })
 
@@ -367,6 +368,14 @@ export default defineComponent({
       }
       return placeholderText.value
     })
+
+    const onInputKeypress = (event) => {
+      // If filters are not enabled, ignore any keypresses
+      if (!filterIsEnabled.value) {
+        event.preventDefault()
+        return false
+      }
+    }
 
     const handleItemSelect = (item: SelectItem) => {
       selectItems.value.forEach(anItem => {
@@ -430,6 +439,7 @@ export default defineComponent({
     })
 
     const inputWidth = ref(0)
+
     onMounted(() => {
       const inputElem = document.getElementById(selectInputId.value)
 
@@ -456,6 +466,7 @@ export default defineComponent({
       triggerFocus,
       inputWidth,
       filterIsEnabled,
+      onInputKeypress,
     }
   },
 })
@@ -530,6 +541,10 @@ export default defineComponent({
 
     &.cursor-default {
       cursor: default;
+    }
+
+    &.prevent-pointer-events {
+      pointer-events: none;
     }
 
     &input.k-input {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -369,7 +369,7 @@ export default defineComponent({
       return placeholderText.value
     })
 
-    const onInputKeypress = (event) => {
+    const onInputKeypress = (event: Event) => {
       // If filters are not enabled, ignore any keypresses
       if (!filterIsEnabled.value) {
         event.preventDefault()

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -332,7 +332,6 @@ export default defineComponent({
     })
 
     const createKPopAttributes = computed(() => {
-      console.log('attrs', attrs)
       return {
         ...defaultKPopAttributes,
         ...props.kpopAttributes,

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -94,7 +94,7 @@
       }
     }
 
-    &:not([type="checkbox"]):not([type="radio"]):not(.k-select-input):read-only {
+    &:not([type="checkbox"]):not([type="radio"]):read-only {
       background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
       box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
     }
@@ -125,7 +125,7 @@
   }
 
   &[type="search"] {
-    padding-left: 36px;
+    padding-left: 36px !important;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23000' fill-opacity='.45' fill-rule='evenodd' d='M6 12c-3.3137085 0-6-2.6862915-6-6s2.6862915-6 6-6 6 2.6862915 6 6c0 1.29583043-.410791 2.49571549-1.1092521 3.47653436l1.2305724 1.23057244 2.8232632 2.8338633c.3897175.3911808.3947266 1.0192147.005164 1.4087774-.3868655.3868655-1.014825.3873148-1.4087774-.005164l-2.8338633-2.8232632-1.23057244-1.2305724C8.49571549 11.589209 7.29583043 12 6 12zm4-6c0-2.209139-1.790861-4-4-4S2 3.790861 2 6s1.790861 4 4 4 4-1.790861 4-4z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: 12px 50%;

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -3,23 +3,23 @@
 .k-input-wrapper .text-on-input {
   position: relative;
 
-  .hovered {
+  .hovered:not(.readonly) {
     color: var(--KInputHover, var(--blue-500));
     transition: color 0.1s ease;
   }
 
-  .focused {
+  .focused:not(.readonly) {
     color: var(--KInputFocus, var(--blue-500));
     transition: color 0.1s ease;
   }
 
   label {
-    &.hovered {
+    &.hovered:not(.readonly) {
       color: var(--KInputHover, var(--blue-500));
       transition: color 0.1s ease;
     }
 
-    &.focused {
+    &.focused:not(.readonly) {
       color: var(--KInputFocus, var(--blue-500));
       transition: color 0.1s ease;
     }


### PR DESCRIPTION
# Summary

- Fixes `.k-input` `disabled` and `readonly` styles so that they are supported both on the component and if a user only utilizes the CSS classes
- Updates `KSelect` `disabled` and `readonly` logic to both be styled correctly given these attributes, but also to respond to or ignore the filter and text input accordingly.
    - Adds a `readonly` KSelect to the `overviewLabel` docs just to display a readonly example

![image](https://user-images.githubusercontent.com/2229946/179636051-268885f1-4535-4016-85cf-b03ca9aa33df.png)


![image](https://user-images.githubusercontent.com/2229946/179636035-24458c0b-1d36-42cf-8d13-e711555e4cdf.png)


---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
