### PR TITLE
feat(kselect): add autosuggest support [KHCP-4292]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ cypress/videos
 
 .temp
 .cache
+.idea
+.husky
 
 docs/.vuepress/.temp/
 docs/.vuepress/.cache/

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -205,6 +205,13 @@ export default defineComponent({
       default: '350',
     },
     /**
+     * The maxHeight of the Popover body - undocumented and only used within KSelect
+     */
+    maxHeight: {
+      type: String,
+      default: 'auto',
+    },
+    /**
      * Custom classes that will be applied to the popover
      */
     popoverClasses: {
@@ -289,7 +296,8 @@ export default defineComponent({
     popoverStyle: function() {
       return {
         width: this.width === 'auto' || this.width.endsWith('%') || this.width.endsWith('px') ? this.width : this.width + 'px',
-        'max-width': this.maxWidth === 'auto' || this.maxWidth.endsWith('%') || this.maxWidth.endsWith('px') ? this.maxWidth : this.maxWidth + 'px',
+        maxWidth: this.maxWidth === 'auto' || this.maxWidth.endsWith('%') || this.maxWidth.endsWith('vw') || this.maxWidth.endsWith('px') ? this.maxWidth : this.maxWidth + 'px',
+        maxHeight: this.maxHeight === 'auto' || this.maxHeight.endsWith('%') || this.maxHeight.endsWith('vh') || this.maxHeight.endsWith('px') ? this.maxHeight : this.maxHeight + 'px',
       }
     },
     popoverClassObj: function() {

--- a/src/components/KSelect/KSelect.spec.ts
+++ b/src/components/KSelect/KSelect.spec.ts
@@ -193,4 +193,27 @@ describe('KSelect', () => {
 
     cy.getTestId(`k-select-item-${itemValue}`).should('contain.text', itemSlotContent)
   })
+
+  it('works in autosuggest mode', () => {
+    const onQueryChange = cy.spy().as('onQueryChange')
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        autosuggest: true,
+        loading: false,
+        items: [],
+        onQueryChange,
+      },
+    })
+
+    cy.get('input').type('a').then(() => {
+      cy.get('@onQueryChange').should('have.been.calledWith', 'a')
+    }).then(() => {
+      cy.wrap(Cypress.vueWrapper.setProps({ loading: true })).getTestId('k-select-loading').should('exist')
+    }).then(() => {
+      cy.wrap(Cypress.vueWrapper.setProps({ loading: false })).getTestId('k-select-loading').should('not.exist')
+    }).then(() => {
+      cy.wrap(Cypress.vueWrapper.setProps({ items: [{ label: 'Label 1', value: 'label1' }] })).getTestId('k-select-item-label1').should('contain.text', 'Label 1')
+    })
+  })
 })

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -41,7 +41,7 @@ export default defineComponent({
       type: Object,
       default: null,
       // Items must have a label and value
-      validator: (item: Record<string, string>): boolean => !!item.label && !!item.value,
+      validator: (item: Record<string, number | string>): boolean => Object.hasOwn(item, 'label') && Object.hasOwn(item, 'value'),
     },
     disabled: {
       type: Boolean,


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Add autosuggest support for KSelect. Port over the changes from #717.

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
