### PR TITLE
feat(kmultiselect): support disabled item

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -21,10 +21,12 @@
 
 ### items
 
-An array of items containing a `label` and `value`. You may also specify that a certain items are `selected` by default.
+An array of items containing a `label` and `value`. You may also specify:
+- a certain items are `selected` by default
+- a certain items are `disabled`
 
 <div>
-  <KMultiselect :items="deepClone(defaultItems)" />
+  <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />
 </div>
 
 ```html
@@ -45,7 +47,8 @@ An array of items containing a `label` and `value`. You may also specify that a 
     value: 'lions'
   }, {
     label: 'Tigers',
-    value: 'tigers'
+    value: 'tigers',
+    disabled: true
   }, {
     label: 'Bears',
     value: 'bears'
@@ -583,6 +586,32 @@ export default defineComponent({
       }, {
         label: 'Tigers',
         value: 'tigers'
+      }, {
+        label: 'Bears',
+        value: 'bears'
+      }, {
+        label: 'A long & truncated item',
+        value: 'long'
+      }],
+      defaultItemsWithDisabled: [{
+        label: 'Cats',
+        value: 'cats',
+        selected: true
+      }, {
+        label: 'Dogs',
+        value: 'dogs'
+      }, {
+        label: 'Bunnies',
+        value: 'bunnies',
+        selected: true
+      },
+      {
+        label: 'Lions',
+        value: 'lions'
+      }, {
+        label: 'Tigers',
+        value: 'tigers',
+        disabled: true
       }, {
         label: 'Bears',
         value: 'bears'

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -62,6 +62,25 @@ describe('KMultiselect', () => {
     cy.getTestId('k-multiselect-selections').should('contain.text', selectedLabel2)
   })
 
+  it('renders with disabled item', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items: [
+          { label: labels[0], value: vals[0], disabled: true },
+          { label: labels[1], value: vals[1] },
+        ],
+      },
+    })
+
+    cy.get('.k-multiselect-input').trigger('click')
+
+    cy.get(`[data-testid="k-multiselect-item-${vals[0]}"] button`).should('have.attr', 'disabled')
+  })
+
   it('renders with correct px width', () => {
     const width = 350
 
@@ -146,6 +165,30 @@ describe('KMultiselect', () => {
 
     cy.getTestId(`k-multiselect-item-${vals[0]}`).eq(1).click()
     cy.getTestId('k-multiselect-selections').should('contain.text', labels[0])
+  })
+
+  it('ignores clicks on disabled item', () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+          disabled: true,
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }],
+      },
+    })
+
+    cy.get('.k-multiselect-input').click()
+
+    cy.getTestId(`k-multiselect-item-${vals[0]}`).eq(1).click()
+    cy.getTestId('k-multiselect-selections').should('not.exist')
   })
 
   it('allows slotting content into the items', async () => {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -251,6 +251,7 @@ export interface MultiselectItem {
   value: string
   key?: string
   selected?: boolean
+  disabled?: boolean
 }
 
 export interface MultiselectFilterFnParams {

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -11,7 +11,8 @@
     >
       <button
         :value="item.value"
-        :class="{ disabled, selected: item.selected }"
+        :class="{ selected: item.selected }"
+        :disabled="item.disabled"
         @click="handleClick"
       >
         <span class="k-multiselect-item-label mr-2">
@@ -42,16 +43,15 @@ export default defineComponent({
       type: Object,
       default: null,
       // Items must have a label and value
-      validator: (item: Record<string, string>): boolean => item.label !== undefined && item.value !== undefined,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
+      validator: (item: Record<string, string | number | boolean>): boolean => item.label !== undefined && item.value !== undefined,
     },
   },
   emits: ['selected'],
   setup(props, { emit }) {
     const handleClick = (): void => {
+      if (props.item.disabled) {
+        return
+      }
       emit('selected', props.item)
     }
 
@@ -88,19 +88,25 @@ export default defineComponent({
     text-align: left;
     font-weight: 400;
 
-    &:not(:disabled),
-    &:not(.disabled) {
+    &:not(:disabled) {
       cursor: pointer;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+
+      .k-multiselect-item-label {
+        opacity: 0.6;
+      }
     }
 
     .k-multiselect-item-label {
       width: auto;
-      line-height: 16px;
+      line-height: 20px;
       color: var(--grey-600);
       font-weight: 500;
       font-size: 14px;
       padding: 8px;
-      margin-bottom: 4px;
 
       :deep(.select-item-label) {
         color: var(--grey-600);
@@ -131,7 +137,7 @@ export default defineComponent({
       width: 24px;
     }
 
-    &:hover {
+    &:not(:disabled):hover {
       background-color: var(--grey-100);
       color: var(--grey-600);
     }

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -12,7 +12,7 @@
       <button
         :value="item.value"
         :class="{ selected: item.selected }"
-        :disabled="item.disabled"
+        :disabled="item.disabled === true ? true : undefined"
         @click="handleClick"
       >
         <span class="k-multiselect-item-label mr-2">


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR adds disabled items support for `KMultiselect`.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
