### PR TITLE
feat(kalert): updates for KHCP-4405

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -412,9 +412,9 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 
 ### size
 
-Controls size (height) of alert.
+Controls size (height) and default font-size of an alert.
 
-- `small` (default)
+- `small`
 
 <div>
   <KAlert

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -10,340 +10,11 @@
 
 ## Props
 
-### Appearances
+### alertMessage
 
-What color and purpose the Alert should be. Shares similar appearances to those of [KButton](/components/button).
+The main content of the alert.
 
-> Note: `appearance` is `info` by default.
-
-- `info`
-- `warning`
-- `success`
-- `danger`
-
-<div>
-  <KAlert
-    appearance="info"
-    alert-message="Info alert message"
-  />
-  <KAlert
-    appearance="warning"
-    alert-message="Warning alert message"
-  />
-  <KAlert
-    appearance="success"
-    alert-message="Success alert message"
-  />
-  <KAlert
-    appearance="danger"
-    alert-message="Danger alert message"
-  />
-</div>
-
-```html
-<KAlert
-  appearance="info"
-  alert-message="Info alert message"
-/>
-<KAlert
-  appearance="warning"
-  alert-message="Warning alert message"
-/>
-<KAlert
-  appearance="success"
-  alert-message="Success alert message"
-/>
-<KAlert
-  appearance="danger"
-  alert-message="Danger alert message"
-/>
-```
-
-### Type
-
-The display type of the alert.
-
-- `banner`
-
-`type="banner"` will have a white background and display an ellipse on the left to indicate appearance.
-
-> Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
-
-<div>
-  <KAlert
-    alert-message="I'm a banner type alert"
-    type="banner"
-  />
-
-  <KAlert
-    alert-message="I'm a banner type alert"
-    appearance="success"
-    type="banner"
-  />
-
-  <KAlert
-    alert-message="I'm a banner type alert"
-    appearance="danger"
-    type="banner"
-  />
-
-  <KAlert
-    alert-message="I'm a banner type alert"
-    appearance="warning"
-    type="banner"
-  />
-</div>
-
-```html
-<KAlert
-  alert-message="I'm a banner type alert"
-  type="banner"
-/>
-<KAlert
-  alert-message="I'm a banner type alert"
-  appearance="success"
-  type="banner"
-/>
-<KAlert
-  alert-message="I'm a banner type alert"
-  appearance="danger"
-  type="banner"
-/>
-<KAlert
-  alert-message="I'm a banner type alert"
-  appearance="warning"
-  type="banner"
-/>
-```
-
-- `alert`
-
-`type="alert"` will have a background based on `appearance`.
-
-> Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
-
-<div>
-  <KAlert
-    alert-message="I'm an alert"
-    dismiss-type="button"
-    type="alert"
-    :is-showing="alert1IsOpen"
-    @closed="alert1IsOpen = false"
-  />
-
-  <KAlert
-    alert-message="I'm an alert"
-    dismiss-type="button"
-    appearance="success"
-    type="alert"
-    :is-showing="alert2IsOpen"
-    @closed="alert2IsOpen = false"
-  />
-
-  <KAlert
-    alert-message="I'm an alert"
-    dismiss-type="button"
-    appearance="danger"
-    type="alert"
-    :is-showing="alert3IsOpen"
-    @closed="alert3IsOpen = false"
-  />
-
-  <KAlert
-    alert-message="I'm an alert"
-    dismiss-type="button"
-    appearance="warning"
-    type="alert"
-    :is-showing="alert4IsOpen"
-    @closed="alert4IsOpen = false"
-  />
-</div>
-
-```html
-<KAlert
-  alert-message="I'm an alert"
-  dismiss-type="button"
-  type="alert"
-  :is-showing="alert1IsOpen"
-  @closed="alert1IsOpen = false"
-/>
-
-<KAlert
-  alert-message="I'm an alert"
-  dismiss-type="button"
-  appearance="success"
-  type="alert"
-  :is-showing="alert2IsOpen"
-  @closed="alert2IsOpen = false"
-/>
-
-<KAlert
-  alert-message="I'm an alert"
-  dismiss-type="button"
-  appearance="danger"
-  type="alert"
-  :is-showing="alert3IsOpen"
-  @closed="alert4IsOpen = false"
-/>
-
-<KAlert
-  alert-message="I'm an alert"
-  dismiss-type="button"
-  appearance="warning"
-  type="alert"
-  :is-showing="alert5IsOpen"
-  @closed="alert5IsOpen = false"
-/>
-```
-
-### title
-
-You can specify a title for the alert in situations where the message is more wordy.
-
-<div>
-  <KAlert
-    :is-showing="extraMsg2"
-    appearance="danger"
-    title="Error: Something went wrong!"
-    @closed="extraMsg2 = false"
-  >
-    <template #icon>
-      <KIcon icon="errorFilled" color="var(--red-500)" size="16" />
-    </template>
-    <template v-slot:alertMessage>
-      Since I have a title, my font-size is smaller.
-    </template>
-  </KAlert>
-</div>
-
-```html
-<KAlert
-  :is-showing="extraMsg2"
-  appearance="danger"
-  title="Error: Something went wrong!"
-  @closed="extraMsg2 = false"
->
-  <template #icon>
-    <KIcon icon="errorFilled" color="var(--red-500)" size="16" />
-  </template>
-  <template v-slot:alertMessage>
-    Since I have a title, my font-size is smaller.
-  </template>
-</KAlert>
-```
-
-### Dismiss Type
-
-KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed.
-
-- `none`
-- `icon`
-- `button`
-
-<div>
-  <KAlert
-    alert-message="Alert that can not be dismissed"
-    type="alert"
-    dismiss-type="none"
-  />
-
-  <KAlert
-    alert-message="Info alert message that is dismissible"
-    appearance="info"
-    type="alert"
-    dismiss-type="icon"
-    :is-showing="infoIsOpen"
-    @closed="infoIsOpen = false"
-  />
-
-  <KAlert
-    alert-message="Warning alert message that is dismissible"
-    appearance="warning"
-    type="alert"
-    dismiss-type="icon"
-    :is-showing="warningIsOpen"
-    @closed="warningIsOpen = false"
-  />
-
-  <KAlert
-    alert-message="Success alert message that is dismissible"
-    appearance="success"
-    type="alert"
-    dismiss-type="icon"
-    :is-showing="successIsOpen"
-    @closed="successIsOpen = false"
-  />
-
-  <KAlert
-    alert-message="Danger alert message that is dismissible"
-    appearance="danger"
-    type="alert"
-    dismiss-type="icon"
-    :is-showing="dangerIsOpen"
-    @closed="dangerIsOpen = false"
-  />
-
-  <KAlert
-    alert-message="Alert with dismiss type as button"
-    type="banner" dismiss-type="button"
-    :is-showing="dismissTypeBtn"
-    @closed="dismissTypeBtn = false"
-  />
-</div>
-
-```html
-<KAlert
-  alert-message="Alert that can not be dismissed"
-  type="alert"
-  dismiss-type="none"
-/>
-
-<KAlert
-  alert-message="Info alert message that is dismissible"
-  appearance="info"
-  type="alert"
-  dismiss-type="icon"
-  :is-showing="infoIsOpen"
-  @closed="infoIsOpen = false"
-/>
-
-<KAlert
-  alert-message="Warning alert message that is dismissible"
-  appearance="warning"
-  type="alert"
-  dismiss-type="icon"
-  :is-showing="warningIsOpen"
-  @closed="warningIsOpen = false"
-/>
-
-<KAlert
-  alert-message="Success alert message that is dismissible"
-  appearance="success"
-  type="alert"
-  dismiss-type="icon"
-  :is-showing="successIsOpen"
-  @closed="successIsOpen = false"
-/>
-
-<KAlert
-  alert-message="Danger alert message that is dismissible"
-  appearance="danger"
-  type="alert"
-  dismiss-type="icon"
-  :is-showing="dangerIsOpen"
-  @closed="dangerIsOpen = false"
-/>
-
-<KAlert
-  alert-message="Alert with dismiss type as button"
-  type="banner"
-  dismiss-type="button"
-  :is-showing="dismissTypeBtn"
-  @closed="defaultIdismissTypeBtnsOpen = false"
-/>
-```
-
-### Hide/Display
+### isShowing
 
 Set whether or not the alert box is shown.
 
@@ -358,91 +29,395 @@ Set whether or not the alert box is shown.
 />
 ```
 
-### Bordered
+### type
 
-Adds border around alert. Used for [KToaster](/components/toaster.html).
+The display type of the alert.
 
-- `is-bordered`
+> Note: By default `appearance="info"`.
 
-<KAlert is-bordered appearance="info" alert-message="Info bordered" />
+- `alert` (default)
 
-```html
-<KAlert
-  is-bordered
-  appearance="info"
-  alert-message="Info bordered"
-/>
-```
-
-### Left Border
-
-Adds border to the left side. Typically used for alerts that show info that may link away like documentation.
-
-- `has-left-border`
-
-<KAlert has-left-border alert-message="Bordered alert" />
+<div>
+  <KAlert alert-message="I'm an alert" />
+</div>
 
 ```html
