### PR TITLE
fix(ktable): update v-on value

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -139,7 +139,7 @@
             :key="`k-table-${tableId}-row-${rowIndex}`"
             :tabindex="isClickable ? 0 : null"
             :role="isClickable ? 'link' : null"
-            v-on="hasSideBorder ? tdlisteners(row, row) : null"
+            v-on="hasSideBorder ? tdlisteners(row, row) : {}"
           >
             <td
               v-for="(value, index) in tableHeaders"


### PR DESCRIPTION
# Summary

`<KTable>` without side borders will throw a warning:

> [Vue warn]: v-on with no argument expects an object value.

<img width="684" alt="image" src="https://user-images.githubusercontent.com/10095631/183348413-149fe614-cab6-4f5e-8e59-a05856a20128.png">

@adamdehaven @kaiarrowood 

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
