### PR TITLE
fix(kcodeblock): a couple of issues

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.spec.ts
+++ b/src/components/KCodeBlock/KCodeBlock.spec.ts
@@ -129,25 +129,40 @@ describe('KCodeBlock', () => {
   it('can be interacted with using default shortcuts', () => {
     const id = 'code-block'
     renderComponent({ id, isSearchable: true, query: 'key' })
+    const codeBlock = cy.get('.k-code-block')
 
     // Tests that scoped shortcuts don’t work when focus is not within the code block.
     cy.document().trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match').should('not.exist')
 
-    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
+    codeBlock.trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L2`)
 
-    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
+    codeBlock.trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L3`)
 
-    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
+    codeBlock.trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L4`)
 
-    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
+    codeBlock.trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L2`)
 
-    cy.get('.k-code-block').trigger('keydown', { code: 'F3', shiftKey: true })
+    codeBlock.trigger('keydown', { code: 'F3', shiftKey: true })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L4`)
+
+    // Switches to filter mode using shortcut.
+    cy.get('.k-filtered-code-block').should('not.exist')
+    codeBlock.trigger('keydown', { code: 'KeyF', altKey: true })
+    cy.get('.k-filtered-code-block').should('exist')
+    cy.get('.k-matched-term').should('have.length', 3)
+
+    // Switches to regular expression mode using shortcut.
+    const searchInput = cy.get('[data-testid="k-code-block-search-input"]')
+    searchInput.clear()
+    searchInput.type('key[12]')
+
+    codeBlock.trigger('keydown', { code: 'KeyR', altKey: true })
+    cy.get('.k-matched-term').should('have.length', 2)
   })
 
   it('shows line number links', () => {

--- a/src/components/KCodeBlock/KCodeBlock.spec.ts
+++ b/src/components/KCodeBlock/KCodeBlock.spec.ts
@@ -54,7 +54,7 @@ describe('KCodeBlock', () => {
     // Jumps to the next (i.e. first) match using F3 and checks that the highlighted line numbers are jumped to in order.
     cy.get('.k-line-is-highlighted-match').should('not.exist')
     for (const lineNumber of expectedLineNumbers) {
-      cy.get('[data-testid="k-code-block"]').trigger('keydown', { key: 'F3', bubbles: true })
+      cy.get('[data-testid="k-code-block"]').trigger('keydown', { code: 'F3', bubbles: true })
       cy.get(`.k-line-is-highlighted-match .k-line-anchor#${id}-L${lineNumber}`).should('be.visible')
     }
 
@@ -131,22 +131,22 @@ describe('KCodeBlock', () => {
     renderComponent({ id, isSearchable: true, query: 'key' })
 
     // Tests that scoped shortcuts don’t work when focus is not within the code block.
-    cy.document().trigger('keydown', { key: 'F3' })
+    cy.document().trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match').should('not.exist')
 
-    cy.get('.k-code-block').trigger('keydown', { key: 'F3' })
+    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L2`)
 
-    cy.get('.k-code-block').trigger('keydown', { key: 'F3' })
+    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L3`)
 
-    cy.get('.k-code-block').trigger('keydown', { key: 'F3' })
+    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L4`)
 
-    cy.get('.k-code-block').trigger('keydown', { key: 'F3' })
+    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L2`)
 
-    cy.get('.k-code-block').trigger('keydown', { key: 'F3', shiftKey: true })
+    cy.get('.k-code-block').trigger('keydown', { code: 'F3', shiftKey: true })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'id').should('equal', `${id}-L4`)
   })
 
@@ -154,7 +154,7 @@ describe('KCodeBlock', () => {
     const id = 'code-block'
     renderComponent({ id, isSearchable: true, query: 'key', showLineNumberLinks: true })
 
-    cy.get('.k-code-block').trigger('keydown', { key: 'F3' })
+    cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'href').should('equal', `#${id}-L2`)
   })
 })

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -83,92 +83,94 @@
         </button>
       </div>
 
