### PR TITLE
fix(kselect): adds watch for selected item

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -233,13 +233,11 @@ See [autosuggest](#autosuggest) for more details.
 
 KSelect works as regular inputs do using v-model for data binding:
 
-
   <div>
     <KLabel>Value:</KLabel> {{ myVal }}
     <KSelect v-model="myVal" :items="deepClone(defaultItems)" />
     <KButton @click="clearIt">Clear</KButton>
   </div>
-
 
 ```html
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -240,12 +240,11 @@ KSelect works as regular inputs do using v-model for data binding:
   </div>
 
 ```html
-<Komponent :data="{myVal: 'test'}" v-slot="{ data }">
   <div>
-    <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect v-model="data.myVal" :items="items" />
+    <KLabel>Value:</KLabel> {{ myVal }}
+    <KSelect v-model="myVal" :items="deepClone(defaultItems)" />
+    <KButton @click="clearIt">Clear</KButton>
   </div>
-</Komponent>
 ```
 
 ### autosuggest

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -233,12 +233,13 @@ See [autosuggest](#autosuggest) for more details.
 
 KSelect works as regular inputs do using v-model for data binding:
 
-<Komponent :data="{myVal: 'test'}" v-slot="{ data }">
+
   <div>
-    <KLabel>Value:</KLabel> {{ data.myVal }}
-    <KSelect v-model="data.myVal" :items="deepClone(defaultItemsUnselect)" />
+    <KLabel>Value:</KLabel> {{ myVal }}
+    <KSelect v-model="myVal" :items="deepClone(defaultItems)" />
+    <KButton @click="clearIt">Clear</KButton>
   </div>
-</Komponent>
+
 
 ```html
 <Komponent :data="{myVal: 'test'}" v-slot="{ data }">
@@ -585,6 +586,7 @@ export default {
       defaultItemsForDebouncedAutosuggest: [],
       itemsForDebouncedAutosuggest: [],
       loadingForDebounced: true,
+      myVal: 'cats'
     }
   },
   mounted() {
@@ -594,6 +596,9 @@ export default {
     handleItemSelect (item) {
       this.mySelect = item.label
     },
+    clearIt () {
+        this.myVal = 'cats'
+      },
     customFilter ({items, query}) {
       return items.filter(item => item.label.toLowerCase().includes(query.toLowerCase()) || item.description.toLowerCase().includes(query.toLowerCase()))
     },

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -415,8 +415,19 @@ export default {
         }
       },
       immediate: true
+    },
+
+    value (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        const theItems = this.selectItems.filter(item => item.value === newVal)
+
+        if (theItems.length) {
+          this.handleItemSelect({ target: { value: theItems[0] } })
+        }
+      }
     }
   },
+
   mounted () {
     const inputElem = document.getElementById(this.selectInputId)
     if (inputElem) {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -422,7 +422,7 @@ export default {
         const theItems = this.selectItems.filter(item => item.value === newVal)
 
         if (theItems.length) {
-          this.handleItemSelect({ target: { value: theItems[0] } })
+          this.handleItemSelect(theItems[0])
         }
       }
     }


### PR DESCRIPTION
# Summary
When KSelect uses `v-model`, we need to update the selected item when the `value` is modified programatically.
<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [x] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
