### PR TITLE
feat(kselect): add clearable prop

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -104,7 +104,7 @@ the Clear icon.
 <KSelect :items="items" />
 ```
 
-The `select` style displays the selected item in the textbox and also displays a chevron. To deselect the item, you need to
+The `select` style displays the selected item in the text box and also displays a chevron. To allow deselecting the item, you need to
 set the `clearable` prop to `true`. See [clearable](#clearable) for an example.
 
 <div>
@@ -127,14 +127,14 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 
 ### clearable
 
-The `clearable` prop is used to enable deselecting the selected item when `appearance` is `'select'`.
+The `clearable` prop is used to enable deselecting the selected item when `appearance` is `'select'`. Defaults to `false`.
 
 <div>
-  <KSelect appearance='select' :items="deepClone(defaultItems)" clearable />
+  <KSelect appearance="select" :items="deepClone(defaultItems)" clearable />
 </div>
 
 ```html
-<KSelect appearance='select' :items="items" clearable />
+<KSelect appearance="select" :items="items" clearable />
 ```
 
 ### buttonText

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -104,8 +104,8 @@ the Clear icon.
 <KSelect :items="items" />
 ```
 
-The `select` style displays the selected item in the textbox and also displays a chevron. There is no
-way to clear the selection once it is made.
+The `select` style displays the selected item in the textbox and also displays a chevron. To deselect the item, you need to
+set the `clearable` prop to `true`. See [clearable](#clearable) for an example.
 
 <div>
   <KSelect appearance='select' :items="deepClone(defaultItems)" />
@@ -123,6 +123,18 @@ The `button` style triggers the dropdown on click and you cannot filter the entr
 
 ```html
 <KSelect appearance='button' :items="items" />
+```
+
+### clearable
+
+The `clearable` prop is used to enable deselecting the selected item when `appearance` is `'select'`.
+
+<div>
+  <KSelect appearance='select' :items="deepClone(defaultItems)" clearable />
+</div>
+
+```html
+<KSelect appearance='select' :items="items" clearable />
 ```
 
 ### buttonText

--- a/packages/KSelect/KSelect.spec.js
+++ b/packages/KSelect/KSelect.spec.js
@@ -248,4 +248,33 @@ describe('KSelect', () => {
     expect(wrapper.find('[data-testid="k-select-loading"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="k-select-item-label1"]').html()).toEqual(expect.stringContaining('Label 1'))
   })
+
+  it('can clear selection when clearable is true', async () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+
+    const wrapper = mount(KSelect, {
+      propsData: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+          selected: true
+        }, {
+          label: labels[1],
+          value: vals[1]
+        }],
+        appearance: 'select',
+        clearable: true
+      }
+    })
+
+    expect(wrapper.find('input').element.value).toBe(labels[0])
+
+    const clearIcon = wrapper.find('.k-select-input .clear-selection-icon')
+
+    clearIcon.trigger('click')
+
+    expect(wrapper.find('input').element.value).toBe('')
+  })
 })

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -85,6 +85,19 @@
             style="position: relative;"
             role="listbox"
           >
+            <button
+              v-if="isClearVisible"
+              :class="{ 'overlay-label-chevron': overlayLabel }"
+              class="clear-selection-icon cursor-pointer non-visual-button"
+              @click="clearSelection"
+              @keyup.enter="clearSelection"
+            >
+              <KIcon
+                icon="close"
+                color="var(--grey-500)"
+                size="15"
+              />
+            </button>
             <KIcon
               v-if="appearance === 'select'"
               :class="{ 'overlay-label-chevron': overlayLabel }"
@@ -99,7 +112,11 @@
               :label="label && overlayLabel ? label : null"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' ? selectedItem.label : placeholderText"
-              :class="{ 'cursor-default prevent-pointer-events': !filterIsEnabled ,'input-placeholder-dark': appearance === 'select'}"
+              :class="{
+                'cursor-default prevent-pointer-events': !filterIsEnabled,
+                'input-placeholder-dark has-chevron': appearance === 'select',
+                'has-clear': isClearVisible
+              }"
               class="k-select-input"
               @keypress="onInputKeypress"
               @keyup="!$attrs.disabled ? triggerFocus(isToggled) : null"
@@ -292,6 +309,13 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    /**
+     * A flag for clearing selection when appearance is 'select'
+     */
+    clearable: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -390,6 +414,9 @@ export default {
       }
 
       return this.placeholderText
