### PR TITLE
fix(kmodal): dismiss icon logic [khcp-4354]

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -141,9 +141,13 @@ Change the [appearance](/components/button.html#props) of the cancel button.
 
 Use this to hide the built-in cancel button (`false` by default).
 
-### showDismissIcon
+### hideDismissIcon
 
-Boolean for whether or not to display the 'X' in the upper right corner to dismiss the dialog (`false` by default).
+When using the `header-image` slot we display a dismiss 'X' button in the upper right corner of the dialog. Boolean for hiding this button (`false` by default).
+
+:::tip
+If you want to have a dismiss icon on your dialog without using the `header-image` slot, you should use the [KPrompt](/components/prompt.html) component.
+:::
 
 ### dismissButtonTheme
 
@@ -156,7 +160,6 @@ Can be `dark` (default) or `light`. You might want to use this if displaying dar
     :is-visible="slottedIsOpen2"
     title="Welcome!"
     hide-cancel-button
-    show-dismiss-icon
     dismiss-button-theme="light"
     text-align="left"
     @canceled="slottedIsOpen2 = false"
@@ -185,7 +188,6 @@ Can be `dark` (default) or `light`. You might want to use this if displaying dar
   :is-visible="isVisible"
   title="Welcome!"
   hide-cancel-button
-  show-dismiss-icon
   text-align="left"
   dismiss-button-theme="light"
   @canceled="isVisible = false"
@@ -213,7 +215,7 @@ Can be `dark` (default) or `light`. You might want to use this if displaying dar
 
 There are 5 designated slots you can use to display content in the modal.
 
-- `header-image` - content displayed above the header, ignores padding.
+- `header-image` - content displayed above the header, ignores padding. Enables the dismiss icon.
 - `header-content`
 - `body-content`
 - `footer-content` - Contains cancel & action buttons by default.
@@ -226,7 +228,6 @@ There are 5 designated slots you can use to display content in the modal.
     :is-visible="slottedIsOpen3"
     title="Look at my slots!"
     content="You know you like these slots."
-    show-dismiss-icon
     dismiss-button-theme="dark"
     @canceled="slottedIsOpen3 = false"
   >
@@ -248,7 +249,6 @@ There are 5 designated slots you can use to display content in the modal.
     :is-visible="slottedIsOpen3"
     title="Look at my slots!"
     content="You know you like these slots."
-    show-dismiss-icon
     dismiss-button-theme="dark"
     @canceled="slottedIsOpen3 = false"
   >

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -143,7 +143,7 @@ Use this to hide the built-in cancel button (`false` by default).
 
 ### hideDismissIcon
 
-When using the `header-image` slot we display a dismiss 'X' button in the upper right corner of the dialog. Boolean for hiding this button (`false` by default).
+When using the `header-image` slot we display a dismiss 'X' button in the upper right corner of the dialog. Set this prop to `true` to hide the button (`false` by default).
 
 :::tip
 If you want to have a dismiss icon on your dialog without using the `header-image` slot, you should use the [KPrompt](/components/prompt.html) component.

--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -11,7 +11,7 @@
 
       <div class="k-modal-dialog modal-dialog">
         <div
-          v-if="showDismissIcon"
+          v-if="hasHeaderImage && !hideDismissIcon"
           class="close-button"
         >
           <KButton
@@ -111,9 +111,10 @@ export default {
       default: false
     },
     /**
-     * Set to true to render an 'x' dismiss button
+     * The dismiss icon is visible by default when using the `header-image` slot.
+     * Set to true to hide the 'x' dismiss button
      */
-    showDismissIcon: {
+    hideDismissIcon: {
       type: Boolean,
       default: false
     },


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Change the dismiss icon logic as described in [KHCP-4354](https://konghq.atlassian.net/browse/KHCP-4354).

![image](https://user-images.githubusercontent.com/67973710/182869838-bb24c91c-7cb2-463a-8254-345d603e5d09.png)


## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: https://github.com/Kong/kongponents/pull/738
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
