### PR TITLE
fix(kselect): remove box shadow on `.k-select-input`

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -699,15 +699,15 @@ export default defineComponent({
   }
 
   .k-select-input {
+    @include input-default;
     position: relative;
     display: inline-block;
     width: 100%;
     box-shadow: none !important;
-    @include input-default;
 
     &.is-readonly {
-      box-shadow: none !important;
       @include input-readonly;
+      box-shadow: none !important;
 
       &.select-input-container {
         input.k-input.form-control:not([type="checkbox"]):not([type="radio"]):not([type="file"]):read-only {


### PR DESCRIPTION
# Summary

The outer container of `KSelect` has a box shadow:

Default:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10095631/203709989-a6af2de9-978f-4fe2-a006-9702b24693da.png">

Hover:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10095631/203710025-722ddf01-3357-4f5d-8da6-a3b299bc9ffd.png">

Focus:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10095631/203710191-2944da24-be14-4e40-b773-5f332102fbed.png">


This PR removes this box shadow.


## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