-      <KButton
-        class="k-regexp-mode-button"
-        type="button"
-        :appearance="regExpButtonAppearance"
-        :aria-pressed="isRegExpMode"
-        :is-rounded="false"
-        size="small"
-        title="Use regular expression (Alt+R)"
-        data-testid="k-code-block-regexp-mode-button"
-        @click="toggleRegExpMode"
-      >
-        <span class="k-visually-hidden">RegExp mode enabled</span>
+      <div class="k-search-actions">
+        <KButton
+          class="k-regexp-mode-button"
+          type="button"
+          :appearance="isRegExpMode ? 'secondary' : 'outline'"
+          :aria-pressed="isRegExpMode"
+          :is-rounded="false"
+          size="small"
+          title="Use regular expression (Alt+R)"
+          data-testid="k-code-block-regexp-mode-button"
+          @click="toggleRegExpMode"
+        >
+          <span class="k-visually-hidden">RegExp mode enabled</span>
 
-        .*
-      </KButton>
+          .*
+        </KButton>
 
-      <KButton
-        class="k-filter-mode-button"
-        type="button"
-        icon="filter"
-        :appearance="isFilterMode ? 'secondary' : 'outline'"
-        :aria-pressed="isFilterMode"
-        :is-rounded="false"
-        size="small"
-        title="Filter results (Alt+F)"
-        data-testid="k-code-block-filter-mode-button"
-        @click="toggleFilterMode"
-      >
-        <template #icon>
-          <KIcon
-            class="k-button-icon"
-            icon="filter"
-            size="16"
-            title="Filter results (Alt+F)"
-            color="currentColor"
-          />
-        </template>
+        <KButton
+          class="k-filter-mode-button"
+          type="button"
+          icon="filter"
+          :appearance="isFilterMode ? 'secondary' : 'outline'"
+          :aria-pressed="isFilterMode"
+          :is-rounded="false"
+          size="small"
+          title="Filter results (Alt+F)"
+          data-testid="k-code-block-filter-mode-button"
+          @click="toggleFilterMode"
+        >
+          <template #icon>
+            <KIcon
+              class="k-button-icon"
+              icon="filter"
+              size="16"
+              title="Filter results (Alt+F)"
+              color="currentColor"
+            />
+          </template>
 
-        <span class="k-visually-hidden">Filter mode enabled</span>
-      </KButton>
+          <span class="k-visually-hidden">Filter mode enabled</span>
+        </KButton>
 
-      <KButton
-        class="k-previous-match-button"
-        type="button"
-        :is-rounded="false"
-        size="small"
-        title="Previous match (Shift+F3)"
-        :disabled="matchingLineNumbers.length === 0 || isFilterMode"
-        data-testid="k-code-block-previous-match-button"
-        @click="jumpToPreviousMatch"
-      >
-        <template #icon>
-          <KIcon
-            class="k-button-icon"
-            icon="chevronUp"
-            size="16"
-            title="Previous match (Shift+F3)"
-            color="currentColor"
-          />
-        </template>
+        <KButton
+          class="k-previous-match-button"
+          type="button"
+          :is-rounded="false"
+          size="small"
+          title="Previous match (Shift+F3)"
+          :disabled="matchingLineNumbers.length === 0 || isFilterMode"
+          data-testid="k-code-block-previous-match-button"
+          @click="jumpToPreviousMatch"
+        >
+          <template #icon>
+            <KIcon
+              class="k-button-icon"
+              icon="chevronUp"
+              size="16"
+              title="Previous match (Shift+F3)"
+              color="currentColor"
+            />
+          </template>
 
-        <span class="k-visually-hidden">Previous match</span>
-      </KButton>
+          <span class="k-visually-hidden">Previous match</span>
+        </KButton>
 
