### PR TITLE
fix(*): remove sass division

### DIFF
--- a/packages/KDropdownMenu/KDropdownItem.vue
+++ b/packages/KDropdownMenu/KDropdownItem.vue
@@ -118,7 +118,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@use 'sass:math';
 @import '~@kongponents/styles/variables';
 
 li.k-dropdown-item {
@@ -128,10 +127,10 @@ li.k-dropdown-item {
   line-height: 1;
 
   &.has-divider {
-    $k-dropdown-item-divider-container-height: 24; // set to the same value as --spacing-lg without the units
-    $k-dropdown-item-divider-position: calc((math.div($k-dropdown-item-divider-container-height, 2) + 1) * -1);
+    $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
+    $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
     position: relative;
-    margin-top: #{$k-dropdown-item-divider-container-height}px;
+    margin-top: $k-dropdown-item-divider-container-height;
 
     &:before {
       position: relative;
@@ -139,7 +138,7 @@ li.k-dropdown-item {
       content: '';
       height: 1px;
       width: 100%;
-      top: #{$k-dropdown-item-divider-position}px;
+      top: $k-dropdown-item-divider-position;
       background: var(--grey-200);
     }
   }


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Remove sass division, we can't guarantee `@use sass:math` will be first.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: https://github.com/Kong/kongponents/pull/795
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
