### PR TITLE
feat(kradio, kcheckbox): support label desc in radio, ckbox [KHCP-4339]

### DIFF
--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -60,20 +60,20 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 Will place label text to the right of the checkbox. Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="labelPropChecked1" label="Label Example" />
+<KCheckbox v-model="checked" label="Label Example" />
 ```
 
-<KCheckbox v-model="labelPropChecked1" label="Label Example" />
+<KCheckbox v-model="checked" label="Label Example" />
 
 ### description
 
 Will place description text under the checkbox label (required). Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="labelPropChecked1" label="Label Example" description="Some subheader text" />
+<KCheckbox v-model="checked" label="Label Example" description="Some subheader text" />
 ```
 
-<KCheckbox v-model="labelPropChecked1" label="Label Example" description="Some subheader text" />
+<KCheckbox v-model="checked" label="Label Example" description="Some subheader text" />
 
 ### HTML attributes
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -55,6 +55,16 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 </KCheckbox>
 ```
 
+### label
+
+Will place label text to the right of the checkbox. Can also be [slotted](#slots).
+
+```html
+<KCheckbox v-model="checked" :label="checked ? 'checked' : 'unchecked'" />
+```
+
+<KCheckbox v-model="labelPropChecked" :label="labelPropChecked ? 'checked' : 'unchecked'" />
+
 ### HTML attributes
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/api/composition-api-setup.html#setup-context).

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -60,20 +60,20 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 Will place label text to the right of the checkbox. Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="labelPropChecked1" label="Lable Example" />
+<KCheckbox v-model="labelPropChecked1" label="Label Example" />
 ```
 
-<KCheckbox v-model="labelPropChecked1" label="Lable Example" />
+<KCheckbox v-model="labelPropChecked1" label="Label Example" />
 
 ### description
 
