### PR TITLE
fix(kpop): disabled prop does not work as expected

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -315,9 +315,16 @@ export default defineComponent({
         this.hidePopper()
       }
     },
+    disabled: {
+      handler() {
+        if (this.isOpen) {
+          this.hidePopper()
+        }
+      },
+      immediate: true,
+    },
   },
   mounted() {
-    if (this.disabled) return
     if (!this.$el.children) {
       this.reference = this.$el
     } else {
@@ -350,6 +357,7 @@ export default defineComponent({
       }, this.popoverTimeout)
     },
     showPopper() {
+      if (this.disabled) return
       this.isOpen = true
       if (this.timer) clearTimeout(this.timer)
       if (this.popperTimer) clearTimeout(this.popperTimer)


### PR DESCRIPTION
# Summary

This pull request fixes an issue where KPop is not working as expected when the `disabled` property changes.

Live demo: https://codesandbox.io/s/kpop-disabled-repro-r57iqb?file=/src/App.vue

KHCP-5183

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] <del>**Docs:** includes a technically accurate README, uses JSDOC where appropriate</del>
