### PR TITLE
feat(kbadge): add dismissable prop [khcp-5146]

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -35,6 +35,19 @@ The Badge component can take the following appearance values:
 <KBadge>DEFAULT</KBadge>
 ```
 
+### dismissable
+
+Use this prop if you want the badge to be dismissable. If the badge text is long enough to need truncation, the label will truncate; the dismiss button is always visible.
+The color of the dismiss button is determined by the badge type and uses the same theming variables as the badge text.
+
+<KBadge appearance="info" dismissable class="mr-2">Close me</KBadge>
+<KBadge appearance="info" dismissable shape="rectangular">Hey! Let me see that awesome truncation</KBadge>
+
+```html
+<KBadge appearance="info" dismissable>Close me</KBadge>
+<KBadge appearance="info" dismissable shape="rectangular">Hey! Let me see that awesome truncation</KBadge>
+```
+
 ### shape
 
 The Badge has two shapes that can be changed with a `shape` property.
@@ -80,28 +93,32 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 
 ## Theming
 
-| Variable                    | Purpose                       |
-| :---------------------      | :---------------------------- |
-| `--KBadgeBorderRadius`      |                               |
-| `--KBadgeFontSize`          |                               |
-| `--KBadgeLineHeight`        |                               |
-| `--KBadgeMinWidth`          |                               |
-| `--KBadgeMaxWidth`          |                               |
-| `--KBadgeWidth`             |                               |
-| `--KBadgePaddingY`          | Vertical top/bottom spacing   |
-| `--KBadgePaddingX`          | Horizontal left/right spacing |
-| `--KBadgeSuccessColor`      |                               |
-| `--KBadgeSuccessBorder`     |                               |
-| `--KBadgeSuccessBackground` |                               |
-| `--KBadgeWarningColor`      |                               |
-| `--KBadgeWarningBorder`     |                               |
-| `--KBadgeWarningBackground` |                               |
-| `--KBadgeInfoColor`         |                               |
-| `--KBadgeInfoBorder`        |                               |
-| `--KBadgeInfoBackground`    |                               |
-| `--KBadgeDangerColor`       |                               |
-| `--KBadgeDangerBorder`      |                               |
-| `--KBadgeDangerBackground`  |                               |
+| Variable                          | Purpose                                 |
+| :---------------------            | :----------------------------           |
+| `--KBadgeBorderRadius`            |                                         |
+| `--KBadgeFontSize`                |                                         |
+| `--KBadgeLineHeight`              |                                         |
+| `--KBadgeMinWidth`                | Min width of badge text                 |
+| `--KBadgeMaxWidth`                | Max width of badge text                 |
+| `--KBadgeWidth`                   | Width of badge text                     |
+| `--KBadgePaddingY`                | Vertical top/bottom spacing             |
+| `--KBadgePaddingX`                | Horizontal left/right spacing           |
+| `--KBadgeSuccessColor`            | Text/dismiss icon color of badge        |
+| `--KBadgeSuccessButtonHoverColor` | Hover color of dismiss button           |
+| `--KBadgeSuccessBorder`           | Border of badge (default to background) |
+| `--KBadgeSuccessBackground`       | Background color of badge               |
+| `--KBadgeWarningColor`            |                                         |
+| `--KBadgeWarningButtonHoverColor` |                                         |
+| `--KBadgeWarningBorder`           |                                         |
+| `--KBadgeWarningBackground`       |                                         |
+| `--KBadgeInfoColor`               |                                         |
+| `--KBadgeInfoButtonHoverColor`    |                                         |
+| `--KBadgeInfoBorder`              |                                         |
+| `--KBadgeInfoBackground`          |                                         |
+| `--KBadgeDangerColor`             |                                         |
+| `--KBadgeDangerButtonHoverColor`  |                                         |
+| `--KBadgeDangerBorder`            |                                         |
+| `--KBadgeDangerBackground`        |                                         |
 
 An example of theming the danger badge:
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -1,15 +1,30 @@
 <template>
   <div
+    v-if="!isDismissed"
     :class="[ `k-badge-${appearance}`, `k-badge-${shape}`]"
     :style="color && backgroundColor && {backgroundColor, color}"
-    class="k-badge truncate"
+    class="k-badge d-inline-flex"
   >
-    <slot />
+    <span class="k-badge-text truncate">
+      <slot />
+    </span>
+    <KButton
+      v-if="dismissable"
+      :is-rounded="shape === 'rounded'"
+      class="k-badge-dismiss-button ml-1"
+      @click="isDismissed = true"
+    >
+      <KIcon
+        icon="close"
+        :color="color"
+        size="10"
+      />
+    </KButton>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 
 export const appearances = {
   default: 'default',
@@ -40,6 +55,11 @@ export default defineComponent({
       default: 'default',
     },
 
+    dismissable: {
+      type: Boolean,
+      default: false,
+    },
+
     shape: {
       type: String,
       required: false,
@@ -61,22 +81,28 @@ export default defineComponent({
       default: '',
     },
   },
+  setup() {
+    const isDismissed = ref(false)
+
+    return {
+      isDismissed,
+    }
+  },
 })
 </script>
 
 <style lang="scss" scoped>
-@import '@/styles/styles.scss';
+@import '@/styles/variables';
+@import '@/styles/functions';
 
 .k-badge {
   display: inline-block;
   font-weight: 300;
   font-size: var(--KBadgeFontSize, 11px);
   line-height: var(--KBadgeLineHeight, var(--type-md, type(md)));
+  width: fit-content;
   height: auto;
   text-align: center;
-  max-width: var(--KBadgeMaxWidth, 200px);
-  min-width: var(--KBadgeMinWidth, 8px);
-  width: var(--KBadgeWidth, auto);
   padding: var(--KBadgePaddingY, 2px) var(--KBadgePaddingX, 6px);
   font-family: var(--font-family-sans, font(sans));
 
@@ -113,6 +139,92 @@ export default defineComponent({
 
   &.k-badge-rounded {
     border-radius: var(--KBadgeBorderRadius, 25px);
+  }
+
+  .k-badge-text {
+    max-width: var(--KBadgeMaxWidth, 200px);
+    min-width: var(--KBadgeMinWidth, 8px);
+    width: var(--KBadgeWidth, auto);
+    align-self: center;
+  }
+
+  .k-badge-dismiss-button {
+    padding: var(--spacing-xxs);
+    // non-visual-button
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    font-weight: 400;
+    // ignore badge padding
+    margin: calc(-1 * var(--KBadgePaddingY, 2px)) calc(-1 * var(--KBadgePaddingX, 6px));
+    margin-left: auto;
+  }
+}
+</style>
+
+<style lang="scss">
+@import '@/styles/variables';
+@import '@/styles/functions';
+
+.k-badge {
+  &.k-badge-default {
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close svg {
+        stroke: var(--KBadgeDefaultColor, var(--blue-500, color(blue-500)));
+      }
+
+      &:hover {
+        background-color: var(--KBadgeDefaultButtonHoverColor, var(--blue-200, color(blue-200)));
+      }
+    }
+  }
+
+  &.k-badge-success {
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close path {
+        stroke: var(--KBadgeSuccessColor, var(--green-700, color(green-700)));
+      }
+
+      &:hover {
+        background-color: var(--KBadgeSuccessButtonHoverColor, var(--green-200, color(green-200)));
+      }
+    }
+  }
+
+  &.k-badge-danger {
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close path {
+        stroke: var(--KBadgeDangerColor, var(--red-700, color(red-700)));
+      }
+
+      &:hover {
+        background-color: var(--KBadgeDangerButtonHoverColor, var(--red-200, color(red-200)));
+      }
+    }
+  }
+
+  &.k-badge-info {
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close path {
+        stroke: var(--KBadgeInfoColor, var(--blue-500, color(blue-500)));
+      }
+
+      &:hover {
+        background-color: var(--KBadgeInfoButtonHoverColor, var(--blue-300, color(blue-300)));
+      }
+    }
+  }
+
+  &.k-badge-warning {
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close path {
+        stroke: var(--KBadgeWarningColor, var(--yellow-600, color(yellow-600)));
+      }
+
+      &:hover {
+        background-color: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, color(yellow-200)));
+      }
+    }
   }
 }
 </style>

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -97,8 +97,8 @@ export default defineComponent({
 
 .k-badge {
   display: inline-block;
-  font-weight: 300;
-  font-size: var(--KBadgeFontSize, 11px);
+  font-weight: 400;
+  font-size: var(--KBadgeFontSize, 12px);
   line-height: var(--KBadgeLineHeight, var(--type-md, type(md)));
   width: fit-content;
   height: auto;

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -149,7 +149,7 @@ export default defineComponent({
   }
 
   .k-badge-dismiss-button {
-    padding: var(--spacing-xxs);
+    padding: var(--spacing-xs);
     // non-visual-button
     background-color: transparent;
     border: none;


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add support for dismissing a `KBadge`.
Also bump the default text size up to `12px`.

![image](https://user-images.githubusercontent.com/67973710/197819264-d61729f7-e092-4b6f-ba86-4f11d436350d.png)


## PR Checklist

* [x] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
