### PR TITLE
fix(ksegmentedcontrol): disallow slot pointer events by default [MA-1189]

### DIFF
--- a/docs/components/segmented-control.md
+++ b/docs/components/segmented-control.md
@@ -80,6 +80,10 @@ You can pass in an optional flag to disable the control or an individual button 
 </KComponent>
 ```
 
+### allowPointerEvents
+
+By default, CSS `pointer-events` is set to `none` for the Segmented Control button slots. Set this prop to `true` to change the behavior to `pointer-events: auto`.
+
 ## Slots
 
 You can customize each option's content using the `option-label` slot. The option's data is provided as a slot param.

--- a/src/components/KSegmentedControl/KSegmentedControl.vue
+++ b/src/components/KSegmentedControl/KSegmentedControl.vue
@@ -1,6 +1,9 @@
 
 <template>
-  <div class="segmented-control d-flex">
+  <div
+    class="segmented-control d-flex"
+    :class="{ 'allow-pointer-events': allowPointerEvents}"
+  >
     <KButton
       v-for="option in options"
       :key="String(label(option))"
@@ -44,6 +47,10 @@ export default defineComponent({
       required: true,
     },
     isDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    allowPointerEvents: {
       type: Boolean,
       default: false,
     },
@@ -152,6 +159,12 @@ export default defineComponent({
       border-color: rgba(color(grey-500), .4);
       background-color: var(--KSegmentedControlUnselectedBackground, var(--white)) !important;
       z-index: 0;
+    }
+  }
+
+  &:not(.allow-pointer-events) {
+    :deep(.k-button) > * {
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION
# Summary

Adds an `allow-pointer-events` slot to `KSegmentedControl` (`false` by default) which disallows pointer events on the button slot content.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
