### PR TITLE
feat(ktable-kcatalog): add toolbar slot [KHCP-5224]

### DIFF
--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -368,6 +368,8 @@ Set the `isLoading` prop to `true` to enable the loading state.
 
 ## Slots
 
+### Main Slots
+
 Both the `title` & `description` of the card items as well as the entire catalog `body` are slottable.
 
 - `body` - The body of the card catalog, if you do not want to use `KCatalogItem` components for the children.
@@ -425,6 +427,24 @@ Use the `cardTitle` and `cardBody` slots to access `item` specific data.
   </template>
 </KCatalog>
 ```
+
+### Toolbar
+
+The `toolbar` slot allows you to slot catalog controls rendered at the top of the `.k-card-catalog` element such as a search input or other UI elements.
+
+If utilizing multiple elements, we recommend adding `display: flex; width: 100%;` to the root slot tag.
+
+<KCatalog :fetcher="fetcherXs">
+  <template #toolbar>
+    <div class="d-flex w-100 justify-content-between">
+      <KInput placeholder="Search" />
+      <KSelect appearance="select" :items="[{ label: 'First option', value: '1', selected: true }, { label: 'Another option', value: '2'}]" />
+    </div>
+  </template>
+</KCatalog>
+
+
+### State Slots
 
 KCatalog has built-in state management for loading, empty, and error states. You can either use the props described in
 the section above or completely slot in your own content.

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -858,12 +858,40 @@ export default {
 
 ## Slots
 
+### Toolbar
+
+The `toolbar` slot allows you to slot table controls rendered right above the `<table>` element such as a search input or other UI elements.
+
+If utilizing multiple elements, we recommend adding `display: flex; width: 100%;` to the root slot tag.
+
+<KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" :hasHover="false">
+  <template #toolbar>
+    <div class="d-flex w-100 justify-content-between">
+      <KInput placeholder="Search" />
+      <KSelect appearance="select" :items="[{ label: 'First option', value: '1', selected: true }, { label: 'Another option', value: '2'}]" />
+    </div>
+  </template>
+</KTable>
+
+```html
+<KTable :fetcher="fetcher" :headers="headers">
+  <template #toolbar>
+    <div class="d-flex w-100 justify-content-between">
+      <KInput placeholder="Search" />
+      <KSelect appearance="select" :items="[{ label: 'Ascending', value: 'asc', selected: true }, { label: 'Descending', value: 'desc'}]" />
+    </div>
+  </template>
+</KTable>
+```
+
+### Column Header and Cell
+
 Both column cells & header cells are slottable in KTable. Use slots to gain access to the row data.
 
 - `column-{column-key}` - Will slot the header cell
 - `{column-key}` - Will slot the column cell of a given row
 
-### Column Header
+#### Column Header
 
 <KTable :headers="tableOptionsHeaders" :fetcher="tableOptionsFetcher">
   <template v-slot:column-name="{ column }">
@@ -896,7 +924,7 @@ export default {
 </script>
 ```
 
-### Column Cell
+#### Column Cell
 
 This example uses the [`KDropdownMenu`](/components/dropdown-menu.html) component as the slot content for the `actions` column.
 

--- a/src/components/KCatalog/KCatalog.spec.ts
+++ b/src/components/KCatalog/KCatalog.spec.ts
@@ -165,6 +165,24 @@ describe('KCatalog', () => {
       cy.getTestId('k-card-catalog-error-state').should('contain', errorSlotContent)
     })
 
