### PR TITLE
fix(kbutton): btn-link styles [khcp-5475]

### DIFF
--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -405,7 +405,7 @@ export default defineComponent({
     &:focus-visible:disabled {
       border-radius: unset;
       text-decoration: none;
-      outline: Highlight auto 1px;
+      outline: auto 1px black;
       outline: -webkit-focus-ring-color auto 1px;
       outline-offset: 3px;
       transition: none;

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -407,7 +407,8 @@ export default defineComponent({
       text-decoration: none;
       outline: Highlight auto 1px;
       outline: -webkit-focus-ring-color auto 1px;
-      outline-offset: 2px;
+      outline-offset: 3px;
+      transition: none;
     }
 
     &:disabled,

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -387,15 +387,29 @@ export default defineComponent({
       color: var(--grey-400) !important;
     }
   }
+
   &.btn-link {
     color: var(--KButtonBtnLink, var(--blue-500, color(blue-500)));
     background-color: transparent;
+    padding: 0;
+
     &:hover:not(:disabled) {
       text-decoration: underline;
     }
+
     &:focus {
-      @include boxShadow(var(--KButtonOutlineBorder, var(--blue-500, color(blue-500))), 0, 2px);
+      text-decoration: underline;
     }
+
+    &:focus-visible,
+    &:focus-visible:disabled {
+      border-radius: unset;
+      text-decoration: none;
+      outline: Highlight auto 1px;
+      outline: -webkit-focus-ring-color auto 1px;
+      outline-offset: 2px;
+    }
+
     &:disabled,
     &[disabled] {
       color: var(--grey-400) !important;

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -405,7 +405,7 @@ export default defineComponent({
     &:focus-visible:disabled {
       border-radius: unset;
       text-decoration: none;
-      outline: auto 1px black;
+      outline: auto 1px;
       outline: -webkit-focus-ring-color auto 1px;
       outline-offset: 3px;
       transition: none;

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -690,6 +690,10 @@ export default defineComponent({
 @import '@/styles/mixins';
 @import '@/styles/functions';
 
+@mixin boxShadow($color, $whiteShadowSpred: 2px, $colorShadowSpread: 4px) {
+  box-shadow: 0 0 0 $whiteShadowSpred var(--white, color(white)), 0 0 0 $colorShadowSpread $color;
+}
+
 .k-select {
   .k-select-item-selection {
     .clear-selection-icon {
@@ -699,8 +703,17 @@ export default defineComponent({
     }
   }
 
-  .k-button .caret {
-    margin-left: auto;
+  .k-button.btn-link {
+    padding: var(--spacing-sm, spacing(sm)) var(--spacing-lg, spacing(lg));
+    text-decoration: none;
+
+    &:focus {
+      @include boxShadow(var(--KButtonOutlineBorder, var(--blue-500, color(blue-500))), 0, 2px);
+    }
+
+    .caret {
+      margin-left: auto;
+    }
   }
 
   .k-select-input {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Remove the padding on `btn-link` appearance buttons and apply outline for `:focus-visible`.
Addresses [KHCP-5475](https://konghq.atlassian.net/browse/KHCP-5475).

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
