### PR TITLE
feat(modal): add tabbable-options prop

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -200,6 +200,9 @@ Can be `dark` (default) or `light`. You might want to use this if displaying dar
 </KModal>
 ```
 
+### tabbableOptions
+Options to be passed to [`focus-trap`](https://github.com/focus-trap/focus-trap), which is responsible for trapping focus inside the modal box. If you're experiencing issues with testing `<KModal>` in `jsdom`, you can pass this prop according to the [focus-trap documentation](https://github.com/focus-trap/focus-trap#testing-in-jsdom).
+
 ## Slots
 
 There are 4 designated slots you can use to display content in the modal.

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -189,6 +189,10 @@ If you don't want to `emit` the `proceed` event upon pressing the `Enter` key, y
 <KPrompt :is-visible="preventProceed" type="danger" message="I don't care if you press Enter" prevent-proceed-on-enter @canceled="preventProceed = false" @proceed="preventProceed = false" />
 ```
 
+### tabbableOptions
+Options to be passed to [`focus-trap`](https://github.com/focus-trap/focus-trap), which is responsible for trapping focus inside the prompt box. If you're experiencing issues with testing `<KPrompt>` in `jsdom`, you can pass this prop according to the [focus-trap documentation](https://github.com/focus-trap/focus-trap#testing-in-jsdom).
+
+
 ## Slots
 
 There are 3 designated slots you can use to display content in the modal.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "date-fns": "^2.29.3",
     "date-fns-tz": "^1.3.7",
     "focus-trap": "^7.1.0",
-    "focus-trap-vue": "^3.3.1",
+    "focus-trap-vue": "^3.4.0",
     "popper.js": "^1.15.0",
     "sortablejs": "^1.15.0",
     "swrv": "^1.0.0",

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -13,6 +13,7 @@
       <FocusTrap
         ref="focusTrap"
         :active="false"
+        :tabbable-options="tabbableOptions"
       >
         <div class="k-modal-dialog modal-dialog">
           <div
@@ -199,6 +200,13 @@ export default defineComponent({
     hideCancelButton: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Options to be passed to tabbable
+     */
+    tabbableOptions: {
+      type: Object,
+      default: () => ({}),
     },
     /**
      * Test mode - for testing only, strips out generated ids

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -2,6 +2,7 @@
   <KModal
     class="k-prompt"
     :is-visible="isVisible"
+    :tabbable-options="tabbableOptions"
     text-align="left"
     :title="displayTitle"
   >
@@ -148,6 +149,13 @@ export default defineComponent({
     preventProceedOnEnter: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Options to be passed to tabbable
+     */
+    tabbableOptions: {
+      type: Object,
+      default: () => ({}),
     },
   },
   emits: ['canceled', 'proceed'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,10 +3354,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-focus-trap-vue@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-3.3.1.tgz#d7934f6569e7e09d7230f62f614cf3499e121b06"
-  integrity sha512-bsZXt0//ZpdvVbcR4KYq/n73XF57a31mHmiKT6FBdv9osqSAYmjbwmdxlytWO786nv8wbCxKZw+t87nYVstB4g==
+focus-trap-vue@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-3.4.0.tgz#ea63ef2dce04e929bc09e2b3df0e36a058574b82"
+  integrity sha512-VAI4gJgsjC8KcjDH+h4j2SxFY2XrXmm47a1EXti8gx311abybzqVhkS32Um7i+00J8RQD7hqL1Kfc26WpsMx0w==
 
 focus-trap@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR adds `tabbable-options` prop for `<KModal>` and `<KPrompt>` in favor of https://github.com/posva/focus-trap-vue/pull/445.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
