### PR TITLE
fix(kmodal): update close button styles [khcp-5508]

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -352,7 +352,7 @@ export default defineComponent({
       z-index: 10000;
 
       .k-button {
-        padding: 6px 2px 6px 3px;
+        padding: var(--spacing-xs);
         margin-top: -8px;
       }
     }

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -352,7 +352,7 @@ export default defineComponent({
       z-index: 10000;
 
       .k-button {
-        padding: 8px 0 8px 8px;
+        padding: 6px 2px 6px 3px;
         margin-top: -8px;
       }
     }

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -264,7 +264,7 @@ export default defineComponent({
         width: 100%;
 
         .close-button .k-button {
-          padding: 8px 0 8px 8px;
+          padding: 6px 2px 6px 3px;
           margin-top: -8px;
         }
       }

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -264,7 +264,7 @@ export default defineComponent({
         width: 100%;
 
         .close-button .k-button {
-          padding: 6px 2px 6px 3px;
+          padding: var(--spacing-xs);
           margin-top: -8px;
         }
       }


### PR DESCRIPTION
# Summary
Before:
<img width="1027" alt="image 820" src="https://user-images.githubusercontent.com/87779967/208700300-23aee2c5-39d8-4e78-9e0c-9bff369ab7c6.png">

After:
<img width="1027" alt="image 819" src="https://user-images.githubusercontent.com/87779967/208700386-fd08e2c5-3db7-4a4f-88d8-8112cd0a2cba.png">

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
