### PR TITLE
fix(*): fix the issue of stepper, select icon

### DIFF
--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -179,8 +179,20 @@ There are 6 designated slots you can use to display content in the fullscreen mo
     <KButton size="medium" @click="sampleIsOpen = false" class="mr-2">Back</KButton>
     <KButton appearance="creation" size="medium" @click="sampleIsOpen = false">Save</KButton>
   </template>
+    <div>
+  <KStepper :steps="[
+      { label: 'I am visible', state: 'completed' },
+      { label: 'Scroll Up', state: 'completed' },
+      { label: 'I am hidden', state: 'pending' }
+    ]"
+  />
+</div>
   <div class="ml-25">
     <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
+    <br><br>
+    <div class="wrapper display-items">
+      <KSelect label="Name" placeholder="I'm labelled!" appearance="select" />
+    </div>
     <br><br>
     <div class="wrapper display-items">
       <input type="text" placeholder="Enter list of tags">
@@ -246,6 +258,9 @@ There are 6 designated slots you can use to display content in the fullscreen mo
   <div class="ml-25">
     <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
     <br><br>
+    <div class="wrapper display-items">
+      <KSelect label="Name" placeholder="I'm labelled!" appearance="select" />
+    </div>
     <div class="wrapper display-items">
       <input type="text" placeholder="Enter list of tags">
       <label for="">Tags</label>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -191,7 +191,11 @@ There are 6 designated slots you can use to display content in the fullscreen mo
     <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
     <br><br>
     <div class="wrapper display-items">
-      <KSelect label="Name" placeholder="I'm labelled!" appearance="select" />
+      <KMultiselect label="Pick Something" :items="deepClone(defaultItemsUnselect)" />
+    </div>
+    <br><br>
+    <div class="wrapper display-items">
+      <KSelect label="Name" placeholder="I'm labelled!" appearance="select" :items="deepClone(defaultItems)" />
     </div>
     <br><br>
     <div class="wrapper display-items">
@@ -259,8 +263,13 @@ There are 6 designated slots you can use to display content in the fullscreen mo
     <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
     <br><br>
     <div class="wrapper display-items">
-      <KSelect label="Name" placeholder="I'm labelled!" appearance="select" />
+      <KMultiselect label="Pick Something" :items="items" />
     </div>
+    <br><br>
+    <div class="wrapper display-items">
+      <KSelect label="Name" placeholder="I'm labelled!" appearance="select" :items="items" />
+    </div>
+    <br><br>
     <div class="wrapper display-items">
       <input type="text" placeholder="Enter list of tags">
       <label for="">Tags</label>
@@ -387,10 +396,48 @@ export default {
       themeIsOpen: false,
       sampleIsOpen: false,
       getItems,
-      contentIsOpen: false
+      contentIsOpen: false,
+      defaultItems: [{
+        label: 'Cats',
+        value: 'cats',
+        selected: true
+      }, {
+        label: 'Dogs',
+        value: 'dogs'
+      }, {
+        label: 'Bunnies',
+        value: 'bunnies'
+      }],
+      defaultItemsUnselect: [{
+        label: 'Cats',
+        value: 'cats'
+      }, {
+        label: 'Dogs',
+        value: 'dogs'
+      }, {
+        label: 'Bunnies',
+        value: 'bunnies'
+      },
+      {
+        label: 'Lions',
+        value: 'lions'
+      }, {
+        label: 'Tigers',
+        value: 'tigers'
+      }, {
+        label: 'Bears',
+        value: 'bears'
+      }, {
+        label: 'A long & truncated item',
+        value: 'long'
+      }]
     }
   },
-
+  methods: {
+    deepClone(obj) {
+      return JSON.parse(JSON.stringify(obj))
+    }
+  }
 }
 </script>
 

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -190,8 +190,8 @@ There are 6 designated slots you can use to display content in the fullscreen mo
   <div class="ml-25">
     <KInputSwitch v-model="checked" label="This plugin is enabled" class="display-items" />
     <br><br>
-    <div class="wrapper display-items">
-      <KMultiselect label="Pick Something" :items="deepClone(defaultItemsUnselect)" />
+    <div>
+      <KMultiselect label="Pick Something" :items="deepClone(defaultItemsMultiselect)" />
     </div>
     <br><br>
     <div class="wrapper display-items">
@@ -408,7 +408,7 @@ export default {
         label: 'Bunnies',
         value: 'bunnies'
       }],
