### PR TITLE
fix(kbutton): not considering visually-hidden text

### DIFF
--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -204,6 +204,7 @@ export default defineComponent({
   position: relative;
   display: inline-flex;
   align-items: center;
+  gap: var(--spacing-xs, spacing(xs));
   padding: var(--KButtonPaddingY, var(--spacing-sm, spacing(sm))) var(--KButtonPaddingX, var(--spacing-lg, spacing(lg)));
   font-family: var(--font-family-sans, font(sans));
   font-size: var(--KButtonFontSize, var(--type-md, type(md)));
@@ -245,16 +246,12 @@ export default defineComponent({
   /* Button w/ Icon */
   > :deep(.kong-icon) {
     display: inline-flex;
-    padding-right: var(--spacing-xs, spacing(xs));
     box-sizing: unset;
   }
 
   &.icon-btn {
     height: 38px;
     justify-content: center;
-    > :deep(.kong-icon) {
-      padding-right: 0;
-    }
   }
 
   /* Size Variations */


### PR DESCRIPTION
# Summary

Replaces the `padding-right` declaration on a button’s icon with a `gap` property on the button itself which allows adding visually-hidden text to an icon button (this would otherwise have an incorrect gap to the right). This works because visually-hidden text won’t participate as a flex or grid item so no gap will be rendered.

---

## Example usage

```vue
<KButton>
  <template #icon>
    <KIcon icon="filter" />
  </template>

  <span class="k-visually-hidden">Filter mode enabled</span>
</KButton>
```

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
