### PR TITLE
fix(kfileupload): hide native button in firefox [KHCP-5462]

### DIFF
--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -293,7 +293,7 @@ export default defineComponent({
     height: 29px;
   }
 
-  // To hide the thumbnail that appears in Safari after uploading a file
+  // To hide the button and thumbnail that appears in Safari and firefox after uploading a file
   :deep(.k-input-wrapper) input[type="file"]::-webkit-file-upload-button,
   :deep(.k-input-wrapper) input[type="file"]::file-selector-button {
     position: absolute;

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -294,7 +294,8 @@ export default defineComponent({
   }
 
   // To hide the thumbnail that appears in Safari after uploading a file
-  :deep(.k-input-wrapper) input[type="file"]::-webkit-file-upload-button {
+  :deep(.k-input-wrapper) input[type="file"]::-webkit-file-upload-button,
+  :deep(.k-input-wrapper) input[type="file"]::file-selector-button {
     position: absolute;
     min-width: 100%;
     min-height: 100%;


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Hides the native file upload button in Firefox

![image](https://user-images.githubusercontent.com/2229946/204547144-06fee241-c8fa-42a0-969a-bc2fd49a7eea.png)


## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