+    it('renders content in the toolbar slot', () => {
+      mount(KCatalog, {
+        props: {
+          testMode: 'true',
+          fetcher: () => {
+            return { data: getItems(1), total: 1 }
+          },
+          disablePagination: true,
+        },
+        slots: {
+          toolbar: () => h('button', {}, 'Toolbar button'),
+        },
+      })
+
+      cy.get('.k-card-catalog .k-catalog-toolbar').find('button').should('be.visible')
+      cy.get('.k-card-catalog .k-catalog-toolbar button').should('contain.text', 'Toolbar button')
+    })
+
     it('can change card sizes - small', () => {
       const total = 5
 

--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -8,6 +8,14 @@
       <h3>{{ title }}</h3>
     </div>
 
+    <div
+      v-if="hasToolbarSlot"
+      class="k-catalog-toolbar mb-5"
+      data-testid="k-catalog-toolbar"
+    >
+      <slot name="toolbar" />
+    </div>
+
     <KSkeleton
       v-if="(testMode === false || testMode === 'loading') && (isCardLoading || isLoading) && !hasError"
       :card-count="4"
@@ -409,7 +417,7 @@ export default defineComponent({
     },
   },
   emits: ['kcatalog-error-cta-clicked', 'kcatalog-empty-state-cta-clicked'],
-  setup(props) {
+  setup(props, { slots }) {
     const defaultFetcherProps = {
       page: 1,
       pageSize: 15,
@@ -423,6 +431,7 @@ export default defineComponent({
     const pageSize = ref(15)
     const isCardLoading = ref(true)
     const hasInitialized = ref(false)
+    const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
 
     const fetchData = async () => {
       isCardLoading.value = true
@@ -503,6 +512,7 @@ export default defineComponent({
       pageSizeChangeHandler,
       total,
       getTestIdString,
+      hasToolbarSlot,
     }
   },
 })
@@ -522,6 +532,10 @@ export default defineComponent({
     grid-gap: var(--spacing-lg);
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
+}
+
+.k-catalog-toolbar > :deep(*) {
+  display: flex;
 }
 </style>
 

--- a/src/components/KTable/KTable.spec.ts
+++ b/src/components/KTable/KTable.spec.ts
@@ -118,6 +118,23 @@ describe('KTable', () => {
       cy.get('.k-table td:last-of-type > *').contains('a', 'Link')
     })
 
+    it('renders content in the toolbar slot', () => {
+      mount(KTable, {
+        props: {
+          testMode: 'true',
+          headers: options.headers,
+          fetcher: () => { return { data: options.data } },
+          disablePagination: true,
+        },
+        slots: {
+          toolbar: () => h('button', {}, 'Toolbar button'),
+        },
+      })
+
+      cy.get('.k-table-container .k-table-toolbar').find('button').should('be.visible')
+      cy.get('.k-table-container .k-table-toolbar button').should('contain.text', 'Toolbar button')
+    })
+
     it('has hover class when passed', () => {
       mount(KTable, {
         props: {
@@ -162,23 +179,6 @@ describe('KTable', () => {
       cy.get('th').each(($el) => {
         cy.wrap($el).should('not.have.class', 'sortable')
       })
-    })
-
-    it.only('renders content in the toolbar slot', () => {
-      mount(KTable, {
-        props: {
-          testMode: 'true',
-          headers: options.headers,
-          fetcher: () => { return { data: options.data } },
-          disablePagination: true,
-        },
-        slots: {
-          toolbar: () => h('button', {}, 'Toolbar button'),
-        },
-      })
-
-      cy.get('.k-table-wrapper .k-table-toolbar').find('button').should('be.visible')
-      cy.get('.k-table-wrapper .k-table-toolbar button').should('contain.text', 'Toolbar button')
     })
   })
 

--- a/src/components/KTable/KTable.spec.ts
+++ b/src/components/KTable/KTable.spec.ts
@@ -164,7 +164,7 @@ describe('KTable', () => {
       })
     })
 
-    it('renders content in the toolbar slot', () => {
+    it.only('renders content in the toolbar slot', () => {
       mount(KTable, {
         props: {
           testMode: 'true',
@@ -177,8 +177,8 @@ describe('KTable', () => {
         },
       })
 
-      cy.get('.k-table .k-table-toolbar').find('button').should('be.visible')
-      cy.get('.k-table .k-table-toolbar button').should('contain.text', 'Toolbar button')
+      cy.get('.k-table-wrapper .k-table-toolbar').find('button').should('be.visible')
+      cy.get('.k-table-wrapper .k-table-toolbar button').should('contain.text', 'Toolbar button')
     })
   })
 

--- a/src/components/KTable/KTable.spec.ts
+++ b/src/components/KTable/KTable.spec.ts
@@ -163,6 +163,23 @@ describe('KTable', () => {
         cy.wrap($el).should('not.have.class', 'sortable')
       })
     })
+
+    it('renders content in the toolbar slot', () => {
+      mount(KTable, {
+        props: {
+          testMode: 'true',
+          headers: options.headers,
+          fetcher: () => { return { data: options.data } },
+          disablePagination: true,
+        },
+        slots: {
+          toolbar: () => h('button', {}, 'Toolbar button'),
+        },
+      })
+
+      cy.get('.k-table .k-table-toolbar').find('button').should('be.visible')
+      cy.get('.k-table .k-table-toolbar button').should('contain.text', 'Toolbar button')
+    })
   })
 
   // describe('events', () => {

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -1,5 +1,13 @@
 <template>
-  <div>
+  <div class="k-table-container">
+    <div
+      v-if="hasToolbarSlot"
+      class="k-table-toolbar mb-5"
+      data-testid="k-table-toolbar"
+    >
+      <slot name="toolbar" />
+    </div>
+
     <KSkeleton
       v-if="(!testMode || testMode === 'loading') && (isTableLoading || isLoading) && !hasError"
       type="table"
@@ -83,13 +91,6 @@
       class="k-table-wrapper"
       @scroll.passive="scrollHandler"
     >
-      <div
-        v-if="hasToolbarSlot"
-        class="k-table-toolbar"
-        data-testid="k-table-toolbar"
-      >
-        <slot name="toolbar" />
-      </div>
       <table
         :class="{'has-hover': hasHover, 'is-clickable': isClickable, 'side-border': hasSideBorder}"
         class="k-table"

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -83,6 +83,13 @@
       class="k-table-wrapper"
       @scroll.passive="scrollHandler"
     >
+      <div
+        v-if="hasToolbarSlot"
+        class="k-table-toolbar"
+        data-testid="k-table-toolbar"
+      >
+        <slot name="toolbar" />
+      </div>
       <table
         :class="{'has-hover': hasHover, 'is-clickable': isClickable, 'side-border': hasSideBorder}"
         class="k-table"
@@ -509,7 +516,7 @@ export default defineComponent({
     },
   },
   emits: ['sort', 'ktable-error-cta-clicked', 'ktable-empty-state-cta-clicked', 'row-click', 'cell-click'],
-  setup(props, { attrs, emit }) {
+  setup(props, { attrs, emit, slots }) {
     const tableId = computed((): string => props.testMode ? 'test-table-id-1234' : uuidv1())
     const defaultFetcherProps = {
       pageSize: 15,
@@ -534,6 +541,7 @@ export default defineComponent({
     const isClickable = ref(false)
     const hasInitialized = ref(false)
     const nextPageClicked = ref(false)
+    const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
     /**
      * Grabs listeners from attrs matching a prefix to attach the
      * event that is dynamic. e.g. `v-on:cell:click`, `@row:focus` etc.
@@ -857,6 +865,7 @@ export default defineComponent({
       previousOffset,
       offset,
       shouldShowPagination,
+      hasToolbarSlot,
     }
   },
 })
@@ -869,6 +878,10 @@ export default defineComponent({
 .k-table-wrapper {
   width: 100%;
   overflow: auto;
+}
+
+.k-table-toolbar > :deep(*) {
+  display: flex;
 }
 
 .k-table {


### PR DESCRIPTION
# Summary

Add `KTable` and `KCatalog` `#toolbar` slot.

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
