### PR TITLE
fix(kpop): popoverTimeout prop

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -349,7 +349,9 @@ export default defineComponent({
   },
   methods: {
     hidePopper() {
-      this.isOpen = false
+      if (this.trigger !== 'hover') {
+        this.isOpen = false
+      }
 
       this.timer = setTimeout(() => {
         this.$emit('closed')


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
This PR fixes a bug that `popoverTimeout` prop does not work (popover disappears immediately after the mouse leaves no matter the value of `popoverTimeout`). I think this might be related to #835.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
