### PR TITLE
fix(ktreelist): remove alias from import path

### DIFF
--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -19,17 +19,18 @@ The value provided to `v-model` should adhere to all the same constraints of the
 :::
 
 <div>
-  <KLabel>Value:</KLabel> {{ myList }}
   <KTreeList class="mt-2" v-model="myList" />
   <br>
   <KButton @click="reset">Reset</KButton>
+  <div class="mt-6"><b>Value:</b> <pre class="json hide-from-percy">{{ JSON.stringify(myList) }}</pre></div>
 </div>
 
 ```html
 <template>
-  <KLabel>Value:</KLabel> {{ myList }}
   <KTreeList v-model="myList" />
   <KButton @click="reset">Reset</KButton>
+  <b>Value:</b>
+  <pre>{{ JSON.stringify(myList) }}</pre>
 </template>
 
 <script lang="ts" setup>
@@ -485,6 +486,14 @@ const handleChildChange = (data) => {
 </script>
 
 <style scoped lang="scss">
+pre.json {
+  font-size: var(--type-sm);
+  white-space: pre-wrap;
+  padding: 16px;
+  background-color: var(--grey-200);
+  border-radius: 8px;
+}
+
 .slot-example :deep(.k-tree-item) .k-tree-item-icon {
   line-height: 1.4;
 }

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -94,8 +94,6 @@ import type { TreeListItem } from './KTreeItem.vue'
 export const getMaximumDepth = ({ children = [] }): number => {
   return children.length === 0 ? 0 : 1 + Math.max(...children.map(getMaximumDepth))
 }
-
-export default {}
 </script>
 
 <script setup lang="ts">

--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -41,8 +41,6 @@ import KIcon from '@/components/KIcon/KIcon.vue'
 export const itemsHaveRequiredProps = (items: TreeListItem[]): boolean => {
   return items.every(i => i.name !== undefined && i.id !== undefined && (!i.children?.length || itemsHaveRequiredProps(i.children)))
 }
-
-export default {}
 </script>
 
 <script lang="ts" setup>

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -72,8 +72,6 @@ const itemsWithinMaximumDepth = (items: TreeListItem[], maxDepth: number): boole
 const treeListIsValid = (items: TreeListItem[]): boolean => {
   return itemsHaveRequiredProps(items) && itemIdsAreUnique(items)
 }
-
-export default {}
 </script>
 
 <script lang="ts" setup>

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -39,7 +39,7 @@ import { computed, ref, watch, onMounted, PropType } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import KTreeDraggable from '@/components/KTreeList/KTreeDraggable.vue'
 import { getMaximumDepth } from './KTreeDraggable.vue'
-import { TreeListItem, itemsHaveRequiredProps } from '@/components/KTreeList/KTreeItem.vue'
+import type { TreeListItem, itemsHaveRequiredProps } from './KTreeItem.vue'
 
 const getIds = (items: TreeListItem[], ids: string[]) => {
   items.forEach((item: TreeListItem) => {

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -39,7 +39,7 @@ import { computed, ref, watch, onMounted, PropType } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import KTreeDraggable from '@/components/KTreeList/KTreeDraggable.vue'
 import { getMaximumDepth } from './KTreeDraggable.vue'
-import type { TreeListItem, itemsHaveRequiredProps } from './KTreeItem.vue'
+import { TreeListItem, itemsHaveRequiredProps } from './KTreeItem.vue'
 
 const getIds = (items: TreeListItem[], ids: string[]) => {
   items.forEach((item: TreeListItem) => {


### PR DESCRIPTION
# Summary

The types inside of `KTreeList.vue` being imported from `KTreeItem.vue` were using the `@/` alias, which will break in consuming packages.

This PR updates the type import to not use the alias.

Also, all of the `KTreeList/` components had `export default {}` at the bottom of the script setup; I'm not sure why...? Removed.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
