### PR TITLE
style(empty-state): update button color [khcp-4222]

### DIFF
--- a/packages/KCatalog/KCatalog.vue
+++ b/packages/KCatalog/KCatalog.vue
@@ -79,7 +79,7 @@
               :to="emptyStateActionRoute ? emptyStateActionRoute : null"
               :data-testid="getTestIdString(emptyStateActionMessage)"
               :icon="emptyStateActionButtonIcon ? emptyStateActionButtonIcon : null"
-              appearance="primary"
+              :appearance="searchInput ? 'btn-link' : 'primary'"
               @click="$emit('KCatalog-empty-state-cta-clicked')"
             >
               {{ emptyStateActionMessage }}

--- a/packages/KTable/KTable.vue
+++ b/packages/KTable/KTable.vue
@@ -54,7 +54,7 @@
               :to="emptyStateActionRoute ? emptyStateActionRoute : null"
               :data-testid="getTestIdString(emptyStateActionMessage)"
               :icon="emptyStateActionButtonIcon ? emptyStateActionButtonIcon : null"
-              appearance="primary"
+              :appearance="searchInput ? 'btn-link' : 'primary'"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
               {{ emptyStateActionMessage }}


### PR DESCRIPTION
# Summary
Updates `KEmptyState` action button color inside `KTable/KCataolg` based on:

- If no data in the list at all, then action button will be a primary button
- if there is data, but if filtered data is empty, then a button link to clear filters

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [x] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
