### PR TITLE
fix(ktable): add a11y attributes

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -107,6 +107,7 @@
                 [sortColumnOrder]: !disableSorting && column.key === sortColumnKey && !column.hideLabel,
                 'is-scrolled': isScrolled
               }"
+              :aria-sort="!disableSorting && column.key === sortColumnKey ? (sortColumnOrder === 'asc' ? 'ascending' : 'descending') : undefined"
               @click="() => {
                 if (!disableSorting && column.sortable) {
                   $emit('sort', {
@@ -130,6 +131,7 @@
 
                 <KIcon
                   v-if="!disableSorting && !column.hideLabel && column.sortable"
+                  aria-hidden="true"
                   icon="chevronDown"
                   color="var(--KTableColor, var(--black-70, color(black-70)))"
                   size="12"


### PR DESCRIPTION
# Summary

This pull request adds accessibility attributes to KTable headers.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
