### PR TITLE
fix: replace all instances of a space

### DIFF
--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -6,7 +6,7 @@
       'danger': isDangerous,
       'k-dropdown-selected-option': selected
     }"
-    :data-testid="`k-dropdown-item-${label.replace(' ', '-')}`"
+    :data-testid="`k-dropdown-item-${label.replace(/ /gi, '-')}`"
     class="k-dropdown-item w-100"
   >
     <a

--- a/src/components/KMenu/KMenuItem.vue
+++ b/src/components/KMenu/KMenuItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :id="menuItemId"
-    :data-testid="item ? `${item.title.replace(' ', '-')}-menu-item` : 'menu-item'"
+    :data-testid="item ? `${item.title.replace(/ /gi, '-')}-menu-item` : 'menu-item'"
     :test-mode="!!testMode || undefined"
     :class="[isOpen ? 'title-dark' : '', {'expando-item' : expandable}]"
     class="k-menu-item"

--- a/src/components/KStepper/KStepper.vue
+++ b/src/components/KStepper/KStepper.vue
@@ -5,7 +5,7 @@
   >
     <KStep
       v-for="(step) in steps"
-      :key="`k-step-${step.label.replace(' ', '-')}`"
+      :key="`k-step-${step.label.replace(/ /gi, '-')}`"
       :label="step.label"
       :state="step.state"
       :max-label-width="maxLabelWidth"


### PR DESCRIPTION
# Summary

Some `data-testid` attributes had incorrect logic to only replace the first instance of a space in the string. This PR replaces _all_ spaces with a dash `-`

## NOTE - This might break tests in Konnect

When we go to merge, we need to pull this into a PR for `khcp-ui` to ensure it doesn't break existing test selectors

### Example (`KDropdownItem`)

#### Before

`data-testid="sidebar-item-Personal-access tokens"`

#### After

`data-testid="sidebar-item-Personal-access-tokens"`

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