-<KAlert
-  has-left-border
-  alert-message="Bordered alert"
-/>
+<KAlert alert-message="I'm an alert" />
 ```
 
-### Right Border
+- `banner`
 
-Adds border to the right side. Typically used for alerts that show info that may link away like documentation.
-
-- `has-right-border`
-
-<KAlert has-right-border alert-message="Bordered alert" />
-
-```html
-<KAlert
-  has-right-border
-  alert-message="Bordered alert"
-/>
-```
-
-### Top Border
-
-Adds border to the top.
-
-- `has-top-border`
-
-<KAlert has-top-border  alert-message="Bordered alert" />
-
-```html
-<KAlert
-  has-top-border
-  alert-message="Bordered alert"
-/>
-```
-
-### Bottom Border
-
-Adds border to the bottom.
-
-- `has-bottom-border`
-
-<KAlert has-bottom-border  alert-message="Bordered alert"/>
-
-```html
-<KAlert
-  has-bottom-border
-  alert-message="Bordered alert"
-/>
-```
-
-### Size
-
-Controls size of alert.
-
-- `small`
+`type="banner"` will have a white background and display an ellipse on the left to indicate appearance.
 
 <div>
   <KAlert
-    style="width:250px"
+    alert-message="I'm a banner type alert"
+    type="banner"
+  />
+</div>
+
+```html
+<KAlert
+  alert-message="I'm a banner type alert"
+  type="banner"
+/>
+```
+
+### dismissType
+
+KAlert allows for dismissal of the banner using an icon or button. An alert is not dismissible if "none" is passed.
+
+- `none` (default)
+- `icon`
+- `button`
+
+<div>
+  <KAlert
+    alert-message="Alert that can not be dismissed"
+    type="alert"
+    dismiss-type="none"
+  />
+
+  <KAlert
+    alert-message="Info alert message that is dismissible"
+    dismiss-type="icon"
+    :is-showing="dismissTypeIcon"
+    @closed="dismissTypeIcon = false"
+  />
+
+  <KAlert
+    alert-message="Alert with dismiss type as button"
+    type="banner"
+    dismiss-type="button"
+    :is-showing="dismissTypeBtn"
+    @closed="dismissTypeBtn = false"
+  />
+</div>
+
+```html
+<KAlert
+  alert-message="Alert that can not be dismissed"
+  type="alert"
+  dismiss-type="none"
+/>
+
+<KAlert
+  alert-message="Info alert message that is dismissible"
+  dismiss-type="icon"
+  :is-showing="isShowing"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  alert-message="Alert with dismiss type as button"
+  type="banner"
+  dismiss-type="button"
+  :is-showing="isShowing"
+  @closed="isShowing = false"
+/>
+```
+
+### appearance
+
+What color and purpose the Alert should be. Shares similar appearances to those of [KButton](/components/button). `appearance` will influence the colors of action/dismiss buttons.
+
+- `info` (default)
+
+<div>
+  <KAlert alert-message="Info alert message" />
+
+  <KAlert
+    :is-showing="infoIsOpen"
+    alert-message="Info alert message that is dismissible"
+    dismiss-type="icon"
+    @closed="infoIsOpen = false"
+  />
+
+  <KAlert
+    :is-showing="infoIsOpen2"
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    @closed="infoIsOpen2 = false"
+  />
+
+  <KAlert
+    alert-message="I'm a banner type alert"
+    type="banner"
+  />
+
+  <KAlert
+    :is-showing="infoIsOpen3"
+    alert-message="Alert with dismiss type as button"
+    type="banner"
+    dismiss-type="button"
+    @closed="infoIsOpen3 = false"
+  />
+</div>
+
+```html
+<KAlert alert-message="Info alert message" />
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Info alert message that is dismissible"
+  dismiss-type="icon"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="I'm an alert"
+  dismiss-type="button"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  alert-message="I'm a banner type alert"
+  type="banner"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert with dismiss type as button"
+  type="banner"
+  dismiss-type="button"
+  @closed="isShowing = false"
+/>
+```
+
+- `warning`
+
+<div>
+  <KAlert alert-message="Warning alert message" appearance="warning" />
+
+  <KAlert
+    :is-showing="warningIsOpen"
+    alert-message="Alert message that is dismissible"
+    dismiss-type="icon"
+    appearance="warning"
+    @closed="warningIsOpen = false"
+  />
+
+  <KAlert
+    :is-showing="warningIsOpen2"
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    appearance="warning"
+    @closed="warningIsOpen2 = false"
+  />
+
+  <KAlert
+    alert-message="I'm a banner type alert"
+    type="banner"
+    appearance="warning"
+  />
+
+  <KAlert
+    :is-showing="warningIsOpen3"
+    alert-message="Alert with dismiss type as button"
+    type="banner"
+    dismiss-type="button"
+    appearance="warning"
+    @closed="warningIsOpen3 = false"
+  />
+</div>
+
+```html
+<KAlert
+  alert-message="Warning alert message"
+  appearance="warning"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert message that is dismissible"
+  dismiss-type="icon"
+  appearance="warning"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="I'm an alert"
+  dismiss-type="button"
+  appearance="warning"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  alert-message="I'm a banner type alert"
+  type="banner"
+  appearance="warning"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert with dismiss type as button"
+  type="banner"
+  dismiss-type="button"
+  appearance="warning"
+  @closed="isShowing = false"
+/>
+```
+
+- `success`
+
+<div>
+  <KAlert alert-message="Success alert message" appearance="success" />
+
+  <KAlert
+    :is-showing="successIsOpen"
+    alert-message="Alert message that is dismissible"
+    dismiss-type="icon"
+    appearance="success"
+    @closed="successIsOpen = false"
+  />
+
+  <KAlert
+    :is-showing="successIsOpen2"
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    appearance="success"
+    @closed="successIsOpen2 = false"
+  />
+
+  <KAlert
+    alert-message="I'm a banner type alert"
+    type="banner"
+    appearance="success"
+  />
+
+  <KAlert
+    :is-showing="successIsOpen3"
+    alert-message="Alert with dismiss type as button"
+    type="banner"
+    dismiss-type="button"
+    appearance="success"
+    @closed="successIsOpen3 = false"
+  />
+</div>
+
+```html
+<KAlert
+  alert-message="Success alert message"
+  appearance="success"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert message that is dismissible"
+  dismiss-type="icon"
+  appearance="success"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="I'm an alert"
+  dismiss-type="button"
+  appearance="success"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  alert-message="I'm a banner type alert"
+  type="banner"
+  appearance="success"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert with dismiss type as button"
+  type="banner"
+  dismiss-type="button"
+  appearance="success"
+  @closed="isShowing = false"
+/>
+```
+
+- `danger`
+
+<div>
+  <KAlert alert-message="Danger alert message" appearance="danger" />
+
+  <KAlert
+    :is-showing="dangerIsOpen"
+    alert-message="Alert message that is dismissible"
+    dismiss-type="icon"
+    appearance="danger"
+    @closed="dangerIsOpen = false"
+  />
+
+  <KAlert
+    :is-showing="dangerIsOpen2"
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    appearance="danger"
+    @closed="dangerIsOpen2 = false"
+  />
+
+  <KAlert
+    alert-message="I'm a banner type alert"
+    type="banner"
+    appearance="danger"
+  />
+
+  <KAlert
+    :is-showing="dangerIsOpen3"
+    alert-message="Alert with dismiss type as button"
+    type="banner"
+    dismiss-type="button"
+    appearance="danger"
+    @closed="dangerIsOpen3 = false"
+  />
+</div>
+
+```html
+<KAlert
+  alert-message="Danger alert message"
+  appearance="danger"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert message that is dismissible"
+  dismiss-type="icon"
+  appearance="danger"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="I'm an alert"
+  dismiss-type="button"
+  appearance="danger"
+  @closed="isShowing = false"
+/>
+
+<KAlert
+  alert-message="I'm a banner type alert"
+  type="banner"
+  appearance="danger"
+/>
+
+<KAlert
+  :is-showing="isShowing"
+  alert-message="Alert with dismiss type as button"
+  type="banner"
+  dismiss-type="button"
+  appearance="danger"
+  @closed="isShowing = false"
+/>
+```
+
+### size
+
+Controls size (height) of alert.
+
+- `small` (default)
+
+<div>
+  <KAlert
     size="small"
     alert-message="Small alert"
   />
@@ -450,110 +425,235 @@ Controls size of alert.
 
 ```html
 <KAlert
-  style="width:250px"
   size="small"
   alert-message="Small alert"
 />
 ```
 
 - `large`
+`size="large"` allows further customization options. You can specify an icon, description text, and additional buttons using the `actionButtons` slot. See the full [Example](#description).
 
-`size="large"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` slot and additional buttons using the `actionButtons` slot.
+### icon
+
+Specify an icon to display to the left of the alert content. If using `type="banner"` this will override the colored ellipse.
+
+> Note: only available with `size="large"`.
+
+### iconSize
+
+The size of the `icon` being displayed (default is `24`).
+
+### iconColor
+
+The color of the `icon` being displayed.
+
+### description
+
+Descriptive text to be displayed below the main alert content.
+
+> Note: only available with `size="large"`.
 
 <div>
   <KAlert
+    :is-showing="extraMsg"
+    alert-message="You’ve had 12 new mentions since you last logged in"
+    description="across 3 services"
+    icon="support"
+    icon-color="var(--purple-400)"
     type="banner"
     dismiss-type="button"
-    appearance="warning"
-    icon="support"
     size="large"
-    :is-showing="extraMsg"
     @closed="extraMsg = false"
   >
     <template v-slot:actionButtons>
       <KButton appearance="primary" size="small">Review</KButton>
     </template>
-    <template v-slot:alertMessage>
-      You’ve had 12 new mentions since you last logged in
-    </template>
-    <template v-slot:description>
-      across 3 services
+  </KAlert>
+</div>
+
+```html
+<KAlert
+  :is-showing="isShowing"
+  alert-message="You’ve had 12 new mentions since you last logged in"
+  description="across 3 services"
+  dismiss-type="button"
+  type="banner"
+  icon="support"
+  icon-color="var(--purple-400)"
+  size="large"
+  @closed="isShowing = false"
+>
+  <template v-slot:actionButtons>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
+</KAlert>
+```
+
+### title
+
+You can specify a title for the alert in situations where the message is more wordy. This content is displayed directly above the main alert content.
+
+<div>
+  <KAlert
+    :is-showing="extraMsg2"
+    title="Error: Something went wrong!"
+    alert-message="Since I have a title, my font-size is smaller."
+    appearance="danger"
+    @closed="extraMsg2 = false"
+  >
+    <template #icon>
+      <KIcon icon="errorFilled" color="var(--red-500)" size="16" />
     </template>
   </KAlert>
 </div>
 
 ```html
 <KAlert
-  type="banner"
-  dismiss-type="button"
-  appearance="warning"
-  icon="support"
-  size="large"
-  :is-showing="extraMsg"
-  @closed="extraMsg = false"
+  :is-showing="isShowing"
+  title="Error: Something went wrong!"
+  alert-message="Since I have a title, my font-size is smaller."
+  appearance="danger"
+  @closed="isShowing = false"
 >
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Review</KButton>
-  </template>
-  <template v-slot:alertMessage>
-    You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:description>
-    across 3 services
+  <template #icon>
+    <KIcon icon="errorFilled" color="var(--red-500)" size="16" />
   </template>
 </KAlert>
 ```
 
-### Fixed
+### isBordered
+
+Adds border around alert. Used for [KToaster](/components/toaster.html).
+
+<KAlert is-bordered alert-message="Info bordered" />
+
+```html
+<KAlert
+  alert-message="Info bordered"
+  is-bordered
+/>
+```
+
+### hasLeftBorder
+
+Adds border to the left side. Typically used for alerts that show info that may link away like documentation.
+
+<KAlert has-left-border alert-message="Bordered alert" />
+
+```html
+<KAlert
+  alert-message="Bordered alert"
+  has-left-border
+/>
+```
+
+### hasRightBorder
+
+Adds border to the right side. Typically used for alerts that show info that may link away like documentation.
+
+<KAlert has-right-border alert-message="Bordered alert" />
+
+```html
+<KAlert
+  alert-message="Bordered alert"
+  has-right-border
+/>
+```
+
+### hasTopBorder
+
+Adds border to the top.
+
+<KAlert has-top-border alert-message="Bordered alert" />
+
+```html
+<KAlert
+  alert-message="Bordered alert"
+  has-top-border
+/>
+```
+
+### hasBottomBorder
+
+Adds border to the bottom.
+
+<KAlert has-bottom-border alert-message="Bordered alert"/>
+
+```html
+<KAlert
+  alert-message="Bordered alert"
+  has-bottom-border
+/>
+```
+
+### isFixed
 
 Fixes KAlert to the top of the container.
 
 > Note: Not demoed
 
-- `is-fixed`
-
 ```html
