### PR TITLE
fix(kselect): remove is-open prop on KInput

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -103,7 +103,6 @@
               :id="selectTextId"
               v-bind="$attrs"
               :model-value="filterStr"
-              :is-open="isToggled.value"
               :label="label && overlayLabel ? label : undefined"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' && !filterIsEnabled ? selectedItem.label : placeholderText"


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

`KInput` does not have `is-open` prop, so `KSelect` should not pass it down. Otherwise the rendered input would be:

<img width="727" alt="image" src="https://user-images.githubusercontent.com/10095631/182334752-081c83d1-911f-42d9-a98d-a67769897220.png">

@adamdehaven 

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
