### PR TITLE
fix(kpop): disallow vue animation classes [KHCP-5349]

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -468,6 +468,14 @@ export default defineComponent({
   box-shadow: 0px 4px 20px var(--black-10);
   padding: var(--KPopPaddingY, 28px) var(--KPopPaddingX, var(--spacing-md, spacing(md)));
 
+  // Prevent Vue animation classes from impacting the positioning of the popover
+  &.fade-enter-active,
+  &.fade-enter-to,
+  &.fade-leave-active,
+  &.fade-leave-to {
+    animation: none !important;
+  }
+
   .k-popover-header {
     align-items: baseline;
     margin-bottom: 28px;


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Vue transition classes are impacting the placement of KPop `.k-popover` elements. Needs something like this:

```scss
&.fade-enter-active,
&.fade-enter-to,
&.fade-leave-active,
&.fade-leave-to {
  animation: none !important;
}
```

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
