### PR TITLE
fix(kcodeblock): code block content overflowing

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -804,7 +804,11 @@ $tabSize: 2;
 }
 
 .k-code-block code {
+  // This is an essential performance regression prevention in scenarios where the code block content is being syntax-highlighted using PrismJS (see https://github.com/PrismJS/prism/issues/2062). I’ve observed noticeable performance issues as recent as October 2022.
   display: block;
+
+  // This element will act as a grid item whose minimum width is initially `auto` which in turn can cause the CSS box to overflow which is not desirable here.
+  min-width: 0;
 }
 
 .k-code-block:focus-visible {


### PR DESCRIPTION
# Summary

Fixes an issue with code block content overflowing in a way that forces the component to grow wider instead of only the code content scrolling horizontally *within* the component. This can happen with long lines of code.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
