### PR TITLE
fix(attrs): bind classes to outermost element

### DIFF
--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -3,7 +3,7 @@
 **KInlineEdit** - A wrapper which adds inline edit capability. Currently only supports single text input.
 
 <KComponent :data="{ inlineText: 'Click to edit me' }" v-slot="{ data }">
-  <KInlineEdit @changed="newVal => data.inlineText = newVal"><h3>{{ data.inlineText }}</h3></KInlineEdit>
+  <KInlineEdit @changed="(newVal) => data.inlineText = newVal"><h3>{{ data.inlineText }}</h3></KInlineEdit>
 </KComponent>
 
 > The `KComponent` component is used in this example to create state.

--- a/docs/style-guide/forms.md
+++ b/docs/style-guide/forms.md
@@ -7,36 +7,26 @@ Here is an example of html elements being styled using the including css.
 ## Text Inputs
 
 <br>
-<input class="k-input mb-2" placeholder="placeholder" />
-<input class="k-input mb-2" type="password" value="123" />
-<input class="k-input mb-2" type="number" value="1"/>
-<input class="k-input mb-2" type="email" value="john.doe@konghq.com"/>
-<input class="k-input mb-2" disabled value="disabled"/>
-<input class="k-input mb-2" readonly value="readonly"/>
-<input class="k-input mb-2" type="search" value="search"/>
-<input class="k-input mb-2 input-error" type="email" value="error"/>
-<select class="k-input">
-  <option value="option1">Option 1</option>
-  <option value="option2">Option 2</option>
-  <option value="option3">Option 3</option>
-</select>
+<div class="k-input-wrapper mb-2"><input class="k-input" placeholder="placeholder" /></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="password" value="123" /></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="number" value="1"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="email" value="john.doe@konghq.com"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" disabled value="disabled"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" readonly value="readonly"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="search" value="search"/></div>
+<div class="k-input-wrapper mb-2 input-error"><input class="k-input" type="email" value="error"/></div>
 
 > Note: Add the `input-error` class to add custom error styling
 
 ```html
-<input class="k-input" placeholder="placeholder" />
-<input class="k-input" type="password" value="123" />
-<input class="k-input" type="number" value="1"/>
-<input class="k-input" type="email" value="john.doe@konghq.com"/>
-<input class="k-input" disabled value="disabled"/>
-<input class="k-input" readonly value="readonly"/>
-<input class="k-input" type="search" value="search"/>
-<input class="k-input input-error" type="email" value="error"/>
-<select class="k-input">
-  <option value="option1">Option 1</option>
-  <option value="option2">Option 2</option>
-  <option value="option3">Option 3</option>
-</select>
+<div class="k-input-wrapper mb-2"><input class="k-input" placeholder="placeholder" /></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="password" value="123" /></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="number" value="1"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="email" value="john.doe@konghq.com"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" disabled value="disabled"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" readonly value="readonly"/></div>
+<div class="k-input-wrapper mb-2"><input class="k-input" type="search" value="search"/></div>
+<div class="k-input-wrapper mb-2 input-error"><input class="k-input" type="email" value="error"/></div>
 ```
 
 ## Checkboxes & Radios
@@ -71,7 +61,9 @@ Additionally you can add block level hint text by using the `.help` class.
 </div>
 <div>
   <label for="text" class="k-input-label">Label Text</label>
-  <input id="text" class="k-input" type="text" />
+  <div class="k-input-wrapper">
+    <input id="text" class="k-input" type="text" />
+  </div>
   <p class="help">This is some helpful hint text!</p>
 </div>
 
@@ -86,7 +78,9 @@ Additionally you can add block level hint text by using the `.help` class.
 </div>
 <div>
   <label for="text" class="k-input-label">Label Text</label>
