### PR TITLE
fix(kmodal): missing kicon dependency

### DIFF
--- a/packages/KModal/KModal.vue
+++ b/packages/KModal/KModal.vue
@@ -90,10 +90,11 @@
 
 <script>
 import KButton from '@kongponents/kbutton/KButton.vue'
+import KIcon from '@kongponents/kicon/KIcon.vue'
 
 export default {
   name: 'KModal',
-  components: { KButton },
+  components: { KButton, KIcon },
 
   props: {
     /**

--- a/packages/KModal/package.json
+++ b/packages/KModal/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@kongponents/kbutton": "^7.1.8",
+    "@kongponents/kicon": "^7.1.8",
     "@kongponents/styles": "^7.1.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
# Summary

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->
Add missing `KIcon` dependency.

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [x] **Yes**, here is a link to the PR: https://github.com/Kong/kongponents/pull/806
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
