### PR TITLE
fix(*): replace Object.hasOwn()

### DIFF
--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -51,7 +51,7 @@ export default defineComponent({
       type: Object as PropType<DropdownItem>,
       default: null,
       // Items must have a label
-      validator: (item: DropdownItem) => Object.hasOwn(item, 'label'),
+      validator: (item: DropdownItem) => item.label !== undefined,
     },
     /**
      * Use this prop to add a divider above the item.

--- a/src/components/KDropdownMenu/KDropdownMenu.vue
+++ b/src/components/KDropdownMenu/KDropdownMenu.vue
@@ -131,7 +131,7 @@ export default defineComponent({
     items: {
       type: Array as PropType<Array<DropdownItem>>,
       default: () => [],
-      validator: (items: DropdownItem[]) => !items.length || items.some(i => Object.hasOwn(i, 'label')),
+      validator: (items: DropdownItem[]) => !items.length || items.some(i => i.label !== undefined),
     },
     disabled: {
       type: Boolean,

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -544,7 +544,7 @@ export default defineComponent({
       selectItems.value = JSON.parse(JSON.stringify(props.items))
       for (let i = 0; i < selectItems.value.length; i++) {
         // Ensure each item has a `selected` property
-        if (selectItems.value[i].selected !== undefined) {
+        if (selectItems.value[i].selected === undefined) {
           selectItems.value[i].selected = false
         }
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -299,7 +299,7 @@ export default defineComponent({
       required: false,
       default: () => [],
       // Items must have a label & value
-      validator: (items: SelectItem[]) => !items.length || items.some(i => Object.hasOwn(i, 'label') && Object.hasOwn(i, 'value')),
+      validator: (items: SelectItem[]) => !items.length || items.some(i => i.label !== undefined && i.value !== undefined),
     },
     /**
      * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
@@ -544,7 +544,7 @@ export default defineComponent({
       selectItems.value = JSON.parse(JSON.stringify(props.items))
       for (let i = 0; i < selectItems.value.length; i++) {
         // Ensure each item has a `selected` property
-        if (!Object.hasOwn(selectItems.value[i], 'selected')) {
+        if (selectItems.value[i].selected !== undefined) {
           selectItems.value[i].selected = false
         }
 

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -41,7 +41,7 @@ export default defineComponent({
       type: Object,
       default: null,
       // Items must have a label and value
-      validator: (item: Record<string, number | string>): boolean => Object.hasOwn(item, 'label') && Object.hasOwn(item, 'value'),
+      validator: (item: Record<string, number | string>): boolean => item.label !== undefined && item.value !== undefined,
     },
     disabled: {
       type: Boolean,

--- a/src/components/KStepper/KStepper.vue
+++ b/src/components/KStepper/KStepper.vue
@@ -33,7 +33,7 @@ export default defineComponent({
     steps: {
       type: Array as PropType<StepItem[]>,
       required: true,
-      validator: (items: StepItem[]) => !items.length || items.every(i => Object.hasOwn(i, 'label')),
+      validator: (items: StepItem[]) => !items.length || items.every(i => i.label !== undefined),
     },
     /**
      * Maximum width of each step's label


### PR DESCRIPTION
# Summary

Replace instances of `Object.hasOwn()` since the browser support is pretty recent.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