-<KAlert is-fixed  alert-message="Info bordered" />
+<KAlert is-fixed alert-message="Info bordered" />
 ```
 
 ## Slots
 
-- `actionButtons` - Slot specifically meant for adding buttons other than Dismiss button
 - `alertMessage` - Default message slot
-- `description` - Alert message description slot available when these conditions are met: `type='banner'`, `size='large'` and `alertMessage` slot is rendered
+- `icon` - Icon to the left of the main alert content
+- `title` - Text displayed directly above the main alert content (font will be bolded)
+- `description` - Descriptive text displayed directly beneath the main alert content (`size='large'` required)
+- `actionButtons` - Slot specifically meant for adding buttons other than Dismiss button
 
 <div>
   <KAlert
-    type="banner"
-    dismiss-type="button"
-    appearance="success"
     :is-showing="extraBtnSlot"
+    dismiss-type="button"
+    size="large"
+    appearance="success"
     @closed="extraBtnSlot = false"
   >
-    <template v-slot:alertMessage>
-      I'm an alert with action buttons
+    <template #icon>
+      <KIcon icon="lock" size="20" color="var(--yellow-400)" />
+    </template>
+    <template #title>
+      Look, Mah!
+    </template>
+    <template #alertMessage>
+      Check out my awesome slots
+    </template>
+    <template #description>
+      I like cats 🐈‍⬛
     </template>
     <template v-slot:actionButtons>
-      <KButton appearance="primary" size="small">Upgrade</KButton>
-      <KButton appearance="primary" size="small">Downgrade</KButton>
+      <KButton appearance="secondary" size="small">🐈‍⬛</KButton>
+      <KButton appearance="creation" size="small">🐶</KButton>
     </template>
   </KAlert>
 </div>
 
 ```html
 <KAlert
-  type="banner"
+  :is-showing="isShowing"
   dismiss-type="button"
+  size="large"
   appearance="success"
-  :is-showing="extraBtnSlot"
-  @closed="extraBtnSlot = false"
+  @closed="isShowing = false"
 >
-    <template v-slot:alertMessage>
-    I'm an alert with action buttons
+  <template #icon>
+    <KIcon icon="lock" size="20" color="var(--yellow-400)" />
+  </template>
+  <template #title>
+    Look, Mah!
+  </template>
+  <template #alertMessage>
+    Check out my awesome slots
+  </template>
+  <template #description>
+    I like cats 🐈‍⬛
   </template>
   <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Upgrade</KButton>
-    <KButton appearance="primary" size="small">Downgrade</KButton>
+    <KButton appearance="secondary" size="small">🐈‍⬛</KButton>
+    <KButton appearance="creation" size="small">🐶</KButton>
   </template>
 </KAlert>
 ```
@@ -642,20 +742,23 @@ An Example of changing the success KAlert variant to lime instead of Kong's gree
 export default {
   data () {
     return {
-      infoIsOpen: true,
-      warningIsOpen: true,
-      successIsOpen: true,
-      dangerIsOpen: true,
-      defaultIsClosed: true,
-      defaultClosed: true,
       dismissTypeBtn: true,
-      extraBtnSlot: true,
+      dismissTypeIcon: true,
+      infoIsOpen: true,
+      infoIsOpen2: true,
+      infoIsOpen3: true,
+      warningIsOpen: true,
+      warningIsOpen2: true,
+      warningIsOpen3: true,
+      successIsOpen: true,
+      successIsOpen2: true,
+      successIsOpen3: true,
+      dangerIsOpen: true,
+      dangerIsOpen2: true,
+      dangerIsOpen3: true,
       extraMsg: true,
       extraMsg2: true,
-      alert1IsOpen: true,
-      alert2IsOpen: true,
-      alert3IsOpen: true,
-      alert4IsOpen: true
+      extraBtnSlot: true
     }
   }
 }

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -2,8 +2,7 @@
 
 **KAlert** is used to display contextual information to a user. These are typically used to notify something may be disabled or there may be an error.
 
-<KAlert
-  alert-message="I'm an alert" />
+<KAlert alert-message="I'm an alert" />
 
 ```html
 <KAlert alert-message="I'm an alert" />
@@ -22,32 +21,42 @@ What color and purpose the Alert should be. Shares similar appearances to those 
 - `success`
 - `danger`
 
-<KAlert
-  appearance="info"
-  alert-message="Info alert message" />
-<KAlert
-  appearance="warning"
-  alert-message="Warning alert message" />
-<KAlert
-  appearance="success"
-  alert-message="Success alert message" />
-<KAlert
-  appearance="danger"
-  alert-message="Danger alert message" />
+<div>
+  <KAlert
+    appearance="info"
+    alert-message="Info alert message"
+  />
+  <KAlert
+    appearance="warning"
+    alert-message="Warning alert message"
+  />
+  <KAlert
+    appearance="success"
+    alert-message="Success alert message"
+  />
+  <KAlert
+    appearance="danger"
+    alert-message="Danger alert message"
+  />
+</div>
 
 ```html
 <KAlert
   appearance="info"
-  alert-message="Info alert message" />
+  alert-message="Info alert message"
+/>
 <KAlert
   appearance="warning"
-  alert-message="Warning alert message" />
+  alert-message="Warning alert message"
+/>
 <KAlert
   appearance="success"
-  alert-message="Success alert message" />
+  alert-message="Success alert message"
+/>
 <KAlert
   appearance="danger"
-  alert-message="Danger alert message" />
+  alert-message="Danger alert message"
+/>
 ```
 
 ### Type
@@ -60,41 +69,51 @@ The display type of the alert.
 
 > Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
 
-<KAlert
-  alert-message="I'm a banner type alert"
-  type="banner" />
-
-<KAlert
-  alert-message="I'm a banner type alert"
-  appearance="success"
-  type="banner" />
+<div>
+  <KAlert
+    alert-message="I'm a banner type alert"
+    type="banner"
+  />
 
   <KAlert
-  alert-message="I'm a banner type alert"
-  appearance="danger"
-  type="banner" />
+    alert-message="I'm a banner type alert"
+    appearance="success"
+    type="banner"
+  />
 
   <KAlert
-  alert-message="I'm a banner type alert"
-  appearance="warning"
-  type="banner" />
+    alert-message="I'm a banner type alert"
+    appearance="danger"
+    type="banner"
+  />
+
+  <KAlert
+    alert-message="I'm a banner type alert"
+    appearance="warning"
+    type="banner"
+  />
+</div>
 
 ```html
 <KAlert
   alert-message="I'm a banner type alert"
-  type="banner" />
+  type="banner"
+/>
 <KAlert
   alert-message="I'm a banner type alert"
   appearance="success"
-  type="banner" />
+  type="banner"
+/>
 <KAlert
   alert-message="I'm a banner type alert"
   appearance="danger"
-  type="banner" />
+  type="banner"
+/>
 <KAlert
   alert-message="I'm a banner type alert"
   appearance="warning"
-  type="banner" />
+  type="banner"
+/>
 ```
 
 - `alert`
@@ -103,68 +122,114 @@ The display type of the alert.
 
 > Note: By default `appearance="info"`. `appearance` will influence the colors of action/dismiss buttons.
 
-<KAlert
-  alert-message="I'm an alert"
-  dismissType="button"
-  type="alert"
-  :isShowing="alert1IsOpen"
-  @closed="alert1IsOpen = false" />
+<div>
+  <KAlert
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    type="alert"
+    :is-showing="alert1IsOpen"
+    @closed="alert1IsOpen = false"
+  />
 
-<KAlert
-  alert-message="I'm an alert"
-  dismissType="button"
-  appearance="success"
-  type="alert"
-  :isShowing="alert2IsOpen"
-  @closed="alert2IsOpen = false" />
+  <KAlert
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    appearance="success"
+    type="alert"
+    :is-showing="alert2IsOpen"
+    @closed="alert2IsOpen = false"
+  />
 
-<KAlert
-  alert-message="I'm an alert"
-  dismissType="button"
-  appearance="danger"
-  type="alert"
-  :isShowing="alert3IsOpen"
-  @closed="alert3IsOpen = false" />
+  <KAlert
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    appearance="danger"
+    type="alert"
+    :is-showing="alert3IsOpen"
+    @closed="alert3IsOpen = false"
+  />
 