-  <input id="text" class="k-input" type="text" />
+  <div class="k-input-wrapper">
+    <input id="text" class="k-input" type="text" />
+  </div>
   <p class="help">This is some helpful hint text!</p>
 </div>
 ```

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -1,8 +1,11 @@
 <template>
-  <label class="k-checkbox">
+  <label
+    class="k-checkbox"
+    :class="$attrs.class"
+  >
     <input
       :checked="modelValue"
-      v-bind="$attrs"
+      v-bind="modifiedAttrs"
       type="checkbox"
       class="k-input"
       @change="handleChange"
@@ -12,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, computed } from 'vue'
 
 export default defineComponent({
   name: 'KCheckbox',
@@ -28,14 +31,24 @@ export default defineComponent({
     },
   },
   emits: ['input', 'change', 'update:modelValue'],
-  setup(props, { emit }) {
+  setup(props, { emit, attrs }) {
     const handleChange = (e: any): void => {
       emit('change', e.target.checked)
       emit('input', e.target.checked)
       emit('update:modelValue', e.target.checked)
     }
 
+    const modifiedAttrs = computed(() => {
+      const $attrs = { ...attrs }
+
+      // delete classes because we bind them to the parent
+      delete $attrs.class
+
+      return $attrs
+    })
+
     return {
+      modifiedAttrs,
       handleChange,
     }
   },

--- a/src/components/KInlineEdit/KInlineEdit.vue
+++ b/src/components/KInlineEdit/KInlineEdit.vue
@@ -161,6 +161,7 @@ export default defineComponent({
       border: 1px solid transparent;
       border-radius: 3px;
       padding: var(--padding);
+      margin-top: 0; // prevent a shift
       margin-left: calc(-1 * var(--spacing-xs)); // align the left side of content
       line-height: 1.25;
       overflow: hidden;

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="[{'input-error' : charLimitExceeded || hasError || String($attrs.class || '').includes('input-error')}]"
+    :class="[$attrs.class, {'input-error' : charLimitExceeded || hasError || String($attrs.class || '').includes('input-error')}]"
     class="k-input-wrapper"
   >
     <div
@@ -177,6 +177,8 @@ export default defineComponent({
     const modifiedAttrs = computed(() => {
       const $attrs = { ...attrs }
 
+      // delete classes because we bind them to the parent
+      delete $attrs.class
       // use @input in template for v-model support
       delete $attrs.input
       delete $attrs.onInput

--- a/src/components/KInputSwitch/KInputSwitch.vue
+++ b/src/components/KInputSwitch/KInputSwitch.vue
@@ -7,6 +7,7 @@
       :for="$attrs.id ? String($attrs.id) : undefined"
       :disabled="disabled"
       class="k-switch k-input-switch"
+      :class="[$attrs.class]"
     >
       <span v-if="(label || $slots.label) && labelPosition === 'left'">
         <slot name="label">{{ label }}</slot>
@@ -30,7 +31,7 @@
     v-else
     :for="$attrs.id ? String($attrs.id) : undefined"
     :disabled="disabled ? disabled : undefined"
-    :class="{ 'switch-with-icon' : enabledIcon }"
+    :class="[$attrs.class, { 'switch-with-icon' : enabledIcon }]"
     class="k-switch k-input-switch"
   >
     <span v-if="(label || $slots.label) && labelPosition === 'left'">
@@ -127,6 +128,7 @@ export default defineComponent({
 
       const modifiedAttrs = Object.assign({}, attrs)
 
+      delete modifiedAttrs.class
       delete modifiedAttrs.disabled
 
       return modifiedAttrs

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -1,8 +1,11 @@
 <template>
-  <label class="k-radio">
+  <label
+    class="k-radio"
+    :class="$attrs.class"
+  >
     <input
       :checked="isSelected"
-      v-bind="$attrs"
+      v-bind="modifiedAttrs"
       type="radio"
       class="k-input"
       @click="handleClick"
@@ -35,7 +38,7 @@ export default defineComponent({
     },
   },
   emits: ['change', 'update:modelValue'],
-  setup(props, { emit }) {
+  setup(props, { emit, attrs }) {
     const isSelected = computed((): boolean => props.selectedValue === props.modelValue)
 
     const handleClick = (): void => {
@@ -43,8 +46,18 @@ export default defineComponent({
       emit('update:modelValue', props.selectedValue)
     }
 
+    const modifiedAttrs = computed(() => {
+      const $attrs = { ...attrs }
+
+      // delete classes because we bind them to the parent
+      delete $attrs.class
+
+      return $attrs
+    })
+
     return {
       isSelected,
+      modifiedAttrs,
       handleClick,
     }
   },

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -75,7 +75,7 @@
               :style="widthStyle"
               show-caret
               :is-rounded="false"
-              v-bind="$attrs"
+              v-bind="modifiedAttrs"
               appearance="btn-link"
               @keyup="evt => triggerFocus(evt, isToggled)"
             >
@@ -117,7 +117,7 @@
             />
             <KInput
               :id="selectTextId"
-              v-bind="$attrs"
+              v-bind="modifiedAttrs"
               :model-value="filterStr"
               :label="label && overlayLabel ? label : undefined"
               :overlay-label="overlayLabel"
@@ -406,6 +406,15 @@ export default defineComponent({
       }
     })
 
+    const modifiedAttrs = computed(() => {
+      const $attrs = { ...attrs }
+
+      // delete classes because we bind them to the parent
+      delete $attrs.class
+
+      return $attrs
+    })
+
     const createKPopAttributes = computed(() => {
       return {
         ...defaultKPopAttributes,
@@ -589,6 +598,7 @@ export default defineComponent({
       selectInputId,
       selectTextId,
       selectItems,
+      modifiedAttrs,
       popper,
       boundKPopAttributes,
       widthValue,

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -2,6 +2,7 @@
   <div
     :style="widthStyle"
     class="k-select"
+    :class="[$attrs.class]"
   >
     <KLabel
       v-if="label && !overlayLabel"

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    :class="{'input-error' : hasError || charLimitExceeded}"
+    :class="[$attrs.class, {'input-error' : hasError || charLimitExceeded}]"
     class="k-input-wrapper mb-2"
   >
     <textarea
       v-if="!label"
-      v-bind="$attrs"
+      v-bind="modifiedAttrs"
       :value="getValue()"
       :rows="rows"
       :cols="cols"
@@ -26,7 +26,7 @@
           <span>{{ label }}</span>
         </label>
         <textarea
-          v-bind="$attrs"
+          v-bind="modifiedAttrs"
           :id="textAreaId"
           :value="getValue()"
           :rows="rows"
@@ -53,7 +53,7 @@
         {{ label }}
       </KLabel>
       <textarea
-        v-bind="$attrs"
+        v-bind="modifiedAttrs"
         :id="textAreaId"
         :value="getValue()"
         :rows="rows"
@@ -153,6 +153,15 @@ export default defineComponent({
 
     const textAreaId = computed((): string => (attrs.id ? String(attrs.id) : props.testMode ? 'test-textArea-id-1234' : uuidv1()))
 
+    const modifiedAttrs = computed(() => {
+      const $attrs = { ...attrs }
+
+      // delete classes because we bind them to the parent
+      delete $attrs.class
+
+      return $attrs
+    })
+
     const charLimitExceeded = computed((): boolean => !props.disableCharacterLimit && currValue.value.length > props.characterLimit)
 
     const inputHandler = (e: any) => {
@@ -190,6 +199,7 @@ export default defineComponent({
       isFocused,
       isHovered,
       textAreaId,
+      modifiedAttrs,
       charLimitExceeded,
       inputHandler,
       getValue,

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -51,6 +51,7 @@
 .form-control {
   &:not([type="checkbox"]):not([type="radio"]) {
     display: block;
+    width: 100%;
     padding: 10px var(--spacing-md, spacing(md));
     color: var(--KInputColor, var(--black-70, color(black-70)));
     font-size: var(--type-md, type(md));


### PR DESCRIPTION
# Summary

Bind classes to the outermost wrapper element instead of the child element(s). 

As an example, this allows for doing `<KInput class="w-100 mr-4" />` and the classes to be applied correctly to the wrapper element.

If merged, Konnect will need to updated to add a class of `w-100` to most `KTextArea` components.

---

## PR Checklist

- [ ] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [ ] **Framework style:** abides by the essential rules in Vue's style guide
- [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
