### PR TITLE
fix(text): kselect placeholder text

### DIFF
--- a/packages/KSelect/KSelect.vue
+++ b/packages/KSelect/KSelect.vue
@@ -111,7 +111,7 @@
               :value="filterStr"
               :label="label && overlayLabel ? label : null"
               :overlay-label="overlayLabel"
-              :placeholder="selectedItem && appearance === 'select' ? selectedItem.label : placeholderText"
+              :placeholder="placeholderText"
               :class="{
                 'cursor-default prevent-pointer-events': !filterIsEnabled,
                 'input-placeholder-dark has-chevron': appearance === 'select',


### PR DESCRIPTION
Updates placeholder text for KSelect auto-suggest.
# Summary
**Before**:
![image 438](https://user-images.githubusercontent.com/87779967/191610913-8e3caf33-c1ec-4922-94ad-56e3e3a5b5a4.png)

**After**:
![image 439](https://user-images.githubusercontent.com/87779967/191610929-07a68f7a-d388-4dc0-8329-49640e2f2014.png)

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [x] **No**, because `this issue is not happening in beta branch`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
