### PR TITLE
refactor(kselect): remove the `items` slot [KHCP-4668]

### DIFF
--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -139,32 +139,26 @@
               v-else
               class="k-select-list ma-0 pa-0"
             >
-              <slot
-                :items="selectItems"
-                :is-open="isToggled"
-                name="items"
+              <KSelectItem
+                v-for="item in filteredItems"
+                :key="item.key"
+                :item="item"
+                @selected="handleItemSelect"
               >
-                <KSelectItem
-                  v-for="item in filteredItems"
-                  :key="item.key"
-                  :item="item"
-                  @selected="handleItemSelect"
-                >
-                  <template v-slot:content>
-                    <slot
-                      :item="item"
-                      name="item-template"
-                      class="select-item-label select-item-desc"
-                    />
-                  </template>
-                </KSelectItem>
-                <KSelectItem
-                  v-if="!filteredItems.length && !$slots.empty"
-                  key="k-select-empty-state"
-                  :item="{ label: 'No results', value: 'no_results' }"
-                  class="k-select-empty-item"
-                />
-              </slot>
+                <template v-slot:content>
+                  <slot
+                    :item="item"
+                    name="item-template"
+                    class="select-item-label select-item-desc"
+                  />
+                </template>
+              </KSelectItem>
+              <KSelectItem
+                v-if="!filteredItems.length && !$slots.empty"
+                key="k-select-empty-state"
+                :item="{ label: 'No results', value: 'no_results' }"
+                class="k-select-empty-item"
+              />
             </ul>
             <slot
               v-if="!loading && !filteredItems.length"


### PR DESCRIPTION
# Summary

Reference: #777

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: #782 
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
