### PR TITLE
fix(kbadge): components not being registered

### DIFF
--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -25,6 +25,8 @@
 
 <script lang="ts">
 import { defineComponent, ref } from 'vue'
+import KButton from '@/components/KButton/KButton.vue'
+import KIcon from '@/components/KIcon/KIcon.vue'
 
 export const appearances = {
   default: 'default',
@@ -41,6 +43,11 @@ export const shapes = {
 }
 
 export default defineComponent({
+  components: {
+    KButton,
+    KIcon,
+  },
+
   props: {
     /**
       * Base styling<br>


### PR DESCRIPTION
# Summary

Fixes the child components not being registered in KBadge.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [X] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
