### PR TITLE
feat(kmodal): add focus trap support for better a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "axios": "^0.27.2",
     "date-fns": "^2.29.3",
     "date-fns-tz": "^1.3.7",
+    "focus-trap": "^7.1.0",
+    "focus-trap-vue": "^3.3.1",
     "popper.js": "^1.15.0",
     "swrv": "^1.0.0",
     "uuid": "^8.3.2",

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -6,94 +6,97 @@
     role="dialog"
     aria-modal="true"
   >
-    <div
-      class="k-modal-backdrop modal-backdrop"
-      @click="(evt) => close(false, evt)"
-    >
-      <div class="k-modal-dialog modal-dialog">
-        <div
-          v-if="hasHeaderImage && !hideDismissIcon"
-          class="close-button"
-        >
-          <KButton
-            class="non-visual-button"
-            aria-label="Close"
-            @click="close(true)"
-          >
-            <KIcon
-              icon="close"
-              :color="dismissButtonColor"
-              size="15"
-            />
-          </KButton>
-        </div>
-        <div class="k-modal-content modal-content">
+    <FocusTrap :active="isVisible">
+      <div
+        class="k-modal-backdrop modal-backdrop"
+        @click="(evt) => close(false, evt)"
+      >
+        <div class="k-modal-dialog modal-dialog">
           <div
-            v-if="hasHeaderImage"
-            class="k-modal-header-image d-flex"
+            v-if="hasHeaderImage && !hideDismissIcon"
+            class="close-button"
           >
-            <slot name="header-image" />
+            <KButton
+              class="non-visual-button"
+              aria-label="Close"
+              @click="close(true)"
+            >
+              <KIcon
+                icon="close"
+                :color="dismissButtonColor"
+                size="15"
+              />
+            </KButton>
           </div>
