### PR TITLE
fix(ktable): client sorting with number values

### DIFF
--- a/src/composables/useUtilities.spec.ts
+++ b/src/composables/useUtilities.spec.ts
@@ -46,7 +46,7 @@ describe('Client-side sorting (deprecated in favor of server-side sorting)', () 
         id: '410ecd35-696e-4e7a-ad35-c69bd4e14cbb',
         username: 'henry',
       }, {
-        custom_id: 145,
+        custom_id: 0,
         id: '410ecd35-696e-4e7a-ad35-c69bd4e14cb3',
         username: 'bobby',
       }, {
@@ -59,7 +59,7 @@ describe('Client-side sorting (deprecated in favor of server-side sorting)', () 
     const { previousKey: sortKey1, sortOrder: sortOrder1 } = clientSideSorter('custom_id', '', 'ascending', items)
 
     expect(items[0].username).equal('bobby')
-    expect(items[0].custom_id).equal(145)
+    expect(items[0].custom_id).equal(0)
     expect(sortKey1).equal('custom_id')
     expect(sortOrder1).equal('ascending')
 

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -60,8 +60,8 @@ export default function useUtilities() {
   const clientSideSorter = (key: string, previousKey: string, sortOrder: string, items: []) => {
     let comparator = null
 
-    const numberComparator = (a: number, b: number) => {
-      if (a && b) {
+    const numberComparator = (a: number, b: number | string) => {
+      if (typeof b === 'number' && !Number.isNaN(a) && !Number.isNaN(b)) {
         return a - b
       }
 


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

Client sorting by a column of number values will have a wrong order if that column contains zeros.

Reproduction link: https://codesandbox.io/s/mystifying-stallman-zzlfmu

I'm not sure why we need to check `if (a && b)` in the first place. IMO if we need to check anything it should be the type of `b`. The code down below guarantees `a` is a number, but leaves `b` unchecked (although in most cases they should be of the same type).

So I changed `if (a && b)` to `if (typeof b === 'number')`. Let me know your opinions. @adamdehaven @kaiarrowood 

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
