### PR TITLE
fix(kradio, kcheckbox): use default slot to compute hasLabel [KHCP-4339]

### DIFF
--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -57,7 +57,7 @@ export default defineComponent({
   },
   emits: ['input', 'change', 'update:modelValue'],
   setup(props, { slots, emit, attrs }) {
-    const hasLabel = computed((): boolean => !!(props.label || slots.label))
+    const hasLabel = computed((): boolean => !!(props.label || slots.default))
 
     const handleChange = (e: any): void => {
       emit('change', e.target.checked)

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -65,7 +65,7 @@ export default defineComponent({
   },
   emits: ['change', 'update:modelValue'],
   setup(props, { slots, emit, attrs }) {
-    const hasLabel = computed((): boolean => !!(props.label || slots.label))
+    const hasLabel = computed((): boolean => !!(props.label || slots.default))
 
     const isSelected = computed((): boolean => props.selectedValue === props.modelValue)
 

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -65,7 +65,7 @@ export default defineComponent({
   },
   emits: ['change', 'update:modelValue'],
   setup(props, { slots, emit, attrs }) {
-    const hasLabel = computed((): boolean => !!(props.label || slots.default))
+    const hasLabel = computed((): boolean => !!(props.label || slots.label))
 
     const isSelected = computed((): boolean => props.selectedValue === props.modelValue)
 

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -22,7 +22,6 @@
     >
       <slot name="description">{{ description }}</slot>
     </div>
-    <slot />
   </label>
 </template>
 
@@ -65,7 +64,7 @@ export default defineComponent({
   },
   emits: ['change', 'update:modelValue'],
   setup(props, { slots, emit, attrs }) {
-    const hasLabel = computed((): boolean => !!(props.label || slots.label))
+    const hasLabel = computed((): boolean => !!(props.label || slots.default))
 
     const isSelected = computed((): boolean => props.selectedValue === props.modelValue)
 


### PR DESCRIPTION
# Summary
Use default slot to compute hasLabel so default slot is rendered, verified in KCheckbox & KRadio docs (screenshots below).

Ticket: https://konghq.atlassian.net/browse/KHCP-4339

### KCheckbox default slot rendered as expected
<img width="1492" alt="Screen Shot 2022-11-16 at 9 43 42 AM" src="https://user-images.githubusercontent.com/2568272/202254502-838eae87-ec0b-4706-abf2-9ed6f671b812.png">

### KRadio default slot rendered as expected
<img width="1490" alt="Screen Shot 2022-11-16 at 9 43 55 AM" src="https://user-images.githubusercontent.com/2568272/202254505-f04c6095-b2bc-433b-8887-f857e21226d9.png">

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
