### PR TITLE
fix(ktable): doc revalidate usage [khcp-4670]

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -383,7 +383,7 @@ export default defineComponent({
 
     const handleDelete = (id) => {
       try {
-        const res = await sniServices.delete(id)
+        const res = await services.delete(id)
 
         key.value++
         revalidate()

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -368,7 +368,7 @@ export default defineComponent({
     const key = ref(0) // initialized to zero
     const fetcher = async ({ pageSize, page, query, offset = null }) => {
       try {
-        const res = await sniServices.getAll(pageSize, offset)
+        const res = await services.getAll(pageSize, offset)
 
         // handle data
       } catch (error) {
@@ -377,7 +377,7 @@ export default defineComponent({
     }
 
     const { revalidate } = composables.useRequest(
-      () => key.value && `snis-list-${key.value}`, // will evaluate to falsey on mount, preventing an extra call
+      () => key.value && `service-list-${key.value}`, // will evaluate to falsey on mount, preventing an extra call
       () => { return fetcher() }
     )
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -351,7 +351,8 @@ export default {
 </script>
 ```
 
-An alternative usage is with the native `key` attribute in conjuction with a `fetcher` and SWRV `revalidate` function. In this case you will want the `key` to start at `0`.
+An alternate implementation is to apply a `key` attribute to the `KTable` in conjunction with a `fetcher` and the SWRV `revalidate` function. To prevent unnecessary calls on mount, the `key` `ref` should have an initial value of `0`.
+
 Since the `fetcher` function will handle the intial GET of the data, we want the cache key for the `revalidate` function to evaluate to `falsey` on page load (to avoid an unnecessary duplicate call), and will manually call `revalidate()` and increment the `key` to trigger a refetch and redraw of the table.
 
 ```html
@@ -376,7 +377,7 @@ export default defineComponent({
     }
 
     const { revalidate } = composables.useRequest(
-      () => key.value && `snis-list-${key.value}`, // will eval falsey on load, which is what we want
+      () => key.value && `snis-list-${key.value}`, // will evaluate to falsey on mount, preventing an extra call
       () => { return fetcher() }
     )
 


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Document correct usage of SWRV revalidate function and key for `KTable`.
For [KHCP-4670](https://konghq.atlassian.net/browse/KHCP-4670).

![image](https://user-images.githubusercontent.com/67973710/191780277-cc649e60-918f-4406-a126-209c27e7b443.png)


## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
