### PR TITLE
chore(percy): hide docs elements in percy

### DIFF
--- a/docs/.vitepress/theme/_percy.scss
+++ b/docs/.vitepress/theme/_percy.scss
@@ -2,7 +2,9 @@
 // https://docs.percy.io/docs/percy-specific-css#percy-css-media-query
 @media only percy {
   // Hide the `Last updated` timestamp on docs pages
-  .VPLastUpdated {
+  .VPLastUpdated,
+  // Hide the KDateTimePicker emitted value `pre` blocks
+  pre.json {
     visibility: hidden !important;
   }
 }

--- a/docs/.vitepress/theme/_percy.scss
+++ b/docs/.vitepress/theme/_percy.scss
@@ -1,0 +1,8 @@
+// Hide elements in percy
+
+@media only percy {
+  // Hide the `Last updated` timestamp on docs pages
+  .VPLastUpdated {
+    visibility: hidden !important;
+  }
+}

--- a/docs/.vitepress/theme/_percy.scss
+++ b/docs/.vitepress/theme/_percy.scss
@@ -1,5 +1,5 @@
 // Hide elements in percy
-
+// https://docs.percy.io/docs/percy-specific-css#percy-css-media-query
 @media only percy {
   // Hide the `Last updated` timestamp on docs pages
   .VPLastUpdated {

--- a/docs/.vitepress/theme/_percy.scss
+++ b/docs/.vitepress/theme/_percy.scss
@@ -3,6 +3,8 @@
 @media only percy {
   // Hide the `Last updated` timestamp on docs pages
   .VPLastUpdated,
+  // Hide the KDateTimePicker display value since it shows the current timestamp and always changes
+  .timepicker-display,
   // Only utilize this class in the `docs/*` directory -- do NOT utilize within the `src/*` directory files
   .hide-from-percy {
     visibility: hidden !important;

--- a/docs/.vitepress/theme/_percy.scss
+++ b/docs/.vitepress/theme/_percy.scss
@@ -3,8 +3,8 @@
 @media only percy {
   // Hide the `Last updated` timestamp on docs pages
   .VPLastUpdated,
-  // Hide the KDateTimePicker emitted value `pre` blocks
-  pre.json {
+  // Only utilize this class in the `docs/*` directory -- do NOT utilize within the `src/*` directory files
+  .hide-from-percy {
     visibility: hidden !important;
   }
 }

--- a/docs/.vitepress/theme/index.scss
+++ b/docs/.vitepress/theme/index.scss
@@ -2,6 +2,7 @@
 // https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css
 @import "./variables";
 @import "./overrides";
+@import "./percy";
 
 html,
 body {

--- a/docs/components/datetime-picker.md
+++ b/docs/components/datetime-picker.md
@@ -22,7 +22,7 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
     width="250"
     :range="false"
   />
-  <div class="mt-6">Emitted value: <pre class="json">{{ JSON.stringify(currentValue0) }}</pre></div>
+  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ JSON.stringify(currentValue0) }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -48,7 +48,7 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
     :minute-increment="5"
     :range="false"
   />
-  <div class="mt-6">Emitted value: <pre class="json">{{ JSON.stringify(emitVal3) }}</pre></div>
+  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ JSON.stringify(emitVal3) }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -75,7 +75,7 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
     :minute-increment="5"
     :range="true"
   />
-  <div class="mt-6">Emitted value: <pre class="json">{{ emitVal4 }}</pre></div>
+  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ emitVal4 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -109,7 +109,7 @@ This instance also makes use of the `minDate` and `maxDate` parameters, which ar
     :range="true"
     :time-periods="exampleTimeFrames"
   />
-  <div class="mt-6">Emitted value: <pre class="json">{{ emitVal5 }}</pre></div>
+  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ emitVal5 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -171,7 +171,7 @@ This instance also makes use of the `minDate` and `maxDate` parameters, which ar
     :range="true"
     :time-periods="exampleTimeFrames"
   />
-  <div class="mt-6">Emitted value: <pre class="json">{{ emitVal5 }}</pre></div>
+  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ emitVal5 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -230,7 +230,7 @@ This utilizes the same time frames as the previous example; however, in this exa
     :range="true"
     :time-periods="exampleTimeFrames"
   />
-  <div class="mt-6">Emitted value: <pre class="json">{{ emitVal6 }}</pre></div>
+  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ emitVal6 }}</pre></div>
 </ClientOnly>
 
 ```html


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Hide the "Last updated" timestamp on docs pages from Percy so it doesn't trigger a change.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