-<KAlert
-  alert-message="I'm an alert"
-  dismissType="button"
-  appearance="warning"
-  type="alert"
-  :isShowing="alert4IsOpen"
-  @closed="alert4IsOpen = false" />
+  <KAlert
+    alert-message="I'm an alert"
+    dismiss-type="button"
+    appearance="warning"
+    type="alert"
+    :is-showing="alert4IsOpen"
+    @closed="alert4IsOpen = false"
+  />
+</div>
 
 ```html
 <KAlert
   alert-message="I'm an alert"
-  dismissType="button"
+  dismiss-type="button"
   type="alert"
-  :isShowing="alert1IsOpen"
-  @closed="alert1IsOpen = false" />
+  :is-showing="alert1IsOpen"
+  @closed="alert1IsOpen = false"
+/>
 
 <KAlert
   alert-message="I'm an alert"
-  dismissType="button"
+  dismiss-type="button"
   appearance="success"
   type="alert"
-  :isShowing="alert2IsOpen"
-  @closed="alert2IsOpen = false" />
+  :is-showing="alert2IsOpen"
+  @closed="alert2IsOpen = false"
+/>
 
 <KAlert
   alert-message="I'm an alert"
-  dismissType="button"
+  dismiss-type="button"
   appearance="danger"
   type="alert"
-  :isShowing="alert3IsOpen"
-  @closed="alert4IsOpen = false" />
+  :is-showing="alert3IsOpen"
+  @closed="alert4IsOpen = false"
+/>
 
 <KAlert
   alert-message="I'm an alert"
-  dismissType="button"
+  dismiss-type="button"
   appearance="warning"
   type="alert"
-  :isShowing="alert5IsOpen"
-  @closed="alert5IsOpen = false" />
+  :is-showing="alert5IsOpen"
+  @closed="alert5IsOpen = false"
+/>
+```
+
+### title
+
+You can specify a title for the alert in situations where the message is more wordy.
+
+<div>
+  <KAlert
+    :is-showing="extraMsg2"
+    appearance="danger"
+    title="Error: Something went wrong!"
+    @closed="extraMsg2 = false"
+  >
+    <template #icon>
+      <KIcon icon="errorFilled" color="var(--red-500)" size="16" />
+    </template>
+    <template v-slot:alertMessage>
+      Since I have a title, my font-size is smaller.
+    </template>
+  </KAlert>
+</div>
+
+```html
+<KAlert
+  :is-showing="extraMsg2"
+  appearance="danger"
+  title="Error: Something went wrong!"
+  @closed="extraMsg2 = false"
+>
+  <template #icon>
+    <KIcon icon="errorFilled" color="var(--red-500)" size="16" />
+  </template>
+  <template v-slot:alertMessage>
+    Since I have a title, my font-size is smaller.
+  </template>
+</KAlert>
 ```
 
 ### Dismiss Type
@@ -175,107 +240,122 @@ KAlert allows for dismissal of the banner using an icon or button. An alert is n
 - `icon`
 - `button`
 
-<KAlert
-  alert-message="Alert that can not be dismissed"
-  type="alert"
-  dismissType="none" />
+<div>
+  <KAlert
+    alert-message="Alert that can not be dismissed"
+    type="alert"
+    dismiss-type="none"
+  />
 
-<KAlert
-  alert-message="Info alert message that is dismissible"
-  appearance="info"
-  type="alert"
-  dismissType="icon"
-  :isShowing="infoIsOpen"
-  @closed="infoIsOpen = false" />
+  <KAlert
+    alert-message="Info alert message that is dismissible"
+    appearance="info"
+    type="alert"
+    dismiss-type="icon"
+    :is-showing="infoIsOpen"
+    @closed="infoIsOpen = false"
+  />
 
-<KAlert
-  alert-message="Warning alert message that is dismissible"
-  appearance="warning"
-  type="alert"
-  dismissType="icon"
-  :isShowing="warningIsOpen"
-  @closed="warningIsOpen = false" />
+  <KAlert
+    alert-message="Warning alert message that is dismissible"
+    appearance="warning"
+    type="alert"
+    dismiss-type="icon"
+    :is-showing="warningIsOpen"
+    @closed="warningIsOpen = false"
+  />
 
-<KAlert
-  alert-message="Success alert message that is dismissible"
-  appearance="success"
-  type="alert"
-  dismissType="icon"
-  :isShowing="successIsOpen"
-  @closed="successIsOpen = false" />
+  <KAlert
+    alert-message="Success alert message that is dismissible"
+    appearance="success"
+    type="alert"
+    dismiss-type="icon"
+    :is-showing="successIsOpen"
+    @closed="successIsOpen = false"
+  />
 
-<KAlert
-  alert-message="Danger alert message that is dismissible"
-  appearance="danger"
-  type="alert"
-  dismissType="icon"
-  :isShowing="dangerIsOpen"
-  @closed="dangerIsOpen = false" />
+  <KAlert
+    alert-message="Danger alert message that is dismissible"
+    appearance="danger"
+    type="alert"
+    dismiss-type="icon"
+    :is-showing="dangerIsOpen"
+    @closed="dangerIsOpen = false"
+  />
 
-<KAlert
-  alert-message="Alert with dismiss type as button"
-  type="banner" dismissType="button"
-  :isShowing="dismissTypeBtn"
-  @closed="dismissTypeBtn = false"/>
+  <KAlert
+    alert-message="Alert with dismiss type as button"
+    type="banner" dismiss-type="button"
+    :is-showing="dismissTypeBtn"
+    @closed="dismissTypeBtn = false"
+  />
+</div>
 
 ```html
 <KAlert
   alert-message="Alert that can not be dismissed"
   type="alert"
-  dismissType="none" />
+  dismiss-type="none"
+/>
 
 <KAlert
   alert-message="Info alert message that is dismissible"
   appearance="info"
   type="alert"
-  dismissType="icon"
-  :isShowing="infoIsOpen"
-  @closed="infoIsOpen = false" />
+  dismiss-type="icon"
+  :is-showing="infoIsOpen"
+  @closed="infoIsOpen = false"
+/>
 
 <KAlert
   alert-message="Warning alert message that is dismissible"
   appearance="warning"
   type="alert"
-  dismissType="icon"
-  :isShowing="warningIsOpen"
-  @closed="warningIsOpen = false" />
+  dismiss-type="icon"
+  :is-showing="warningIsOpen"
+  @closed="warningIsOpen = false"
+/>
 
 <KAlert
   alert-message="Success alert message that is dismissible"
   appearance="success"
   type="alert"
-  dismissType="icon"
-  :isShowing="successIsOpen"
-  @closed="successIsOpen = false" />
+  dismiss-type="icon"
+  :is-showing="successIsOpen"
+  @closed="successIsOpen = false"
+/>
 
 <KAlert
   alert-message="Danger alert message that is dismissible"
   appearance="danger"
   type="alert"
-  dismissType="icon"
-  :isShowing="dangerIsOpen"
-  @closed="dangerIsOpen = false" />
+  dismiss-type="icon"
+  :is-showing="dangerIsOpen"
+  @closed="dangerIsOpen = false"
+/>
 
 <KAlert
   alert-message="Alert with dismiss type as button"
   type="banner"
-  dismissType="button"
-  :isShowing="dismissTypeBtn"
-  @closed="defaultIdismissTypeBtnsOpen = false"/>
+  dismiss-type="button"
+  :is-showing="dismissTypeBtn"
+  @closed="defaultIdismissTypeBtnsOpen = false"
+/>
 ```
 
 ### Hide/Display
 
 Set whether or not the alert box is shown.
 
-> Note: By default isShowing is set to true.
+> Note: By default is-showing is set to true.
 
-- `isShowing`
+- `is-showing`
 
 ```html
 <KAlert
   :is-showing="false"
-  alert-message="isShowing set to false"/>
+  alert-message="is-showing set to false"
+/>
 ```
 
 ### Bordered
@@ -284,16 +364,14 @@ Adds border around alert. Used for [KToaster](/components/toaster.html).
 
 - `is-bordered`
 
-<KAlert
-  is-bordered
-  appearance="info"
-  alert-message="Info bordered"/>
+<KAlert is-bordered appearance="info" alert-message="Info bordered" />
 
 ```html
 <KAlert
   is-bordered
   appearance="info"
-  alert-message="Info bordered"/>
+  alert-message="Info bordered"
+/>
 ```
 
 ### Left Border
@@ -302,14 +380,13 @@ Adds border to the left side. Typically used for alerts that show info that may 
 
 - `has-left-border`
 
-<KAlert
-  has-left-border
-  alert-message="Bordered alert"/>
+<KAlert has-left-border alert-message="Bordered alert" />
 
 ```html
 <KAlert
   has-left-border
-  alert-message="Bordered alert"/>
+  alert-message="Bordered alert"
+/>
 ```
 
 ### Right Border
@@ -318,14 +395,13 @@ Adds border to the right side. Typically used for alerts that show info that may
 
 - `has-right-border`
 
-<KAlert
-  has-right-border
-  alert-message="Bordered alert"/>
+<KAlert has-right-border alert-message="Bordered alert" />
 
 ```html
 <KAlert
   has-right-border
-  alert-message="Bordered alert"/>
+  alert-message="Bordered alert"
+/>
 ```
 
 ### Top Border
@@ -334,14 +410,13 @@ Adds border to the top.
 
 - `has-top-border`
 
-<KAlert
-  has-top-border
-  alert-message="Bordered alert"/>
+<KAlert has-top-border  alert-message="Bordered alert" />
 
 ```html
 <KAlert
   has-top-border
-  alert-message="Bordered alert"/>
+  alert-message="Bordered alert"
+/>
 ```
 
 ### Bottom Border
@@ -350,14 +425,13 @@ Adds border to the bottom.
 
 - `has-bottom-border`
 
-<KAlert
-  has-bottom-border
-  alert-message="Bordered alert"/>
+<KAlert has-bottom-border  alert-message="Bordered alert"/>
 
 ```html
 <KAlert
   has-bottom-border
-  alert-message="Bordered alert"/>
+  alert-message="Bordered alert"
+/>
 ```
 
 ### Size
@@ -366,51 +440,61 @@ Controls size of alert.
 
 - `small`
 
-<KAlert
-  style="width:250px"
-  size="small"
-  alert-message="Small alert"/>
+<div>
+  <KAlert
+    style="width:250px"
+    size="small"
+    alert-message="Small alert"
+  />
+</div>
 
 ```html
 <KAlert
   style="width:250px"
   size="small"
-  alert-message="Small alert"/>
+  alert-message="Small alert"
+/>
 ```
 
 - `large`
 
-`size="large" type="banner"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` slot and additional buttons using the `actionButtons` slot.
+`size="large"` allows further customization options. You can specify an icon to be displayed on the left in place of the colored ellipse using the `icon` property, description text to be displayed below the main alert message using the `description` slot and additional buttons using the `actionButtons` slot.
 
-<KAlert
-  type="banner"
-  dismissType="button"
-  appearance="warning"
-  icon="support"
-  size="large"
-  :isShowing="extraMsg"
-  @closed="extraMsg = false">
-  <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Review</KButton></template>
-  <template v-slot:alertMessage>
-    You’ve had 12 new mentions since you last logged in
-  </template>
-  <template v-slot:description>
-    across 3 services
-  </template>
-</KAlert>
+<div>
+  <KAlert
+    type="banner"
+    dismiss-type="button"
+    appearance="warning"
+    icon="support"
+    size="large"
+    :is-showing="extraMsg"
+    @closed="extraMsg = false"
+  >
+    <template v-slot:actionButtons>
+      <KButton appearance="primary" size="small">Review</KButton>
+    </template>
+    <template v-slot:alertMessage>
+      You’ve had 12 new mentions since you last logged in
+    </template>
+    <template v-slot:description>
+      across 3 services
+    </template>
+  </KAlert>
+</div>
 
 ```html
 <KAlert
   type="banner"
-  dismissType="button"
+  dismiss-type="button"
   appearance="warning"
   icon="support"
   size="large"
-  :isShowing="extraMsg"
-  @closed="extraMsg = false">
+  :is-showing="extraMsg"
+  @closed="extraMsg = false"
+>
   <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Review</KButton></template>
+    <KButton appearance="primary" size="small">Review</KButton>
+  </template>
   <template v-slot:alertMessage>
     You’ve had 12 new mentions since you last logged in
   </template>
@@ -429,9 +513,7 @@ Fixes KAlert to the top of the container.
 - `is-fixed`
 
 ```html
