### PR TITLE
fix(kpop): do not remove on destroy [KHCP-5139]

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -342,11 +342,9 @@ export default defineComponent({
   },
   methods: {
     hidePopper() {
-      if (this.trigger !== 'hover') {
-        this.isOpen = false
-      }
+      this.isOpen = false
+
       this.timer = setTimeout(() => {
-        this.isOpen = false
         this.$emit('closed')
         this.destroy()
       }, this.popoverTimeout)
@@ -381,7 +379,6 @@ export default defineComponent({
         placement,
         // Use positionFixed to avoid popover content being cut off by parent boundaries
         positionFixed: this.positionFixed,
-        removeOnDestroy: true,
         modifiers: {
           // Ensures element does not ovflow outside of boundary
           preventOverflow: {

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -434,7 +434,7 @@ export default defineComponent({
     destroy() {
       if (this.popper) {
         this.isOpen = false
-        this.popper.destroy()
+        this.popper.disableEventListeners()
         this.popper = null
       }
     },


### PR DESCRIPTION
# Summary

`KPop` is throwing an error because of the `removeOnDestroy` setting on the Popperjs element. On the first `popper.destroy()` call the parent exists and the `removeChild` call works successfully; however, subsequent calls fail because the parentNode is no longer defined. I believe this is because of changes in Vue 3 and how the virtual DOM is rendered.

---

## PR Checklist

- [x] Does not introduce dependencies
- [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
- [ ] **Tests pass:** check the output of yarn test packages/<Kongponent>
- [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
- [x] **Framework style:** abides by the essential rules in Vue's style guide
- [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs), or leftover comments
- [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