-          <div
-            v-if="$slots['header-content'] || !hideTitle"
-            role="heading"
-            aria-level="2"
-            :class="{
-              'header-left': textAlign === 'left',
-              'header-centered': textAlign === 'center',
-              'header-right': textAlign === 'right',
-              'mb-5': !hasHeaderImage,
-              'mb-4': hasHeaderImage
-            }"
-            class="k-modal-header modal-header"
-          >
-            <slot name="header-content">
-              {{ title }}
-            </slot>
-          </div>
-          <div
-            :class="{
-              'content-left': textAlign === 'left',
-              'content-centered': textAlign === 'center',
-              'content-right': textAlign === 'right',
-            }"
-            class="k-modal-body modal-body"
-          >
-            <slot name="body-content">
-              {{ content }}
-            </slot>
-          </div>
-          <div class="k-modal-footer modal-footer d-flex">
-            <slot name="footer-content">
-              <KButton
-                v-if="!hideCancelButton"
-                :appearance="cancelButtonAppearance"
-                @click="close(true)"
-                @keyup.esc="close(true)"
-              >
-                {{ cancelButtonText }}
-              </KButton>
-              <div class="k-modal-action-buttons">
-                <slot name="action-buttons">
-                  <KButton
-                    :appearance="actionButtonAppearance"
-                    @click="proceed"
-                    @keyup.enter="proceed"
-                  >
-                    {{ actionButtonText }}
-                  </KButton>
-                </slot>
-              </div>
-            </slot>
+          <div class="k-modal-content modal-content">
+            <div
+              v-if="hasHeaderImage"
+              class="k-modal-header-image d-flex"
+            >
+              <slot name="header-image" />
+            </div>
+            <div
+              v-if="$slots['header-content'] || !hideTitle"
+              role="heading"
+              aria-level="2"
+              :class="{
+                'header-left': textAlign === 'left',
+                'header-centered': textAlign === 'center',
+                'header-right': textAlign === 'right',
+                'mb-5': !hasHeaderImage,
+                'mb-4': hasHeaderImage
+              }"
+              class="k-modal-header modal-header"
+            >
+              <slot name="header-content">
+                {{ title }}
+              </slot>
+            </div>
+            <div
+              :class="{
+                'content-left': textAlign === 'left',
+                'content-centered': textAlign === 'center',
+                'content-right': textAlign === 'right',
+              }"
+              class="k-modal-body modal-body"
+            >
+              <slot name="body-content">
+                {{ content }}
+              </slot>
+            </div>
+            <div class="k-modal-footer modal-footer d-flex">
+              <slot name="footer-content">
+                <KButton
+                  v-if="!hideCancelButton"
+                  :appearance="cancelButtonAppearance"
+                  @click="close(true)"
+                  @keyup.esc="close(true)"
+                >
+                  {{ cancelButtonText }}
+                </KButton>
+                <div class="k-modal-action-buttons">
+                  <slot name="action-buttons">
+                    <KButton
+                      :appearance="actionButtonAppearance"
+                      @click="proceed"
+                      @keyup.enter="proceed"
+                    >
+                      {{ actionButtonText }}
+                    </KButton>
+                  </slot>
+                </div>
+              </slot>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </FocusTrap>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, computed, onMounted, onUnmounted, watchEffect } from 'vue'
+import { FocusTrap } from 'focus-trap-vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 
@@ -103,6 +106,7 @@ export default defineComponent({
   components: {
     KButton,
     KIcon,
+    FocusTrap,
   },
 
   props: {

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -6,7 +6,10 @@
     role="dialog"
     aria-modal="true"
   >
-    <FocusTrap :active="isVisible">
+    <FocusTrap
+      ref="focusTrap"
+      :active="false"
+    >
       <div
         class="k-modal-backdrop modal-backdrop"
         @click="(evt) => close(false, evt)"
@@ -95,7 +98,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, onMounted, onUnmounted, watchEffect } from 'vue'
+import { defineComponent, computed, nextTick, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { FocusTrap } from 'focus-trap-vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -208,6 +211,7 @@ export default defineComponent({
   emits: ['canceled', 'proceed'],
 
   setup(props, { emit, slots }) {
+    const focusTrap = ref<InstanceType<typeof FocusTrap> | null>(null)
     const hasHeaderImage = computed((): boolean => {
       return !!slots['header-image']
     })
@@ -249,6 +253,15 @@ export default defineComponent({
       }
     })
 
+    watch(() => props.isVisible, async (isVisible) => {
+      if (isVisible) {
+        await nextTick()
+        focusTrap.value?.activate()
+      } else {
+        focusTrap.value?.deactivate()
+      }
+    })
+
     onMounted(() => {
       document.addEventListener('keydown', handleKeydown)
 
@@ -269,6 +282,7 @@ export default defineComponent({
       dismissButtonColor,
       close,
       proceed,
+      focusTrap,
     }
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3273,6 +3273,18 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+focus-trap-vue@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-3.3.1.tgz#d7934f6569e7e09d7230f62f614cf3499e121b06"
+  integrity sha512-bsZXt0//ZpdvVbcR4KYq/n73XF57a31mHmiKT6FBdv9osqSAYmjbwmdxlytWO786nv8wbCxKZw+t87nYVstB4g==
+
+focus-trap@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.1.0.tgz#3226e977d76b1fd555c2e4f7ff91f10371f0f2cc"
+  integrity sha512-CuJvwUBfJCWcU6fc4xr3UwMF5vWnox4isXAixCwrPzCsPKOQjP9T+nTlYT2t+vOmQL8MOQ16eim99XhjQHAuiQ==
+  dependencies:
+    tabbable "^6.0.1"
+
 follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
@@ -6349,6 +6361,11 @@ swrv@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/swrv/-/swrv-1.0.1.tgz#06f4db51e7adc0c90acc23dcb8603a52be011e94"
   integrity sha512-FZMXK/mOp7LYBHrQ/zWnZXfoZ8ONrVV9eOJ4+p0OdEcsafLLrODPaeJFGDcI6CV/3o3J/t5GY9ozVGg10NC8ng==
+
+tabbable@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.0.1.tgz#427a09b13c83ae41eed3e88abb76a4af28bde1a6"
+  integrity sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==
 
 tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
   version "6.1.11"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR traps focus inside `<KModal>` for the sake of a11y, which fixes [a vpat violation](https://docs.google.com/spreadsheets/d/1JinlVfNFFvxCB2qug3YYc-wGhg8ptpF3/edit#gid=684765038&range=51:51):

<img width="623" alt="image" src="https://user-images.githubusercontent.com/10095631/204966600-b5f6e095-1b85-4085-8323-3c99e9807ed0.png">

I checked [vuetify](https://github.com/vuetifyjs/vuetify/blob/bb9412cb3efefd4852b3220705cc41ecfb4d438f/packages/vuetify/src/components/VDialog/VDialog.ts#L216-L217) and [element](https://github.com/element-plus/element-plus/blob/33ca7ee4f06febfd9bcec33bb66e62e27f0102c1/packages/components/dialog/src/dialog.vue#L28-L36), and they both trap focus inside modals, so I think this is something we should do in kongponents.

This PR introduces two new dependencies, resulting in a 5KB~ package size increase:
<img width="1168" alt="image" src="https://user-images.githubusercontent.com/10095631/204967183-48f5fb45-018d-4b90-93bf-6c0e90208a57.png">

Let me know what you think.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