-<KAlert
-  is-fixed
-  alert-message="Info bordered"/>
+<KAlert is-fixed  alert-message="Info bordered" />
 ```
 
 ## Slots
@@ -440,32 +522,36 @@ Fixes KAlert to the top of the container.
 - `alertMessage` - Default message slot
 - `description` - Alert message description slot available when these conditions are met: `type='banner'`, `size='large'` and `alertMessage` slot is rendered
 
-<KAlert
-  type="banner"
-  dismissType="button"
-  appearance="success"
-  :isShowing="extraBtnSlot"
-  @closed="extraBtnSlot = false">
-  <template v-slot:alertMessage>
-    I'm an alert with action buttons
-  </template>
- <template v-slot:actionButtons>
-    <KButton appearance="primary" size="small">Upgrade</KButton>
-    <KButton appearance="primary" size="small">Downgrade</KButton>
-  </template>
-</KAlert>
+<div>
+  <KAlert
+    type="banner"
+    dismiss-type="button"
+    appearance="success"
+    :is-showing="extraBtnSlot"
+    @closed="extraBtnSlot = false"
+  >
+    <template v-slot:alertMessage>
+      I'm an alert with action buttons
+    </template>
+    <template v-slot:actionButtons>
+      <KButton appearance="primary" size="small">Upgrade</KButton>
+      <KButton appearance="primary" size="small">Downgrade</KButton>
+    </template>
+  </KAlert>
+</div>
 
 ```html
 <KAlert
   type="banner"
-  dismissType="button"
+  dismiss-type="button"
   appearance="success"
-  :isShowing="extraBtnSlot"
-  @closed="extraBtnSlot = false">
+  :is-showing="extraBtnSlot"
+  @closed="extraBtnSlot = false"
+>
     <template v-slot:alertMessage>
     I'm an alert with action buttons
   </template>
- <template v-slot:actionButtons>
+  <template v-slot:actionButtons>
     <KButton appearance="primary" size="small">Upgrade</KButton>
     <KButton appearance="primary" size="small">Downgrade</KButton>
   </template>
@@ -479,7 +565,9 @@ Fixes KAlert to the top of the container.
 <KAlert appearance="success" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
-    <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
+    <p>
+      Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.
+    </p>
   </template>
 </KAlert>
 
@@ -487,7 +575,9 @@ Fixes KAlert to the top of the container.
 <KAlert appearance="info" class="mt-5">
   <template v-slot:alertMessage>
     <div class="mt-2 bold">Failure Modes</div>
-    <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
+    <p>
+      Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.
+    </p>
   </template>
 </KAlert>
 ```
@@ -501,10 +591,9 @@ Fixes KAlert to the top of the container.
 </KAlert>
 
 ```html
-<KAlert appearance="info" class="mt-5">
+<KAlert appearance="warning" class="mt-5">
   <template v-slot:alertMessage>
-    <div class="mt-2 bold">Failure Modes</div>
-    <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
+    Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 ```
@@ -526,17 +615,13 @@ Fixes KAlert to the top of the container.
 | `--KAlertWarningBorder`| Warning variant border
 | `--KAlertWarningBackground` | Warning variant background color
 
-\
-An Example of changing the success KAlert variant to lime instead of Kong's green might
-look like.
+An Example of changing the success KAlert variant to lime instead of Kong's green might look like.
 
 > Note: We are scoping the overrides to a wrapper in this example
 
-<template>
-  <div class="alert-wrapper">
-    <KAlert appearance="success" alert-message="Im Lime" />
-  </div>
-</template>
+<div class="alert-wrapper">
+  <KAlert appearance="success" alert-message="Im Lime" />
+</div>
 
 ```html
 <template>
