### PR TITLE
fix(kstepper): include all vue files in package

### DIFF
--- a/packages/KStepper/package.json
+++ b/packages/KStepper/package.json
@@ -7,7 +7,8 @@
   "source": "KStepper.vue",
   "files": [
     "dist",
-    "KStepper.vue"
+    "KStepper.vue",
+    "*.vue"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Summary

Should fix the following error:
![Screen Shot 2022-08-12 at 3 28 41 PM](https://user-images.githubusercontent.com/2080476/184447364-cdacda96-2684-4ccd-9c3a-bb6970c8ef7e.png)


<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
