### PR TITLE
chore: build script generating incomplete types in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:docs": "vuepress build docs",
     "build:kongponents": "yarn typecheck && vite build && yarn copy:css-variables && vue-tsc --emitDeclarationOnly",
     "copy:css-variables": "copyfiles -f src/styles/_variables.scss dist",
-    "build": "yarn build:kongponents && yarn build:docs && yarn build:cli",
+    "build": "yarn build:cli && yarn build:kongponents && yarn build:docs",
     "commit": "cz",
     "create-kongponent": "node ./bin/index.js",
     "dev": "vite",


### PR DESCRIPTION
# Summary

Fixes the build script generating a `dist/types/index.d.ts` file that merely contains `export {};` because of the build:cli script running last (this doesn’t happen with published packages because the order of scripts is reversed in the CI workflow).

## Notes

I suppose this happens somehow because cli/tsconfig.json extends the base tsconfig.json file?

---

## PR Checklist

- [x] Does not introduce dependencies
- [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [x] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
