### PR TITLE
fix(kpop): always remove click listeners since they are always added

### DIFF
--- a/packages/KPop/KPop.vue
+++ b/packages/KPop/KPop.vue
@@ -305,11 +305,12 @@ export default {
 
   beforeDestroy () {
     const popper = this.$refs.popper
-    if (popper && this.trigger === 'click') {
-      this.reference && this.reference.removeEventListener('click', this.handleClick)
-      popper.removeEventListener('click', this.showPopper)
-      document.documentElement.removeEventListener('click', this.handleClick)
-    } else if (this.reference) {
+
+    document.documentElement.removeEventListener('click', this.handleClick)
+    popper && popper.removeEventListener('click', this.showPopper)
+
+    if (this.reference) {
+      this.reference.removeEventListener('click', this.handleClick)
       this.reference.removeEventListener('mouseenter', this.createInstance)
       this.reference.removeEventListener('mouseleave', this.toggle)
       this.reference.removeEventListener('focus', this.createInstance)


### PR DESCRIPTION
# Summary

There was a bug with KPop where it was always registering a click listener on the document root element, but only removing it when the trigger type was 'click'. This caused event listeners to not fire for other elements after the kpop element was destroyed.

<!-- Add a summary of your changes, and include a link to JIRA as necessary. -->

## Vue 3

**Did you create a corresponding PR to add this change to the `beta` branch? (required)**

- [ ] **Yes**, here is a link to the PR: `[link to beta branch PR]`
- [ ] **No**, I did not create a PR for the `beta` branch and I have added the `port to beta branch` tag to this PR.
- [ ] **No**, because `[type your reasons]`

If you have questions, tag `@adamdehaven` or `@kaiarrowood`.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
