### PR TITLE
fix(kselect): broken input with autosuggest [KHCP-5153]

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -134,6 +134,7 @@
               @keyup="evt => triggerFocus(evt, isToggled)"
               @update:model-value="onQueryChange"
               @focus="onInputFocus"
+              @blur="onInputBlur"
             />
           </div>
           <template #content>
@@ -355,6 +356,7 @@ export default defineComponent({
     const selectTextId = computed((): string => props.testMode ? 'test-select-text-id-1234' : uuidv1())
     const selectItems: Ref<SelectItem[]> = ref([])
     const initialFocusTriggered: Ref<boolean> = ref(false)
+    const inputFocused: Ref<boolean> = ref(false)
     const popper = ref(null)
     // we need this so we can create a watcher for programmatic changes to the modelValue
     const value = computed({
@@ -522,10 +524,15 @@ export default defineComponent({
     }
 
     const onInputFocus = (): void => {
+      inputFocused.value = true
       if (!initialFocusTriggered.value) {
         initialFocusTriggered.value = true
         emit('query-change', '')
       }
+    }
+
+    const onInputBlur = (): void => {
+      inputFocused.value = false
     }
 
     watch(value, (newVal, oldVal) => {
@@ -558,7 +565,7 @@ export default defineComponent({
           selectedItem.value = selectItems.value[i]
           selectItems.value[i].key += '-selected'
 
-          if (props.appearance === 'select') {
+          if (props.appearance === 'select' && !inputFocused.value) {
             filterStr.value = selectedItem.value.label
           }
         }
@@ -615,6 +622,7 @@ export default defineComponent({
       onInputKeypress,
       onQueryChange,
       onInputFocus,
+      onInputBlur,
       onPopoverOpen,
     }
   },


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This pull request fixes an issue where users cannot change the value of the input box in `KSelect`.

### Background

Using `KSelect` with autosuggest and having `v-model` defined and its value matches one item in `items`.

A live demo on CSB: https://codesandbox.io/s/kselect-autosuggest-repro-ynkd93?file=/src/App.vue

### Steps to reproduce

1. Focus on the input box
2. Input `aa` or `aab`
3. The `aabbaa` keeps showing up in the input
4. Try deleting `aabbaa` from the right side
5. The `aabbaa` keeps showing up in the input

**KHCP-5153**

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] <del>**Docs:** includes a technically accurate README, uses JSDOC where appropriate</del>
