### PR TITLE
fix(kselect): remove is-open prop on KInput

### DIFF
--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -94,7 +94,6 @@
               :id="selectTextId"
               v-bind="$attrs"
               :value="filterStr"
-              :is-open="isToggled"
               :label="label && overlayLabel ? label : null"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' ? selectedItem.label : placeholderText"


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

`KInput` does not have `is-open` prop, so `KSelect` should not pass it down. Otherwise the rendered input would be:

![image](https://user-images.githubusercontent.com/10095631/182336347-711a40e8-4638-4265-b67e-6635da73462a.png)

@adamdehaven

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: #727
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
