### PR TITLE
fix(modal): not importing icon component

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -95,10 +95,15 @@
 <script lang="ts">
 import { defineComponent, computed, onMounted, onUnmounted, watchEffect } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
+import KIcon from '@/components/KIcon/KIcon.vue'
 
 export default defineComponent({
   name: 'KModal',
-  components: { KButton },
+
+  components: {
+    KButton,
+    KIcon,
+  },
 
   props: {
     /**


### PR DESCRIPTION
# Summary

Fixes an issue with the modal component not importing the `KIcon` component that it uses.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
