### PR TITLE
fix(kselect): vertical alignment for arrow icon

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -727,6 +727,7 @@ export default defineComponent({
     }
 
     .kong-icon {
+      display: inline-flex;
       &.overlay-label-chevron {
         margin-top: 25px;
       }


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Fixed a style bug that the arrow icon of `KSelect` is not vertically centered:

<img width="353" alt="image" src="https://user-images.githubusercontent.com/10095631/201587162-7cec28ef-8568-4d08-9999-00068fb675db.png">

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
