### PR TITLE
fix(kselect): update popover width when it opens

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -49,6 +49,7 @@
           @opened="() => {
             filterStr = ''
             toggle()
+            onPopoverOpen()
           }"
           @closed="() => {
             if (selectedItem && appearance === 'select') {
@@ -170,7 +171,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, computed, watch, onMounted, PropType } from 'vue'
+import { defineComponent, ref, Ref, computed, watch, PropType } from 'vue'
 import { v1 as uuidv1 } from 'uuid'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -499,13 +500,13 @@ export default defineComponent({
 
     const inputWidth = ref(0)
 
-    onMounted(() => {
+    const onPopoverOpen = () => {
       const inputElem = document.getElementById(selectInputId.value)
 
       if (inputElem) {
         inputWidth.value = inputElem.offsetWidth
       }
-    })
+    }
 
     return {
       filterStr,
@@ -528,6 +529,7 @@ export default defineComponent({
       onInputKeypress,
       onQueryChange,
       onInputFocus,
+      onPopoverOpen,
     }
   },
 })


### PR DESCRIPTION
# Summary

The popover's width is only set in the `onMounted` hook. This works fine except:
1. `<KSelect>`'s visibility is controlled by `v-show`: https://codesandbox.io/s/crazy-moon-vokjk5
2. `<KSelect>` has a relative `width` and user resizes the viewport: https://codesandbox.io/s/happy-hawking-ngq8td

The perfect solution would be to use `MutationObserver`, but I think updating popover's width every time it opens can solve most of the problem (except when user resizes the viewport while the popover is open, which IMO is acceptable).

Let me know what you think. @adamdehaven @kaiarrowood 

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
