### PR TITLE
fix(select-input): update background issue styles [khcp-5396]

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -56,8 +56,8 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 Enable this prop to overlay the label on the input element's border. Defaults to `false`.
 Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
 
-<KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />
-<KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" />
+<KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" class="mt-5" />
+<KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" class="mt-5" />
 
 ```html
 <KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -54,10 +54,10 @@ The label for the select.
 
 Enable this prop to overlay the label on the input element's border for `select` and `dropdown` appearances. Defaults to `false`.
 
-<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
-<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" />
-<KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
-<KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
+<KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
+<KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
+<KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
 
 ```html
 <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="items" />

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -6,7 +6,6 @@
     <div
       v-if="label && overlayLabel"
       :class="`k-input-label-wrapper-${size}`"
-      class="mt-5"
     >
       <div class="text-on-input">
         <label

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -882,7 +882,7 @@ export default defineComponent({
     }
 
     .k-multiselect-clear-icon {
-      position: relative;
+      position: absolute;
       top: 8px;
       right: 10px;
     }
@@ -914,7 +914,6 @@ export default defineComponent({
     .k-multiselect-input {
       position: relative;
       display: inline-block;
-      width: 100%;
     }
   }
 }
@@ -936,7 +935,6 @@ export default defineComponent({
       }
 
       input.k-input:not([type="checkbox"]):not([type="radio"]) {
-        background-color: transparent;
         // slightly smaller than container so we can see
         // the container's box-shadow
         height: calc(100% - 2px);

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -109,6 +109,13 @@
                 size="18"
               />
             </KButton>
+            <KIcon
+              v-if="appearance === 'select'"
+              icon="chevronDown"
+              color="var(--grey-500)"
+              size="18"
+              :class="{ 'overlay-label-chevron': overlayLabel }"
+            />
             <KInput
               :id="selectTextId"
               v-bind="modifiedAttrs"
@@ -129,13 +136,6 @@
               @update:model-value="onQueryChange"
               @focus="onInputFocus"
               @blur="onInputBlur"
-            />
-            <KIcon
-              v-if="appearance === 'select'"
-              icon="chevronDown"
-              color="var(--grey-500)"
-              size="18"
-              :class="{ 'overlay-label-chevron': overlayLabel }"
             />
           </div>
           <template #content>
@@ -647,7 +647,7 @@ export default defineComponent({
 
     &.overlay-label-item-selection {
       position: relative;
-      top: 15px;
+      top: -8px;
     }
 
     .selected-item-label {
@@ -701,6 +701,10 @@ export default defineComponent({
     display: inline-block;
     width: 100%;
 
+    .kong-icon-chevronDown {
+      margin-right: 10px;
+    }
+
     &.cursor-default {
       cursor: default;
     }
@@ -728,9 +732,6 @@ export default defineComponent({
 
     .kong-icon {
       display: inline-flex;
-      &.overlay-label-chevron {
-        margin-top: 25px;
-      }
     }
 
     .clear-selection-icon {
@@ -755,13 +756,11 @@ export default defineComponent({
     flex: 0 0 40%;
     display: flex;
     align-items: center;
-
-    .k-select-input {
-      margin-right: -25px;
-    }
+    flex-direction: row-reverse;
+    border: 1px solid var(--grey-300) !important;
 
     input.k-input {
-      background-color: transparent;
+      box-shadow: none !important;
     }
   }
 

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -31,10 +31,10 @@
 
   label {
     position: absolute;
-    top: -8px;
+    top: -16px;
     left: 13px;
     width: auto;
-    padding: 2px 4px;
+    padding: 1px 4px;
     z-index: 1;
 
     font-size: 11px;

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -31,18 +31,18 @@
 
   label {
     position: absolute;
-    top: -16px;
+    top: -8px;
     left: 13px;
     width: auto;
-    padding: 1px 4px;
+    padding: 2px 4px;
     z-index: 1;
-
+    line-height: 1; 
     font-size: 11px;
     font-weight: 500;
     color: var(--KInputBorder, var(--grey-600));
     background-color: var(--KInputBackground, var(--white));
     display: inline-block;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
     transition: color 0.1s ease;
   }
 }


### PR DESCRIPTION
Addresses:
[https://konghq.atlassian.net/browse/KHCP-5396](https://konghq.atlassian.net/browse/KHCP-5396)
# Summary

Issue:
Background color of KSelect kongponent:
![image 750](https://user-images.githubusercontent.com/87779967/202516764-5da952a3-86ed-4c33-aac2-51ad24731ef9.png)

Also fixes the overlay issue:
**Before:**
![image 754](https://user-images.githubusercontent.com/87779967/202726328-5f39e772-1a27-4121-a177-41c3879ceecf.png)

**After:**
![image 753](https://user-images.githubusercontent.com/87779967/202726326-aa8d39e8-e19d-49ec-b9bf-0e13e8ce9ae0.png)
`Note:` I have verified that things are looking as expected in all across Kongponents, I would appreciate a through functionality review for this PR. I tried to symlink but it is not working and can't check the impact of these updates across Konnect.

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