-      defaultItemsUnselect: [{
+      defaultItemsMultiselect: [{
         label: 'Cats',
         value: 'cats'
       }, {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -869,7 +869,6 @@ export default defineComponent({
 
   .k-multiselect-icon {
     position: absolute;
-    z-index: 1;
     right: 1px;
     top: 1px;
 
@@ -934,6 +933,7 @@ export default defineComponent({
       }
 
       input.k-input:not([type="checkbox"]):not([type="radio"]) {
+        background-color: transparent;
         // slightly smaller than container so we can see
         // the container's box-shadow
         height: calc(100% - 2px);

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -87,6 +87,7 @@
             :id="selectInputId"
             :class="{ 'k-select-input': appearance === 'select', 'no-filter': !filterIsEnabled }"
             data-testid="k-select-input"
+            class="select-input-container"
             style="position: relative;"
             role="listbox"
             @click="evt => {
@@ -108,13 +109,6 @@
                 size="18"
               />
             </KButton>
-            <KIcon
-              v-if="appearance === 'select'"
-              icon="chevronDown"
-              color="var(--grey-500)"
-              size="18"
-              :class="{ 'overlay-label-chevron': overlayLabel }"
-            />
             <KInput
               :id="selectTextId"
               v-bind="modifiedAttrs"
@@ -135,6 +129,13 @@
               @update:model-value="onQueryChange"
               @focus="onInputFocus"
               @blur="onInputBlur"
+            />
+            <KIcon
+              v-if="appearance === 'select'"
+              icon="chevronDown"
+              color="var(--grey-500)"
+              size="18"
+              :class="{ 'overlay-label-chevron': overlayLabel }"
             />
           </div>
           <template #content>
@@ -725,14 +726,8 @@ export default defineComponent({
     }
 
     .kong-icon {
-      position: absolute;
-      top: 60%;
-      right: 16px;
-      transform: translateY(-50%);
-      z-index: 9;
-
       &.overlay-label-chevron {
-        top: 70%;
+        margin-top: 25px;
       }
     }
 
@@ -753,8 +748,19 @@ export default defineComponent({
     }
   }
 
-  div.k-select-input.no-filter {
+  div.k-select-input.select-input-container {
     cursor: pointer !important;
+    flex: 0 0 40%;
+    display: flex;
+    align-items: center;
+
+    .k-select-input {
+      margin-right: -25px;
+    }
+
+    input.k-input {
+      background-color: transparent;
+    }
   }
 
   .k-select-button .has-caret .kong-icon {

--- a/src/components/KStepper/KStep.vue
+++ b/src/components/KStepper/KStep.vue
@@ -107,10 +107,10 @@ export default defineComponent({
     &::after {
       content: "";
       height: 2px;
-      width: calc(100% - var(--size) - calc(var(--spacing) * 2));
-      left: calc(50% + calc(var(--size) / 2 + var(--spacing)));
-      position: absolute;
+      width: calc(100% - var(--KStepIconSize, 26px) - calc(var(--spacing) * 2));
       top: calc(#{var(--KStepIconSize, 24px)} / 2);
+      left: calc(50% + calc(var(--KStepIconSize, 30px) / 1.8 + var(--spacing)));
+      position: absolute;
       background-color: var(--KStepDividerColorDefault, var(--grey-300));
     }
 

--- a/src/components/KStepper/KStep.vue
+++ b/src/components/KStepper/KStep.vue
@@ -71,6 +71,10 @@ export default defineComponent({
   padding: var(--spacing-sm) 0;
   flex: 1 1 0%;
 
+  // For Divider
+  --size: 2rem;
+  --spacing: 0.5rem;
+
   &:last-child > .k-step-container::after {
     display: none;
   }
@@ -103,11 +107,10 @@ export default defineComponent({
     &::after {
       content: "";
       height: 2px;
-      width: 100%;
+      width: calc(100% - var(--size) - calc(var(--spacing) * 2));
+      left: calc(50% + calc(var(--size) / 2 + var(--spacing)));
       position: absolute;
       top: calc(#{var(--KStepIconSize, 24px)} / 2);
-      left: 50%;
-      z-index: 0;
       background-color: var(--KStepDividerColorDefault, var(--grey-300));
     }
 

--- a/src/components/KStepper/KStep.vue
+++ b/src/components/KStepper/KStep.vue
@@ -72,8 +72,7 @@ export default defineComponent({
   flex: 1 1 0%;
 
   // For Divider
-  --size: 2rem;
-  --spacing: 0.5rem;
+  --divider-spacing: 0.5rem;
 
   &:last-child > .k-step-container::after {
     display: none;
@@ -107,9 +106,9 @@ export default defineComponent({
     &::after {
       content: "";
       height: 2px;
-      width: calc(100% - var(--KStepIconSize, 26px) - calc(var(--spacing) * 2));
-      top: calc(#{var(--KStepIconSize, 24px)} / 2);
-      left: calc(50% + calc(var(--KStepIconSize, 30px) / 1.8 + var(--spacing)));
+      width: calc(100% - var(--KStepIconSize, 26px) - calc(var(--divider-spacing) * 2));
+      top: calc(#{var(--KStepIconSize, var(--spacing-lg, spacing(lg)))} / 2);
+      left: calc(50% + calc(var(--KStepIconSize, 26px) / 1.5 + var(--divider-spacing)));
       position: absolute;
       background-color: var(--KStepDividerColorDefault, var(--grey-300));
     }

--- a/src/components/KStepper/KStepState.vue
+++ b/src/components/KStepper/KStepState.vue
@@ -34,7 +34,6 @@ export default defineComponent({
 <style lang="scss" scoped>
 .k-step-state {
   background: var(--KStepBackgroundColor, var(--white));
-  z-index: 1;
 }
 </style>
 

--- a/src/components/KStepper/KStepper.vue
+++ b/src/components/KStepper/KStepper.vue
@@ -55,6 +55,5 @@ export default defineComponent({
   overflow-x: auto;
   display: flex;
   position: relative;
-  z-index: -1;
 }
 </style>

--- a/src/components/KStepper/KStepper.vue
+++ b/src/components/KStepper/KStepper.vue
@@ -55,5 +55,6 @@ export default defineComponent({
   overflow-x: auto;
   display: flex;
   position: relative;
+  z-index: -1;
 }
 </style>


### PR DESCRIPTION
Addresses:
[https://konghq.atlassian.net/browse/KHCP-4160](https://konghq.atlassian.net/browse/KHCP-4160)
# Summary
Fixes the issue where KModalFullscreen gets overlapped by KSelect Caret/KMultiSelect Caret/KStepper.

To repro, go to Create New Upstream modal, click on a KSelect, then scroll down.

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
