### PR TITLE
fix(kmodal): allow clicking on elements within the modal body [KHCP-4212]

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -7,11 +7,9 @@
     aria-modal="true">
     <div
       class="k-modal-backdrop modal-backdrop"
-      @click="close">
+      @click="(evt) => close(false, evt)">
 
-      <div
-        class="k-modal-dialog modal-dialog"
-        @click.stop>
+      <div class="k-modal-dialog modal-dialog">
         <div class="k-modal-content modal-content">
           <div
             v-if="$scopedSlots.title || !hideTitle"
@@ -27,8 +25,8 @@
             <slot name="footer-content">
               <KButton
                 :appearance="cancelButtonAppearance"
-                @click="close"
-                @keyup.esc="close">
+                @click="close(true)"
+                @keyup.esc="close(true)">
                 {{ cancelButtonText }}
               </KButton>
               <div class="k-modal-action-buttons">
@@ -150,11 +148,14 @@ export default {
   methods: {
     handleKeydown (e) {
       if (this.isVisible && e.keyCode === 27) {
-        this.close()
+        this.close(true)
       }
     },
-    close () {
-      this.$emit('canceled')
+    close (force = false, event) {
+      // Close if force === true or if the user clicks on .k-modal-backdrop
+      if (force || event.target.classList.contains('k-modal-backdrop')) {
+        this.$emit('canceled')
+      }
     },
     proceed () {
       this.$emit('proceed')


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Update `KModal` to not capture all clicks inside the body (allows usage of `KSelect` within the modal)

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
