### PR TITLE
feat(ktabs): Remove bottom margin from all Tabs usage [KHCP-5439]

### DIFF
--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -99,7 +99,7 @@ export default defineComponent({
 .k-tabs {
   ul {
     display: flex;
-    margin-bottom: var(--spacing-md, spacing(md));
+    margin-bottom: 0;
     padding-left: 0;
     list-style: none;
     font-size: 18px;


### PR DESCRIPTION
Task in Jira: https://konghq.atlassian.net/browse/KHCP-5439

# Summary
- **Feat** - Set margin-bottom: 0

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