-Will place description text under the checkbox label. Can also be [slotted](#slots).
+Will place description text under the checkbox label (required). Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="labelPropChecked1" label="Lable Example" description="Some subheader text" />
+<KCheckbox v-model="labelPropChecked1" label="Label Example" description="Some subheader text" />
 ```
 
-<KCheckbox v-model="labelPropChecked1" label="Lable Example" description="Some subheader text" />
+<KCheckbox v-model="labelPropChecked1" label="Label Example" description="Some subheader text" />
 
 ### HTML attributes
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -60,10 +60,20 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 Will place label text to the right of the checkbox. Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="checked" :label="checked ? 'checked' : 'unchecked'" />
+<KCheckbox v-model="checked" label="Lable Example" />
 ```
 
-<KCheckbox v-model="labelPropChecked" :label="labelPropChecked ? 'checked' : 'unchecked'" />
+<KCheckbox v-model="labelPropChecked1" label="Lable Example" />
+
+### description
+
+Will place description text under the checkbox label. Can also be [slotted](#slots).
+
+```html
+<KCheckbox v-model="checked" label="Lable Example" description="Some subheader text" />
+```
+
+<KCheckbox v-model="labelPropChecked1" label="Lable Example" description="Some subheader text" />
 
 ### HTML attributes
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -60,7 +60,7 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 Will place label text to the right of the checkbox. Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="checked" label="Lable Example" />
+<KCheckbox v-model="labelPropChecked1" label="Lable Example" />
 ```
 
 <KCheckbox v-model="labelPropChecked1" label="Lable Example" />
@@ -70,7 +70,7 @@ Will place label text to the right of the checkbox. Can also be [slotted](#slots
 Will place description text under the checkbox label. Can also be [slotted](#slots).
 
 ```html
-<KCheckbox v-model="checked" label="Lable Example" description="Some subheader text" />
+<KCheckbox v-model="labelPropChecked1" label="Lable Example" description="Some subheader text" />
 ```
 
 <KCheckbox v-model="labelPropChecked1" label="Lable Example" description="Some subheader text" />

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -50,13 +50,23 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 
 ### label
 
-Will place label text to the right of the checkbox. Can also be [slotted](#slots).
+Will place label text to the right of the radio. Can also be [slotted](#slots).
 
 ```html
-<KRadio v-model="checked" :label="checked ? 'checked' : 'unchecked'" />
+<KRadio v-model="selected" label="Lable Example" />
 ```
 
-<KRadio v-model="labelPropChecked" :label="labelPropChecked ? 'checked' : 'unchecked'" />
+<KRadio v-model="selected" label="Lable Example" />
+
+### description
+
+Will place description text under the radio label. Can also be [slotted](#slots).
+
+```html
+<KRadio v-model="selected" label="Lable Example" description="Some subheader text" />
+```
+
+<KRadio v-model="selected" label="Lable Example" description="Some subheader text" />
 
 ### selectedValue
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -53,20 +53,20 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 Will place label text to the right of the radio. Can also be [slotted](#slots).
 
 ```html
-<KRadio v-model="selected" label="Lable Example" />
+<KRadio :selected-value="true" v-model="radio" label="Lable Example" />
 ```
 
-<KRadio v-model="selected" label="Lable Example" />
+<KRadio :selected-value="true" v-model="radio" label="Lable Example" />
 
 ### description
 
 Will place description text under the radio label. Can also be [slotted](#slots).
 
 ```html
-<KRadio v-model="selected" label="Lable Example" description="Some subheader text" />
+<KRadio :selected-value="true" v-model="radio" label="Lable Example" description="Some subheader text" />
 ```
 
-<KRadio v-model="selected" label="Lable Example" description="Some subheader text" />
+<KRadio :selected-value="true" v-model="radio" label="Lable Example" description="Some subheader text" />
 
 ### selectedValue
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -53,20 +53,20 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 Will place label text to the right of the radio. Can also be [slotted](#slots).
 
 ```html
-<KRadio :selected-value="true" v-model="radio" label="Lable Example" />
+<KRadio :selected-value="true" v-model="radio" label="Label Example" />
 ```
 
-<KRadio :selected-value="true" v-model="radio" label="Lable Example" />
+<KRadio :selected-value="true" v-model="radio" label="Label Example" />
 
 ### description
 
-Will place description text under the radio label. Can also be [slotted](#slots).
+Will place description text under the radio label (required). Can also be [slotted](#slots).
 
 ```html
-<KRadio :selected-value="true" v-model="radio" label="Lable Example" description="Some subheader text" />
+<KRadio :selected-value="true" v-model="radio" label="Label Example" description="Some subheader text" />
 ```
 
-<KRadio :selected-value="true" v-model="radio" label="Lable Example" description="Some subheader text" />
+<KRadio :selected-value="true" v-model="radio" label="Label Example" description="Some subheader text" />
 
 ### selectedValue
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -48,6 +48,16 @@ export default defineComponent({
 
 Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-model` binds to the `modelValue` prop of the component and sets the current checked state of the input. You can read more about passing values via `v-model` [here](https://vuejs.org/guide/components/events.html#usage-with-v-model).
 
+### label
+
+Will place label text to the right of the checkbox. Can also be [slotted](#slots).
+
+```html
+<KRadio v-model="checked" :label="checked ? 'checked' : 'unchecked'" />
+```
+
+<KRadio v-model="labelPropChecked" :label="labelPropChecked ? 'checked' : 'unchecked'" />
+
 ### selectedValue
 
 The value of the `KRadio` option that will be emitted by the `change` and `update:modelValue` events.

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -10,7 +10,9 @@
       class="k-input"
       @change="handleChange"
     >
-    <slot />
+    <span v-if="(label || $slots.label)">
+      <slot name="label">{{ label }}</slot>
+    </span>
   </label>
 </template>
 
@@ -28,6 +30,13 @@ export default defineComponent({
       type: Boolean,
       default: false,
       required: true,
+    },
+    /**
+     * Overrides default label text
+     */
+    label: {
+      type: String,
+      default: '',
     },
   },
   emits: ['input', 'change', 'update:modelValue'],

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -105,8 +105,6 @@ export default defineComponent({
   font-size: var(--type-sm, type(sm));
   line-height: 20px;
   color: var(--black-45, rgba(0, 0, 0, 0.45));
-
-  /* Inside auto layout */
   flex: none;
   order: 1;
   flex-grow: 0;

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -14,7 +14,7 @@
       v-if="(label || $slots.label)"
       class="k-checkbox-label"
     >
-      <slot name="label">{{ label }}</slot>
+      <slot>{{ label }}</slot>
     </span>
     <div
       v-if="(label || $slots.label) && (description || $slots.description)"
@@ -85,19 +85,13 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-checkbox-label {
-  /* Body/Popover Content - Regular - 400 */
   font-style: normal;
   font-weight: 400;
-  font-size: 14px;
+  font-size: var(--type-sm, type(sm));;
   line-height: 20px;
-  /* identical to box height, or 143% */
   display: inline-block;
   align-items: center;
-
-  /* Black/85 */
   color: var(--black-85, rgba(0, 0, 0, 0.85));
-
-  /* Inside auto layout */
   flex: none;
   order: 0;
   flex-grow: 0;
@@ -106,14 +100,10 @@ export default defineComponent({
 .k-checkbox-description {
   padding-top: var(--spacing-xxs);
   padding-left: var(--spacing-lg);
-  /* Body/Popover Content - Regular - 400 */
   font-style: normal;
   font-weight: 400;
-  font-size: 14px;
+  font-size: var(--type-sm, type(sm));
   line-height: 20px;
-  /* identical to box height, or 143% */
-
-  /* Black/45 */
   color: var(--black-45, rgba(0, 0, 0, 0.45));
 
   /* Inside auto layout */
@@ -123,21 +113,13 @@ export default defineComponent({
 }
 
 .k-checkbox-label:has(+ .k-checkbox-description) {
-  /* Headline/H4 - Semibold - 600
-  .type-sm
-  */
   font-style: normal;
   font-weight: 600;
-  font-size: 14px;
+  font-size: var(--type-sm, type(sm));
   line-height: 18px;
-  /* identical to box height, or 129% */
   display: inline-block;
   align-items: center;
-
-  /* Black/85 */
   color: var(--black-85, rgba(0, 0, 0, 0.85));
-
-  /* Inside auto layout */
   flex: none;
   order: 0;
   flex-grow: 0;

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -130,4 +130,30 @@ export default defineComponent({
   flex-grow: 0;
 }
 
+.k-checkbox-label:has(+ .k-checkbox-description) {
+  /* Label Example */
+  width: 98px;
+  height: 18px;
+
+  /* Headline/H4 - Semibold - 600
+  .type-sm
+  */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 18px;
+  /* identical to box height, or 129% */
+  display: inline-block;
+  align-items: center;
+
+  /* Black/85 */
+  color: rgba(0, 0, 0, 0.85);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+}
+
 </style>

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -85,12 +85,7 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-checkbox-label {
-  /* Label Example */
-  width: 96px;
-  height: 20px;
-
   /* Body/Popover Content - Regular - 400 */
-  font-family: 'Inter';
   font-style: normal;
   font-weight: 400;
   font-size: 14px;
@@ -100,7 +95,7 @@ export default defineComponent({
   align-items: center;
 
   /* Black/85 */
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--black-85, rgba(0, 0, 0, 0.85));
 
   /* Inside auto layout */
   flex: none;
@@ -109,12 +104,9 @@ export default defineComponent({
 }
 
 .k-checkbox-description {
-  /* Some subheader text */
-  width: 142px;
-  height: 20px;
-
+  padding-top: var(--spacing-xxs);
+  padding-left: var(--spacing-lg);
   /* Body/Popover Content - Regular - 400 */
-  font-family: 'Inter';
   font-style: normal;
   font-weight: 400;
   font-size: 14px;
@@ -122,7 +114,7 @@ export default defineComponent({
   /* identical to box height, or 143% */
 
   /* Black/45 */
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--black-45, rgba(0, 0, 0, 0.45));
 
   /* Inside auto layout */
   flex: none;
@@ -131,14 +123,9 @@ export default defineComponent({
 }
 
 .k-checkbox-label:has(+ .k-checkbox-description) {
-  /* Label Example */
-  width: 98px;
-  height: 18px;
-
   /* Headline/H4 - Semibold - 600
   .type-sm
   */
-  font-family: 'Inter';
   font-style: normal;
   font-weight: 600;
   font-size: 14px;
@@ -148,7 +135,7 @@ export default defineComponent({
   align-items: center;
 
   /* Black/85 */
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--black-85, rgba(0, 0, 0, 0.85));
 
   /* Inside auto layout */
   flex: none;

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -10,10 +10,16 @@
       class="k-input"
       @change="handleChange"
     >
-    <span v-if="(label || $slots.label)">
+    <span
+      v-if="(label || $slots.label)"
+      class="k-checkbox-label"
+    >
       <slot name="label">{{ label }}</slot>
     </span>
-    <div v-if="(description || $slots.description)">
+    <div
+      v-if="(label || $slots.label) && (description || $slots.description)"
+      class="k-checkbox-description"
+    >
       <slot name="description">{{ description }}</slot>
     </div>
   </label>
@@ -39,14 +45,14 @@ export default defineComponent({
      */
     label: {
       type: String,
-      default: 'amushdee',
+      default: '',
     },
     /**
      * Overrides default description text
      */
     description: {
       type: String,
-      default: 'gampushkii',
+      default: '',
     },
   },
   emits: ['input', 'change', 'update:modelValue'],
@@ -77,5 +83,77 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import '@/styles/variables';
 @import '@/styles/functions';
+
+.k-checkbox-label {
+  /* Label Example */
+  width: 96px;
+  height: 20px;
+
+  /* Body/Popover Content - Regular - 400 */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  /* identical to box height, or 143% */
+  display: flex;
+  align-items: center;
+
+  /* Black/85 */
+  color: rgba(0, 0, 0, 0.85);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+
+  .k-checkbox-label + .k-checkbox-description {
+    /* Label Example */
+    width: 98px;
+    height: 18px;
+
+    /* Headline/H4 - Semibold - 600
+    .type-sm
+    */
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 18px;
+    /* identical to box height, or 129% */
+    display: flex;
+    align-items: center;
+
+    /* Black/85 */
+    color: rgba(0, 0, 0, 0.85);
+
+    /* Inside auto layout */
+    flex: none;
+    order: 0;
+    flex-grow: 0;
+  }
+}
+
+.k-checkbox-description {
+  /* Some subheader text */
+  width: 142px;
+  height: 20px;
+
+  /* Body/Popover Content - Regular - 400 */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  /* identical to box height, or 143% */
+
+  /* Black/45 */
+  color: rgba(0, 0, 0, 0.45);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 1;
+  flex-grow: 0;
+}
 
 </style>

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -13,6 +13,9 @@
     <span v-if="(label || $slots.label)">
       <slot name="label">{{ label }}</slot>
     </span>
+    <div v-if="(description || $slots.description)">
+      <slot name="description">{{ description }}</slot>
+    </div>
   </label>
 </template>
 
@@ -36,7 +39,14 @@ export default defineComponent({
      */
     label: {
       type: String,
-      default: '',
+      default: 'amushdee',
+    },
+    /**
+     * Overrides default description text
+     */
+    description: {
+      type: String,
+      default: 'gampushkii',
     },
   },
   emits: ['input', 'change', 'update:modelValue'],

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -106,32 +106,6 @@ export default defineComponent({
   flex: none;
   order: 0;
   flex-grow: 0;
-
-  .k-checkbox-label + .k-checkbox-description {
-    /* Label Example */
-    width: 98px;
-    height: 18px;
-
-    /* Headline/H4 - Semibold - 600
-    .type-sm
-    */
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 18px;
-    /* identical to box height, or 129% */
-    display: flex;
-    align-items: center;
-
-    /* Black/85 */
-    color: rgba(0, 0, 0, 0.85);
-
-    /* Inside auto layout */
-    flex: none;
-    order: 0;
-    flex-grow: 0;
-  }
 }
 
 .k-checkbox-description {

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -96,7 +96,7 @@ export default defineComponent({
   font-size: 14px;
   line-height: 20px;
   /* identical to box height, or 143% */
-  display: flex;
+  display: inline-block;
   align-items: center;
 
   /* Black/85 */

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -88,35 +88,19 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-checkbox-label {
-  font-style: normal;
-  font-weight: 400;
   font-size: var(--type-sm, type(sm));;
-  line-height: 20px;
-  display: inline-block;
-  align-items: center;
-  color: var(--black-85, rgba(0, 0, 0, 0.85));
-  flex: none;
-  order: 0;
-  flex-grow: 0;
 }
 
 .k-checkbox-description {
   padding-top: var(--spacing-xxs);
   padding-left: var(--spacing-lg);
-  font-style: normal;
-  font-weight: 400;
   font-size: var(--type-sm, type(sm));
   line-height: 20px;
   color: var(--black-45, rgba(0, 0, 0, 0.45));
-  flex: none;
-  order: 1;
-  flex-grow: 0;
 }
 
 .k-checkbox-label:has(+ .k-checkbox-description) {
   font-weight: 600;
-  line-height: 18px;
-  color: var(--black-85, rgba(0, 0, 0, 0.85));
 }
 
 </style>

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -11,13 +11,13 @@
       @change="handleChange"
     >
     <span
-      v-if="(label || $slots.label)"
+      v-if="hasLabel"
       class="k-checkbox-label"
     >
       <slot>{{ label }}</slot>
     </span>
     <div
-      v-if="(label || $slots.label) && (description || $slots.description)"
+      v-if="hasLabel && (description || $slots.description)"
       class="k-checkbox-description"
     >
       <slot name="description">{{ description }}</slot>
@@ -56,7 +56,9 @@ export default defineComponent({
     },
   },
   emits: ['input', 'change', 'update:modelValue'],
-  setup(props, { emit, attrs }) {
+  setup(props, { slots, emit, attrs }) {
+    const hasLabel = computed((): boolean => !!(props.label || slots.label))
+
     const handleChange = (e: any): void => {
       emit('change', e.target.checked)
       emit('input', e.target.checked)
@@ -73,6 +75,7 @@ export default defineComponent({
     })
 
     return {
+      hasLabel,
       modifiedAttrs,
       handleChange,
     }
@@ -111,16 +114,9 @@ export default defineComponent({
 }
 
 .k-checkbox-label:has(+ .k-checkbox-description) {
-  font-style: normal;
   font-weight: 600;
-  font-size: var(--type-sm, type(sm));
   line-height: 18px;
-  display: inline-block;
-  align-items: center;
   color: var(--black-85, rgba(0, 0, 0, 0.85));
-  flex: none;
-  order: 0;
-  flex-grow: 0;
 }
 
 </style>

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -140,4 +140,30 @@ export default defineComponent({
   flex-grow: 0;
 }
 
+.k-radio-label:has(+ .k-radio-description) {
+  /* Label Example */
+  width: 98px;
+  height: 18px;
+
+  /* Headline/H4 - Semibold - 600
+  .type-sm
+  */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 18px;
+  /* identical to box height, or 129% */
+  display: inline-block;
+  align-items: center;
+
+  /* Black/85 */
+  color: rgba(0, 0, 0, 0.85);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+}
+
 </style>

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -106,7 +106,7 @@ export default defineComponent({
   font-size: 14px;
   line-height: 20px;
   /* identical to box height, or 143% */
-  display: flex;
+  display: inline-block;
   align-items: center;
 
   /* Black/85 */

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -98,35 +98,19 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-radio-label {
-  font-style: normal;
-  font-weight: 400;
   font-size: var(--type-sm, type(sm));
-  line-height: 20px;
-  display: inline-block;
-  align-items: center;
-  color: var(--black-85, rgba(0, 0, 0, 0.85));
-  flex: none;
-  order: 0;
-  flex-grow: 0;
 }
 
 .k-radio-description {
   padding-top: var(--spacing-xxs);
   padding-left: var(--spacing-lg);
-  font-style: normal;
-  font-weight: 400;
   font-size: var(--type-sm, type(sm));
   line-height: 20px;
   color: var(--black-45, rgba(0, 0, 0, 0.45));
-  flex: none;
-  order: 1;
-  flex-grow: 0;
 }
 
 .k-radio-label:has(+ .k-radio-description) {
   font-weight: 600;
-  line-height: 18px;
-  color: var(--black-85, rgba(0, 0, 0, 0.85));
 }
 
 </style>

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -11,13 +11,13 @@
       @click="handleClick"
     >
     <span
-      v-if="(label || $slots.label)"
+      v-if="hasLabel"
       class="k-radio-label"
     >
       <slot>{{ label }}</slot>
     </span>
     <div
-      v-if="(label || $slots.label) && (description || $slots.description)"
+      v-if="hasLabel && (description || $slots.description)"
       class="k-radio-description"
     >
       <slot name="description">{{ description }}</slot>
@@ -64,7 +64,9 @@ export default defineComponent({
     },
   },
   emits: ['change', 'update:modelValue'],
-  setup(props, { emit, attrs }) {
+  setup(props, { slots, emit, attrs }) {
+    const hasLabel = computed((): boolean => !!(props.label || slots.label))
+
     const isSelected = computed((): boolean => props.selectedValue === props.modelValue)
 
     const handleClick = (): void => {
@@ -82,6 +84,7 @@ export default defineComponent({
     })
 
     return {
+      hasLabel,
       isSelected,
       modifiedAttrs,
       handleClick,
@@ -121,16 +124,9 @@ export default defineComponent({
 }
 
 .k-radio-label:has(+ .k-radio-description) {
-  font-style: normal;
   font-weight: 600;
-  font-size: var(--type-sm, type(sm));
   line-height: 18px;
-  display: inline-block;
-  align-items: center;
   color: var(--black-85, rgba(0, 0, 0, 0.85));
-  flex: none;
-  order: 0;
-  flex-grow: 0;
 }
 
 </style>

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -10,6 +10,9 @@
       class="k-input"
       @click="handleClick"
     >
+    <span v-if="(label || $slots.label)">
+      <slot name="label">{{ label }}</slot>
+    </span>
     <slot />
   </label>
 </template>
@@ -28,6 +31,13 @@ export default defineComponent({
       type: [String, Number, Boolean, Object],
       default: 'on',
       required: true,
+    },
+    /**
+     * Overrides default label text
+     */
+    label: {
+      type: String,
+      default: '',
     },
     /**
      * The value emitted from the radio on change if selected

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -14,7 +14,7 @@
       v-if="(label || $slots.label)"
       class="k-radio-label"
     >
-      <slot name="label">{{ label }}</slot>
+      <slot>{{ label }}</slot>
     </span>
     <div
       v-if="(label || $slots.label) && (description || $slots.description)"
@@ -95,19 +95,13 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-radio-label {
-  /* Body/Popover Content - Regular - 400 */
   font-style: normal;
   font-weight: 400;
-  font-size: 14px;
+  font-size: var(--type-sm, type(sm));
   line-height: 20px;
-  /* identical to box height, or 143% */
   display: inline-block;
   align-items: center;
-
-  /* Black/85 */
   color: var(--black-85, rgba(0, 0, 0, 0.85));
-
-  /* Inside auto layout */
   flex: none;
   order: 0;
   flex-grow: 0;
@@ -116,38 +110,24 @@ export default defineComponent({
 .k-radio-description {
   padding-top: var(--spacing-xxs);
   padding-left: var(--spacing-lg);
-  /* Body/Popover Content - Regular - 400 */
   font-style: normal;
   font-weight: 400;
-  font-size: 14px;
+  font-size: var(--type-sm, type(sm));
   line-height: 20px;
-  /* identical to box height, or 143% */
-
-  /* Black/45 */
   color: var(--black-45, rgba(0, 0, 0, 0.45));
-
-  /* Inside auto layout */
   flex: none;
   order: 1;
   flex-grow: 0;
 }
 
 .k-radio-label:has(+ .k-radio-description) {
-  /* Headline/H4 - Semibold - 600
-  .type-sm
-  */
   font-style: normal;
   font-weight: 600;
-  font-size: 14px;
+  font-size: var(--type-sm, type(sm));
   line-height: 18px;
-  /* identical to box height, or 129% */
   display: inline-block;
   align-items: center;
-
-  /* Black/85 */
   color: var(--black-85, rgba(0, 0, 0, 0.85));
-
-  /* Inside auto layout */
   flex: none;
   order: 0;
   flex-grow: 0;

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -13,6 +13,9 @@
     <span v-if="(label || $slots.label)">
       <slot name="label">{{ label }}</slot>
     </span>
+    <div v-if="(description || $slots.description)">
+      <slot name="description">{{ description }}</slot>
+    </div>
     <slot />
   </label>
 </template>
@@ -38,6 +41,13 @@ export default defineComponent({
     label: {
       type: String,
       default: '',
+    },
+    /**
+     * Overrides default description text
+     */
+    description: {
+      type: String,
+      default: 'gampushkii',
     },
     /**
      * The value emitted from the radio on change if selected

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -95,12 +95,7 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-radio-label {
-  /* Label Example */
-  width: 96px;
-  height: 20px;
-
   /* Body/Popover Content - Regular - 400 */
-  font-family: 'Inter';
   font-style: normal;
   font-weight: 400;
   font-size: 14px;
@@ -110,7 +105,7 @@ export default defineComponent({
   align-items: center;
 
   /* Black/85 */
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--black-85, rgba(0, 0, 0, 0.85));
 
   /* Inside auto layout */
   flex: none;
@@ -119,12 +114,9 @@ export default defineComponent({
 }
 
 .k-radio-description {
-  /* Some subheader text */
-  width: 142px;
-  height: 20px;
-
+  padding-top: var(--spacing-xxs);
+  padding-left: var(--spacing-lg);
   /* Body/Popover Content - Regular - 400 */
-  font-family: 'Inter';
   font-style: normal;
   font-weight: 400;
   font-size: 14px;
@@ -132,7 +124,7 @@ export default defineComponent({
   /* identical to box height, or 143% */
 
   /* Black/45 */
-  color: rgba(0, 0, 0, 0.45);
+  color: var(--black-45, rgba(0, 0, 0, 0.45));
 
   /* Inside auto layout */
   flex: none;
@@ -141,14 +133,9 @@ export default defineComponent({
 }
 
 .k-radio-label:has(+ .k-radio-description) {
-  /* Label Example */
-  width: 98px;
-  height: 18px;
-
   /* Headline/H4 - Semibold - 600
   .type-sm
   */
-  font-family: 'Inter';
   font-style: normal;
   font-weight: 600;
   font-size: 14px;
@@ -158,7 +145,7 @@ export default defineComponent({
   align-items: center;
 
   /* Black/85 */
-  color: rgba(0, 0, 0, 0.85);
+  color: var(--black-85, rgba(0, 0, 0, 0.85));
 
   /* Inside auto layout */
   flex: none;

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -10,10 +10,16 @@
       class="k-input"
       @click="handleClick"
     >
-    <span v-if="(label || $slots.label)">
+    <span
+      v-if="(label || $slots.label)"
+      class="k-radio-label"
+    >
       <slot name="label">{{ label }}</slot>
     </span>
-    <div v-if="(description || $slots.description)">
+    <div
+      v-if="(label || $slots.label) && (description || $slots.description)"
+      class="k-radio-description"
+    >
       <slot name="description">{{ description }}</slot>
     </div>
     <slot />
@@ -47,7 +53,7 @@ export default defineComponent({
      */
     description: {
       type: String,
-      default: 'gampushkii',
+      default: '',
     },
     /**
      * The value emitted from the radio on change if selected
@@ -87,5 +93,77 @@ export default defineComponent({
 <style lang="scss" scoped>
 @import '@/styles/variables';
 @import '@/styles/functions';
+
+.k-radio-label {
+  /* Label Example */
+  width: 96px;
+  height: 20px;
+
+  /* Body/Popover Content - Regular - 400 */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  /* identical to box height, or 143% */
+  display: flex;
+  align-items: center;
+
+  /* Black/85 */
+  color: rgba(0, 0, 0, 0.85);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+}
+
+.k-radio-label + .k-radio-description {
+  /* Label Example */
+  width: 98px;
+  height: 18px;
+
+  /* Headline/H4 - Semibold - 600
+  .type-sm
+  */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 18px;
+  /* identical to box height, or 129% */
+  display: flex;
+  align-items: center;
+
+  /* Black/85 */
+  color: rgba(0, 0, 0, 0.85);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+}
+
+.k-radio-description {
+  /* Some subheader text */
+  width: 142px;
+  height: 20px;
+
+  /* Body/Popover Content - Regular - 400 */
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  /* identical to box height, or 143% */
+
+  /* Black/45 */
+  color: rgba(0, 0, 0, 0.45);
+
+  /* Inside auto layout */
+  flex: none;
+  order: 1;
+  flex-grow: 0;
+}
 
 </style>

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -118,32 +118,6 @@ export default defineComponent({
   flex-grow: 0;
 }
 
-.k-radio-label + .k-radio-description {
-  /* Label Example */
-  width: 98px;
-  height: 18px;
-
-  /* Headline/H4 - Semibold - 600
-  .type-sm
-  */
-  font-family: 'Inter';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 18px;
-  /* identical to box height, or 129% */
-  display: flex;
-  align-items: center;
-
-  /* Black/85 */
-  color: rgba(0, 0, 0, 0.85);
-
-  /* Inside auto layout */
-  flex: none;
-  order: 0;
-  flex-grow: 0;
-}
-
 .k-radio-description {
   /* Some subheader text */
   width: 142px;


### PR DESCRIPTION
Update KRadio and KCheckbox to support a label with description text

### KRadio Label with Description
<img width="1496" alt="Screen Shot 2022-11-14 at 3 13 07 PM" src="https://user-images.githubusercontent.com/2568272/201788098-1093210f-72fc-459a-a657-18f5471a9dff.png">


### KCheckbox Label with Description
<img width="1524" alt="Screen Shot 2022-11-14 at 3 12 49 PM" src="https://user-images.githubusercontent.com/2568272/201788086-049f22e1-2401-4ba0-942d-4af3f87cd749.png">

# Summary

* Added support for a label along with description subtext for both KRadio and KCheckbox.
* Also updated docs with examples.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