+    },
+    isClearVisible () {
+      return this.appearance === 'select' && this.clearable && !!this.selectedItem
     }
   },
   watch: {
@@ -472,6 +499,10 @@ export default {
         anItem.key = anItem.key.replace(/-selected/gi, '')
       })
       this.selectedItem = null
+      if (this.appearance === 'select') {
+        this.filterStr = ''
+      }
+
       // this 'input' event must be emitted for v-model binding to work properly
       this.$emit('input', null)
       this.$emit('change', null)
@@ -573,8 +604,16 @@ export default {
       }
     }
 
-   .input-placeholder-dark input::placeholder {
+    .input-placeholder-dark input::placeholder {
       color: var(--KInputColor, var(--black-70, rgba(0, 0, 0, 0.7))) !important;
+    }
+
+    .has-chevron input.k-input {
+      padding-right: 25px;
+    }
+
+    .has-clear input.k-input {
+      padding-right: 50px;
     }
 
     input.k-input {
@@ -590,6 +629,21 @@ export default {
 
       &.overlay-label-chevron {
         top: 55%;
+      }
+    }
+
+    .clear-selection-icon {
+      position: absolute;
+      top: 13px;
+      right: 22px;
+      z-index: 9;
+
+      &.overlay-label-chevron {
+        top: 55%;
+      }
+
+      .kong-icon-close {
+        position: static;
       }
     }
   }

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -95,7 +95,7 @@
               <KIcon
                 icon="close"
                 color="var(--grey-500)"
-                size="15"
+                size="10"
               />
             </button>
             <KIcon
@@ -315,7 +315,7 @@ export default {
      */
     clearable: {
       type: Boolean,
-      default: false
+      default: true
     }
   },
 
@@ -623,7 +623,7 @@ export default {
 
     .kong-icon {
       position: absolute;
-      top: 15px;
+      top: 12px;
       right: 6px;
       z-index: 9;
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -315,7 +315,7 @@ export default {
      */
     clearable: {
       type: Boolean,
-      default: true
+      default: false
     }
   },
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -85,25 +85,25 @@
             style="position: relative;"
             role="listbox"
           >
-            <button
+            <KButton
               v-if="isClearVisible"
-              :class="{ 'overlay-label-chevron': overlayLabel }"
+              :class="{ 'overlay-label-clear': overlayLabel }"
               class="clear-selection-icon cursor-pointer non-visual-button"
               @click="clearSelection"
               @keyup.enter="clearSelection"
             >
               <KIcon
-                icon="close"
+                icon="clear"
                 color="var(--grey-500)"
-                size="10"
+                size="18"
               />
-            </button>
+            </KButton>
             <KIcon
               v-if="appearance === 'select'"
               :class="{ 'overlay-label-chevron': overlayLabel }"
               :icon="isToggled ? 'chevronUp' : 'chevronDown'"
               color="var(--grey-500)"
-              size="15"
+              size="18"
             />
             <KInput
               :id="selectTextId"
@@ -623,7 +623,7 @@ export default {
 
     .kong-icon {
       position: absolute;
-      top: 12px;
+      top: 15px;
       right: 6px;
       z-index: 9;
 
@@ -637,13 +637,15 @@ export default {
       top: 13px;
       right: 22px;
       z-index: 9;
+      padding: 0;
 
-      &.overlay-label-chevron {
-        top: 55%;
+      &.overlay-label-clear {
+        top: 36px;
       }
 
-      .kong-icon-close {
+      .kong-icon-clear {
         position: static;
+        display: block;
       }
     }
   }

--- a/packages/KSelect/__snapshots__/KSelect.spec.js.snap
+++ b/packages/KSelect/__snapshots__/KSelect.spec.js.snap
@@ -8,6 +8,7 @@ exports[`KSelect matches snapshot 1`] = `
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
         <!---->
+        <!---->
         <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->
           <!---->
@@ -38,6 +39,7 @@ exports[`KSelect renders props when passed 1`] = `
     <!---->
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
+        <!---->
         <!---->
         <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->
@@ -82,6 +84,7 @@ exports[`KSelect renders with selected item 1`] = `
     </div>
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button">
       <div id="test-select-input-id-1234" data-testid="k-select-input" role="listbox" class="" style="position: relative;">
+        <!---->
         <!---->
         <div class="k-input-wrapper k-select-input"><input id="test-select-text-id-1234" placeholder="Filter..." class="form-control k-input k-input-medium">
           <!---->


### PR DESCRIPTION
# Summary

Adds `clearable` to `<KSelect>`.

@adamdehaven @kaiarrowood 

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: #762
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because this PR needs to be approved first

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
