### PR TITLE
fix(kmodal): add focus trap activation delay

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -273,7 +273,7 @@ export default defineComponent({
       }
     }, { immediate: true })
 
-    onMounted(async () => {
+    onMounted(() => {
       document.addEventListener('keydown', handleKeydown)
 
       if (props.isVisible) {
@@ -282,7 +282,7 @@ export default defineComponent({
       }
     })
 
-    onUnmounted(async () => {
+    onUnmounted(() => {
       document.removeEventListener('keydown', handleKeydown)
       // Reset body overflow
       document?.body?.classList.remove('k-modal-overflow-hidden')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
     include: [
       'cypress',
       'vue',
+      'focus-trap',
+      'focus-trap-vue',
     ],
   },
 })


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Add a delay for focus trap activation to ensure the focused element doesn't capture the event that caused the activation. Resolves #946.

## PR Checklist

* [X] Does not introduce dependencies
* [X] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [X] **Tests pass:** check the output of yarn test
* [X] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [X] **Framework style:** abides by the essential rules in Vue's style guide
* [X] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
