### PR TITLE
fix(datetimepicker): store previously selected relative tf [MA-1122]

### DIFF
--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -170,6 +170,7 @@ export interface DateTimePickerState {
   hidePopover: boolean
   selectedRange: TimeRange
   selectedTimeframe: TimePeriod
+  previouslySelectedTimeframe: TimePeriod
   tabName: string
 }
 
@@ -339,6 +340,7 @@ export default defineComponent({
       hidePopover: false,
       selectedRange: { start: new Date(), end: new Date(), timePeriodsKey: '' },
       selectedTimeframe: props.timePeriods[0]?.values[0],
+      previouslySelectedTimeframe: props.timePeriods[0]?.values[0],
       tabName: 'relative',
     })
 
@@ -378,7 +380,7 @@ export default defineComponent({
      * @param {*} timeframe
      */
     const changeRelativeTimeframe = (timeframe: TimePeriod): void => {
-      state.selectedTimeframe = timeframe
+      state.selectedTimeframe = state.previouslySelectedTimeframe = timeframe
 
       // Format the start/end values as human readable date
       const start: Date = state.selectedTimeframe.start()
@@ -503,6 +505,13 @@ export default defineComponent({
     watch(selectedCalendarRange, (newValue, oldValue) => {
       if (newValue !== undefined && newValue !== oldValue) {
         changeCalendarRange(newValue)
+      }
+    }, { immediate: true })
+
+    watch(() => state.tabName, (newValue, oldValue) => {
+      // If the user has switched back to Relative time frames, update timepicker state
+      if (oldValue !== undefined && newValue === 'relative') {
+        changeRelativeTimeframe(state.previouslySelectedTimeframe)
       }
     }, { immediate: true })
 


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/MA-1122

### Bug explanation:
- Open up the date time picker, go to **Relative** tab; Click any Timeframe button (this saves the `timePeriodsKey` in `state.selectedRange`)
- Change tabs to **Custom** and make a range selection; this wipes out the saved `timePeriodsKey`
- Go back to **Relative** tab, take no action. Previous value is still shown, so you assume clicking on “Apply” will emit that value; but it does not 😭 

### Solution:
- Always keep track of the previously selected timeframe, and whenever the user chooses to click back to **Relative** tab, we simply update the state with that value


## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
