### PR TITLE
fix(kooltip): z-index bump

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -294,7 +294,7 @@ export default {
       right: var(--spacing-lg);
       top: var(--spacing-lg);
       // 1 more than .k-modal-dialog
-      z-index: 1000;
+      z-index: 10000;
       .k-button {
         padding: 8px 0 8px 8px;
         margin-top: -8px;

--- a/packages/KoolTip/KoolTip.vue
+++ b/packages/KoolTip/KoolTip.vue
@@ -95,7 +95,7 @@ export default {
 <style lang="scss">
 @import '~@kongponents/styles/variables';
 
-.kooltip {
+.kooltip.k-popover {
   --KPopColor: var(--KoolTipColor, var(--white, color(white)));
   --KPopBackground: var(--KoolTipBackground, var(--black-400, color(black-400)));
   --KPopBodySize: var(--type-sm);
@@ -103,5 +103,6 @@ export default {
   --KPopPaddingY: var(--spacing-xs);
   --KPopBorder: none;
   pointer-events: none;
+  z-index: 9999;
 }
 </style>


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
z-index of `Kooltip` needs to be at least as high as z-index of `KModal` so they will show when inside.

Tested locally with:

```
<KModal
    :is-visible="slottedIsOpen3"
    title="Look at my slots!"
    content="You know you like these slots."
    show-dismiss-icon
    dismiss-button-theme="dark"
    @canceled="slottedIsOpen3 = false"
  >
    <template v-slot:header-image>
      <div class="slot-image-content">
        <h4 class="mx-7 my-5">I'm slotted baby!</h4>
        <div>
          <KoolTip placement="right" label="A label that appears on the right">
            <KButton>right</KButton>
          </KoolTip>
          <KLabel info="This is an example">Input Title</KLabel>
        </div>
      </div>
    </template>
    <template v-slot:action-buttons>
      <KButton appearance="btn-link" class="mr-2" @click="slottedIsOpen3 = false">Pass</KButton>
      <KButton appearance="primary" @click="slottedIsOpen3 = false">I sure do!</KButton>
    </template>
  </KModal>
```

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: https://github.com/Kong/kongponents/pull/726
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
