### PR TITLE
fix(kmodal): delay focus-trap activation

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, nextTick, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
+import { defineComponent, computed, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { FocusTrap } from 'focus-trap-vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -253,11 +253,18 @@ export default defineComponent({
       }
     })
 
-    watch(() => props.isVisible, async (isVisible) => {
+    let timer: number | null = null
+
+    watch(() => props.isVisible, (isVisible) => {
       if (isVisible) {
-        await nextTick()
-        focusTrap.value?.activate()
+        timer = setTimeout(() => {
+          focusTrap.value?.activate()
+        }, 200)
       } else {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
         focusTrap.value?.deactivate()
       }
     })


### PR DESCRIPTION
# Summary

Wait a bit longer to `activate` the FocusTrap.

This is because in KM unit tests, FocusTrap (somehow) cannot find its child nodes after `nextTick`.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
