### PR TITLE
style(ktextarea): fix styles [khcp-5265]

### DIFF
--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -224,18 +224,6 @@ export default defineComponent({
     font-family: var(--font-family-sans);
     resize: none;
 
-    &::placeholder {
-      color: var(--KInputPlaceholderColor, var(--grey-500, color(grey-500)));
-    }
-
-    &:hover {
-      color: var(--grey-600);
-    }
-
-    &:hover::placeholder {
-      color: var(--KInputPlaceholderColor, var(--grey-600, color(grey-600)));
-    }
-
     &:focus::placeholder {
       color: transparent;
     }

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -61,7 +61,7 @@
 .style-body-lg {
   font-size: 16px !important;
   line-height: 24px !important;
-  font-weight: 300 !important;
+  font-weight: 400 !important;
 }
 .style-body-lg-bold {
   font-size: 16px !important;


### PR DESCRIPTION
# Summary
Addresses:
[https://konghq.atlassian.net/browse/KHCP-5265](https://konghq.atlassian.net/browse/KHCP-5265)
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
**Before:**

**hover-**
![image 663](https://user-images.githubusercontent.com/87779967/200402256-708599e5-7c55-4c72-9480-3c4cabda83bb.png)

**placeholder text color -** 
![image 658](https://user-images.githubusercontent.com/87779967/200402246-58112428-68cd-4810-960b-46509a269c44.png)

**text font weight -**
![image 661](https://user-images.githubusercontent.com/87779967/200402253-6d3b0a82-fbdb-462c-9d2e-daa34a0d15e0.png)

**After:**

**hover-**
![image 662](https://user-images.githubusercontent.com/87779967/200402255-6330ac40-d7c1-4819-ae2d-43fcac478af9.png)

**placeholder text color -** 
![image 659](https://user-images.githubusercontent.com/87779967/200402247-b78b8205-0028-4dac-8468-10a0ac86c7ae.png)

**text font weight -**
![image 660](https://user-images.githubusercontent.com/87779967/200402250-86f34f4f-b372-4475-9003-70458e20c4a5.png)
## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