-      <KButton
-        class="k-next-match-button"
-        type="button"
-        :is-rounded="false"
-        size="small"
-        title="Next match (F3)"
-        :disabled="matchingLineNumbers.length === 0 || isFilterMode"
-        data-testid="k-code-block-next-match-button"
-        @click="jumpToNextMatch"
-      >
-        <template #icon>
-          <KIcon
-            class="k-button-icon"
-            icon="chevronDown"
-            size="16"
-            title="Next match (F3)"
-            color="currentColor"
-          />
-        </template>
+        <KButton
+          class="k-next-match-button"
+          type="button"
+          :is-rounded="false"
+          size="small"
+          title="Next match (F3)"
+          :disabled="matchingLineNumbers.length === 0 || isFilterMode"
+          data-testid="k-code-block-next-match-button"
+          @click="jumpToNextMatch"
+        >
+          <template #icon>
+            <KIcon
+              class="k-button-icon"
+              icon="chevronDown"
+              size="16"
+              title="Next match (F3)"
+              color="currentColor"
+            />
+          </template>
 
-        <span class="k-visually-hidden">Next match</span>
-      </KButton>
+          <span class="k-visually-hidden">Next match</span>
+        </KButton>
+      </div>
     </div>
 
     <div class="k-code-block-content">
@@ -401,7 +403,6 @@ const maxLineNumberWidth = computed(() => totalLines.value[totalLines.value.leng
 const linePrefix = computed(() => props.id.toLowerCase().replace(/\s+/g, '-'))
 const isProcessing = computed(() => props.isProcessing || isProcessingInternally.value)
 const isShowingFilteredCode = computed(() => isFilterMode.value && filteredCode.value !== '')
-const regExpButtonAppearance = computed(() => regExpError.value !== null ? 'danger' : isRegExpMode.value ? 'secondary' : 'outline')
 const filteredCode = computed(function() {
   if (query.value === '') {
     return ''
@@ -791,6 +792,7 @@ $tabSize: 2;
 
 .k-code-block-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   gap: var(--spacing-xxs, spacing(xxs));
@@ -806,7 +808,7 @@ $tabSize: 2;
   border-top-right-radius: 0;
 }
 
-.k-code-block-actions > .k-button {
+.k-code-block-actions .k-button {
   align-self: stretch;
 }
 
@@ -814,6 +816,13 @@ $tabSize: 2;
   display: inline-flex;
   justify-content: center;
   align-items: center;
+}
+
+.k-search-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: var(--spacing-xxs, spacing(xxs));
 }
 
 .k-is-processing-icon:not(.k-is-processing-icon-is-visible) {
@@ -843,7 +852,8 @@ $tabSize: 2;
 }
 
 .k-code-block-search-input {
-  width: 15ch;
+  width: 100%;
+  max-width: 15ch;
   appearance: none;
   margin: 0;
   padding: 0 var(--spacing-xs, spacing(xs));

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -91,7 +91,7 @@
           :aria-pressed="isRegExpMode"
           :is-rounded="false"
           size="small"
-          title="Use regular expression (Alt+R)"
+          :title="`Use regular expression (${ALT_SHORTCUT_LABEL}+R)`"
           data-testid="k-code-block-regexp-mode-button"
           @click="toggleRegExpMode"
         >
@@ -108,7 +108,7 @@
           :aria-pressed="isFilterMode"
           :is-rounded="false"
           size="small"
-          title="Filter results (Alt+F)"
+          :title="`Filter results (${ALT_SHORTCUT_LABEL}+F)`"
           data-testid="k-code-block-filter-mode-button"
           @click="toggleFilterMode"
         >
@@ -117,7 +117,7 @@
               class="k-button-icon"
               icon="filter"
               size="16"
-              title="Filter results (Alt+F)"
+              :title="`Filter results (${ALT_SHORTCUT_LABEL}+F)`"
               color="currentColor"
             />
           </template>
@@ -223,14 +223,14 @@
         appearance="outline"
         :is-rounded="false"
         size="small"
-        title="Copy (Alt+C)"
+        :title="`Copy (${ALT_SHORTCUT_LABEL}+C)`"
         data-testid="k-code-block-copy-button"
         @click="copyCode"
       >
         <KIcon
           icon="copy"
           size="16"
-          title="Copy (Alt+C)"
+          :title="`Copy (${ALT_SHORTCUT_LABEL}+C)`"
           color="currentColor"
         />
 
@@ -281,6 +281,9 @@ type Command = {
 
   shouldPreventDefaultAction?: boolean
 }
+
+const IS_MAYBE_MAC = window.navigator.platform.toLowerCase().includes('mac')
+const ALT_SHORTCUT_LABEL = IS_MAYBE_MAC ? 'Options' : 'Alt'
 
 /**
  * Maps shortcuts to their associated command keywords.
@@ -646,20 +649,13 @@ const commands: Record<CommandKeywords, Command> = {
   },
 }
 
-const KEY_REPLACEMENT: Record<string, string> = {
-  ' ': 'space',
-  Control: '',
-  Shift: '',
-  Alt: '',
-}
-
 function triggerShortcuts(event: KeyboardEvent): void {
-  const key = KEY_REPLACEMENT[event.key] !== undefined ? KEY_REPLACEMENT[event.key] : event.key.toLowerCase()
+  const code = normalizeKeyCode(event.code)
   const shortcut = [
     event.ctrlKey ? 'ctrl' : '',
     event.shiftKey ? 'shift' : '',
     event.altKey ? 'alt' : '',
-    key,
+    code,
   ].filter((key) => key !== '').join('+')
   const commandKey = keyMap[shortcut]
 
@@ -687,6 +683,17 @@ function triggerShortcuts(event: KeyboardEvent): void {
   }
 
   command.trigger(event)
+}
+
+const MODIFIER_KEY_CODES = ['ControlLeft', 'ControlRight', 'ShiftLeft', 'ShiftRight', 'AltLeft']
+
+function normalizeKeyCode(code: string): string {
+  // Returns relevant modifier keys as the empty string which is going to be filtered out.
+  if (MODIFIER_KEY_CODES.includes(code)) {
+    return ''
+  }
+
+  return code.replace(/^Key/, '').toLowerCase()
 }
 
 function jumpToNextMatch(): void {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -614,6 +614,7 @@ const commands: Record<CommandKeywords, Command> = {
     isAllowedContext(event: Event) {
       return codeBlock.value !== null && event.composedPath().includes(codeBlock.value)
     },
+    shouldPreventDefaultAction: true,
   },
 
   toggleRegExpMode: {
@@ -621,6 +622,7 @@ const commands: Record<CommandKeywords, Command> = {
     isAllowedContext(event: Event) {
       return codeBlock.value !== null && event.composedPath().includes(codeBlock.value)
     },
+    shouldPreventDefaultAction: true,
   },
 
   jumpToNextMatch: {
@@ -646,6 +648,7 @@ const commands: Record<CommandKeywords, Command> = {
     isAllowedContext(event: Event) {
       return codeBlock.value !== null && event.composedPath().includes(codeBlock.value)
     },
+    shouldPreventDefaultAction: true,
   },
 }
 


### PR DESCRIPTION
# Summary

fix(kcodeblock): handling small resolutions poorly:

Addresses a few issues with the rendering of `KCodeBlock` in smaller resolutions. The actions bar items are now wrapping appropriately and the search input no longer extends beyond the available size.

fix(kcodeblock): shortcuts using Alt not working on macOS:

Fixes a bug where the default shortcuts involving the Alt key weren’t working on macOS because Options+letter commonly results in a differently typed character. The shortcut mechanism now checks the `event.code` property instead of `event.key` to do this more reliably.

fix(kcodeblock): not preventing default action for some shortcuts:

Fixes an issue with not correctly preventing the default action for some shortcuts (e.g. `Alt+F` opening a Chrome menu by default).

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
