### PR TITLE
docs(kselect): add missing documentation slots [KHCP-4631]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -464,6 +464,12 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ## Slots
 
+- `item-template` - The template for each item in the dropdown list
+- `loading` - Slot for the loading indicator
+- `empty` - Slot for the empty state in the dropdown list
+
+### Item Template
+
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
 If you use the `.select-item-label` and `.select-item-desc` classes within the slot as shown in the example below, the dropdown items will inherit preconfigured styles for two-level select items which you're then free to customize.
@@ -514,6 +520,14 @@ export default {
 }
 </script>
 ```
+
+### Loading
+
+You can use the `loading` slot to customize the loading indicator. Note that this only applies when `autoggest` is `true`. See [autosuggest](#autosuggest) for an example of this slot.
+
+### Empty State
+
+You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
 
 ## Events
 


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

This PR adds `loading` and `empty` slots docs.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: #777 
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
