### PR TITLE
feat(kdropdownmenu): new component [khcp-690]

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -57,6 +57,7 @@ module.exports = {
               '/components/button',
               '/components/card',
               '/components/catalog',
+              '/components/dropdown-menu',
               '/components/input-checkbox',
               '/components/empty-state',
               '/components/icon',

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -12,6 +12,8 @@ import KCard from '../../packages/KCard/KCard.vue'
 import KCatalog from '../../packages/KCatalog/KCatalog.vue'
 import KCatalogItem from '../../packages/KCatalog/KCatalogItem.vue'
 import KClipboardProvider from '../../packages/KClipboardProvider/KClipboardProvider.js'
+import KDropdownMenu from '../../packages/KDropdownMenu/KDropdownMenu.vue'
+import KDropdownItem from '../../packages/KDropdownMenu/KDropdownItem.vue'
 import KMultiselect from '../../packages/KMultiselect/KMultiselect.vue'
 import KEmptyState from '../../packages/KEmptyState/KEmptyState.vue'
 import KIcon from '../../packages/KIcon/KIcon.vue'
@@ -57,6 +59,8 @@ export default ({
   Vue.component('KCatalog', KCatalog)
   Vue.component('KCatalogItem', KCatalogItem)
   Vue.component('KClipboardProvider', KClipboardProvider)
+  Vue.component('KDropdownMenu', KDropdownMenu)
+  Vue.component('KDropdownItem', KDropdownItem)
   Vue.component('KMultiselect', KMultiselect)
   Vue.component('KEmptyState', KEmptyState)
   Vue.component('KIcon', KIcon)

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -353,7 +353,7 @@ There are 3 primary item types:
 export default {
   data () {
     return {
-      selectedLabel: 'Selected an item',
+      selectedLabel: 'Select an item',
       selectedItem: '',
       menuItems: [{
         label: 'US (United States)',

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -1,62 +1,8 @@
 # DropdownMenu
 
-**KDropdownMenu** - Dropdown Menu component
+**KDropdownMenu** is a button (or any slotted content) that is clicked to trigger a popover containing menu items beneath it.
 
-<div>
-  <KDropdownMenu :kpop-attributes="{ placement: 'bottomStart', width: '200' }">
-    <template #default="{ isOpen }">
-      <KButton
-        :is-open="isOpen"
-        appearance="creation"
-        icon="gearFilled"
-      />
-    </template>
-    <template #items>
-      <KDropdownItem
-        :item="{ label: 'I am a link', to: { path: '/' } }"
-        disabled
-      />
-      <KDropdownItem>
-        Generic item
-      </KDropdownItem>
-      <KDropdownItem
-        has-divider
-        class="danger"
-        @click="clickHandler"
-      >
-        Danger button
-      </KDropdownItem>
-    </template>
-  </KDropdownMenu>
-</div>
-
-```html
-<KDropdownMenu :kpop-attributes="{ placement: 'bottomStart', width: '200' }">
-  <template #default="{ isOpen }">
-    <KButton
-      :is-open="isOpen"
-      appearance="creation"
-      icon="gearFilled"
-    />
-  </template>
-  <template #items>
-    <KDropdownItem
-      :item="{ label: 'I am a link', to: { path: '/' } }"
-      disabled
-    />
-    <KDropdownItem>
-      Generic item
-    </KDropdownItem>
-    <KDropdownItem
-      has-divider
-      class="danger"
-      @click="clickHandler"
-    >
-      Danger button
-    </KDropdownItem>
-  </template>
-</KDropdownMenu>
-```
+HOW DOES THIS DIFFER FROM KSELECT
 
 <div>
   <KDropdownMenu
@@ -157,25 +103,148 @@
 
 ## Props
 
-### Prop1
+### label
 
-Description of prop1
+The label for the menu.
 
-Actual component using prop1
-<KDropdownMenu />
+### items
+
+An array of items containing a `label` and `to` will render a menu of router-links.
+
+<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" />
 
 ```html
-<KDropdownMenu prop1="variation1" />
+<KDropdownMenu
+  label="Documentation"
+  :items="[
+    { label: 'Home', to: { path: '/' } },
+    { label: 'Button docs', to: { path: '/components/button.html' } },
+    { label: 'My docs', to: { path: '/components/dropdown-menu.html' } }
+  ]"
+/>
 ```
 
 ## Slots
 
-- `default` - default slot description
-- `slot1` - slot1 description
+There are 2 supported slots:
+
+- `default` - The trigger element for opening/closing the menu. Returns the `isOpen` state.
+- `items` - For an example of using the items slot see the [`KDropdownItem`](#KDropdownItem) section.
+
+<div>
+  <KDropdownMenu :items="deepClone(defaultItemsUnselected)">
+    <template #default="{ isOpen }">
+        <KButton
+          :is-open="isOpen"
+          appearance="creation"
+        >
+          Menu
+        </KButton>
+      </template>
+  </KDropdownMenu>
+</div>
 
 ```html
-<KDropdownMenu>
-  here is some slot content
+<KDropdownMenu :items="items">
+  <template #default="{ isOpen }">
+      <KButton
+        :is-open="isOpen"
+        appearance="creation"
+      >
+        Menu
+      </KButton>
+    </template>
+</KDropdownMenu>
+```
+
+## KDropdownItem
+
+**KDropdownMenu** generates a **KDropdownItem** for each item in the `items` property. At the most basic level, **KDropdownItem** is a wrapper around each item to display it correctly inside `KDropdownMenu`. You can use the `items` slot of the `KDropdownMenu` to manually create your own menu items.
+
+### Properties
+
+- `item` - the properties the router-link is built from, it expects a `label` and a `to`.
+- `disabled` - a boolean (default to `false`), whether or not to disable the item.
+- `selected` - a boolean (default to `false`), whether or not the item is selected.
+- `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
+
+```html
+<KDropdownItem :item="{ label: 'Leave the page', to: { path: '/' } }" />
+```
+
+There are 3 primary item types:
+
+- `router-link`
+  - the generic type generated using the `items` prop on `KDropdownMenu`
+  - the generic type generated using the `item` prop on `KDropdownItem`
+- `button` - this item is generated if a handler is specified for the `@click` event on a `KDropdownItem`
+- `custom` - no special handling, you completely control the content
+
+<div>
+  <KDropdownMenu label="Variety">
+    <template #items>
+      <KDropdownItem :item="youAreHere" />
+      <KDropdownItem @click="clickHandler">
+        A button
+      </KDropdownItem>
+      <KDropdownItem
+        disabled
+        @click="clickHandler"
+      >
+        Disabled button
+      </KDropdownItem>
+      <KDropdownItem
+        has-divider
+        class="danger"
+      >
+        <a
+          href="http://www.google.com"
+          rel="noopener"
+          target="_blank"
+        >
+          External link
+          <KIcon
+            icon="externalLink"
+            size="12"
+            class="ml-2"
+          />
+        </a>
+      </KDropdownItem>
+    </template>
+  </KDropdownMenu>
+</div>
+
+```html
+<KDropdownMenu label="Variety">
+  <template #items>
+    <KDropdownItem :item="{ label: 'You are here', to: { path: '/components/dropdown-menu.html' } }" />
+    <KDropdownItem @click="clickHandler">
+      A button
+    </KDropdownItem>
+    <KDropdownItem
+      disabled
+      @click="clickHandler"
+    >
+      Disabled button
+    </KDropdownItem>
+    <KDropdownItem
+      has-divider
+      class="danger"
+    >
+      <a
+        href="http://www.google.com"
+        rel="noopener"
+        target="_blank"
+      >
+        External link
+        <KIcon
+          icon="externalLink"
+          size="12"
+          class="ml-2"
+        />
+      </a>
+    </KDropdownItem>
+  </template>
 </KDropdownMenu>
 ```
 
@@ -214,7 +283,13 @@ like:
 export default {
   data () {
     return {
-      defaultIsOpen: false
+      defaultIsOpen: false,
+      defaultItemsUnselected: [
+        { label: 'Home', to: { path: '/' } },
+        { label: 'Button docs', to: { path: '/components/button.html' } },
+        { label: 'My docs', to: { path: '/components/dropdown-menu.html' } }
+      ],
+      youAreHere: { label: 'You are here', to: { path: '/components/dropdown-menu.html' } }
     }
   },
   methods: {

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -253,7 +253,7 @@ There are 2 supported slots:
 ### Properties
 
 - `item` - the properties the router-link is built from, it expects a `label` and a `to`.
-- `disabled` - a boolean (default to `false`), whether or not to disable the item.
+- `disabled` - a boolean (defaults to `false`), whether or not to disable the item.
 - `selected` - a boolean (default to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -31,7 +31,7 @@ Use this prop to specify the display style for the dropdown menu. Can be either 
 The `menu` style is the standard you have seen in the example above. Uses a standard `primary` `KButton` with hover state over items and no notion of "selection".
 
 The `selectionMenu` style is good for a clearer representation of the currently selected menu item. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop.
-If using the `items` slot, `KDropdownItem` children should use the `selectionMenuChild` prop to fire a `changed` event when clicked. You will need to manually control selectedness of each item using the `selected` prop.
+If using the `items` slot, `KDropdownItem` children should use the `selectionMenuChild` prop to fire a `changed` event when clicked. You will need to manually control the reactive state of the selected item.
 
 <div>
   <KDropdownMenu

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -1,0 +1,135 @@
+# DropdownMenu
+
+**KDropdownMenu** - Dropdown Menu component
+
+<div>
+  <KDropdownMenu :kpop-attributes="{ placement: 'bottomStart', width: '200' }">
+    <template #default="{ isOpen }">
+      <KButton
+        :is-open="isOpen"
+        appearance="creation"
+        icon="gearFilled"
+      />
+    </template>
+    <template #items>
+      <KDropdownItem
+        :item="{ label: 'I am a link', to: { path: '/' } }"
+        disabled
+      />
+      <KDropdownItem>
+        Generic item
+      </KDropdownItem>
+      <KDropdownItem
+        has-divider
+        class="danger"
+        @click="clickHandler"
+      >
+        Danger button
+      </KDropdownItem>
+    </template>
+  </KDropdownMenu>
+</div>
+
+```html
+<KDropdownMenu :kpop-attributes="{ placement: 'bottomEnd', width: '200' }">
+  <template #default="{ isOpen }">
+    <KButton
+      :is-open="isOpen"
+      appearance="creation"
+      icon="gearFilled"
+    />
+  </template>
+  <template #items>
+    <KDropdownItem
+      :item="{ label: 'I am a link', to: '/' }"
+      disabled
+    />
+    <KDropdownItem>
+      Generic item
+    </KDropdownItem>
+    <KDropdownItem
+      has-divider
+      class="danger"
+      @click="clickHandler"
+    >
+      Danger button
+    </KDropdownItem>
+  </template>
+</KDropdownMenu>
+```
+
+## Props
+
+### Prop1
+
+Description of prop1
+
+Actual component using prop1
+<KDropdownMenu />
+
+```html
+<KDropdownMenu prop1="variation1" />
+```
+
+## Slots
+
+- `default` - default slot description
+- `slot1` - slot1 description
+
+```html
+<KDropdownMenu>
+  here is some slot content
+</KDropdownMenu>
+```
+
+## Theming
+
+| Variable | Purpose
+|:-------- |:-------
+| `--KDropdownMenuBorderColor`| KDropdownMenu border color
+
+An Example of changing the border color of KDropdownMenu to lime might look
+like:
+
+> Note: We are scoping the overrides to a wrapper in this example
+
+<template>
+  <div class="KDropdownMenu-wrapper">
+    <KDropdownMenu />
+  </div>
+</template>
+
+```html
+<template>
+  <div class="KDropdownMenu-wrapper">
+    <KDropdownMenu />
+  </div>
+</template>
+
+<style>
+.KDropdownMenu-wrapper {
+  --KDropdownMenu-wrapperBorderColor: lime;
+}
+</style>
+```
+
+<script>
+export default {
+  data () {
+    return {
+      defaultIsOpen: false
+    }
+  },
+  methods: {
+    clickHandler () {
+      this.$toaster.open('Button was clicked')
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.KDropdownMenu-wrapper {
+  --KDropdownMenu-wrapperBorderColor: lime;
+}
+</style>

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -1,4 +1,4 @@
-# DropdownMenu
+# Dropdown Menu
 
 **KDropdownMenu** is a button (or any slotted content) that is clicked to trigger a menu popover beneath it.
 
@@ -28,10 +28,10 @@ An array of item objects containing a `label` property and other optional proper
 ### appearance
 
 Use this prop to specify the display style for the dropdown menu. Can be either `menu` (default) or `selectionMenu`.
-The `menu` style is the standard you have seen in the example above.
+The `menu` style is the standard you have seen in the example above. Uses a standard `primary` `KButton` with hover state over items and no notion of "selection".
 
-The `selectionMenu` style is good for a clearer representation of what is selected. `selected` state is handled automatically when
-clicking a `KDropdownItem` if used in conjunction with the `items` prop. You will need to manually control selectedness if you are using the `items` slot.
+The `selectionMenu` style is good for a clearer representation of the currently selected menu item. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop.
+If using the `items` slot, `KDropdownItem` children should use the `selectionMenuChild` prop to fire a `changed` event when clicked. You will need to manually control selectedness of each item using the `selected` prop.
 
 <div>
   <KDropdownMenu
@@ -41,16 +41,12 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
   >
     <template #items>
       <KDropdownItem
-        :selected="selectedItem === 'us'"
-        @click="clickHandler('US selected', 'us', 'US (United States)')"
+        v-for="item in menuItems"
+        selection-menu-child
+        :selected="selectedItem === item.value"
+        @click="clickHandler(null, item)"
       >
-        US (United States)
-      </KDropdownItem>
-      <KDropdownItem
-        :selected="selectedItem === 'fr'"
-        @click="clickHandler('France selected', 'fr', 'FR (France)')"
-      >
-        FR (France)
+        {{ item.label }}
       </KDropdownItem>
     </template>
   </KDropdownMenu>
@@ -64,16 +60,12 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
 >
   <template #items>
     <KDropdownItem
-      :selected="selectedItem === 'us'"
-      @click="clickHandler('US selected', 'us', 'US (United States)')"
+      v-for="item in menuItems"
+      selection-menu-child
+      :selected="selectedItem === item.value"
+      @click="clickHandler(null, item)"
     >
-      US (United States)
-    </KDropdownItem>
-    <KDropdownItem
-      :selected="selectedItem === 'fr'"
-      @click="clickHandler('France selected', 'fr', 'FR (France)')"
-    >
-      FR (France)
+      {{ item.label }}
     </KDropdownItem>
   </template>
 </KDropdownMenu>
@@ -84,19 +76,27 @@ export default {
     return {
       selectedItem: '',
       selectedLabel: 'Select an item'
+      menuItems: [{
+        label: 'US (United States)',
+        value: 'us'
+      },
+      {
+        label: 'FR (France)',
+        value: 'fr'
+      }]
     }
   },
   methods: {
-    clickHandler (msg, val, label) {
-      if (val !== undefined) {
-        this.selectedItem = val
+    clickHandler (msg, item) {
+      if (item.value !== undefined) {
+        this.selectedItem = item.value
       }
 
-      if (label) {
-        this.selectedLabel = label
+      if (item.label) {
+        this.selectedLabel = item.label
       }
 
-      this.$toaster.open(msg)
+      this.$toaster.open(msg || `${item.label} clicked!`)
     }
   }
 }
@@ -217,7 +217,7 @@ Text to display on hover if dropdown is disabled.
 
 There are 2 supported slots:
 
-- `default` - The trigger element for opening/closing the menu. Returns the `isOpen` state.
+- `default` - The trigger element for opening/closing the menu. Slot provides `isOpen` - whether the menu is open or not.
 - `items` - For an example of using the items slot see the [`KDropdownItem`](#KDropdownItem) section.
 
 <div>
@@ -275,7 +275,7 @@ There are 3 primary item types:
   <KDropdownMenu label="Variety">
     <template #items>
       <KDropdownItem :item="youAreHere" />
-      <KDropdownItem @click="clickHandler">
+      <KDropdownItem @click="clickHandler('Button clicked!')">
         A button
       </KDropdownItem>
       <KDropdownItem
@@ -345,8 +345,9 @@ There are 3 primary item types:
 
 | Event     | Description             |
 | :-------- | :------------------ |
-| `click` | Fires when a menu item is clicked |
-| `changed` | Fires when items with `selectionMenuChild` prop are clicked; returns `selectedItem` Object or null |
+| `click` | Fires when a `button` type menu item is clicked |
+| `changed` | Fires when items with `selectionMenuChild` prop are clicked; returns the menu item Object or null |
+| `toggleDropdown` | Fires when the button to toggle the menu is clicked; returns true if the menu is open, or false |
 
 <script>
 export default {
@@ -354,6 +355,14 @@ export default {
     return {
       selectedLabel: 'Selected an item',
       selectedItem: '',
+      menuItems: [{
+        label: 'US (United States)',
+        value: 'us'
+      },
+      {
+        label: 'FR (France)',
+        value: 'fr'
+      }],
       defaultItemsUnselected: [
         { label: 'Home', to: { path: '/' } },
         { label: 'Button docs', to: { path: '/components/button.html' } },
@@ -363,19 +372,20 @@ export default {
     }
   },
   methods: {
-    clickHandler (msg, val, label) {
+    clickHandler (msg, item) {
       let text = 'Button was clicked'
 
       if (msg) {
         text = msg
       }
 
-      if (val !== undefined) {
-        this.selectedItem = val
+      if (item && item.value !== undefined) {
+        this.selectedItem = item.value
       }
 
-      if (label) {
-        this.selectedLabel = label
+      if (item && item.label) {
+        this.selectedLabel = item.label
+        text = `${item.label} clicked!`
       }
 
       this.$toaster.open(text)

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -254,7 +254,7 @@ There are 2 supported slots:
 
 - `item` - the properties the router-link is built from, it expects a `label` and a `to`.
 - `disabled` - a boolean (defaults to `false`), whether or not to disable the item.
-- `selected` - a boolean (default to `false`), whether or not the item is selected.
+- `selected` - a boolean (defaults to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)
 - `selectionMenuChild` - a boolean (defaults to `false`), whether the parent is a `selectionMenu` or not (used for events)

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -354,7 +354,7 @@ There are 3 primary item types:
 | Event     | Description             |
 | :-------- | :------------------ |
 | `click` | Fires when a `button` type menu item is clicked |
-| `change` | Fires when items within a `selectionMenu` are clicked; returns the selected menu item object or null |
+| `change` | Fires when items within a `selectionMenu` are clicked; returns the selected menu item object or `null` |
 | `toggleDropdown` | Fires when the button to toggle the menu is clicked; returns `true` if the menu is open, or `false` |
 
 <script>

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -355,7 +355,7 @@ There are 3 primary item types:
 | :-------- | :------------------ |
 | `click` | Fires when a `button` type menu item is clicked |
 | `change` | Fires when items within a `selectionMenu` are clicked; returns the selected menu item object or null |
-| `toggleDropdown` | Fires when the button to toggle the menu is clicked; returns true if the menu is open, or false |
+| `toggleDropdown` | Fires when the button to toggle the menu is clicked; returns `true` if the menu is open, or `false` |
 
 <script>
 export default {

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -257,7 +257,7 @@ There are 2 supported slots:
 - `selected` - a boolean (default to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)
-- `selectionMenuChild` - a boolean (default to `false`), whether the parent is a `selectionMenu` or not (used for events)
+- `selectionMenuChild` - a boolean (defaults to `false`), whether the parent is a `selectionMenu` or not (used for events)
 
 ```html
 <KDropdownItem :item="{ label: 'Leave the page', to: { path: '/' } }" />

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -91,6 +91,30 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
     </KDropdownItem>
   </template>
 </KDropdownMenu>
+
+<script>
+export default {
+  data() {
+    return {
+      selectedItem: '',
+      selectedLabel: 'Select an item'
+    }
+  },
+  methods: {
+    clickHandler (msg, val, label) {
+      if (val !== undefined) {
+        this.selectedItem = val
+      }
+
+      if (label) {
+        this.selectedLabel = label
+      }
+
+      this.$toaster.open(msg)
+    }
+  }
+}
+</script>
 ```
 
 ### kpopAttributes

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -12,7 +12,7 @@ The label for the menu.
 
 ### items
 
-An array of items containing a `label` and other optional properties will render a menu of [`KDropdownItems`](#KDropdownItem) .
+An array of item objects containing a `label` property and other optional properties which will render a menu of [`KDropdownItems`](#KDropdownItem) .
 
 ```html
 <KDropdownMenu

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -1,14 +1,11 @@
 # DropdownMenu
 
-**KDropdownMenu** is a button (or any slotted content) that is clicked to trigger a popover containing menu items beneath it.
-
-HOW DOES THIS DIFFER FROM KSELECT
+**KDropdownMenu** is a button (or any slotted content) that is clicked to trigger a menu popover beneath it.
 
 <div>
   <KDropdownMenu
     class="more-actions-dropdown"
     :kpop-attributes="{
-      placement: 'bottomEnd',
       popoverClasses: 'mt-5 more-actions-popover',
       width: '150'
     }"
@@ -47,21 +44,43 @@ HOW DOES THIS DIFFER FROM KSELECT
   </KDropdownMenu>
 </div>
 
+## Props
+
+### label
+
+The label for the menu.
+
+### items
+
+An array of items containing a `label` and `to` will render a menu of router-links.
+
+<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" />
+
+```html
+<KDropdownMenu
+  label="Documentation"
+  :items="[
+    { label: 'Home', to: { path: '/' } },
+    { label: 'Button docs', to: { path: '/components/button.html' } },
+    { label: 'My docs', to: { path: '/components/dropdown-menu.html' } }
+  ]"
+/>
+```
+
+### appearance
+
+Use this prop to specify the display style for the dropdown menu. Can be either `menu` (default) or `selectionMenu`.
+
 <div>
   <KDropdownMenu
-    class="top-bar-dropdown-menu d-flex mr-1"
-    :kpop-attributes="{ placement: 'bottomStart', width: '220', disabled: false }"
-    :disabled="false"
-    disabled-tooltip="tooltip text"
-    :class="{ 'global-switcher-disabled': false }"
+    :kpop-attributes="{ width: '220' }"
+    appearance="selectionMenu"
   >
     <template #default="{ isOpen }">
       <KButton
         class="top-bar-dropdown-trigger"
         :class="{ 'is-active': isOpen }"
         :is-open="isOpen"
-        :disabled="false"
-        data-testid="top-bar-dropdown-menu-toggle-button"
       >
         Selected Item
       </KButton>
@@ -101,26 +120,52 @@ HOW DOES THIS DIFFER FROM KSELECT
   </KDropdownMenu>
 </div>
 
-## Props
+### kpopAttributes
 
-### label
+Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popover.html) dropdown.
 
-The label for the menu.
-
-### items
-
-An array of items containing a `label` and `to` will render a menu of router-links.
-
-<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" />
+<div>
+  <KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" :kpop-attributes="{
+      popoverClasses: 'mt-2 a-custom-popover',
+      width: '150'
+    }"
+  />
+</div>
 
 ```html
 <KDropdownMenu
   label="Documentation"
-  :items="[
-    { label: 'Home', to: { path: '/' } },
-    { label: 'Button docs', to: { path: '/components/button.html' } },
-    { label: 'My docs', to: { path: '/components/dropdown-menu.html' } }
-  ]"
+  :items="items"
+  :kpop-attributes="{
+    popoverClasses: 'mt-2 a-custom-popover',
+    width: '150'
+  }"
+/>
+```
+
+### disabled
+
+Use this prop to disable the dropdown, can be used in conjunction with `disabledTooltip` prop.
+
+### disabledTooltip
+
+Text to display on hover if dropdown is disabled.
+
+<div>
+  <KDropdownMenu
+    label="Documentation"
+    :disabled="true"
+    disabled-tooltip="You can't click me"
+    :items="deepClone(defaultItemsUnselected)"
+  />
+</div>
+
+```html
+<KDropdownMenu
+  label="Documentation"
+  :disabled="true"
+  disabled-tooltip="You can't click me"
+  :items="deepClone(defaultItemsUnselected)"
 />
 ```
 
@@ -167,6 +212,7 @@ There are 2 supported slots:
 - `disabled` - a boolean (default to `false`), whether or not to disable the item.
 - `selected` - a boolean (default to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
+- `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)
 
 ```html
 <KDropdownItem :item="{ label: 'Leave the page', to: { path: '/' } }" />
@@ -195,7 +241,8 @@ There are 3 primary item types:
       </KDropdownItem>
       <KDropdownItem
         has-divider
-        class="danger"
+        is-dangerous
+        class="d-inline-block"
       >
         <a
           href="http://www.google.com"
@@ -229,7 +276,8 @@ There are 3 primary item types:
     </KDropdownItem>
     <KDropdownItem
       has-divider
-      class="danger"
+      is-dangerous
+      class="d-inline-block"
     >
       <a
         href="http://www.google.com"
@@ -301,6 +349,9 @@ export default {
       }
 
       this.$toaster.open(text)
+    },
+    deepClone(obj) {
+      return JSON.parse(JSON.stringify(obj))
     }
   }
 }

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -31,6 +31,7 @@ Use this prop to specify the display style for the dropdown menu. Can be either 
 The `menu` style is the standard you have seen in the example above. Uses a standard `primary` `KButton` with hover state over items and no notion of "selection".
 
 The `selectionMenu` style is used when a visual indication of the currently selected menu item is needed. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop. Each item should have a `label` and a `value`.
+
 If using the `items` slot, you will have access to the `handleSelection()` method which should be called on each item's click event and takes the `item` data as a parameter. This will enable you to attach to the `@change` event (which returns the selected item) to track your selection.
 
 <div>

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -265,7 +265,7 @@ There are 2 supported slots:
 
 There are 3 primary item types:
 
-- `router-link`
+- `link`
   - the generic type generated using the `items` prop on `KDropdownMenu`
   - the generic type generated using the `item` prop on `KDropdownItem`
 - `button` - this item is generated if a handler is specified for the `@click` event on a `KDropdownItem`

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -39,10 +39,7 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
     appearance="selectionMenu"
   >
     <template #default="{ isOpen }">
-      <KButton
-        :class="{ 'is-active': isOpen }"
-        :is-open="isOpen"
-      >
+      <KButton :is-open="isOpen">
         {{ selectedLabel }}
       </KButton>
     </template>
@@ -69,10 +66,7 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
   appearance="selectionMenu"
 >
   <template #default="{ isOpen }">
-    <KButton
-      :class="{ 'is-active': isOpen }"
-      :is-open="isOpen"
-    >
+    <KButton :is-open="isOpen">
       {{ selectedLabel }}
     </KButton>
   </template>
@@ -115,6 +109,20 @@ export default {
   }
 }
 </script>
+```
+
+### showCaret
+
+Use this prop if you would like the trigger button to display the caret.
+
+<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" show-caret />
+
+```html
+<KDropdownMenu
+  label="Documentation"
+  :items="items"
+  show-caret
+/>
 ```
 
 ### kpopAttributes

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -345,7 +345,7 @@ There are 3 primary item types:
 
 | Event     | Description             |
 | :-------- | :------------------ |
-| `clicked` | Fires when a menu item is clicked |
+| `click` | Fires when a menu item is clicked |
 | `changed` | Fires when items with `selectionMenuChild` prop are clicked; returns `selectedItem` Object or null |
 
 <script>

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -248,7 +248,7 @@ There are 2 supported slots:
 
 ## KDropdownItem
 
-**KDropdownMenu** generates a **KDropdownItem** for each item in the `items` property. At the most basic level, **KDropdownItem** is a wrapper around each item to display it correctly inside `KDropdownMenu`. You can use the `items` slot of the `KDropdownMenu` to manually create your own menu items.
+**KDropdownMenu** generates a **KDropdownItem** for each object in the `items` prop array. At the most basic level, **KDropdownItem** is a wrapper around each item to display it correctly inside `KDropdownMenu`. You can use the `items` slot of the `KDropdownMenu` to manually create your own menu items.
 
 ### Properties
 

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -31,7 +31,7 @@
 </div>
 
 ```html
-<KDropdownMenu :kpop-attributes="{ placement: 'bottomEnd', width: '200' }">
+<KDropdownMenu :kpop-attributes="{ placement: 'bottomStart', width: '200' }">
   <template #default="{ isOpen }">
     <KButton
       :is-open="isOpen"
@@ -41,7 +41,7 @@
   </template>
   <template #items>
     <KDropdownItem
-      :item="{ label: 'I am a link', to: '/' }"
+      :item="{ label: 'I am a link', to: { path: '/' } }"
       disabled
     />
     <KDropdownItem>
@@ -57,6 +57,103 @@
   </template>
 </KDropdownMenu>
 ```
+
+<div>
+  <KDropdownMenu
+    class="more-actions-dropdown"
+    :kpop-attributes="{
+      placement: 'bottomEnd',
+      popoverClasses: 'mt-5 more-actions-popover',
+      width: '150'
+    }"
+  >
+    <template #default>
+      <KButton
+        appearance="secondary"
+        size="small"
+        class="float-right non-visual-button"
+        data-testid="more-actions-btn"
+      >
+        <template #icon>
+          <KIcon
+            icon="more"
+            color="var(--black-400)"
+            size="16"
+          />
+        </template>
+      </KButton>
+    </template>
+    <template #items>
+      <KDropdownItem
+        :item="{
+          to: { path: '/components/button.html' },
+          label: 'View KButton docs'
+        }"
+      />
+      <KDropdownItem
+        :disabled="false"
+        class="danger"
+        @click.prevent="clickHandler('Deleted successfully!')"
+      >
+        Delete
+      </KDropdownItem>
+    </template>
+  </KDropdownMenu>
+</div>
+
+<div>
+  <KDropdownMenu
+    class="top-bar-dropdown-menu d-flex mr-1"
+    :kpop-attributes="{ placement: 'bottomStart', width: '220', disabled: false }"
+    :disabled="false"
+    disabled-tooltip="tooltip text"
+    :class="{ 'global-switcher-disabled': false }"
+  >
+    <template #default="{ isOpen }">
+      <KButton
+        class="top-bar-dropdown-trigger"
+        :class="{ 'is-active': isOpen }"
+        :is-open="isOpen"
+        :disabled="false"
+        data-testid="top-bar-dropdown-menu-toggle-button"
+      >
+        Selected Item
+      </KButton>
+    </template>
+    <template #items>
+      <KDropdownItem
+        @click="clickHandler('US selected')"
+      >
+        US (United States)
+      </KDropdownItem>
+      <KDropdownItem
+        :class="{'top-bar-dropdown-selected-option': false }"
+        @click="clickHandler('US selected')"
+      >
+        US2 (United States)
+      </KDropdownItem>
+      <KDropdownItem
+        v-if="false"
+        has-divider
+        data-testid="geo-switcher-global-more-regions-option"
+      >
+        <ExternalLink
+          :href="pricingURL"
+          hide-icon
+          class="w-100"
+          data-testid="geo-switcher-global-more-regions-option-link"
+        >
+          <div class="d-block">
+            <div>{{ english.geo.moreRegions }}</div>
+            <div class="mt-2">
+              <HelpKonnectEnterpriseLogo />
+            </div>
+          </div>
+        </ExternalLink>
+      </KDropdownItem>
+    </template>
+  </KDropdownMenu>
+</div>
 
 ## Props
 
@@ -121,8 +218,14 @@ export default {
     }
   },
   methods: {
-    clickHandler () {
-      this.$toaster.open('Button was clicked')
+    clickHandler (msg) {
+      let text = 'Button was clicked'
+
+      if (msg) {
+        text = msg
+      }
+
+      this.$toaster.open(text)
     }
   }
 }

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -30,7 +30,7 @@ An array of item objects containing a `label` property and other optional proper
 Use this prop to specify the display style for the dropdown menu. Can be either `menu` (default) or `selectionMenu`.
 The `menu` style is the standard you have seen in the example above. Uses a standard `primary` `KButton` with hover state over items and no notion of "selection".
 
-The `selectionMenu` style is used when a visual indication of the currently selected menu item is needed. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop.
+The `selectionMenu` style is used when a visual indication of the currently selected menu item is needed. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop. Each item should have a `label` and a `value`.
 If using the `items` slot, you will have access to the `handleSelection()` method which should be called on each item's click event and takes the `item` data as a parameter. This will enable you to attach to the `@change` event (which returns the selected item) to track your selection.
 
 <div>
@@ -73,8 +73,8 @@ export default {
   data() {
     return {
       selectedItem: {
-        value: '',
-        label: 'Select an item'
+        label: 'Select an item',
+        value: ''
       },
       menuItems: [{
         label: 'US (United States)',
@@ -259,9 +259,9 @@ There are 2 supported slots:
 
 ### Properties
 
-- `item` - the properties the router-link is built from, it expects a `label` and a `to`.
+- `item` - the properties the router-link is built from, it expects a `label` and optionally a `to` (for a router-link item) or `value` (for a `selectionMenu` item).
 - `disabled` - a boolean (defaults to `false`), whether or not to disable the item.
-- `selected` - a boolean (defaults to `false`), whether or not the item is selected.
+- `selected` - a boolean (defaults to `false`), whether or not the item is selected if using `selectionMenu` appearance.
 - `hasDivider` - a boolean (defaults to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (defaults to `false`), whether or not to apply danger styles (text color is red)
 

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -36,13 +36,10 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
 <div>
   <KDropdownMenu
     :kpop-attributes="{ width: '220' }"
+    :label="selectedLabel"
     appearance="selectionMenu"
+    show-caret
   >
-    <template #default="{ isOpen }">
-      <KButton :is-open="isOpen">
-        {{ selectedLabel }}
-      </KButton>
-    </template>
     <template #items>
       <KDropdownItem
         :selected="selectedItem === 'us'"
@@ -63,13 +60,10 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
 ```html
 <KDropdownMenu
   :kpop-attributes="{ width: '220' }"
+  :label="selectedLabel"
   appearance="selectionMenu"
+  show-caret
 >
-  <template #default="{ isOpen }">
-    <KButton :is-open="isOpen">
-      {{ selectedLabel }}
-    </KButton>
-  </template>
   <template #items>
     <KDropdownItem
       :selected="selectedItem === 'us'"

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -18,9 +18,9 @@ An array of item objects containing a `label` property and other optional proper
 <KDropdownMenu
   label="Documentation"
   :items="[
-    { label: 'Home', to: { path: '/' } },
-    { label: 'Button docs', to: { path: '/components/button.html' } },
-    { label: 'My docs', to: { path: '/components/dropdown-menu.html' } }
+    { label: 'Props', to: { path: '/components/dropdown-menu.html#props' } },
+    { label: 'Slots', to: { path: '/components/dropdown-menu.html#slots' } },
+    { label: 'Top', to: { path: '/components/dropdown-menu.html' } }
   ]"
 />
 ```
@@ -30,21 +30,20 @@ An array of item objects containing a `label` property and other optional proper
 Use this prop to specify the display style for the dropdown menu. Can be either `menu` (default) or `selectionMenu`.
 The `menu` style is the standard you have seen in the example above. Uses a standard `primary` `KButton` with hover state over items and no notion of "selection".
 
-The `selectionMenu` style is good for a clearer representation of the currently selected menu item. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop.
-If using the `items` slot, `KDropdownItem` children should use the `selectionMenuChild` prop to fire a `changed` event when clicked. You will need to manually control the reactive state of the selected item.
+The `selectionMenu` style is used when a visual indication of the currently selected menu item is needed. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop.
+If using the `items` slot, you will have access to the `handleSelection()` method which should be called on each item's click event and takes the `item` data as a parameter. This will enable you to attach to the `@change` event (which returns the selected item) to track your selection.
 
 <div>
   <KDropdownMenu
-    :kpop-attributes="{ width: '220' }"
-    :label="selectedLabel"
+    :label="selectedItem.label"
     appearance="selectionMenu"
+    @change="(selection) => handleChange(selection)"
   >
-    <template #items>
+    <template #items="{ handleSelection }">
       <KDropdownItem
         v-for="item in menuItems"
-        selection-menu-child
-        :selected="selectedItem === item.value"
-        @click="clickHandler(null, item)"
+        :selected="selectedItem.value === item.value"
+        @click="handleSelection(item)"
       >
         {{ item.label }}
       </KDropdownItem>
@@ -54,16 +53,15 @@ If using the `items` slot, `KDropdownItem` children should use the `selectionMen
 
 ```html
 <KDropdownMenu
-  :kpop-attributes="{ width: '220' }"
-  :label="selectedLabel"
+  :label="selectedItem.label"
   appearance="selectionMenu"
+  @change="(selection) => handleChange(selection)"
 >
-  <template #items>
+  <template #items="{ handleSelection }">
     <KDropdownItem
       v-for="item in menuItems"
-      selection-menu-child
-      :selected="selectedItem === item.value"
-      @click="clickHandler(null, item)"
+      :selected="selectedItem.value === item.value"
+      @click="handleSelection(item)"
     >
       {{ item.label }}
     </KDropdownItem>
@@ -74,8 +72,10 @@ If using the `items` slot, `KDropdownItem` children should use the `selectionMen
 export default {
   data() {
     return {
-      selectedItem: '',
-      selectedLabel: 'Select an item'
+      selectedItem: {
+        value: '',
+        label: 'Select an item'
+      },
       menuItems: [{
         label: 'US (United States)',
         value: 'us'
@@ -87,16 +87,9 @@ export default {
     }
   },
   methods: {
-    clickHandler (msg, item) {
-      if (item.value !== undefined) {
-        this.selectedItem = item.value
-      }
-
-      if (item.label) {
-        this.selectedLabel = item.label
-      }
-
-      this.$toaster.open(msg || `${item.label} clicked!`)
+    handleChange (item) {
+      this.selectedItem = item
+      this.$toaster.open(`${item.label} clicked!`)
     }
   }
 }
@@ -117,20 +110,34 @@ Use this prop if you would like the trigger button to display the caret.
 />
 ```
 
+### width
+
+The width of the dropdown body. Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
+
+<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" width="500" />
+
+```html
+<KDropdownMenu
+  label="Documentation"
+  :items="items"
+  width="500"
+/>
+```
+
 ### kpopAttributes
 
 Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popover.html) dropdown.
 
 <div>
   <KCard
-    title="Card Title"
-    body="Body Content"
+    title="KPopAttributes FTW"
+    body="Click the three dots in the upper right corner to see the example in action"
   >
     <template #actions>
       <KDropdownMenu
         :kpop-attributes="{
           popoverClasses: 'mt-5',
-          width: '180'
+          maxWidth: '100'
         }"
         :items="deepClone(defaultItemsUnselected)"
       >
@@ -156,14 +163,14 @@ Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popo
 
 ```html
 <KCard
-  title="Card Title"
-  body="Body Content"
+  title="KPopAttributes FTW"
+  body="Click the three dots in the upper right corner to see the example in action"
 >
   <template #actions>
     <KDropdownMenu
       :kpop-attributes="{
         popoverClasses: 'mt-5',
-        width: '180'
+        maxWidth: '100'
       }"
       :items="deepClone(defaultItemsUnselected)"
     >
@@ -257,7 +264,6 @@ There are 2 supported slots:
 - `selected` - a boolean (defaults to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (defaults to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (defaults to `false`), whether or not to apply danger styles (text color is red)
-- `selectionMenuChild` - a boolean (defaults to `false`), whether the parent is a `selectionMenu` or not (used for events)
 
 ```html
 <KDropdownItem :item="{ label: 'Leave the page', to: { path: '/' } }" />
@@ -298,6 +304,7 @@ There are 3 primary item types:
           <KIcon
             icon="externalLink"
             size="12"
+            color="var(--red-500)"
             class="ml-2"
           />
         </a>
@@ -333,6 +340,7 @@ There are 3 primary item types:
         <KIcon
           icon="externalLink"
           size="12"
+          color="var(--red-500)"
           class="ml-2"
         />
       </a>
@@ -346,15 +354,17 @@ There are 3 primary item types:
 | Event     | Description             |
 | :-------- | :------------------ |
 | `click` | Fires when a `button` type menu item is clicked |
-| `changed` | Fires when items with `selectionMenuChild` prop are clicked; returns the menu item Object or null |
+| `change` | Fires when items within a `selectionMenu` are clicked; returns the selected menu item object or null |
 | `toggleDropdown` | Fires when the button to toggle the menu is clicked; returns true if the menu is open, or false |
 
 <script>
 export default {
   data () {
     return {
-      selectedLabel: 'Select an item',
-      selectedItem: '',
+      selectedItem: {
+        value: '',
+        label: 'Selet an item'
+      },
       menuItems: [{
         label: 'US (United States)',
         value: 'us'
@@ -364,28 +374,23 @@ export default {
         value: 'fr'
       }],
       defaultItemsUnselected: [
-        { label: 'Home', to: { path: '/' } },
-        { label: 'Button docs', to: { path: '/components/button.html' } },
-        { label: 'My docs', to: { path: '/components/dropdown-menu.html' } }
+        { label: 'Props', to: { path: '/components/dropdown-menu.html#props' } },
+        { label: 'Slots', to: { path: '/components/dropdown-menu.html#slots' } },
+        { label: 'Top', to: { path: '/components/dropdown-menu.html' } }
       ],
       youAreHere: { label: 'You are here', to: { path: '/components/dropdown-menu.html' } }
     }
   },
   methods: {
-    clickHandler (msg, item) {
+    handleChange (item) {
+      this.selectedItem = item
+      this.$toaster.open(`${item.label} clicked!`)
+    },
+    clickHandler (msg) {
       let text = 'Button was clicked'
 
       if (msg) {
         text = msg
-      }
-
-      if (item && item.value !== undefined) {
-        this.selectedItem = item.value
-      }
-
-      if (item && item.label) {
-        this.selectedLabel = item.label
-        text = `${item.label} clicked!`
       }
 
       this.$toaster.open(text)
@@ -396,9 +401,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss">
-.KDropdownMenu-wrapper {
-  --KDropdownMenu-wrapperBorderColor: lime;
-}
-</style>

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -38,7 +38,6 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
     :kpop-attributes="{ width: '220' }"
     :label="selectedLabel"
     appearance="selectionMenu"
-    show-caret
   >
     <template #items>
       <KDropdownItem
@@ -62,7 +61,6 @@ clicking a `KDropdownItem` if used in conjunction with the `items` prop. You wil
   :kpop-attributes="{ width: '220' }"
   :label="selectedLabel"
   appearance="selectionMenu"
-  show-caret
 >
   <template #items>
     <KDropdownItem

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -363,7 +363,7 @@ export default {
     return {
       selectedItem: {
         value: '',
-        label: 'Selet an item'
+        label: 'Select an item'
       },
       menuItems: [{
         label: 'US (United States)',

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -30,6 +30,12 @@ An array of item objects containing a `label` property and other optional proper
 Use this prop to specify the display style for the dropdown menu. Can be either `menu` (default) or `selectionMenu`.
 The `menu` style is the standard you have seen in the example above. Uses a standard `primary` `KButton` with hover state over items and no notion of "selection".
 
+<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" />
+
+```html
+<KDropdownMenu label="Documentation" :items="items" />
+```
+
 The `selectionMenu` style is used when a visual indication of the currently selected menu item is needed. `selected` state is handled automatically when clicking a `KDropdownItem` if used in conjunction with the `items` prop. Each item should have a `label` and a `value`.
 
 If using the `items` slot, you will have access to the `handleSelection()` method which should be called on each item's click event and takes the `item` data as a parameter. This will enable you to attach to the `@change` event (which returns the selected item) to track your selection.
@@ -113,7 +119,7 @@ Use this prop if you would like the trigger button to display the caret.
 
 ### width
 
-The width of the dropdown body. Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
+The width of the dropdown body (defaults to `auto`). Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
 
 <KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" width="500" />
 

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -256,7 +256,7 @@ There are 2 supported slots:
 - `disabled` - a boolean (defaults to `false`), whether or not to disable the item.
 - `selected` - a boolean (defaults to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (defaults to `false`), whether or not the item should have a divider bar displayed above it
-- `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)
+- `isDangerous` - a boolean (defaults to `false`), whether or not to apply danger styles (text color is red)
 - `selectionMenuChild` - a boolean (defaults to `false`), whether the parent is a `selectionMenu` or not (used for events)
 
 ```html

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -255,7 +255,7 @@ There are 2 supported slots:
 - `item` - the properties the router-link is built from, it expects a `label` and a `to`.
 - `disabled` - a boolean (defaults to `false`), whether or not to disable the item.
 - `selected` - a boolean (defaults to `false`), whether or not the item is selected.
-- `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
+- `hasDivider` - a boolean (defaults to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)
 - `selectionMenuChild` - a boolean (defaults to `false`), whether the parent is a `selectionMenu` or not (used for events)
 

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -2,47 +2,7 @@
 
 **KDropdownMenu** is a button (or any slotted content) that is clicked to trigger a menu popover beneath it.
 
-<div>
-  <KDropdownMenu
-    class="more-actions-dropdown"
-    :kpop-attributes="{
-      popoverClasses: 'mt-5 more-actions-popover',
-      width: '150'
-    }"
-  >
-    <template #default>
-      <KButton
-        appearance="secondary"
-        size="small"
-        class="float-right non-visual-button"
-        data-testid="more-actions-btn"
-      >
-        <template #icon>
-          <KIcon
-            icon="more"
-            color="var(--black-400)"
-            size="16"
-          />
-        </template>
-      </KButton>
-    </template>
-    <template #items>
-      <KDropdownItem
-        :item="{
-          to: { path: '/components/button.html' },
-          label: 'View KButton docs'
-        }"
-      />
-      <KDropdownItem
-        :disabled="false"
-        class="danger"
-        @click.prevent="clickHandler('Deleted successfully!')"
-      >
-        Delete
-      </KDropdownItem>
-    </template>
-  </KDropdownMenu>
-</div>
+<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" />
 
 ## Props
 
@@ -52,9 +12,7 @@ The label for the menu.
 
 ### items
 
-An array of items containing a `label` and `to` will render a menu of router-links.
-
-<KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" />
+An array of items containing a `label` and other optional properties will render a menu of [`KDropdownItems`](#KDropdownItem) .
 
 ```html
 <KDropdownMenu
@@ -70,6 +28,10 @@ An array of items containing a `label` and `to` will render a menu of router-lin
 ### appearance
 
 Use this prop to specify the display style for the dropdown menu. Can be either `menu` (default) or `selectionMenu`.
+The `menu` style is the standard you have seen in the example above.
+
+The `selectionMenu` style is good for a clearer representation of what is selected. `selected` state is handled automatically when
+clicking a `KDropdownItem` if used in conjunction with the `items` prop. You will need to manually control selectedness if you are using the `items` slot.
 
 <div>
   <KDropdownMenu
@@ -78,69 +40,127 @@ Use this prop to specify the display style for the dropdown menu. Can be either 
   >
     <template #default="{ isOpen }">
       <KButton
-        class="top-bar-dropdown-trigger"
         :class="{ 'is-active': isOpen }"
         :is-open="isOpen"
       >
-        Selected Item
+        {{ selectedLabel }}
       </KButton>
     </template>
     <template #items>
       <KDropdownItem
-        @click="clickHandler('US selected')"
+        :selected="selectedItem === 'us'"
+        @click="clickHandler('US selected', 'us', 'US (United States)')"
       >
         US (United States)
       </KDropdownItem>
       <KDropdownItem
-        :class="{'top-bar-dropdown-selected-option': false }"
-        @click="clickHandler('US selected')"
+        :selected="selectedItem === 'fr'"
+        @click="clickHandler('France selected', 'fr', 'FR (France)')"
       >
-        US2 (United States)
-      </KDropdownItem>
-      <KDropdownItem
-        v-if="false"
-        has-divider
-        data-testid="geo-switcher-global-more-regions-option"
-      >
-        <ExternalLink
-          :href="pricingURL"
-          hide-icon
-          class="w-100"
-          data-testid="geo-switcher-global-more-regions-option-link"
-        >
-          <div class="d-block">
-            <div>{{ english.geo.moreRegions }}</div>
-            <div class="mt-2">
-              <HelpKonnectEnterpriseLogo />
-            </div>
-          </div>
-        </ExternalLink>
+        FR (France)
       </KDropdownItem>
     </template>
   </KDropdownMenu>
 </div>
+
+```html
+<KDropdownMenu
+  :kpop-attributes="{ width: '220' }"
+  appearance="selectionMenu"
+>
+  <template #default="{ isOpen }">
+    <KButton
+      :class="{ 'is-active': isOpen }"
+      :is-open="isOpen"
+    >
+      {{ selectedLabel }}
+    </KButton>
+  </template>
+  <template #items>
+    <KDropdownItem
+      :selected="selectedItem === 'us'"
+      @click="clickHandler('US selected', 'us', 'US (United States)')"
+    >
+      US (United States)
+    </KDropdownItem>
+    <KDropdownItem
+      :selected="selectedItem === 'fr'"
+      @click="clickHandler('France selected', 'fr', 'FR (France)')"
+    >
+      FR (France)
+    </KDropdownItem>
+  </template>
+</KDropdownMenu>
+```
 
 ### kpopAttributes
 
 Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popover.html) dropdown.
 
 <div>
-  <KDropdownMenu label="Documentation" :items="deepClone(defaultItemsUnselected)" :kpop-attributes="{
-      popoverClasses: 'mt-2 a-custom-popover',
-      width: '150'
-    }"
-  />
+  <KCard
+    title="Card Title"
+    body="Body Content"
+  >
+    <template #actions>
+      <KDropdownMenu
+        :kpop-attributes="{
+          popoverClasses: 'mt-5',
+          width: '180'
+        }"
+        :items="deepClone(defaultItemsUnselected)"
+      >
+        <template #default>
+          <KButton
+            appearance="secondary"
+            size="small"
+            class="non-visual-button"
+          >
+            <template #icon>
+              <KIcon
+                icon="more"
+                color="var(--black-400)"
+                size="16"
+              />
+            </template>
+          </KButton>
+        </template>
+      </KDropdownMenu>
+    </template>
+  </KCard>
 </div>
 
 ```html
-<KDropdownMenu
-  label="Documentation"
-  :items="items"
-  :kpop-attributes="{
-    popoverClasses: 'mt-2 a-custom-popover',
-    width: '150'
-  }"
-/>
+<KCard
+  title="Card Title"
+  body="Body Content"
+>
+  <template #actions>
+    <KDropdownMenu
+      :kpop-attributes="{
+        popoverClasses: 'mt-5',
+        width: '180'
+      }"
+      :items="deepClone(defaultItemsUnselected)"
+    >
+      <template #default>
+        <KButton
+          appearance="secondary"
+          size="small"
+          class="non-visual-button"
+        >
+          <template #icon>
+            <KIcon
+              icon="more"
+              color="var(--black-400)"
+              size="16"
+            />
+          </template>
+        </KButton>
+      </template>
+    </KDropdownMenu>
+  </template>
+</KCard>
 ```
 
 ### disabled
@@ -213,6 +233,7 @@ There are 2 supported slots:
 - `selected` - a boolean (default to `false`), whether or not the item is selected.
 - `hasDivider` - a boolean (default to `false`), whether or not the item should have a divider bar displayed above it
 - `isDangerous` - a boolean (default to `false`), whether or not to apply danger styles (text color is red)
+- `selectionMenuChild` - a boolean (default to `false`), whether the parent is a `selectionMenu` or not (used for events)
 
 ```html
 <KDropdownItem :item="{ label: 'Leave the page', to: { path: '/' } }" />
@@ -296,42 +317,19 @@ There are 3 primary item types:
 </KDropdownMenu>
 ```
 
-## Theming
+### Events
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KDropdownMenuBorderColor`| KDropdownMenu border color
-
-An Example of changing the border color of KDropdownMenu to lime might look
-like:
-
-> Note: We are scoping the overrides to a wrapper in this example
-
-<template>
-  <div class="KDropdownMenu-wrapper">
-    <KDropdownMenu />
-  </div>
-</template>
-
-```html
-<template>
-  <div class="KDropdownMenu-wrapper">
-    <KDropdownMenu />
-  </div>
-</template>
-
-<style>
-.KDropdownMenu-wrapper {
-  --KDropdownMenu-wrapperBorderColor: lime;
-}
-</style>
-```
+| Event     | Description             |
+| :-------- | :------------------ |
+| `clicked` | Fires when a menu item is clicked |
+| `changed` | Fires when items with `selectionMenuChild` prop are clicked; returns `selectedItem` Object or null |
 
 <script>
 export default {
   data () {
     return {
-      defaultIsOpen: false,
+      selectedLabel: 'Selected an item',
+      selectedItem: '',
       defaultItemsUnselected: [
         { label: 'Home', to: { path: '/' } },
         { label: 'Button docs', to: { path: '/components/button.html' } },
@@ -341,11 +339,19 @@ export default {
     }
   },
   methods: {
-    clickHandler (msg) {
+    clickHandler (msg, val, label) {
       let text = 'Button was clicked'
 
       if (msg) {
         text = msg
+      }
+
+      if (val !== undefined) {
+        this.selectedItem = val
+      }
+
+      if (label) {
+        this.selectedLabel = label
       }
 
       this.$toaster.open(text)

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -2,7 +2,7 @@
 
 <div v-if="hasMounted">
 
-**Select** - Dropdown/Select component
+**Select** - Select component
 <div>
   <KSelect label="Pick Something:" :items="deepClone(defaultItemsUnselect)" />
 </div>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -912,6 +912,8 @@ export default {
 
 ### Column Cell
 
+This example makes use of the [`KDropdownMenu`](/components/dropdown-menu.html) component as the slot content for the `actions` column.
+
 <KTable
   :headers="tableOptionsHeaders"
   :fetcher="tableOptionsFetcher">
@@ -919,7 +921,37 @@ export default {
     <span v-if="rowValue" style="color: green">&#10003;</span>
     <span v-else style="color: red">&#10007;</span>
   </template>
-  <template v-slot:actions><KButton appearance="btn-link">Edit</KButton></template>
+  <template v-slot:actions>
+    <KDropdownMenu>
+      <template #default>
+        <KButton
+          appearance="secondary"
+          size="small"
+          class="non-visual-button"
+        >
+          <template #icon>
+            <KIcon
+              icon="more"
+              color="var(--black-400)"
+              size="16"
+            />
+          </template>
+        </KButton>
+      </template>
+      <template #items>
+        <KDropdownItem @click="clickHandler('Edit clicked!')">
+          Edit
+        </KDropdownItem>
+        <KDropdownItem
+          has-divider
+          is-dangerous
+          @click="clickHandler('Delete clicked!')"
+        >
+          Delete
+        </KDropdownItem>
+      </template>
+    </KDropdownMenu>
+  </template>
 </KTable>
 
 ```html
@@ -934,7 +966,37 @@ export default {
       <span v-else style="color: red">&#10007;</span>
     </template>
     <!-- Slot each "actions" cell in each row & link -->
-    <template v-slot:actions><a href="">Edit</a></template>
+    <template v-slot:actions>
+      <KDropdownMenu>
+        <template #default>
+          <KButton
+            appearance="secondary"
+            size="small"
+            class="non-visual-button"
+          >
+            <template #icon>
+              <KIcon
+                icon="more"
+                color="var(--black-400)"
+                size="16"
+              />
+            </template>
+          </KButton>
+        </template>
+        <template #items>
+          <KDropdownItem @click="clickHandler('Edit clicked!')">
+            Edit
+          </KDropdownItem>
+          <KDropdownItem
+            has-divider
+            is-dangerous
+            @click="clickHandler('Delete clicked!')"
+          >
+            Delete
+          </KDropdownItem>
+        </template>
+      </KDropdownMenu>
+    </template>
   </KTable>
 </template>
 <script>
@@ -1645,6 +1707,9 @@ for (let i = ((page-1)* pageSize); i < limit; i++) {
       } else {
         this.$toaster.open('Row click event fired!')
       }
+    },
+    clickHandler (msg) {
+      this.$toaster.open(msg)
     },
     linkHander (e) {
       alert('a link was clicked')

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -912,7 +912,7 @@ export default {
 
 ### Column Cell
 
-This example makes use of the [`KDropdownMenu`](/components/dropdown-menu.html) component as the slot content for the `actions` column.
+This example uses the [`KDropdownMenu`](/components/dropdown-menu.html) component as the slot content for the `actions` column.
 
 <KTable
   :headers="tableOptionsHeaders"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sass-loader": "^7.1.0",
     "vue-jest": "3.0.2",
     "vue-loader": "15.7.0",
-    "vue-router": "^3.0.7",
+    "vue-router": "^3.5.4",
     "vue-template-compiler": "2.6.10",
     "vuepress": "^1.5.2",
     "vuepress-plugin-live": "^1.5.3",

--- a/packages/KButton/package.json
+++ b/packages/KButton/package.json
@@ -22,6 +22,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "vue-router": "^3.5.4"
+  },
   "dependencies": {
     "@kongponents/kicon": "^6.35.5",
     "@kongponents/styles": "^6.35.5"

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -20,9 +20,9 @@
     <KButton
       v-else-if="type === 'button'"
       :disabled="disabled"
-      :class="classList"
-      class="k-dropdown-item-trigger"
+      class="k-dropdown-item-trigger btn-link k-button non-visual-button"
       v-on="listeners"
+      @click="handleClick"
     >
       <slot>{{ label }}</slot>
     </KButton>
@@ -72,21 +72,12 @@ export default {
       default: false
     }
   },
-  data () {
-    return {
-      classList: 'btn-link k-button non-visual-button'
-    }
-  },
   computed: {
-    listeners () {
-      return {
-        ...this.$listeners
-      }
-    },
     type () {
       if (this.item && this.item.to) {
         return 'link'
-      } else if (this.listeners.click || this.selectionMenuChild) {
+      } else if (this.$listeners.click || this.selectionMenuChild) {
+        // checking $listeners since we deleted click from listeners
         return 'button'
       }
 
@@ -97,11 +88,19 @@ export default {
     },
     to () {
       return (this.item && this.item.to) || undefined
+    },
+    listeners () {
+      const listeners = { ...this.$listeners }
+
+      // use @click in template and emit
+      delete listeners['click']
+
+      return listeners
     }
   },
   methods: {
-    handleClick () {
-      this.$emit('click', this.item)
+    handleClick (evt) {
+      this.$emit('click', evt)
 
       if (this.selectionMenuChild) {
         this.$emit('changed', this.item)

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    :class="{ 'has-divider': type !== 'link' && hasDivider, 'disabled': type === 'default' && disabled }"
+    :class="{ 'has-divider': type !== 'link' && hasDivider, 'disabled': type === 'default' && disabled, 'danger': isDangerous }"
     class="k-dropdown-item"
   >
     <router-link
@@ -8,6 +8,7 @@
       :data-testid="label"
       :class="{ 'disabled': disabled, 'has-divider': hasDivider }"
       :to="!disabled ? to : $router.currentRoute.path"
+      class="k-dropdown-item-trigger"
     >
       <slot>{{ label }}</slot>
     </router-link>
@@ -15,11 +16,15 @@
       v-else-if="type === 'button'"
       :disabled="disabled"
       :class="classList"
+      class="k-dropdown-item-trigger"
       v-on="listeners"
     >
       <slot>{{ label }}</slot>
     </KButton>
-    <div v-else>
+    <div
+      v-else
+      class="k-dropdown-item-trigger"
+    >
       <slot>{{ label }}</slot>
     </div>
   </li>
@@ -42,6 +47,10 @@ export default {
      * Use this prop to add a divider above the item
      */
     hasDivider: {
+      type: Boolean,
+      default: false
+    },
+    isDangerous: {
       type: Boolean,
       default: false
     },
@@ -110,7 +119,7 @@ li.k-dropdown-item {
     background-color: var(--grey-100);
   }
 
-  button, a, & > div {
+  .k-dropdown-item-trigger {
     text-align: left;
     padding: var(--spacing-md) var(--spacing-lg);
     text-decoration: none;

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -6,14 +6,15 @@
       'danger': isDangerous,
       'k-dropdown-selected-option': selected
     }"
+    :data-testid="`k-dropdown-item-${label.replace(' ', '-')}`"
     class="k-dropdown-item w-100"
   >
     <router-link
       v-if="type === 'link' && to"
-      :data-testid="label"
-      :class="{ 'disabled': disabled, 'has-divider': hasDivider }"
       :to="!disabled ? to : $router.currentRoute.path"
+      :class="{ 'disabled': disabled, 'has-divider': hasDivider }"
       class="k-dropdown-item-trigger"
+      data-testid="k-dropdown-item-trigger"
     >
       <slot>{{ label }}</slot>
     </router-link>
@@ -21,6 +22,7 @@
       v-else-if="type === 'button'"
       :disabled="disabled"
       class="k-dropdown-item-trigger btn-link k-button non-visual-button"
+      data-testid="k-dropdown-item-trigger"
       v-on="listeners"
       @click="handleClick"
     >
@@ -29,6 +31,7 @@
     <div
       v-else
       class="k-dropdown-item-trigger"
+      data-testid="k-dropdown-item-trigger"
     >
       <slot>{{ label }}</slot>
     </div>

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -53,7 +53,7 @@ export default {
       validator: (item) => Object.hasOwn(item, 'label')
     },
     /**
-     * Use this prop to add a divider above the item
+     * Use this prop to add a divider above the item.
      */
     hasDivider: {
       type: Boolean,

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -21,6 +21,7 @@
     <KButton
       v-else-if="type === 'button'"
       :disabled="disabled"
+      :is-rounded="false"
       class="k-dropdown-item-trigger btn-link k-button non-visual-button"
       data-testid="k-dropdown-item-trigger"
       v-on="listeners"

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -1,0 +1,139 @@
+<template>
+  <li
+    :class="{ 'has-divider': type !== 'link' && hasDivider, 'disabled': type === 'default' && disabled }"
+    class="k-dropdown-item"
+  >
+    <router-link
+      v-if="type === 'link' && to"
+      :data-testid="label"
+      :class="{ 'disabled': disabled, 'has-divider': hasDivider }"
+      :to="!disabled ? to : $router.currentRoute.path"
+    >
+      <slot>{{ label }}</slot>
+    </router-link>
+    <KButton
+      v-else-if="type === 'button'"
+      :disabled="disabled"
+      :class="classList"
+      v-on="listeners"
+    >
+      <slot>{{ label }}</slot>
+    </KButton>
+    <div v-else>
+      <slot>{{ label }}</slot>
+    </div>
+  </li>
+</template>
+
+<script>
+import KButton from '@kongponents/kbutton/KButton.vue'
+
+export default {
+  name: 'KDropdownItem',
+  components: { KButton },
+  props: {
+    item: {
+      type: Object,
+      default: null,
+      // Items must have a label
+      validator: (item) => item.hasOwnProperty('label')
+    },
+    /**
+     * Use this prop to add a divider above the item
+     */
+    hasDivider: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data () {
+    return {
+      classList: 'btn-link k-button non-visual-button'
+    }
+  },
+  computed: {
+    listeners () {
+      return {
+        ...this.$listeners
+      }
+    },
+    type () {
+      if (this.item && this.item.to) {
+        return 'link'
+      } else if (this.listeners.click) {
+        return 'button'
+      }
+
+      return 'default'
+    },
+    label () {
+      return (this.item && this.item.label) || ''
+    },
+    to () {
+      return (this.item && this.item.to) || undefined
+    }
+  },
+  methods: {
+    handleClick () {
+      this.$emit('click', this.item)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
+li.k-dropdown-item {
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  line-height: 1;
+
+  &.has-divider {
+    border-top: 1px solid var(--grey-200) !important;
+  }
+
+  svg {
+    margin-right: .75rem;
+  }
+
+  &:hover {
+    background-color: var(--grey-100);
+  }
+
+  button, a, & > div {
+    text-align: left;
+    padding: var(--spacing-md) var(--spacing-lg);
+    text-decoration: none;
+    width: 100%;
+    color: var(--black-70);
+
+    &:disabled,
+    &.disabled {
+      cursor: not-allowed !important;
+      color: var(--grey-400) !important;
+
+      &:hover {
+        background-color: var(--grey-200) !important;
+      }
+    }
+  }
+
+  &.danger {
+    button:not(:disabled),
+    a:not(:disabled) {
+      color: var(--red-500);
+      transition: all 300ms;
+
+      &:hover {
+        color: var(--red-500);
+      }
+    }
+  }
+}
+</style>

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -141,6 +141,10 @@ li.k-dropdown-item {
     width: 100%;
     color: var(--black-70);
 
+    &a, &button {
+      text-decoration: none !important;
+    }
+
     &:disabled,
     &.disabled {
       cursor: not-allowed !important;
@@ -161,6 +165,16 @@ li.k-dropdown-item {
       &:hover {
         color: var(--red-500);
       }
+    }
+  }
+}
+</style>
+
+<style lang="scss">
+.k-dropdown-item {
+  a, button {
+    &.k-dropdown-item-trigger {
+      text-decoration: none !important;
     }
   }
 }

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -1,6 +1,11 @@
 <template>
   <li
-    :class="{ 'has-divider': type !== 'link' && hasDivider, 'disabled': type === 'default' && disabled, 'danger': isDangerous }"
+    :class="{
+      'has-divider': type !== 'link' && hasDivider,
+      'disabled': type === 'default' && disabled,
+      'danger': isDangerous,
+      'k-dropdown-selected-option': selected
+    }"
     class="k-dropdown-item"
   >
     <router-link
@@ -61,6 +66,10 @@ export default {
     selected: {
       type: Boolean,
       default: false
+    },
+    selectionMenuChild: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -77,7 +86,7 @@ export default {
     type () {
       if (this.item && this.item.to) {
         return 'link'
-      } else if (this.listeners.click) {
+      } else if (this.listeners.click || this.selectionMenuChild) {
         return 'button'
       }
 
@@ -93,6 +102,10 @@ export default {
   methods: {
     handleClick () {
       this.$emit('click', this.item)
+
+      if (this.selectionMenuChild) {
+        this.$emit('changed', this.item)
+      }
     }
   }
 }

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -46,7 +46,7 @@ export default {
       type: Object,
       default: null,
       // Items must have a label
-      validator: (item) => item.hasOwnProperty('label')
+      validator: (item) => Object.hasOwn(item, 'label')
     },
     /**
      * Use this prop to add a divider above the item

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -141,10 +141,6 @@ li.k-dropdown-item {
     width: 100%;
     color: var(--black-70);
 
-    &a, &button {
-      text-decoration: none !important;
-    }
-
     &:disabled,
     &.disabled {
       cursor: not-allowed !important;

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -67,6 +67,9 @@ export default {
       type: Boolean,
       default: false
     },
+    /**
+     * Internal use only - for tracking selection in conjunction with items prop.
+     */
     selectionMenuChild: {
       type: Boolean,
       default: false

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -6,7 +6,7 @@
       'danger': isDangerous,
       'k-dropdown-selected-option': selected
     }"
-    class="k-dropdown-item"
+    class="k-dropdown-item w-100"
   >
     <router-link
       v-if="type === 'link' && to"

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -103,7 +103,7 @@ export default {
       this.$emit('click', evt)
 
       if (this.selectionMenuChild) {
-        this.$emit('changed', this.item)
+        this.$emit('change', this.item)
       }
     }
   }

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -48,6 +48,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    selected: {
+      type: Boolean,
+      default: false
     }
   },
   data () {

--- a/packages/KDropdownMenu/KDropdownMenu.spec.js
+++ b/packages/KDropdownMenu/KDropdownMenu.spec.js
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils'
+import KDropdownMenu from '@/KDropdownMenu/KDropdownMenu'
+
+describe('KDropdownMenu', () => {
+  it('matches snapshot', () => {
+    const wrapper = mount(KDropdownMenu)
+
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+})

--- a/packages/KDropdownMenu/KDropdownMenu.spec.js
+++ b/packages/KDropdownMenu/KDropdownMenu.spec.js
@@ -1,9 +1,21 @@
 import { mount } from '@vue/test-utils'
 import KDropdownMenu from '@/KDropdownMenu/KDropdownMenu'
 
+/**
+ * ALL TESTS MUST USE testMode: true
+ * We generate unique IDs for reference by aria properties. Test mode strips these out
+ * allowing for successful snapshot verification.
+ * propsData: {
+ *   testMode: true
+ * }
+ */
 describe('KDropdownMenu', () => {
   it('matches snapshot', () => {
-    const wrapper = mount(KDropdownMenu)
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true
+      }
+    })
 
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/packages/KDropdownMenu/KDropdownMenu.spec.js
+++ b/packages/KDropdownMenu/KDropdownMenu.spec.js
@@ -1,6 +1,21 @@
 import { mount } from '@vue/test-utils'
 import KDropdownMenu from '@/KDropdownMenu/KDropdownMenu'
 
+const defaultMenuItems = [
+  { label: 'Props' },
+  { label: 'Slots' },
+  { label: 'Top' }
+]
+
+const selectionMenuItems = [{
+  label: 'US (United States)',
+  value: 'us'
+},
+{
+  label: 'FR (France)',
+  value: 'fr'
+}]
+
 /**
  * ALL TESTS MUST USE testMode: true
  * We generate unique IDs for reference by aria properties. Test mode strips these out
@@ -10,6 +25,127 @@ import KDropdownMenu from '@/KDropdownMenu/KDropdownMenu'
  * }
  */
 describe('KDropdownMenu', () => {
+  it('renders props when passed', () => {
+    const labelProp = 'Drop it!'
+
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true,
+        label: labelProp,
+        items: defaultMenuItems
+      }
+    })
+
+    const triggerBtn = wrapper.find('[data-testid="k-dropdown-trigger"]')
+
+    expect(triggerBtn.text()).toEqual(labelProp)
+
+    triggerBtn.trigger('click')
+
+    expect(wrapper.find('[data-testid="k-dropdown-list"]').exists()).toBe(true)
+    expect(wrapper.find(`[data-testid="k-dropdown-item-${defaultMenuItems[0].label}"]`).html()).toEqual(expect.stringContaining(defaultMenuItems[0].label))
+    expect(wrapper.find(`[data-testid="k-dropdown-item-${defaultMenuItems[1].label}"]`).html()).toEqual(expect.stringContaining(defaultMenuItems[1].label))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with correct px width', async () => {
+    const width = 350
+
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true,
+        width: width + '',
+        items: defaultMenuItems
+      }
+    })
+    const triggerBtn = wrapper.find('[data-testid="k-dropdown-trigger"]')
+    const popover = wrapper.find('.k-dropdown-popover')
+
+    triggerBtn.trigger('click')
+
+    expect(popover.element.style['width']).toEqual(width + 'px')
+  })
+
+  it('renders disabled props when passed', () => {
+    const tooltipText = 'A sweet tooltip'
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true,
+        label: 'Click me',
+        disabled: true,
+        disabledTooltip: tooltipText,
+        items: defaultMenuItems
+      }
+    })
+    // button disabled
+    const triggerBtn = wrapper.find('.k-dropdown-btn[disabled="disabled"]')
+
+    expect(triggerBtn.exists()).toBe(true)
+    // hover
+    triggerBtn.trigger('mouseenter')
+
+    expect(wrapper.find(`.kooltip`).html()).toEqual(expect.stringContaining(tooltipText))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('renders with correct appearance - selectionMenu', () => {
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true,
+        appearance: 'selectionMenu',
+        items: selectionMenuItems
+      }
+    })
+
+    expect(wrapper.find('.selection-dropdown-menu').exists()).toBe(true)
+  })
+
+  it('renders with selected item', () => {
+    const selectedLabel = 'Label 1'
+
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true,
+        items: [
+          { label: selectedLabel, value: 'label1', selected: true },
+          ...selectionMenuItems
+        ]
+      }
+    })
+
+    const triggerBtn = wrapper.find('[data-testid="k-dropdown-trigger"]')
+
+    triggerBtn.trigger('click')
+
+    expect(wrapper.find('[data-testid="k-dropdown-list"]').exists()).toBe(true)
+
+    expect(wrapper.find('.k-dropdown-selected-option').html()).toEqual(expect.stringContaining(selectedLabel))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('allows slotting content', async () => {
+    const itemSlotContent = 'I am slotted baby!'
+    const triggerSlotContent = 'Click Me!'
+    const wrapper = mount(KDropdownMenu, {
+      propsData: {
+        testMode: true
+      },
+      scopedSlots: {
+        items: `<span>${itemSlotContent}</span>`,
+        default: `<button>${triggerSlotContent}</button>`
+      }
+    })
+
+    const triggerBtn = wrapper.find('[data-testid="k-dropdown-trigger"]')
+    const popover = wrapper.find('.k-dropdown-popover')
+
+    triggerBtn.trigger('click')
+
+    expect(triggerBtn.html()).toEqual(expect.stringContaining(triggerSlotContent))
+    expect(popover.html()).toEqual(expect.stringContaining(itemSlotContent))
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('matches snapshot', () => {
     const wrapper = mount(KDropdownMenu, {
       propsData: {

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -41,8 +41,8 @@
                 v-if="label"
                 :disabled="disabled"
                 :is-open="showCaret || appearance === 'selectionMenu' ? isToggled : undefined"
-                :class="{ 'is-active': showCaret ? isToggled : undefined }"
                 :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
+                :class="{ 'is-active': showCaret ? isToggled : undefined }"
                 class="k-dropdown-btn"
                 data-testid="k-dropdown-btn"
               >

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -11,6 +11,7 @@
           return isToggled
         }"
         :test-mode="testMode"
+        data-testid="k-dropdown-menu-popover"
         @opened="() => {
           toggle()
           $emit('toggleDropdown', true)
@@ -20,40 +21,41 @@
           $emit('toggleDropdown', false)
         }"
       >
-        <div class="d-flex">
-          <component
-            :is="!!disabledTooltip ? 'Kooltip' : 'div'"
-            :label="disabledTooltip"
-            :position="!!disabledTooltip ? 'bottom' : undefined"
-            :position-fixed="!!disabledTooltip ? true : undefined"
-            :max-width="!!disabledTooltip ? '240' : undefined"
-            class="k-dropdown-trigger dropdown-trigger"
+        <component
+          :is="!!disabledTooltip ? 'Kooltip' : 'div'"
+          :label="disabledTooltip"
+          :position="!!disabledTooltip ? 'bottom' : undefined"
+          :position-fixed="!!disabledTooltip ? true : undefined"
+          :max-width="!!disabledTooltip ? '240' : undefined"
+          class="k-dropdown-trigger dropdown-trigger"
+          data-testid="k-dropdown-trigger"
+        >
+          <slot
+            :is-open="isToggled"
+            name="default"
           >
-            <slot
-              :is-open="isToggled"
-              name="default"
-            >
-              <!-- Must wrap in div to allow tooltip when disabled -->
-              <div>
-                <KButton
-                  v-if="label"
-                  :disabled="disabled"
-                  :is-open="showCaret || appearance === 'selectionMenu' ? isToggled : undefined"
-                  :class="{ 'is-active': showCaret ? isToggled : undefined }"
-                  :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
-                  class="k-dropdown-btn"
-                >
-                  {{ label }}
-                </KButton>
-              </div>
-            </slot>
-          </component>
-        </div>
+            <!-- Must wrap in div to allow tooltip when disabled -->
+            <div>
+              <KButton
+                v-if="label"
+                :disabled="disabled"
+                :is-open="showCaret || appearance === 'selectionMenu' ? isToggled : undefined"
+                :class="{ 'is-active': showCaret ? isToggled : undefined }"
+                :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
+                class="k-dropdown-btn"
+                data-testid="k-dropdown-btn"
+              >
+                {{ label }}
+              </KButton>
+            </div>
+          </slot>
+        </component>
         <template #content>
-          <ul class="k-dropdown-list dropdown-list">
+          <ul
+            class="k-dropdown-list dropdown-list"
+            data-testid="k-dropdown-list">
             <slot
               :items="items"
-              :is-open="isToggled"
               :handle-selection="handleSelection"
               name="items"
             >
@@ -165,6 +167,15 @@ export default {
     selectedItem (newVal, oldVal) {
       if (newVal.value !== oldVal.value) {
         this.$emit('change', newVal)
+      }
+    }
+  },
+  mounted () {
+    if (this.items) {
+      const selectionArr = this.items.filter(item => item.selected)
+
+      if (selectionArr.length) {
+        this.selectedItem = selectionArr[0]
       }
     }
   },

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -37,7 +37,7 @@
                 <KButton
                   v-if="label"
                   :disabled="disabled"
-                  :is-open="showCaret ? isToggled : undefined"
+                  :is-open="showCaret || appearance === 'selectionMenu' ? isToggled : undefined"
                   :class="{ 'is-active': showCaret ? isToggled : undefined }"
                   :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
                   class="k-dropdown-btn"

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -38,7 +38,8 @@
                   v-if="label"
                   :disabled="disabled"
                   :is-open="showCaret ? isToggled : undefined"
-                  appearance="primary"
+                  :class="{ 'is-active': showCaret ? isToggled : undefined }"
+                  :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
                   class="k-dropdown-btn"
                 >
                   {{ label }}

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="{'selection-dropdown-menu': appearance === 'selection'}"
+    :class="{'selection-dropdown-menu': appearance === 'selectionMenu'}"
     class="k-dropdown k-dropdown-menu"
   >
     <KToggle v-slot="{toggle, isToggled}">
@@ -20,20 +20,24 @@
             :position="!!disabledTooltip ? 'bottom' : undefined"
             :position-fixed="!!disabledTooltip ? true : undefined"
             :max-width="!!disabledTooltip ? '240' : undefined"
+            class="dropdown-trigger"
           >
             <slot
               :is-open="isToggled"
               name="default"
             >
-              <KButton
-                v-if="label"
-                :disabled="disabled"
-                appearance="primary"
-                class="k-dropdown-btn"
-                @click="toggle"
-              >
-                {{ label }}
-              </KButton>
+              <!-- Must wrap in div to allow tooltip when disabled -->
+              <div>
+                <KButton
+                  v-if="label"
+                  :disabled="disabled"
+                  appearance="primary"
+                  class="k-dropdown-btn"
+                  @click="toggle"
+                >
+                  {{ label }}
+                </KButton>
+              </div>
             </slot>
           </component>
         </div>
@@ -69,7 +73,8 @@ const defaultKPopAttributes = {
   hideCaret: true,
   popoverClasses: 'k-dropdown-popover mt-1',
   popoverTimeout: 0,
-  positionFixed: true
+  positionFixed: true,
+  placement: 'bottomStart'
 }
 
 export default {
@@ -84,7 +89,13 @@ export default {
   props: {
     appearance: {
       type: String,
-      default: 'menu'
+      default: 'menu',
+      validator: (value) => {
+        return [
+          'menu',
+          'selectionMenu'
+        ].indexOf(value) !== -1
+      }
     },
     label: {
       type: String,
@@ -144,40 +155,6 @@ export default {
   .k-dropdown-list.dropdown-list {
     min-width: 148px;
   }
-
-  &.selection-dropdown-menu {
-    .dropdown-trigger.k-button {
-      border: 0;
-      width: auto;
-      color: var(--grey-600);
-      white-space: nowrap;
-
-      &:focus {
-        box-shadow: none;
-      }
-
-      &:active:disabled {
-        background-color: var(--white);
-      }
-
-      &.is-active {
-        background-color: var(--grey-100);
-      }
-
-      // Set dropdown icon color
-      --KButtonOutlineColor: var(--grey-500);
-    }
-
-    .k-popover.k-dropdown-popover {
-      z-index: 10000 !important;
-
-      .k-popover-content {
-        ul.k-dropdown-list {
-          margin-left: 7px;
-        }
-      }
-    }
-  }
 }
 </style>
 
@@ -207,8 +184,36 @@ export default {
 }
 
 .selection-dropdown-menu {
+  .dropdown-trigger .k-button {
+    border: 0;
+    width: auto;
+    color: var(--grey-600);
+    white-space: nowrap;
+
+    &:focus {
+      box-shadow: none;
+    }
+
+    &:active:disabled {
+      background-color: var(--white);
+    }
+
+    &.is-active {
+      background-color: var(--grey-100);
+    }
+
+    // Set dropdown icon color
+    --KButtonOutlineColor: var(--grey-500);
+  }
+
   .k-popover.k-dropdown-popover {
     z-index: 10000 !important;
+
+    .k-popover-content {
+      ul.k-dropdown-list {
+        margin-left: 7px;
+      }
+    }
 
     li {
       .non-visual-button {

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -26,13 +26,13 @@
               name="default"
             >
               <KButton
-                v-if="btnText"
+                v-if="label"
                 :disabled="disabled"
                 appearance="primary"
                 class="k-dropdown-btn"
                 @click="toggle"
               >
-                {{ btnText }}
+                {{ label }}
               </KButton>
             </slot>
           </component>
@@ -86,7 +86,7 @@ export default {
       type: String,
       default: 'menu'
     },
-    btnText: {
+    label: {
       type: String,
       default: ''
     },

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -10,6 +10,7 @@
           toggle();
           return isToggled
         }"
+        :test-mode="testMode"
         @opened="() => {
           toggle()
           $emit('toggleDropdown', true)
@@ -140,6 +141,13 @@ export default {
     disabledTooltip: {
       type: String,
       default: ''
+    },
+    /**
+     * Test mode - for testing only, strips out generated ids
+     */
+    testMode: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -188,10 +196,6 @@ export default {
     border-top: 0.325em solid;
     border-right: 0.325em solid transparent;
     border-left: 0.325em solid transparent;
-  }
-
-  .k-dropdown-list.dropdown-list {
-    min-width: 148px;
   }
 }
 </style>

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -223,6 +223,7 @@ export default {
 
       &.k-dropdown-selected-option {
         background-color: var(--blue-100);
+        margin-left: -7px;
 
         .non-visual-button {
           font-weight: 500 !important;

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -27,6 +27,7 @@
           :position="!!disabledTooltip ? 'bottom' : undefined"
           :position-fixed="!!disabledTooltip ? true : undefined"
           :max-width="!!disabledTooltip ? '240' : undefined"
+          :test-mode="testMode"
           class="k-dropdown-trigger dropdown-trigger"
           data-testid="k-dropdown-trigger"
         >

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -10,6 +10,7 @@
           toggle();
           return isToggled
         }"
+        target=".k-dropdown-trigger"
         @opened="() => {
           toggle()
           $emit('toggleDropdown', true)
@@ -26,7 +27,7 @@
             :position="!!disabledTooltip ? 'bottom' : undefined"
             :position-fixed="!!disabledTooltip ? true : undefined"
             :max-width="!!disabledTooltip ? '240' : undefined"
-            class="dropdown-trigger"
+            class="k-dropdown-trigger dropdown-trigger"
           >
             <slot
               :is-open="isToggled"
@@ -58,7 +59,7 @@
               <KDropdownItem
                 v-for="(item, idx) in items"
                 v-bind="item"
-                :key="`${item.label.replace(' ', '-')}-${idx}`"
+                :key="`${item.label}-${idx}`"
                 :item="item"
                 :selection-menu-child="appearance === 'selectionMenu'"
               />

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -102,7 +102,7 @@ export default {
         return [
           'menu',
           'selectionMenu'
-        ].indexOf(value) !== -1
+        ].includes(value)
       }
     },
     label: {

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -10,7 +10,6 @@
           toggle();
           return isToggled
         }"
-        target=".k-dropdown-trigger"
         @opened="() => {
           toggle()
           $emit('toggleDropdown', true)
@@ -54,6 +53,7 @@
             <slot
               :items="items"
               :is-open="isToggled"
+              :handle-selection="handleSelection"
               name="items"
             >
               <KDropdownItem
@@ -62,6 +62,7 @@
                 :key="`${item.label}-${idx}`"
                 :item="item"
                 :selection-menu-child="appearance === 'selectionMenu'"
+                @change="(selection) => handleSelection(selection)"
               />
             </slot>
           </ul>
@@ -114,6 +115,10 @@ export default {
       type: Boolean,
       default: false
     },
+    width: {
+      type: String,
+      default: ''
+    },
     // kpopAttributes is used to pass properties directly to the wrapped KPop component.
     // Commonly-overridden properties include:
     // - width
@@ -142,8 +147,26 @@ export default {
       boundKPopAttributes: {
         ...defaultKPopAttributes,
         ...this.kpopAttributes,
+        width: this.width ? this.width : undefined,
         popoverClasses: `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses}`
+      },
+      selectedItem: {}
+    }
+  },
+  watch: {
+    selectedItem (newVal, oldVal) {
+      if (newVal.value !== oldVal.value) {
+        this.$emit('change', newVal)
       }
+    }
+  },
+  methods: {
+    handleSelection (item) {
+      if (this.appearance !== 'selectionMenu') {
+        return
+      }
+
+      this.selectedItem = item
     }
   }
 }
@@ -153,6 +176,8 @@ export default {
 @import '~@kongponents/styles/variables';
 
 .k-dropdown-menu {
+  width: fit-content;
+
   .drodpown-trigger:after {
     display: inline-block;
     width: 0;

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="k-dropdown">
+  <div
+    :class="{'selection-dropdown-menu': appearance === 'selection'}"
+    class="k-dropdown k-dropdown-menu"
+  >
     <KToggle v-slot="{toggle, isToggled}">
       <KPop
         v-bind="boundKPopAttributes"
@@ -45,6 +48,7 @@
                 v-for="(item, idx) in items"
                 :key="`${item.label.replace(' ', '-')}-${idx}`"
                 :item="item"
+                :selected="item.selected"
               />
             </slot>
           </ul>
@@ -78,6 +82,10 @@ export default {
     KToggle
   },
   props: {
+    appearance: {
+      type: String,
+      default: 'menu'
+    },
     btnText: {
       type: String,
       default: ''
@@ -120,7 +128,7 @@ export default {
 <style lang="scss" scoped>
 @import '~@kongponents/styles/variables';
 
-.k-dropdown {
+.k-dropdown-menu {
   .drodpown-trigger:after {
     display: inline-block;
     width: 0;
@@ -135,6 +143,40 @@ export default {
 
   .k-dropdown-list.dropdown-list {
     min-width: 148px;
+  }
+
+  &.selection-dropdown-menu {
+    .dropdown-trigger.k-button {
+      border: 0;
+      width: auto;
+      color: var(--grey-600);
+      white-space: nowrap;
+
+      &:focus {
+        box-shadow: none;
+      }
+
+      &:active:disabled {
+        background-color: var(--white);
+      }
+
+      &.is-active {
+        background-color: var(--grey-100);
+      }
+
+      // Set dropdown icon color
+      --KButtonOutlineColor: var(--grey-500);
+    }
+
+    .k-popover.k-dropdown-popover {
+      z-index: 10000 !important;
+
+      .k-popover-content {
+        ul.k-dropdown-list {
+          margin-left: 7px;
+        }
+      }
+    }
   }
 }
 </style>
@@ -160,6 +202,26 @@ export default {
     &:active,
     &:focus {
       text-decoration: none;
+    }
+  }
+}
+
+.selection-dropdown-menu {
+  .k-popover.k-dropdown-popover {
+    z-index: 10000 !important;
+
+    li {
+      .non-visual-button {
+        font-weight: 400 !important;
+      }
+
+      &.k-dropdown-selected-option {
+        background-color: var(--blue-100);
+
+        .non-visual-button {
+          font-weight: 500 !important;
+        }
+      }
     }
   }
 }

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -10,8 +10,14 @@
           toggle();
           return isToggled
         }"
-        @opened="toggle"
-        @closed="toggle"
+        @opened="() => {
+          toggle()
+          $emit('toggleDropdown', true)
+        }"
+        @closed="() => {
+          toggle()
+          $emit('toggleDropdown', false)
+        }"
       >
         <div class="d-flex">
           <component
@@ -31,9 +37,9 @@
                 <KButton
                   v-if="label"
                   :disabled="disabled"
+                  :is-open="showCaret ? isToggled : undefined"
                   appearance="primary"
                   class="k-dropdown-btn"
-                  @click="toggle"
                 >
                   {{ label }}
                 </KButton>
@@ -101,6 +107,10 @@ export default {
     label: {
       type: String,
       default: ''
+    },
+    showCaret: {
+      type: Boolean,
+      default: false
     },
     // kpopAttributes is used to pass properties directly to the wrapped KPop component.
     // Commonly-overridden properties include:
@@ -210,12 +220,6 @@ export default {
   .k-popover.k-dropdown-popover {
     z-index: 10000 !important;
 
-    .k-popover-content {
-      ul.k-dropdown-list {
-        margin-left: 7px;
-      }
-    }
-
     li {
       .non-visual-button {
         font-weight: 400 !important;
@@ -223,7 +227,6 @@ export default {
 
       &.k-dropdown-selected-option {
         background-color: var(--blue-100);
-        margin-left: -7px;
 
         .non-visual-button {
           font-weight: 500 !important;

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -50,9 +50,10 @@
             >
               <KDropdownItem
                 v-for="(item, idx) in items"
+                v-bind="item"
                 :key="`${item.label.replace(' ', '-')}-${idx}`"
                 :item="item"
-                :selected="item.selected"
+                :selection-menu-child="appearance === 'selectionMenu'"
               />
             </slot>
           </ul>

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -11,19 +11,28 @@
         @closed="toggle"
       >
         <div class="d-flex">
-          <slot
-            :is-open="isToggled"
-            name="default"
+          <component
+            :is="!!disabledTooltip ? 'Kooltip' : 'div'"
+            :label="disabledTooltip"
+            :position="!!disabledTooltip ? 'bottom' : undefined"
+            :position-fixed="!!disabledTooltip ? true : undefined"
+            :max-width="!!disabledTooltip ? '240' : undefined"
           >
-            <KButton
-              v-if="btnText"
-              class="k-dropdown-btn"
-              appearance="primary"
-              @click="toggle"
+            <slot
+              :is-open="isToggled"
+              name="default"
             >
-              {{ btnText }}
-            </KButton>
-          </slot>
+              <KButton
+                v-if="btnText"
+                :disabled="disabled"
+                appearance="primary"
+                class="k-dropdown-btn"
+                @click="toggle"
+              >
+                {{ btnText }}
+              </KButton>
+            </slot>
+          </component>
         </div>
         <template #content>
           <ul class="k-dropdown-list dropdown-list">
@@ -33,8 +42,8 @@
               name="items"
             >
               <KDropdownItem
-                v-for="item in items"
-                :key="item.label"
+                v-for="(item, idx) in items"
+                :key="`${item.label.replace(' ', '-')}-${idx}`"
                 :item="item"
               />
             </slot>
@@ -47,6 +56,7 @@
 
 <script>
 import KButton from '@kongponents/kbutton/KButton.vue'
+import Kooltip from '@kongponents/kooltip/KoolTip.vue'
 import KPop from '@kongponents/kpop/KPop.vue'
 import KToggle from '@kongponents/ktoggle/KToggle'
 import KDropdownItem from './KDropdownItem.vue'
@@ -63,6 +73,7 @@ export default {
   components: {
     KButton,
     KDropdownItem,
+    Kooltip,
     KPop,
     KToggle
   },
@@ -84,6 +95,14 @@ export default {
     items: {
       type: Array,
       default: () => []
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    disabledTooltip: {
+      type: String,
+      default: ''
     }
   },
   data () {

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="k-dropdown">
+    <KToggle v-slot="{toggle, isToggled}">
+      <KPop
+        v-bind="boundKPopAttributes"
+        :on-popover-click="() => {
+          toggle();
+          return isToggled
+        }"
+        @opened="toggle"
+        @closed="toggle"
+      >
+        <div class="d-flex">
+          <slot
+            :is-open="isToggled"
+            name="default"
+          >
+            <KButton
+              v-if="btnText"
+              class="k-dropdown-btn"
+              appearance="primary"
+              @click="toggle"
+            >
+              {{ btnText }}
+            </KButton>
+          </slot>
+        </div>
+        <template #content>
+          <ul class="k-dropdown-list dropdown-list">
+            <slot
+              :items="items"
+              :is-open="isToggled"
+              name="items"
+            >
+              <KDropdownItem
+                v-for="item in items"
+                :key="item.label"
+                :item="item"
+              />
+            </slot>
+          </ul>
+        </template>
+      </KPop>
+    </KToggle>
+  </div>
+</template>
+
+<script>
+import KButton from '@kongponents/kbutton/KButton.vue'
+import KPop from '@kongponents/kpop/KPop.vue'
+import KToggle from '@kongponents/ktoggle/KToggle'
+import KDropdownItem from './KDropdownItem.vue'
+
+const defaultKPopAttributes = {
+  hideCaret: true,
+  popoverClasses: 'k-dropdown-popover mt-1',
+  popoverTimeout: 0,
+  positionFixed: true
+}
+
+export default {
+  name: 'KDropdownMenu',
+  components: {
+    KButton,
+    KDropdownItem,
+    KPop,
+    KToggle
+  },
+  props: {
+    btnText: {
+      type: String,
+      default: ''
+    },
+    // kpopAttributes is used to pass properties directly to the wrapped KPop component.
+    // Commonly-overridden properties include:
+    // - width
+    // - placement
+    // - popoverClasses
+    // - target
+    kpopAttributes: {
+      type: Object,
+      default: () => ({})
+    },
+    items: {
+      type: Array,
+      default: () => []
+    }
+  },
+  data () {
+    return {
+      boundKPopAttributes: {
+        ...defaultKPopAttributes,
+        ...this.kpopAttributes,
+        popoverClasses: `${defaultKPopAttributes.popoverClasses} ${this.kpopAttributes.popoverClasses}`
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '~@kongponents/styles/variables';
+
+.k-dropdown {
+  .drodpown-trigger:after {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: var(--spacing-xs, spacing(xs));
+    vertical-align: middle;
+    content: "";
+    border-top: 0.325em solid;
+    border-right: 0.325em solid transparent;
+    border-left: 0.325em solid transparent;
+  }
+
+  .k-dropdown-list.dropdown-list {
+    min-width: 148px;
+  }
+}
+</style>
+
+<style lang="scss">
+@import '~@kongponents/styles/variables';
+
+.k-popover.k-dropdown-popover {
+  --KPopPaddingY: var(--spacing-sm);
+  --KPopPaddingX: 0;
+  border: 1px solid var(--black-10);
+
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  a {
+    flex: 1;
+    color: var(--black-70);
+
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+}
+</style>

--- a/packages/KDropdownMenu/README.md
+++ b/packages/KDropdownMenu/README.md
@@ -1,0 +1,9 @@
+# @kongponents/kdropdownmenu
+
+[![](https://img.shields.io/npm/v/@kongponents/kdropdownmenu.svg?style=flat-square)](https://www.npmjs.com/package/@kongponents/kdropdownmenu)
+
+```html
+<KDropdownMenu :description="'hello world'">
+  Hello from a slot
+</KDropdownMenu>
+```

--- a/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
+++ b/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KDropdownMenu matches snapshot 1`] = `
+<div class="k-dropdown k-dropdown-menu">
+  <div id="82f5c551-135b-11ed-8370-dd8999b55918" aria-controls="82f5c550-135b-11ed-8370-dd8999b55918" role="button">
+    <div class="d-flex">
+      <div label="" class="k-dropdown-trigger dropdown-trigger">
+        <div>
+          <!---->
+        </div>
+      </div>
+    </div>
+    <div id="82f5c550-135b-11ed-8370-dd8999b55918" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; display: none;" name="fade">
+      <!---->
+      <div class="k-popover-content">
+        <ul class="k-dropdown-list dropdown-list"></ul>
+      </div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;

--- a/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
+++ b/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
@@ -10,7 +10,7 @@ exports[`KDropdownMenu matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; display: none;" name="fade">
+    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
       <!---->
       <div class="k-popover-content">
         <ul class="k-dropdown-list dropdown-list"></ul>

--- a/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
+++ b/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`KDropdownMenu matches snapshot 1`] = `
 <div class="k-dropdown k-dropdown-menu">
-  <div id="82f5c551-135b-11ed-8370-dd8999b55918" aria-controls="82f5c550-135b-11ed-8370-dd8999b55918" role="button">
+  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
     <div class="d-flex">
       <div label="" class="k-dropdown-trigger dropdown-trigger">
         <div>
@@ -10,7 +10,7 @@ exports[`KDropdownMenu matches snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div id="82f5c550-135b-11ed-8370-dd8999b55918" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; display: none;" name="fade">
+    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; display: none;" name="fade">
       <!---->
       <div class="k-popover-content">
         <ul class="k-dropdown-list dropdown-list"></ul>

--- a/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
+++ b/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
@@ -1,19 +1,128 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KDropdownMenu allows slotting content 1`] = `
+<div class="k-dropdown k-dropdown-menu">
+  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
+    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger"><button>Click Me!</button></div>
+    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
+      <!---->
+      <div class="k-popover-content">
+        <ul data-testid="k-dropdown-list" class="k-dropdown-list dropdown-list"><span>I am slotted baby!</span></ul>
+      </div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
 exports[`KDropdownMenu matches snapshot 1`] = `
 <div class="k-dropdown k-dropdown-menu">
-  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
-    <div class="d-flex">
-      <div label="" class="k-dropdown-trigger dropdown-trigger">
-        <div>
-          <!---->
-        </div>
+  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
+    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
+      <div>
+        <!---->
       </div>
     </div>
     <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
       <!---->
       <div class="k-popover-content">
-        <ul class="k-dropdown-list dropdown-list"></ul>
+        <ul data-testid="k-dropdown-list" class="k-dropdown-list dropdown-list"></ul>
+      </div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KDropdownMenu renders disabled props when passed 1`] = `
+<div class="k-dropdown k-dropdown-menu">
+  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
+    <div id="3160e4b1-136d-11ed-9ddc-a1b90be1e26f" aria-controls="3160e4b0-136d-11ed-9ddc-a1b90be1e26f" role="button" class="k-dropdown-trigger dropdown-trigger">
+      <div><button type="button" class="k-button k-dropdown-btn medium rounded primary" disabled="disabled" data-testid="k-dropdown-btn">
+          <!---->
+          Click me
+          <!----></button></div>
+      <div id="3160e4b0-136d-11ed-9ddc-a1b90be1e26f" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: 240px; max-height: auto; display: none;" name="fade">
+        <!---->
+        <div class="k-popover-content">
+          <div role="tooltip">A sweet tooltip</div>
+        </div>
+        <!---->
+      </div>
+    </div>
+    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
+      <!---->
+      <div class="k-popover-content">
+        <ul data-testid="k-dropdown-list" class="k-dropdown-list dropdown-list">
+          <li data-testid="k-dropdown-item-Props" class="k-dropdown-item w-100" label="Props">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Props</div>
+          </li>
+          <li data-testid="k-dropdown-item-Slots" class="k-dropdown-item w-100" label="Slots">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Slots</div>
+          </li>
+          <li data-testid="k-dropdown-item-Top" class="k-dropdown-item w-100" label="Top">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Top</div>
+          </li>
+        </ul>
+      </div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KDropdownMenu renders props when passed 1`] = `
+<div class="k-dropdown k-dropdown-menu">
+  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
+    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
+      <div><button type="button" class="k-button k-dropdown-btn medium rounded primary" data-testid="k-dropdown-btn">
+          <!---->
+          Drop it!
+          <!----></button></div>
+    </div>
+    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
+      <!---->
+      <div class="k-popover-content">
+        <ul data-testid="k-dropdown-list" class="k-dropdown-list dropdown-list">
+          <li data-testid="k-dropdown-item-Props" class="k-dropdown-item w-100" label="Props">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Props</div>
+          </li>
+          <li data-testid="k-dropdown-item-Slots" class="k-dropdown-item w-100" label="Slots">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Slots</div>
+          </li>
+          <li data-testid="k-dropdown-item-Top" class="k-dropdown-item w-100" label="Top">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Top</div>
+          </li>
+        </ul>
+      </div>
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`KDropdownMenu renders with selected item 1`] = `
+<div class="k-dropdown k-dropdown-menu">
+  <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
+    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
+      <div>
+        <!---->
+      </div>
+    </div>
+    <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
+      <!---->
+      <div class="k-popover-content">
+        <ul data-testid="k-dropdown-list" class="k-dropdown-list dropdown-list">
+          <li data-testid="k-dropdown-item-Label-1" class="k-dropdown-item w-100 k-dropdown-selected-option" label="Label 1" value="label1">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">Label 1</div>
+          </li>
+          <li data-testid="k-dropdown-item-US-(United States)" class="k-dropdown-item w-100" label="US (United States)" value="us">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">US (United States)</div>
+          </li>
+          <li data-testid="k-dropdown-item-FR-(France)" class="k-dropdown-item w-100" label="FR (France)" value="fr">
+            <div data-testid="k-dropdown-item-trigger" class="k-dropdown-item-trigger">FR (France)</div>
+          </li>
+        </ul>
       </div>
       <!---->
     </div>

--- a/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
+++ b/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`KDropdownMenu allows slotting content 1`] = `
 <div class="k-dropdown k-dropdown-menu">
   <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
-    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger"><button>Click Me!</button></div>
+    <div label="" test-mode="true" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger"><button>Click Me!</button></div>
     <div id="test-popover-id-1234" role="region" class="k-popover k-dropdown-popover mt-1 undefined hide-caret" style="width: 200px; max-width: 350px; max-height: auto; display: none;" name="fade">
       <!---->
       <div class="k-popover-content">
@@ -18,7 +18,7 @@ exports[`KDropdownMenu allows slotting content 1`] = `
 exports[`KDropdownMenu matches snapshot 1`] = `
 <div class="k-dropdown k-dropdown-menu">
   <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
-    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
+    <div label="" test-mode="true" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
       <div>
         <!---->
       </div>
@@ -37,12 +37,12 @@ exports[`KDropdownMenu matches snapshot 1`] = `
 exports[`KDropdownMenu renders disabled props when passed 1`] = `
 <div class="k-dropdown k-dropdown-menu">
   <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
-    <div id="3160e4b1-136d-11ed-9ddc-a1b90be1e26f" aria-controls="3160e4b0-136d-11ed-9ddc-a1b90be1e26f" role="button" class="k-dropdown-trigger dropdown-trigger">
+    <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" class="k-dropdown-trigger dropdown-trigger">
       <div><button type="button" class="k-button k-dropdown-btn medium rounded primary" disabled="disabled" data-testid="k-dropdown-btn">
           <!---->
           Click me
           <!----></button></div>
-      <div id="3160e4b0-136d-11ed-9ddc-a1b90be1e26f" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: 240px; max-height: auto; display: none;" name="fade">
+      <div id="test-popover-id-1234" role="region" class="k-popover kooltip mt-2  hide-caret" style="width: auto; max-width: 240px; max-height: auto; display: none;" name="fade">
         <!---->
         <div class="k-popover-content">
           <div role="tooltip">A sweet tooltip</div>
@@ -74,7 +74,7 @@ exports[`KDropdownMenu renders disabled props when passed 1`] = `
 exports[`KDropdownMenu renders props when passed 1`] = `
 <div class="k-dropdown k-dropdown-menu">
   <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
-    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
+    <div label="" test-mode="true" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
       <div><button type="button" class="k-button k-dropdown-btn medium rounded primary" data-testid="k-dropdown-btn">
           <!---->
           Drop it!
@@ -104,7 +104,7 @@ exports[`KDropdownMenu renders props when passed 1`] = `
 exports[`KDropdownMenu renders with selected item 1`] = `
 <div class="k-dropdown k-dropdown-menu">
   <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
-    <div label="" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
+    <div label="" test-mode="true" data-testid="k-dropdown-trigger" class="k-dropdown-trigger dropdown-trigger">
       <div>
         <!---->
       </div>

--- a/packages/KDropdownMenu/index.js
+++ b/packages/KDropdownMenu/index.js
@@ -1,15 +1,15 @@
-import KDropdown from './KDropdown'
-import KDropdownItem from './KDropdownItem'
+import KDropdownMenu from './KDropdownMenu.vue'
+import KDropdownItem from './KDropdownItem.vue'
 
 const Plugin = {
   install (Vue) {
-    Vue.component('KDropdown', KDropdown)
+    Vue.component('KDropdownMenu', KDropdownMenu)
     Vue.component('KDropdownItem', KDropdownItem)
   }
 }
 
 export default Plugin
-export { KDropdown, KDropdownItem }
+export { KDropdownMenu, KDropdownItem }
 
 if (typeof window !== 'undefined' && window.Vue) {
   window.Vue.use(Plugin)

--- a/packages/KDropdownMenu/index.js
+++ b/packages/KDropdownMenu/index.js
@@ -1,0 +1,16 @@
+import KDropdown from './KDropdown'
+import KDropdownItem from './KDropdownItem'
+
+const Plugin = {
+  install (Vue) {
+    Vue.component('KDropdown', KDropdown)
+    Vue.component('KDropdownItem', KDropdownItem)
+  }
+}
+
+export default Plugin
+export { KDropdown, KDropdownItem }
+
+if (typeof window !== 'undefined' && window.Vue) {
+  window.Vue.use(Plugin)
+}

--- a/packages/KDropdownMenu/package.json
+++ b/packages/KDropdownMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kdropdownmenu",
-  "version": "6.33.9",
+  "version": "6.35.5",
   "description": "Dropdown Menu component",
   "main": "dist/KDropdownMenu.umd.min.js",
   "componentName": "KDropdownMenu",
@@ -27,9 +27,10 @@
     "vue-router": "^3.5.4"
   },
   "dependencies": {
-    "@kongponents/kbutton": "^6.33.9",
-    "@kongponents/kpop": "^6.33.9",
-    "@kongponents/ktoggle": "^6.33.9",
-    "@kongponents/styles": "^6.33.9"
+    "@kongponents/kbutton": "^6.35.5",
+    "@kongponents/kooltip": "^6.35.5",
+    "@kongponents/kpop": "^6.35.5",
+    "@kongponents/ktoggle": "^6.35.5",
+    "@kongponents/styles": "^6.35.5"
   }
 }

--- a/packages/KDropdownMenu/package.json
+++ b/packages/KDropdownMenu/package.json
@@ -23,6 +23,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "vue-router": "^3.5.4"
+  },
   "dependencies": {
     "@kongponents/kbutton": "^6.33.9",
     "@kongponents/kpop": "^6.33.9",

--- a/packages/KDropdownMenu/package.json
+++ b/packages/KDropdownMenu/package.json
@@ -4,7 +4,7 @@
   "description": "Dropdown Menu component",
   "main": "dist/KDropdownMenu.umd.min.js",
   "componentName": "KDropdownMenu",
-  "source": "KDropdownMenu.vue",
+  "source": "index.js",
   "files": [
     "dist",
     "*.vue",

--- a/packages/KDropdownMenu/package.json
+++ b/packages/KDropdownMenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kongponents/kdropdownmenu",
-  "version": "0.1.0",
+  "version": "6.33.9",
   "description": "Dropdown Menu component",
   "main": "dist/KDropdownMenu.umd.min.js",
   "componentName": "KDropdownMenu",

--- a/packages/KDropdownMenu/package.json
+++ b/packages/KDropdownMenu/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@kongponents/kdropdownmenu",
+  "version": "0.1.0",
+  "description": "Dropdown Menu component",
+  "main": "dist/KDropdownMenu.umd.min.js",
+  "componentName": "KDropdownMenu",
+  "source": "KDropdownMenu.vue",
+  "files": [
+    "dist",
+    "*.vue",
+    "index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kong/kongponents.git"
+  },
+  "author": "Kong Inc",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Kong/kongponents/issues"
+  },
+  "homepage": "https://github.com/Kong/kongponents#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@kongponents/kbutton": "^6.33.9",
+    "@kongponents/kpop": "^6.33.9",
+    "@kongponents/ktoggle": "^6.33.9",
+    "@kongponents/styles": "^6.33.9"
+  }
+}

--- a/packages/Krumbs/package.json
+++ b/packages/Krumbs/package.json
@@ -19,10 +19,7 @@
     "url": "https://github.com/Kong/kongponents/issues"
   },
   "peerDependencies": {
-    "vue-router": "^3.0.2"
-  },
-  "devDependencies": {
-    "vue-router": "^3.0.2"
+    "vue-router": "^3.5.4"
   },
   "homepage": "https://github.com/Kong/kongponents#readme",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15482,10 +15482,15 @@ vue-prism-editor@^0.3.0:
     escape-html "^1.0.3"
     unescape "^1.0.1"
 
-vue-router@^3.0.2, vue-router@^3.0.7, vue-router@^3.1.3:
+vue-router@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.1.3.tgz#e6b14fabc0c0ee9fda0e2cbbda74b350e28e412b"
   integrity sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ==
+
+vue-router@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.4.tgz#c453c0b36bc75554de066fefc3f2a9c3212aca70"
+  integrity sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==
 
 vue-server-renderer@^2.6.10:
   version "2.6.10"


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- Add new `KDropdownMenu` kongponent - ported from `khcp-ui`.
- Bump `vue-router` to match version used in `khcp-ui`
- Add it as a `peerDependency` to `KButton`

For [KHCP-690](https://konghq.atlassian.net/browse/KHCP-690).

![image](https://user-images.githubusercontent.com/67973710/182693558-0df14479-ff62-40a4-91e0-49f482bbac6e.png)


## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
