### PR TITLE
fix(kmodal): prevent click propagation [KHCP-4525]

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -4,7 +4,8 @@
     :aria-label="title"
     class="k-modal"
     role="dialog"
-    aria-modal="true">
+    aria-modal="true"
+    @click.stop>
     <div
       class="k-modal-backdrop modal-backdrop"
       @click="(evt) => close(false, evt)">


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Stop the propagation of `click` events on a `KModal`. 

Resolves a situation like this:

> I don’t want to have to manually stop propagation on @proceed (or any click event) of KPrompts/KModals that are defined within a KTable structure to avoid triggering the row click.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, waiting to see if this works.

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
