### PR TITLE
refactor(kselect): cannot read properties of undefined (reading replace) [KHCP-4680]

### DIFF
--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -432,7 +432,7 @@ export default {
           if (this.selectItems[i].label) {
             this.selectItems[i].key = `${this.selectItems[i].label.replace(' ', '-')}-${i}`
           } else {
-            this.selectItems[i].key = `test-label-${i}`
+            this.selectItems[i].key = `k-select-item-label-${i}`
           }
 
           if (this.selectItems[i].value === this.value || this.selectItems[i].selected) {

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -429,7 +429,10 @@ export default {
             this.selectItems[i].selected = false
           }
 
-          this.selectItems[i].key = `${this.selectItems[i].label.replace(' ', '-').replace(/[^a-z0-9-_]/gi, '')}-${i}`
+          if (this.selectItems[i].label) {
+            this.selectItems[i].key = `${this.selectItems[i].label.replace(' ', '-')}-${i}`
+          }
+
           if (this.selectItems[i].value === this.value || this.selectItems[i].selected) {
             this.selectItems[i].selected = true
             this.selectedItem = this.selectItems[i]

--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -431,6 +431,8 @@ export default {
 
           if (this.selectItems[i].label) {
             this.selectItems[i].key = `${this.selectItems[i].label.replace(' ', '-')}-${i}`
+          } else {
+            this.selectItems[i].key = `test-label-${i}`
           }
 
           if (this.selectItems[i].value === this.value || this.selectItems[i].selected) {


### PR DESCRIPTION
Task in Jira: https://konghq.atlassian.net/browse/KHCP-4680

# Summary
- **Fix** - Add an additional condition.
- **Refactor** - Removal of redundant `replace`.

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
