### PR TITLE
fix(kdropdownmenu): add icon/buttonAppearance props

### DIFF
--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -117,6 +117,20 @@ Use this prop if you would like the trigger button to display the caret.
 />
 ```
 
+### icon
+
+Icon to be displayed on the dropdown button.
+
+<KDropdownMenu icon="cogwheel" :items="deepClone(defaultItemsUnselected)" show-caret />
+
+```html
+<KDropdownMenu
+  icon="cogwheel"
+  :items="items"
+  show-caret
+/>
+```
+
 ### width
 
 The width of the dropdown body (defaults to `auto`). Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -103,6 +103,20 @@ export default {
 </script>
 ```
 
+### buttonAppearance
+
+Use this prop to customize the trigger **KButton** [appearance](/components/button.html#appearance).
+
+<KDropdownMenu label="Documentation" button-appearance="creation" :items="deepClone(defaultItemsUnselected)" show-caret />
+
+```html
+<KDropdownMenu
+  label="Documentation"
+  button-appearance="creation"
+  :items="items"
+/>
+```
+
 ### showCaret
 
 Use this prop if you would like the trigger button to display the caret.
@@ -119,7 +133,7 @@ Use this prop if you would like the trigger button to display the caret.
 
 ### icon
 
-Icon to be displayed on the dropdown button.
+A string for the `KIcon` to be displayed on the dropdown button with or in place of the button label.
 
 <KDropdownMenu icon="cogwheel" :items="deepClone(defaultItemsUnselected)" show-caret />
 

--- a/packages/KButton/KButton.vue
+++ b/packages/KButton/KButton.vue
@@ -3,32 +3,39 @@
     v-if="typeof to === 'string'"
     :type="type"
     :href="to"
-    :class="[size, {'icon-btn': !hasText && hasIcon, 'rounded': isRounded}, appearance]"
+    :disabled="disabled"
+    :class="[size, { 'icon-btn': !hasText && hasIcon, 'rounded': isRounded }, appearance]"
     class="k-button"
-    v-on="listeners">
+    v-on="listeners"
+  >
     <slot name="icon">
       <KIcon
         v-if="icon"
         :color="iconColor"
         :icon="icon"
         class="k-button-icon"
-        size="16" />
+        size="16"
+      />
     </slot>
-    <slot/>
+
+    <slot />
+
     <KIcon
       v-if="isOpen !== undefined"
       :class="[caretClasses]"
       :color="iconColor"
       view-box="2 2 15 15"
       size="16"
-      icon="chevronDown"/>
+      icon="chevronDown"
+    />
   </a>
   <component
     v-else
     :type="type"
     :is="buttonType"
     :to="to"
-    :class="[size, {'icon-btn': !hasText && hasIcon, 'rounded': isRounded}, appearance, caretClasses]"
+    :disabled="disabled"
+    :class="[size, { 'icon-btn': !hasText && hasIcon, 'rounded': isRounded }, appearance, caretClasses]"
     class="k-button"
     v-on="listeners">
     <slot name="icon">
@@ -37,16 +44,20 @@
         :color="iconColor"
         :icon="icon"
         class="k-button-icon"
-        size="16" />
+        size="16"
+      />
     </slot>
-    <slot/>
+
+    <slot />
+
     <KIcon
       v-if="isOpen !== undefined"
       :class="['caret', caretClasses]"
       :color="iconColor"
       view-box="2 2 15 15"
       size="16"
-      icon="chevronDown"/>
+      icon="chevronDown"
+    />
   </component>
 </template>
 
@@ -117,6 +128,10 @@ export default {
     icon: {
       type: String,
       default: ''
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -152,7 +167,7 @@ export default {
     },
 
     iconColor () {
-      if (this.$attrs.disabled) {
+      if (this.disabled) {
         return 'var(--grey-400)'
       } else if (['primary', 'danger', 'creation'].includes(this.appearance)) {
         return 'white'

--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -50,7 +50,7 @@ export default {
       type: Object,
       default: null,
       // Items must have a label
-      validator: (item) => Object.hasOwn(item, 'label')
+      validator: (item) => item.label !== undefined
     },
     /**
      * Use this prop to add a divider above the item.

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -41,7 +41,7 @@
                 v-if="label || icon"
                 :disabled="disabled"
                 :is-open="showCaret || appearance === 'selectionMenu' ? isToggled : undefined"
-                :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
+                :appearance="appearance === 'selectionMenu' ? 'outline' : buttonAppearance"
                 :icon="icon"
                 :class="{ 'is-active': showCaret ? isToggled : undefined }"
                 class="k-dropdown-btn"
@@ -111,6 +111,10 @@ export default {
           'selectionMenu'
         ].includes(value)
       }
+    },
+    buttonAppearance: {
+      type: String,
+      default: 'primary'
     },
     label: {
       type: String,

--- a/packages/KDropdownMenu/KDropdownMenu.vue
+++ b/packages/KDropdownMenu/KDropdownMenu.vue
@@ -38,10 +38,11 @@
             <!-- Must wrap in div to allow tooltip when disabled -->
             <div>
               <KButton
-                v-if="label"
+                v-if="label || icon"
                 :disabled="disabled"
                 :is-open="showCaret || appearance === 'selectionMenu' ? isToggled : undefined"
                 :appearance="appearance === 'selectionMenu' ? 'outline' : 'primary'"
+                :icon="icon"
                 :class="{ 'is-active': showCaret ? isToggled : undefined }"
                 class="k-dropdown-btn"
                 data-testid="k-dropdown-btn"
@@ -112,6 +113,10 @@ export default {
       }
     },
     label: {
+      type: String,
+      default: ''
+    },
+    icon: {
       type: String,
       default: ''
     },

--- a/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
+++ b/packages/KDropdownMenu/__snapshots__/KDropdownMenu.spec.js.snap
@@ -38,7 +38,7 @@ exports[`KDropdownMenu renders disabled props when passed 1`] = `
 <div class="k-dropdown k-dropdown-menu">
   <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" data-testid="k-dropdown-menu-popover">
     <div id="test-target-id-1234" aria-controls="test-popover-id-1234" role="button" class="k-dropdown-trigger dropdown-trigger">
-      <div><button type="button" class="k-button k-dropdown-btn medium rounded primary" disabled="disabled" data-testid="k-dropdown-btn">
+      <div><button type="button" disabled="disabled" class="k-button k-dropdown-btn medium rounded primary" data-testid="k-dropdown-btn">
           <!---->
           Click me
           <!----></button></div>

--- a/packages/KInput/KInput.vue
+++ b/packages/KInput/KInput.vue
@@ -169,10 +169,10 @@ export default {
       return this.modelValueChanged ? `${this.currValue.toString().length} / ${this.characterLimit}` : `${this.value.toString().length} / ${this.characterLimit}`
     },
     isDisabled () {
-      return this.$attrs.hasOwnProperty('disabled')
+      return this.$attrs.disabled !== undefined
     },
     isReadonly () {
-      return this.$attrs.hasOwnProperty('readonly')
+      return this.$attrs.readonly !== undefined
     },
     listeners () {
       const listeners = { ...this.$listeners }

--- a/packages/KMultiselect/KMultiselect.vue
+++ b/packages/KMultiselect/KMultiselect.vue
@@ -103,7 +103,7 @@ export default {
       default: () => [],
       // Items must have a label and a selected property
       validator: (items) => items
-        .some(i => i.hasOwnProperty('label') && i.hasOwnProperty('selected'))
+        .some(i => i.label !== undefined && i.selected !== undefined)
     },
     /**
      * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.

--- a/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
+++ b/packages/KMultiselect/__snapshots__/KMultiselect.spec.js.snap
@@ -24,7 +24,7 @@ exports[`KMultiselect matches snapshot 1`] = `
               Item 2
             </li>
           </ul>
-          <div class="k-multiselect-footer"><button type="button" class="k-button k-multiselect-apply small rounded secondary" disabled="disabled">
+          <div class="k-multiselect-footer"><button type="button" disabled="disabled" class="k-button k-multiselect-apply small rounded secondary">
               <!----> Apply
               <!----></button></div>
         </div>

--- a/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
+++ b/packages/KPrompt/__snapshots__/KPrompt.spec.js.snap
@@ -91,7 +91,7 @@ exports[`KPrompt has a pending state 1`] = `
           <div class="k-prompt-action-buttons"><button type="button" class="k-button k-prompt-cancel mr-2 medium rounded outline">
               <!---->
               Cancel
-              <!----></button> <button type="button" class="k-button k-prompt-proceed medium rounded primary" disabled="disabled"><span class="kong-icon kong-icon-spinner" viewbox="0 0 16 16"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <!----></button> <button type="button" disabled="disabled" class="k-button k-prompt-proceed medium rounded primary"><span class="kong-icon kong-icon-spinner" viewbox="0 0 16 16"><svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <title>Loading</title>
   <g>
     <path d="M5 10a5 5 0 1 0 5-5" fill="none" stroke="#A3BBCC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -266,7 +266,7 @@ export default {
       required: false,
       default: () => [],
       // Items must have a label & value
-      validator: (items) => !items.length || items.some(i => i.hasOwnProperty('label') && i.hasOwnProperty('value'))
+      validator: (items) => !items.length || items.some(i => i.label !== undefined && i.value !== undefined)
     },
     /**
      * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -431,7 +431,7 @@ export default {
 
         for (let i = 0; i < this.selectItems.length; i++) {
           // Ensure each item has a `selected` property
-          if (this.selectItems[i].selected !== undefined) {
+          if (this.selectItems[i].selected === undefined) {
             this.selectItems[i].selected = false
           }
 

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -431,7 +431,7 @@ export default {
 
         for (let i = 0; i < this.selectItems.length; i++) {
           // Ensure each item has a `selected` property
-          if (!Object.hasOwn(this.selectItems[i], 'selected')) {
+          if (this.selectItems[i].selected !== undefined) {
             this.selectItems[i].selected = false
           }
 

--- a/packages/KSelect/KSelectItem.vue
+++ b/packages/KSelect/KSelectItem.vue
@@ -36,7 +36,7 @@ export default {
       type: Object,
       default: null,
       // Items must have a label and value
-      validator: (item) => item.hasOwnProperty('label') && item.hasOwnProperty('value')
+      validator: (item) => item.label !== undefined && item.value !== undefined
     },
     disabled: {
       type: Boolean,

--- a/packages/KStepper/KStepper.vue
+++ b/packages/KStepper/KStepper.vue
@@ -26,7 +26,7 @@ export default {
     steps: {
       type: Array,
       required: true,
-      validator: (items) => items.length && items.every(i => Object.hasOwn(i, 'label'))
+      validator: (items) => items.length && items.every(i => i.label !== undefined)
     },
     maxLabelWidth: {
       type: String,


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
- Add props to `KDropdownMenu`: `icon`, `buttonAppearance`
- Remove usage of `hasOwn`/`hasOwnProperty`
- Fix display of icons in disabled `KButton` getting the wrong color

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
