### PR TITLE
fix(kinput): input-error styles [KHCP-5100]

### DIFF
--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="{'input-error' : charLimitExceeded || hasError}"
+    :class="[{'input-error' : charLimitExceeded || hasError || String($attrs.class || '').includes('input-error')}]"
     class="k-input-wrapper"
   >
     <div
@@ -297,8 +297,10 @@ export default defineComponent({
 
   &.input-error {
     .text-on-input label.hovered,
-    .text-on-input label:hover {
-      color: var(--red-500);
+    .text-on-input label:hover,
+    .text-on-input label.focused,
+    .text-on-input label:focus {
+      color: var(--red-500) !important;
     }
   }
 }

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -60,7 +60,7 @@
     border-radius: 3px;
     box-sizing: border-box;
     @include input-default;
-    
+
     &.k-input-small {
       font-size: var(--type-xs, type(xs));
       padding: var(--spacing-xs, spacing(xs)) var(--spacing-sm, spacing(sm));
@@ -146,7 +146,9 @@
 }
 
 .k-input-wrapper.input-error {
-  .k-input {
+  .k-input,
+  .k-input:hover,
+  .k-input:focus {
     outline: none !important;
     box-shadow: inset 0 0 0 1.5px var(--KInputError, var(--red-500, color(red-500))) !important;
     transition: color 0.1s ease;


### PR DESCRIPTION
# Summary

Fixes issues with the `input-error` class being applied to KInput.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
