### PR TITLE
fix: not being able to import style.css

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,7 +87,7 @@ import { createApp } from 'vue'
 import Kongponents from '@kong/kongponents'
 
 // Import Kongponents styles (path may vary)
-import '../node_modules/@kong/kongponents/dist/style.css'
+import '@kong/kongponents/dist/style.css'
 
 const app = createApp(App)
 
@@ -113,7 +113,7 @@ Import and registration can be done globally in your Vue entry file (e.g. `main.
   import { KButton } from '@kong/kongponents'
 
   // Import Kongponents styles (path may vary, shown here for Vite)
-  import '../node_modules/@kong/kongponents/dist/style.css'
+  import '@kong/kongponents/dist/style.css'
   // If using Vue-CLI and webpack, you can likely use this path instead: import '~@kong/kongponents/dist/style.css'
 
   const app = createApp(App)
@@ -143,7 +143,7 @@ Import and registration can be done globally in your Vue entry file (e.g. `main.
 
   <style>
   /* Import Kongponents styles (path may vary, shown here for Vite) */
-  @import "../../node_modules/@kong/kongponents/dist/style.css";
+  @import "@kong/kongponents/dist/style.css";
   /* If using Vue-CLI and webpack, you can likely use this path instead: import '~@kong/kongponents/dist/style.css' */
   </style>
   ```

--- a/docs/style-guide/usage.md
+++ b/docs/style-guide/usage.md
@@ -24,7 +24,7 @@ Next, add the following to your Vue app entry file (e.g. `main.ts`)
 
 ```ts
 // Path may vary
-import '../node_modules/@kong/kongponents/dist/style.css'
+import '@kong/kongponents/dist/style.css'
 // If using Vue-CLI and webpack, you can likely use this path instead:
 // import '~@kong/kongponents/dist/style.css'
 ```
@@ -35,7 +35,7 @@ Alternatively, you can import styles into your `SCSS`
 
 ```scss
 // Path may vary
-@import "../../node_modules/@kong/kongponents/dist/style.css";
+@import "@kong/kongponents/dist/style.css";
 /*
 If using Vue-CLI and webpack, you can likely use this path instead:
 import '~@kong/kongponents/dist/style.css'
@@ -56,14 +56,14 @@ You can even **scope** the styles and/or variables to a container class to preve
 @use "sass:meta";
 
 // Import Kongponents Sass variables (path may vary)
-@import "../../../node_modules/@kong/kongponents/dist/_variables.scss";
+@import "@kong/kongponents/dist/_variables.scss";
 
 .your-custom-container {
   // Include Kongponents CSS Variables mixin from the import above
   @include kongponents-css-variables;
 
   // Import Kongponents styles (path may vary)
-  @include meta.load-css("../../../node_modules/@kong/kongponents/dist/style.css");
+  @include meta.load-css("@kong/kongponents/dist/style.css");
 
   // Additional CSS rules for your app
   color: #333;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     ".": {
       "import": "./dist/kongponents.es.js",
       "require": "./dist/kongponents.umd.js"
-    }
+    },
+    "./dist/style.css": "./dist/style.css",
+    "./dist/_variables.scss": "./dist/_variables.scss"
   },
   "scripts": {
     "build:cli": "rimraf ./bin && tsc --project ./cli/tsconfig.json && chmod u+x ./bin/index.js",


### PR DESCRIPTION
# Summary

Fixes an issue with not being able to import the style.css file using a bare module specifier (i.e. `import '@kong/kongponents/dist/style.css'`) due to the absence of the specifier definition from the package.json file’s `exports` field. A workaround for this issue is using `import '../node_modules/@kong/kongponents/dist/style.css'`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
