### PR TITLE
fix(kpop): update target default

### DIFF
--- a/src/components/KPagination/KPagination.spec.ts
+++ b/src/components/KPagination/KPagination.spec.ts
@@ -76,7 +76,7 @@ describe('KPagination', () => {
 
     cy.getTestId('k-select-input').find('.k-button').should('contain.text', '2 items per page')
     cy.getTestId('k-select-input').find('button').click({ multiple: true, force: true })
-    cy.getTestId('k-select-item-4').find('button').click({ multiple: true, force: true })
+    cy.getTestId('k-select-item-4').eq(1).find('button').click({ multiple: true, force: true })
     cy.getTestId('k-select-input').find('.k-button').should('contain.text', '4 items per page')
   })
 })

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -144,7 +144,7 @@ export default defineComponent({
      */
     target: {
       type: String,
-      default: 'body',
+      default: '',
     },
     /**
      * The tag to wrap the popover around
@@ -358,7 +358,7 @@ export default defineComponent({
       this.showPopper()
       const placement = placements[this.placement] ? placements[this.placement] : 'auto'
       const popperEl = this.$refs.popper
-      const theTarget = this.target === 'body' && !this.isSvg && !this.testMode ? document.querySelector(this.target) : document.getElementById(this.targetId)
+      const theTarget = this.target && !this.isSvg && !!document.querySelector(this.target) ? document.querySelector(this.target) : document.getElementById(this.targetId)
 
       if (theTarget) {
         theTarget.appendChild(popperEl)

--- a/src/components/KSelect/KSelect.spec.ts
+++ b/src/components/KSelect/KSelect.spec.ts
@@ -169,7 +169,7 @@ describe('KSelect', () => {
     cy.getTestId(`k-select-item-${vals[1]}`).should('not.be.visible')
 
     cy.getTestId(`k-select-item-${vals[0]}`).eq(1).click({ force: true })
-    cy.get('.k-select-input').should('have.value', labels[0])
+    cy.get('.selected-item-label').should('contain.text', labels[0])
   })
 
   it('allows slotting content into the items', async () => {


### PR DESCRIPTION
# Summary

Update the default target for KPop.vue so that it properly attaches to the generated target id or the provided target

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