@@ -554,8 +639,8 @@ look like.
 ```
 
 <script>
-  export default {
-      data () {
+export default {
+  data () {
     return {
       infoIsOpen: true,
       warningIsOpen: true,
@@ -566,6 +651,7 @@ look like.
       dismissTypeBtn: true,
       extraBtnSlot: true,
       extraMsg: true,
+      extraMsg2: true,
       alert1IsOpen: true,
       alert2IsOpen: true,
       alert3IsOpen: true,
@@ -581,6 +667,7 @@ look like.
     margin-bottom: 1rem;
   }
 }
+
 .alert-wrapper {
   --KAlertSuccessBackground: lime;
   --KAlertSuccessColor: forestgreen;

--- a/packages/KAlert/KAlert.spec.js
+++ b/packages/KAlert/KAlert.spec.js
@@ -64,10 +64,10 @@ describe('KAlert', () => {
       }
     })
 
-    expect(wrapperBorderLeft.attributes('class')).toContain('hasLeftBorder')
-    expect(wrapperBorderRight.attributes('class')).toContain('hasRightBorder')
-    expect(wrapperBorderBottom.attributes('class')).toContain('hasBottomBorder')
-    expect(wrapperBorderTop.attributes('class')).toContain('hasTopBorder')
+    expect(wrapperBorderLeft.attributes('class')).toContain('has-left-border')
+    expect(wrapperBorderRight.attributes('class')).toContain('has-right-border')
+    expect(wrapperBorderBottom.attributes('class')).toContain('has-bottom-border')
+    expect(wrapperBorderTop.attributes('class')).toContain('has-top-border')
   })
 
   it('renders large alert box', () => {

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -4,15 +4,14 @@
     :class="[
       appearance,
       size,
-      type,
       dismissType,
-      { 'isBordered':isBordered },
-      { 'hasLeftBorder':hasLeftBorder },
-      { 'hasRightBorder':hasRightBorder },
-      { 'hasTopBorder':hasTopBorder },
-      { 'hasBottomBorder':hasBottomBorder },
-      { 'isCentered': isCentered },
-      { 'isFixed': isFixed },
+      { 'is-bordered': isBordered },
+      { 'has-left-border': hasLeftBorder },
+      { 'has-right-border': hasRightBorder },
+      { 'has-top-border': hasTopBorder },
+      { 'has-bottom-border': hasBottomBorder },
+      { 'is-centered': isCentered },
+      { 'is-fixed': isFixed },
       { 'is-banner': type === 'banner' }
     ]"
     class="k-alert"
@@ -27,6 +26,7 @@
     <span
       v-if="icon || $slots.icon"
       :class="{
+        'mr-3': type !== 'banner',
         'k-alert-icon-container-large': size === 'large'
       }"
       class="k-alert-icon-container"
@@ -40,7 +40,7 @@
         />
       </slot>
     </span>
-    <div class="k-alert-msg-text px-3">
+    <div class="k-alert-msg-text">
       <div
         v-if="title || $scopedSlots.title"
         class="k-alert-title bold-600"
@@ -310,6 +310,109 @@ export default {
     color: var(--blue-600, color(blue-600));
   }
 
+  & > div .k-alert-msg {
+    font-weight: 400;
+    font-size: var(--type-md, type(md));
+    line-height: 24px;
+    padding: 2px 0;
+    margin-left: 2px;
+
+    &.k-alert-subtext {
+      font-size: var(--type-sm);
+    }
+
+    p:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+
+  .k-alert-description-text {
+    display: block;
+    padding-top: var(--spacing-xxs);
+    font-weight: 400;
+    font-size: 13px;
+    line-height: 24px;
+    color: var(--grey-500);
+  }
+
+  // Action Buttons
+  .k-alert-action {
+    display: inline-flex;
+    position: relative;
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-left: auto;
+    height: 100%;
+
+    & button {
+      height: 30px;
+      font-weight: 400;
+      font-size: 13px;
+      line-height: 13px;
+
+      &:not(:first-of-type) {
+        margin-left: var(--spacing-sm);
+      }
+    }
+
+    &.info button.primary {
+      --KButtonPrimaryBase: var(--blue-500);
+      --KButtonPrimaryHover: var(--blue-200);
+      color: var(--blue-500);
+      background-color: var(--blue-100);
+    }
+    &.info button.outline {
+      --KButtonOutlineBorder: var(--blue-500);
+      --KButtonOutlineHoverBorder: var(--blue-600);
+      --KButtonOutlineActive: var(--blue-100);
+      --KButtonOutlineActiveBorder: var(--blue-500);
+      color: var(--blue-500);
+      border: 1px solid var(--blue-400);
+    }
+    &.warning button.primary {
+      --KButtonPrimaryBase: var(--yellow-500);
+      --KButtonPrimaryHover: var(--yellow-200);
+      color: var(--yellow-500);
+      background-color: var(--yellow-100);
+    }
+    &.warning button.outline {
+      --KButtonOutlineBorder: var(--yellow-500);
+      --KButtonOutlineHoverBorder: var(--yellow-500);
+      --KButtonOutlineActive: var(--yellow-100);
+      --KButtonOutlineActiveBorder: var(--yellow-500);
+      color: var(--yellow-500);
+      border: 1px solid var(--yellow-300);
+    }
+    &.success button.primary {
+      --KButtonPrimaryBase: var(--green-600);
+      --KButtonPrimaryHover: var(--green-200);
+      color: var(--green-600);
+      background-color: var(--green-100);
+    }
+    &.success button.outline {
+      --KButtonOutlineBorder: var(--green-600);
+      --KButtonOutlineHoverBorder: var(--green-600);
+      --KButtonOutlineActive: var(--green-100);
+      --KButtonOutlineActiveBorder: var(--green-600);
+      color: var(--green-600);
+      border: 1px solid var(--green-400);
+    }
+    &.danger button.primary {
+      --KButtonPrimaryHover: var(--red-200);
+      --KButtonPrimaryBase: var(--red-700);
+      color: var(--red-700);
+      background-color: var(--red-100);
+    }
+    &.danger button.outline {
+      --KButtonOutlineBorder: var(--red-700);
+      --KButtonOutlineColor: var(--red-700);
+      --KButtonOutlineHoverBorder: var(--red-700);
+      --KButtonOutlineActive: var(--red-100);
+      --KButtonOutlineActiveBorder: var(--red-700);
+      border: 1px solid var(--red-500);
+    }
+  }
+  // Dismiss button
   .close {
     position: absolute;
     top: 0;
@@ -326,46 +429,109 @@ export default {
       text-decoration: none;
       opacity: 1;
     }
+
+    & > .kong-icon {
+      &.info {
+        stroke: var(--KAlertInfoColor, var(--blue-500, color(blue-500)));
+      }
+      &.success {
+        stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
+      }
+      &.danger {
+        stroke: var(--KAlertDangerColor, var(--red-700, color(red-700)));
+      }
+      &.warning {
+        stroke: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
+      }
+    }
+  }
+
+  // Sizes
+  &.small {
+    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
+
+     & > div .k-alert-msg {
+      font-size: var(--type-sm, type(sm));
+     }
+  }
+  &.large {
+    min-height: 80px;
+    border-radius: 2px;
+
+    .k-alert-icon-container-large {
+      padding: var(--spacing-lg) 0;
+    }
+  }
+
+  // Types
+  &.is-banner {
+    background-color: var(--white);
+    color: var(--grey-600);
+    padding: 0;
+
+    .k-alert-ellipse {
+      height: 6px;
+      width: 6px;
+      border-radius: 50%;
+      display: inline-block;
+      margin: auto 8px;
+
+      &.info {
+        background-color: var(--blue-400);
+      }
+      &.success {
+        background-color: var(--green-400);
+      }
+      &.warning {
+        background-color: var(--yellow-400);
+      }
+      &.danger {
+        background-color: var(--red-400);
+      }
+    }
+
+    .button > div .k-alert-msg.k-alert-text {
+      padding-left: 0;
+      font-size: var(--type-md, type(md));
+      line-height: 24px;
+    }
+
+    & > div.k-alert-msg-text {
+      padding: var(--spacing-sm) var(--spacing-md);
+    }
   }
 
   // Variants
-  &.isFixed {
+  &.is-fixed {
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
   }
-  &.isBordered {
+  &.is-bordered {
     border: 1px solid;
   }
-  &.isCentered {
+  &.is-centered {
     justify-content: center;
   }
-  &.hasLeftBorder {
+  &.has-left-border {
     border-left: 3px solid;
     border-radius: 0;
   }
-  &.hasRightBorder {
+  &.has-right-border {
     border-right: 3px solid;
     border-radius: 0;
   }
-  &.hasTopBorder {
+  &.has-top-border {
     border-top: 3px solid;
     border-radius: 0;
   }
-  &.hasBottomBorder {
+  &.has-bottom-border {
     border-bottom: 3px solid;
     border-radius: 0;
   }
-  &.small {
-    font-size: var(--type-sm, type(sm));
-    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xs, spacing(xs));
-  }
-  &.large {
-    min-height: 80px;
-    border-radius: 2px;
-  }
-  // Appearances
+
+  // Appearances - MUST FOLLOW VARIANTS
   &.info {
     color: var(--KAlertInfoColor, var(--blue-600, color(blue-600)));
     border-color: var(--KAlertInfoBorder, var(--blue-300, color(blue-300)));
@@ -386,167 +552,10 @@ export default {
     border-color: var(--KAlertWarningBorder, var(--yellow-200, color(yellow-200)));
     background-color: var(--KAlertWarningBackground, var(--yellow-100, color(yellow-100)));
   }
-  & > div .k-alert-msg {
-    font-weight: 400;
-    font-size: var(--type-md, type(md));
-    line-height: 24px;
-    padding: 2px 0;
-    margin-left: 2px;
-
-    &.k-alert-subtext {
-      font-size: var(--type-sm);
-    }
-
-    p:last-of-type {
-      margin-bottom: 0;
-    }
-  }
-}
-
-div.k-alert.banner {
-  background-color: var(--white);
-  color: var(--grey-600);
-  padding: 0;
-}
-
-button.close > .kong-icon {
-  &.info {
-    stroke: var(--KAlertInfoColor, var(--blue-500, color(blue-500)));
-  }
-  &.success {
-    stroke: var(--KAlertSuccessColor, var(--green-600, color(green-600)));
-  }
-  &.danger {
-    stroke: var(--KAlertDangerColor, var(--red-700, color(red-700)));
-  }
-  &.warning {
-    stroke: var(--KAlertWarningColor, var(--yellow-500, color(yellow-500)));
-  }
-}
-
-.k-alert-ellipse {
-  height: 6px;
-  width: 6px;
-  border-radius: 50%;
-  display: inline-block;
-  margin: auto 8px;
-
-  &.info {
-    background-color: var(--blue-400);
-  }
-  &.success {
-    background-color: var(--green-400);
-  }
-  &.warning {
-    background-color: var(--yellow-400);
-  }
-  &.danger {
-    background-color: var(--red-400);
-  }
-}
-
-.k-alert-icon-container-large {
-  padding: var(--spacing-lg) 0;
 }
 
 .toaster-item .k-alert .k-alert-msg {
   padding: 0;
   margin: 0;
-}
-
-.k-alert-action {
-  display: inline-flex;
-  position: relative;
-  margin-top: auto;
-  margin-bottom: auto;
-  margin-left: auto;
-  height: 100%;
-
-  & button {
-    height: 30px;
-    font-weight: 400;
-    font-size: 13px;
-    line-height: 13px;
-
-    &:not(:first-of-type) {
-      margin-left: var(--spacing-sm);
-    }
-  }
-
-  &.info button.primary {
-    color: var(--blue-500);
-    background-color: var(--blue-100);
-    --KButtonPrimaryBase: var(--blue-500);
-    --KButtonPrimaryHover: var(--blue-200);
-  }
-  &.info button.outline {
-    color: var(--blue-500);
-    border: 1px solid var(--blue-400);
-    --KButtonOutlineBorder: var(--blue-500);
-    --KButtonOutlineHoverBorder: var(--blue-600);
-     --KButtonOutlineActive: var(--blue-100);
-    --KButtonOutlineActiveBorder: var(--blue-500);
-  }
-  &.warning button.primary {
-    color: var(--yellow-500);
-    background-color: var(--yellow-100);
-    --KButtonPrimaryBase: var(--yellow-500);
-    --KButtonPrimaryHover: var(--yellow-200);
-  }
-  &.warning button.outline {
-    color: var(--yellow-500);
-    border: 1px solid var(--yellow-300);
-    --KButtonOutlineBorder: var(--yellow-500);
-    --KButtonOutlineHoverBorder: var(--yellow-500);
-    --KButtonOutlineActive: var(--yellow-100);
-    --KButtonOutlineActiveBorder: var(--yellow-500);
-  }
-  &.success button.primary {
-    color: var(--green-600);
-    background-color: var(--green-100);
-    --KButtonPrimaryBase: var(--green-600);
-    --KButtonPrimaryHover: var(--green-200);
-  }
-  &.success button.outline {
-    color: var(--green-600);
-    border: 1px solid var(--green-400);
-    --KButtonOutlineBorder: var(--green-600);
-    --KButtonOutlineHoverBorder: var(--green-600);
-    --KButtonOutlineActive: var(--green-100);
-    --KButtonOutlineActiveBorder: var(--green-600);
-  }
-  &.danger button.primary {
-    color: var(--red-700);
-    background-color: var(--red-100);
-    --KButtonPrimaryHover: var(--red-200);
-    --KButtonPrimaryBase: var(--red-700);
-  }
-  &.danger button.outline {
-    border: 1px solid var(--red-500);
-    --KButtonOutlineBorder: var(--red-700);
-    --KButtonOutlineColor: var(--red-700);
-    --KButtonOutlineHoverBorder: var(--red-700);
-    --KButtonOutlineActive: var(--red-100);
-    --KButtonOutlineActiveBorder: var(--red-700);
-  }
-}
-
-.k-alert-description-text {
-  display: block;
-  padding-top: var(--spacing-xxs);
-  font-weight: 400;
-  font-size: 13px;
-  line-height: 24px;
-  color: var(--grey-500);
-}
-
-.k-alert.banner.button > div .k-alert-msg.k-alert-text {
-  padding-left: 0;
-  font-size: var(--type-md, type(md));
-  line-height: 24px;
-}
-
-.k-alert.banner > div.k-alert-msg-text {
-  padding: var(--spacing-sm) var(--spacing-md);
 }
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -12,7 +12,8 @@
       { 'hasTopBorder':hasTopBorder },
       { 'hasBottomBorder':hasBottomBorder },
       { 'isCentered': isCentered },
-      { 'isFixed': isFixed }
+      { 'isFixed': isFixed },
+      { 'is-banner': type === 'banner' }
     ]"
     class="k-alert"
     role="alert"
@@ -25,7 +26,10 @@
     />
     <span
       v-if="icon || $slots.icon"
-      :class="{ 'mr-3': size !== 'large' }"
+      :class="{
+        'k-alert-icon-container-large': size === 'large'
+      }"
+      class="k-alert-icon-container"
     >
       <slot name="icon">
         <KIcon
@@ -36,7 +40,7 @@
         />
       </slot>
     </span>
-    <div class="k-alert-msg-text pr-3">
+    <div class="k-alert-msg-text px-3">
       <div
         v-if="title || $scopedSlots.title"
         class="k-alert-title bold-600"
@@ -291,15 +295,13 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style lang="scss" scoped>
 @import '~@kongponents/styles/variables';
 
 .k-alert {
   position: relative;
   display: flex;
   padding: 14px;
-  font-family: inherit;
-  font-size: 1rem;
   border-radius: 4px;
   overflow-wrap: anywhere;
 
@@ -307,10 +309,11 @@ export default {
     text-decoration: underline;
     color: var(--blue-600, color(blue-600));
   }
+
   .close {
     position: absolute;
     top: 0;
-    right: 8px;
+    right: var(--spacing-xs);
     bottom: 0;
     border: 0;
     background-color: transparent;
@@ -324,6 +327,7 @@ export default {
       opacity: 1;
     }
   }
+
   // Variants
   &.isFixed {
     position: fixed;
@@ -441,8 +445,8 @@ button.close > .kong-icon {
   }
 }
 
-.k-alert-icon {
-  padding: 23px 5px 25px 21px;
+.k-alert-icon-container-large {
+  padding: var(--spacing-lg) 0;
 }
 
 .toaster-item .k-alert .k-alert-msg {
@@ -529,7 +533,7 @@ button.close > .kong-icon {
 
 .k-alert-description-text {
   display: block;
-  padding-top: 4px;
+  padding-top: var(--spacing-xxs);
   font-weight: 400;
   font-size: 13px;
   line-height: 24px;
@@ -543,6 +547,6 @@ button.close > .kong-icon {
 }
 
 .k-alert.banner > div.k-alert-msg-text {
-  padding: 12px 16px;
+  padding: var(--spacing-sm) var(--spacing-md);
 }
 </style>

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -42,7 +42,7 @@
     </span>
     <div class="k-alert-msg-text">
       <div
-        v-if="title || $scopedSlots.title"
+        v-if="title || $slots.title"
         class="k-alert-title bold-600"
       >
         <slot name="title">
@@ -52,7 +52,7 @@
       <div
         :class="{
           'k-alert-text': size === 'large',
-          'k-alert-subtext': title || $scopedSlots.title
+          'k-alert-subtext': title || $slots.title
         }"
         class="k-alert-msg"
       >
@@ -62,7 +62,7 @@
         </slot>
       </div>
       <div
-        v-if="size === 'large' && (description || $scopedSlots.description)"
+        v-if="size === 'large' && (description || $slots.description)"
         class="k-alert-description-text"
       >
         <!-- @slot Use this slot to pass alert message description for large alerts  -->

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -463,44 +463,6 @@ export default {
     }
   }
 
-  // Types
-  &.is-banner {
-    background-color: var(--white);
-    color: var(--grey-600);
-    padding: 0;
-
-    .k-alert-ellipse {
-      height: 6px;
-      width: 6px;
-      border-radius: 50%;
-      display: inline-block;
-      margin: auto 8px;
-
-      &.info {
-        background-color: var(--blue-400);
-      }
-      &.success {
-        background-color: var(--green-400);
-      }
-      &.warning {
-        background-color: var(--yellow-400);
-      }
-      &.danger {
-        background-color: var(--red-400);
-      }
-    }
-
-    .button > div .k-alert-msg.k-alert-text {
-      padding-left: 0;
-      font-size: var(--type-md, type(md));
-      line-height: 24px;
-    }
-
-    & > div.k-alert-msg-text {
-      padding: var(--spacing-sm) var(--spacing-md);
-    }
-  }
-
   // Variants
   &.is-fixed {
     position: fixed;
@@ -551,6 +513,44 @@ export default {
     color: var(--KAlertWarningColor, var(--yellow-600, color(yellow-600)));
     border-color: var(--KAlertWarningBorder, var(--yellow-200, color(yellow-200)));
     background-color: var(--KAlertWarningBackground, var(--yellow-100, color(yellow-100)));
+  }
+
+  // Types - MUST FOLLOW APPEARANCES
+  &.is-banner {
+    background-color: var(--white);
+    color: var(--grey-600);
+    padding: 0;
+
+    .k-alert-ellipse {
+      height: 6px;
+      width: 6px;
+      border-radius: 50%;
+      display: inline-block;
+      margin: auto 8px;
+
+      &.info {
+        background-color: var(--blue-400);
+      }
+      &.success {
+        background-color: var(--green-400);
+      }
+      &.warning {
+        background-color: var(--yellow-400);
+      }
+      &.danger {
+        background-color: var(--red-400);
+      }
+    }
+
+    .button > div .k-alert-msg.k-alert-text {
+      padding-left: 0;
+      font-size: var(--type-md, type(md));
+      line-height: 24px;
+    }
+
+    & > div.k-alert-msg-text {
+      padding: var(--spacing-sm) var(--spacing-md);
+    }
   }
 }
 

--- a/packages/KAlert/KAlert.vue
+++ b/packages/KAlert/KAlert.vue
@@ -6,74 +6,103 @@
       size,
       type,
       dismissType,
-      {'isBordered':isBordered},
-      {'hasLeftBorder':hasLeftBorder},
-      {'hasRightBorder':hasRightBorder},
-      {'hasTopBorder':hasTopBorder},
-      {'hasBottomBorder':hasBottomBorder},
-      {'isCentered': isCentered},
-      {'isFixed': isFixed}
+      { 'isBordered':isBordered },
+      { 'hasLeftBorder':hasLeftBorder },
+      { 'hasRightBorder':hasRightBorder },
+      { 'hasTopBorder':hasTopBorder },
+      { 'hasBottomBorder':hasBottomBorder },
+      { 'isCentered': isCentered },
+      { 'isFixed': isFixed }
     ]"
     class="k-alert"
     role="alert"
-    @click.stop>
+    @click.stop
+  >
+    <span
+      v-if="type === 'banner' && size !== 'large'"
+      :class="appearance"
+      class="k-alert-ellipse"
+    />
+    <span
+      v-if="icon || $slots.icon"
+      :class="{ 'mr-3': size !== 'large' }"
+    >
+      <slot name="icon">
+        <KIcon
+          :size="iconSize"
+          :color="iconColor"
+          :icon="icon"
+          class="k-alert-icon"
+        />
+      </slot>
+    </span>
+    <div class="k-alert-msg-text pr-3">
+      <div
+        v-if="title || $scopedSlots.title"
+        class="k-alert-title bold-600"
+      >
+        <slot name="title">
+          {{ title }}
+        </slot>
+      </div>
+      <div
+        :class="{
+          'k-alert-text': size === 'large',
+          'k-alert-subtext': title || $scopedSlots.title
+        }"
+        class="k-alert-msg"
+      >
+        <!-- @slot Use this slot to pass default alert message  -->
+        <slot name="alertMessage">
+          {{ alertMessage }}
+        </slot>
+      </div>
+      <div
+        v-if="size === 'large' && (description || $scopedSlots.description)"
+        class="k-alert-description-text"
+      >
+        <!-- @slot Use this slot to pass alert message description for large alerts  -->
+        <slot name="description">
+          {{ description }}
+        </slot>
+      </div>
+    </div>
     <button
       v-if="dismissType === 'icon'"
       type="button"
       aria-label="Close"
       class="close"
-      @click="dismissAlert">
+      @click="dismissAlert"
+    >
       <KIcon
         :color="appearance"
         :class="appearance"
         icon="close"
-        size="14" />
+        size="14"
+      />
     </button>
     <div
+      v-if="hasActionButtons || dismissType !== 'none'"
       :class="appearance"
-      class="k-alert-action ml-3">
+      class="k-alert-action">
       <!-- @slot Use this slot to pass extra buttons other than Dismiss  -->
       <slot
         v-if="hasActionButtons"
-        name="actionButtons">
+        name="actionButtons"
+      >
         <KButton
           size="small"
           @click="proceed"
-          @keyup.enter="proceed"/>
+          @keyup.enter="proceed"
+        />
       </slot>
       <KButton
         v-if="dismissType === 'button'"
         size="small"
-        @click="dismissAlert">
+        @click="dismissAlert"
+      >
         Dismiss
       </KButton>
-    </div>
-    <span
-      v-if="(type === 'banner' && (size !== 'large'))"
-      :class="appearance"
-      class="k-alert-ellipse"/>
-    <span v-if="size === 'large'">
-      <KIcon
-        :size="iconSize"
-        :color="iconColor"
-        :icon="icon ? icon : 'notificationInbox'"
-        class="k-alert-icon" />
-    </span>
-    <div class="k-alert-msg-text">
-      <div
-        :class="type === 'banner' && size === 'large' ? 'k-alert-text' : ''"
-        class="k-alert-msg">
-        <!-- @slot Use this slot to pass default alert message  -->
-        <slot name="alertMessage">{{ alertMessage }}
-        </slot>
-      </div>
-      <div
-        v-if="type === 'banner' && (size === 'large') && hasAlertDescription"
-        class="k-alert-description-text">
-        <!-- @slot Use this slot to pass alert message description for large banner type alert  -->
-        <slot name="description">{{ description }}
-        </slot>
-      </div>
     </div>
   </div>
 </template>
@@ -88,6 +117,7 @@ export const appearances = {
   danger: 'danger',
   warning: 'warning'
 }
+
 export default {
   name: 'KAlert',
   components: { KIcon, KButton },
@@ -174,7 +204,14 @@ export default {
      */
     iconColor: {
       type: String,
-      default: 'var(--red-500)'
+      default: ''
+    },
+    /**
+     * Alert message title
+     */
+    title: {
+      type: String,
+      default: ''
     },
     /**
     * Alert message description
@@ -240,9 +277,6 @@ export default {
   computed: {
     hasActionButtons () {
       return !!this.$slots.actionButtons
-    },
-    hasAlertDescription () {
-      return !!this.$slots.alertMessage
     }
   },
 
@@ -263,12 +297,12 @@ export default {
 .k-alert {
   position: relative;
   display: flex;
-  align-items: center;
   padding: 14px;
   font-family: inherit;
   font-size: 1rem;
   border-radius: 4px;
   overflow-wrap: anywhere;
+
   a {
     text-decoration: underline;
     color: var(--blue-600, color(blue-600));
@@ -283,6 +317,7 @@ export default {
     transition: all 200ms ease;
     cursor: pointer;
     opacity: .5;
+
     &:hover,
     &:active {
       text-decoration: none;
@@ -350,9 +385,13 @@ export default {
   & > div .k-alert-msg {
     font-weight: 400;
     font-size: var(--type-md, type(md));
-    line-height: 1.3;
+    line-height: 24px;
     padding: 2px 0;
     margin-left: 2px;
+
+    &.k-alert-subtext {
+      font-size: var(--type-sm);
+    }
 
     p:last-of-type {
       margin-bottom: 0;
@@ -386,7 +425,7 @@ button.close > .kong-icon {
   width: 6px;
   border-radius: 50%;
   display: inline-block;
-  margin: 24px 8px 26px 22px;
+  margin: auto 8px;
 
   &.info {
     background-color: var(--blue-400);
@@ -413,14 +452,21 @@ button.close > .kong-icon {
 
 .k-alert-action {
   display: inline-flex;
-  position: absolute;
-  right: 13px;
+  position: relative;
+  margin-top: auto;
+  margin-bottom: auto;
+  margin-left: auto;
+  height: 100%;
+
   & button {
     height: 30px;
-    margin-left: 13px;
     font-weight: 400;
     font-size: 13px;
     line-height: 13px;
+
+    &:not(:first-of-type) {
+      margin-left: var(--spacing-sm);
+    }
   }
 
   &.info button.primary {
@@ -497,6 +543,6 @@ button.close > .kong-icon {
 }
 
 .k-alert.banner > div.k-alert-msg-text {
-  padding: 12px 210px 12px 16px;
+  padding: 12px 16px;
 }
 </style>

--- a/packages/KAlert/__snapshots__/KAlert.spec.js.snap
+++ b/packages/KAlert/__snapshots__/KAlert.spec.js.snap
@@ -1,90 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KAlert Renders danger variant 1`] = `
-<div role="alert" class="k-alert danger alert none" message="I am danger">
-  <!---->
-  <div class="k-alert-action ml-3 danger">
-    <!---->
-    <!---->
-  </div>
+<div role="alert" class="k-alert danger none" message="I am danger">
   <!---->
   <!---->
   <div class="k-alert-msg-text">
+    <!---->
     <div class="k-alert-msg">
+
     </div>
     <!---->
   </div>
+  <!---->
+  <!---->
 </div>
 `;
 
 exports[`KAlert Renders info variant 1`] = `
-<div role="alert" class="k-alert info alert none" message="I am info">
-  <!---->
-  <div class="k-alert-action ml-3 info">
-    <!---->
-    <!---->
-  </div>
+<div role="alert" class="k-alert info none" message="I am info">
   <!---->
   <!---->
   <div class="k-alert-msg-text">
+    <!---->
     <div class="k-alert-msg">
+
     </div>
     <!---->
   </div>
+  <!---->
+  <!---->
 </div>
 `;
 
 exports[`KAlert Renders success variant 1`] = `
-<div role="alert" class="k-alert success alert none" message="I am success">
-  <!---->
-  <div class="k-alert-action ml-3 success">
-    <!---->
-    <!---->
-  </div>
+<div role="alert" class="k-alert success none" message="I am success">
   <!---->
   <!---->
   <div class="k-alert-msg-text">
+    <!---->
     <div class="k-alert-msg">
+
     </div>
     <!---->
   </div>
+  <!---->
+  <!---->
 </div>
 `;
 
 exports[`KAlert Renders warning variant 1`] = `
-<div role="alert" class="k-alert warning alert none" message="I am warning">
-  <!---->
-  <div class="k-alert-action ml-3 warning">
-    <!---->
-    <!---->
-  </div>
+<div role="alert" class="k-alert warning none" message="I am warning">
   <!---->
   <!---->
   <div class="k-alert-msg-text">
+    <!---->
     <div class="k-alert-msg">
+
     </div>
     <!---->
   </div>
+  <!---->
+  <!---->
 </div>
 `;
 
 exports[`KAlert renders slots when passed 1`] = `
-<div role="alert" class="k-alert info large banner button" hasactionbuttons="true">
+<div role="alert" class="k-alert info large button is-banner" hasactionbuttons="true">
   <!---->
-  <div class="k-alert-action ml-3 info"><span>Action button</span> <button type="button" class="k-button small rounded outline">
-      <!---->
-      Dismiss
-      <!----></button></div>
-  <!----> <span><span class="kong-icon k-alert-icon kong-icon-notificationInbox"><svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>Notifications</title>
-  <circle cx="16" cy="16" r="16" fill="#A3BBCC"></circle>
-  <path fill="#A3BBCC" d="M8 11h16.37v10.03H8z"></path>
-  <path type="secondary" fill="#fff" d="M16.17 21.03h-7.3c-.45 0-.74-.21-.84-.62a.8.8 0 0 1-.03-.23v-6.36c0-.06.03-.15.08-.2l2.52-2.44c.14-.14.3-.18.49-.18h10.18c.21 0 .38.07.54.22l2.46 2.4c.07.06.1.13.1.23v6.3c0 .57-.31.89-.9.89l-7.3-.01Zm-3-7.41v.1a1.98 1.98 0 0 0 1.8 1.96c.79.06 1.6.05 2.4 0 .89-.05 1.57-.7 1.77-1.56.04-.16.05-.33.08-.5h3.49l-.03-.05-1.6-1.56a.34.34 0 0 0-.17-.05h-9.45a.35.35 0 0 0-.2.08l-1.54 1.49a.88.88 0 0 0-.08.1l3.53-.01Z"></path>
-</svg>
-</span></span>
+  <!---->
   <div class="k-alert-msg-text">
+    <!---->
     <div class="k-alert-msg k-alert-text"><span>Hello World</span></div>
     <div class="k-alert-description-text"><span>I am an alert</span></div>
   </div>
+  <!---->
+  <div class="k-alert-action info"><span>Action button</span> <button type="button" class="k-button small rounded outline">
+      <!---->
+      Dismiss
+      <!----></button></div>
 </div>
 `;

