### PR TITLE
fix(kcodeblock): code-block-render event being emitted too soon

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -262,6 +262,8 @@ The `KCodeBlock` component does not have syntax highlighting built in; however, 
 
 Below is an integration example for the popular syntax highlighting library [PrismJS](https://prismjs.com/).
 
+It makes use of the [`code-block-render` event](#code-block-render) to apply syntax highlighting.
+
 ```html
 <template>
   <KCodeBlock
@@ -311,11 +313,9 @@ const isProcessing = ref(false)
 /**
  * Applies PrismJS syntax highlighting.
  *
- * **Note**: In order for plugins to work,
- * a higher level function like `Prism.highlightElement`
- * or `Prism.highlightAll` **must** be used.
- * A lower level function like `Prism.highlight`
- * does not call Prism’s hooks which make plugins to work.
+ * **Note**: Use higher-level functions like `Prism.highlightElement` for highlighting.
+ * Lower-level functions like `Prism.highlight` don’t run any of the hooks
+ * that are used to make plugins work.
  */
 function highlight({ preElement, codeElement, language, code }) {
   isProcessing.value = true

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -433,7 +433,11 @@ const filteredCode = computed(function() {
     .join('\n')
 })
 
-watch(() => props.code, function() {
+watch(() => props.code, async function() {
+  // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.
+  await nextTick()
+
+  // Changing the code causes the code block to be re-rendered.
   emitCodeBlockRenderEvent()
   updateMatchingLineNumbers()
 })
@@ -450,10 +454,10 @@ watch(() => isShowingFilteredCode.value, async function() {
   }
 
   if (!isShowingFilteredCode.value) {
-    // Waits one Vue tick in which the full code block is re-rendered after switching off filter mode. Only then does it make sense to emit the corresponding event.
+  // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.
     await nextTick()
 
-    // Turning off filter mode causes the full code block to be re-rendered
+    // Turning off filter mode causes the full code block to be re-rendered.
     emitCodeBlockRenderEvent()
     updateMatchingLineNumbers()
   }


### PR DESCRIPTION
# Summary

Fixes a small issue with the `code-block-render` event being emitted before re-rendering is actually done. This is only an issue **when changing the `props.code`** as the event is already delayed by one Vue tick when turning off filter mode and doesn’t need to be delayed when emitting the event as part of the `mounted` life cycle hook.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
