### PR TITLE
fix(kstepper): remove unused prop which is throwing errors

### DIFF
--- a/packages/KStepper/KStep.vue
+++ b/packages/KStepper/KStep.vue
@@ -4,10 +4,7 @@
       :class="{ 'completed': state === 'completed' }"
       class="k-step-container"
     >
-      <KStepState
-        :state="state"
-        :step-size="stepSize"
-      />
+      <KStepState :state="state" />
 
       <div
         :class="{


### PR DESCRIPTION
# Summary

Removes an unused prop which is throwing errors:
![Screen Shot 2022-08-19 at 4 37 27 PM](https://user-images.githubusercontent.com/2080476/185715898-21dc8dad-bafe-4bad-8877-cbe581146725.png)

Here's the commit I used as a reference for safely removing this: https://github.com/Kong/kongponents/pull/745/commits/5db26878b48742ba61beaa2c2609086b2a28da92

Looks like this has already been fixed in the `beta` branch: https://github.com/Kong/kongponents/blob/beta/src/components/KStepper/KStep.vue#L7

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
