### PR TITLE
fix(kmodal): allow clicking on elements within the modal body BETA [KHCP-4212]

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -8,12 +8,9 @@
   >
     <div
       class="k-modal-backdrop modal-backdrop"
-      @click="close"
+      @click="(evt) => close(false, evt)"
     >
-      <div
-        class="k-modal-dialog modal-dialog"
-        @click.stop
-      >
+      <div class="k-modal-dialog modal-dialog">
         <div class="k-modal-content modal-content">
           <div
             v-if="$slots.title || !hideTitle"
@@ -34,8 +31,8 @@
             <slot name="footer-content">
               <KButton
                 :appearance="cancelButtonAppearance"
-                @click="close"
-                @keyup.esc="close"
+                @click="close(true)"
+                @keyup.esc="close(true)"
               >
                 {{ cancelButtonText }}
               </KButton>
@@ -129,12 +126,15 @@ export default defineComponent({
   setup(props, { emit }) {
     const handleKeydown = (e: any): void => {
       if (props.isVisible && e.keyCode === 27) {
-        close()
+        close(true)
       }
     }
 
-    const close = (): void => {
-      emit('canceled')
+    const close = (force = false, event?: any): void => {
+      // Close if force === true or if the user clicks on .k-modal-backdrop
+      if (force || event?.target?.classList?.contains('k-modal-backdrop')) {
+        emit('canceled')
+      }
     }
 
     const proceed = (): void => {


### PR DESCRIPTION
# Summary
Update `KModal` to not capture all clicks inside the body (allows usage of `KSelect` within the modal)
<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