--- a/packages/KIcon/__snapshots__/KIcon.spec.js.snap
+++ b/packages/KIcon/__snapshots__/KIcon.spec.js.snap
@@ -218,6 +218,16 @@ exports[`KIcon renders drag icon 1`] = `
 </span>
 `;
 
+exports[`KIcon renders errorFilled icon 1`] = `
+<span class="kong-icon kong-icon-errorFilled"><svg width="16" height="16" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <title>errorFilled</title>
+  <circle cx="8" cy="8" r="8" fill="#A3BBCC"></circle>
+  <rect type="secondary" x="10.829" y="3.757" width="2" height="10" rx="1" transform="rotate(45 10.829 3.757)" fill="#fff"></rect>
+  <rect type="secondary" x="12.243" y="10.828" width="2" height="10" rx="1" transform="rotate(135 12.243 10.828)" fill="#fff"></rect>
+</svg>
+</span>
+`;
+
 exports[`KIcon renders expand icon 1`] = `
 <span class="kong-icon kong-icon-expand"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" width="24" height="24">
   <title>expand</title>

--- a/packages/KIcon/icons/icn-error-filled.svg
+++ b/packages/KIcon/icons/icn-error-filled.svg
@@ -1,0 +1,6 @@
+<svg width="16" height="16" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Error</title>
+  <circle cx="8" cy="8" r="8" fill="#A3BBCC" />
+  <rect type="secondary" x="10.829" y="3.757" width="2" height="10" rx="1" transform="rotate(45 10.829 3.757)" fill="#fff" />
+  <rect type="secondary" x="12.243" y="10.828" width="2" height="10" rx="1" transform="rotate(135 12.243 10.828)" fill="#fff" />
+</svg>

--- a/packages/KIcon/icons/index.js
+++ b/packages/KIcon/icons/index.js
@@ -26,6 +26,7 @@ import devPortal from './icn-dev-portal.svg'
 import disabled from './icn-disabled.svg'
 import document from './icn-document.svg'
 import drag from './icn-drag.svg'
+import errorFilled from './icn-error-filled.svg'
 import expand from './icn-expand.svg'
 import externalLink from './icn-external-link.svg'
 import featureRequest from './icn-feature-request.svg'
@@ -113,6 +114,7 @@ export default {
   disabled,
   document,
   drag,
+  errorFilled,
   expand,
   externalLink,
   featureRequest,

--- a/packages/KToaster/__snapshots__/KToaster.spec.js.snap
+++ b/packages/KToaster/__snapshots__/KToaster.spec.js.snap
@@ -1,81 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KToaster KToaster.vue renders toaster 1`] = `
-<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close info"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<span name="toaster" tag="div" class="toaster-container-outer"><div class="toaster-item"><div role="alert" class="k-alert info icon has-left-border"><!----> <!----> <div class="k-alert-msg-text"><!----> <div class="k-alert-msg"><div class="message">hey toasty</div></div> <!----></div> <button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close info"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Close</title>
   <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
 </svg>
 </span></button>
-<div class="k-alert-action ml-3 info">
+<div class="k-alert-action info">
   <!---->
-  <!---->
-</div>
-<!---->
-<!---->
-<div class="k-alert-msg-text">
-  <div class="k-alert-msg">
-    <div class="message">hey toasty</div>
-  </div>
   <!---->
 </div>
 </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert success alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close success"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div role="alert" class="k-alert success icon has-left-border">
+    <!---->
+    <!---->
+    <div class="k-alert-msg-text">
+      <!---->
+      <div class="k-alert-msg">
+        <div class="message">hey toasty</div>
+      </div>
+      <!---->
+    </div> <button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close success"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Close</title>
   <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
 </svg>
 </span></button>
-    <div class="k-alert-action ml-3 success">
+    <div class="k-alert-action success">
       <!---->
-      <!---->
-    </div>
-    <!---->
-    <!---->
-    <div class="k-alert-msg-text">
-      <div class="k-alert-msg">
-        <div class="message">hey toasty</div>
-      </div>
       <!---->
     </div>
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close danger"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div role="alert" class="k-alert danger icon has-left-border">
+    <!---->
+    <!---->
+    <div class="k-alert-msg-text">
+      <!---->
+      <div class="k-alert-msg">
+        <div class="message">hey toasty</div>
+      </div>
+      <!---->
+    </div> <button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close danger"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Close</title>
   <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
 </svg>
 </span></button>
-    <div class="k-alert-action ml-3 danger">
+    <div class="k-alert-action danger">
       <!---->
-      <!---->
-    </div>
-    <!---->
-    <!---->
-    <div class="k-alert-msg-text">
-      <div class="k-alert-msg">
-        <div class="message">hey toasty</div>
-      </div>
       <!---->
     </div>
   </div>
 </div>
 <div class="toaster-item">
-  <div role="alert" class="k-alert danger alert icon hasLeftBorder"><button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close danger"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <div role="alert" class="k-alert danger icon has-left-border">
+    <!---->
+    <!---->
+    <div class="k-alert-msg-text">
+      <!---->
+      <div class="k-alert-msg">
+        <div class="message">hey toasty</div>
+      </div>
+      <!---->
+    </div> <button type="button" aria-label="Close" class="close"><span class="kong-icon kong-icon-close danger"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Close</title>
   <path d="M16 4 3 17m13 0L3 4" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round"></path>
 </svg>
 </span></button>
-    <div class="k-alert-action ml-3 danger">
+    <div class="k-alert-action danger">
       <!---->
-      <!---->
-    </div>
-    <!---->
-    <!---->
-    <div class="k-alert-msg-text">
-      <div class="k-alert-msg">
-        <div class="message">hey toasty</div>
-      </div>
       <!---->
     </div>
   </div>


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Updates for [KHCP-4405](https://konghq.atlassian.net/browse/KHCP-4405).
- Add new KIcon: `errorFilled`
- Refactor `KAlert` docs and styles
  - Don't restrict `icon` to `large` `banner` alerts
  - Change `description` to only depend on `large` size
  - Previously undocumented props: `iconSize`, `iconColor`, `description`
  - New props: `title`
  - New slots: `icon`, `title`

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
