### PR TITLE
feat(kbadge): add borderColor prop

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -43,7 +43,15 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="warning" is-bordered class="mr-2">WARNING</KBadge>
 <KBadge appearance="danger" is-bordered class="mr-2">DANGER</KBadge>
 <KBadge appearance="info" is-bordered class="mr-2">INFO</KBadge>
-<KBadge is-bordered>DEFAULT</KBadge>
+<KBadge is-bordered class="mr-2">DEFAULT</KBadge>
+<KBadge
+  background-color="var(--purple-100)"
+  border-color="var(--purple-400)"
+  color="var(--purple-400)"
+  is-bordered
+>
+  CUSTOM
+</KBadge>
 
 ```html
 <KBadge appearance="success" is-bordered>SUCCESS</KBadge>
@@ -51,6 +59,14 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="danger" is-bordered>DANGER</KBadge>
 <KBadge appearance="info" is-bordered>INFO</KBadge>
 <KBadge is-bordered>DEFAULT</KBadge>
+<KBadge
+  background-color="var(--purple-100)"
+  border-color="var(--purple-400)"
+  color="var(--purple-400)"
+  is-bordered
+>
+  CUSTOM
+</KBadge>
 ```
 
 ### shape
@@ -68,7 +84,7 @@ The Badge has two shapes that can be changed with a `shape` property.
 <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 ```
 
-### color, background-color
+### color, background-color, border-color
 
 Using the `custom` appearance in conjunction with `color` and `background-color`:
 
@@ -76,7 +92,16 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="var(--red-100)" background-color="var(--red-400)" class="mr-2">Badge</KBadge>
 <KBadge color="var(--blue-200)" background-color="var(--blue-500)" class="mr-2">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
-<KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<KBadge color="var(--red-500)" background-color="var(--red-300)" class="mr-2">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<KBadge
+  background-color="var(--blue-100)"
+  border-color="var(--blue-400)"
+  color="var(--blue-400)"
+  is-bordered
+>
+  Production Server
+</KBadge>
+
 
 ```html
 <KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>
@@ -84,6 +109,14 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
 <KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<KBadge
+  background-color="var(--blue-100)"
+  border-color="var(--blue-400)"
+  color="var(--blue-400)"
+  is-bordered
+>
+  Production Server
+</KBadge>
 ```
 
 ### dismissable

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -44,15 +44,6 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="danger" is-bordered class="mr-2">DANGER</KBadge>
 <KBadge appearance="info" is-bordered class="mr-2">INFO</KBadge>
 <KBadge is-bordered class="mr-2">DEFAULT</KBadge>
-<KBadge
-  appearance="custom"
-  background-color="var(--purple-100)"
-  border-color="var(--purple-400)"
-  color="var(--purple-400)"
-  is-bordered
->
-  CUSTOM
-</KBadge>
 
 ```html
 <KBadge appearance="success" is-bordered>SUCCESS</KBadge>
@@ -60,15 +51,6 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="danger" is-bordered>DANGER</KBadge>
 <KBadge appearance="info" is-bordered>INFO</KBadge>
 <KBadge is-bordered>DEFAULT</KBadge>
-<KBadge
-  appearance="custom"
-  background-color="var(--purple-100)"
-  border-color="var(--purple-400)"
-  color="var(--purple-400)"
-  is-bordered
->
-  CUSTOM
-</KBadge>
 ```
 
 ### shape
@@ -88,11 +70,11 @@ The Badge has two shapes that can be changed with a `shape` property.
 
 ### color
 
-Using the `custom` appearance in conjunction with `color`
+Use this prop to modify the badge text color
 
 ### backgroundColor
 
-Using the `custom` appearance in conjunction with `background-color`:
+Use this prop to modify the background color of the badge
 
 <KBadge color="var(--yellow-500)" background-color="var(--yellow-200)" class="mr-2">Custom</KBadge>
 <KBadge color="var(--red-100)" background-color="var(--red-400)" class="mr-2">Badge</KBadge>
@@ -109,7 +91,7 @@ Using the `custom` appearance in conjunction with `background-color`:
 ```
 ### borderColor
 
-Use this prop in conjunction with the `is-bordered` and `appearance="custom"` props to customize the color of the badge border.
+Use this prop in conjunction with the `is-bordered` to customize the color of the badge border.
 
 <KBadge
   appearance="custom"

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -94,7 +94,7 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="var(--red-100)" background-color="var(--red-400)" class="mr-2">Badge</KBadge>
 <KBadge color="var(--blue-200)" background-color="var(--blue-500)" class="mr-2">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
-<KBadge color="var(--red-500)" background-color="var(--red-300)" class="mr-2">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 
 ```html
 <KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -86,9 +86,13 @@ The Badge has two shapes that can be changed with a `shape` property.
 <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 ```
 
-### color, background-color
+### color
 
-Using the `custom` appearance in conjunction with `color` and `background-color`:
+Using the `custom` appearance in conjunction with `color`
+
+### backgroundColor
+
+Using the `custom` appearance in conjunction with `background-color`:
 
 <KBadge color="var(--yellow-500)" background-color="var(--yellow-200)" class="mr-2">Custom</KBadge>
 <KBadge color="var(--red-100)" background-color="var(--red-400)" class="mr-2">Badge</KBadge>
@@ -103,7 +107,7 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
 <KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 ```
-### border-color
+### borderColor
 
 Use this prop in conjunction with the `is-bordered` and `appearance="custom"` props to customize the color of the badge border.
 
@@ -129,7 +133,7 @@ Use this prop in conjunction with the `is-bordered` and `appearance="custom"` pr
 </KBadge>
 ```
 
-### hover-color
+### hoverColor
 
 Use this prop in conjunction with the `dismissable` and `appearance="custom"` props to customize the color of the dismiss button when hovered.
 
@@ -237,38 +241,90 @@ If you want to show the tooltip regardless of whether the badge text is truncate
 | `--KBadgeDangerBackground`        |                                         |
 -->
 
-An example of theming the danger badge:
+An example of theming a custom badge:
 
 > Note: We are scoping the overrides to a wrapper in this example
 
 <div class="KBadge-wrapper">
-  <KBadge appearance="danger">DANGER - RADIOACTIVE MATERIAL</KBadge>
+  <KBadge
+    appearance="custom"
+    background-color="var(--grey-200)"
+    border-color="var(--grey-500)"
+    color="var(--grey-500)"
+    is-bordered
+  >
+    <div class="d-flex aling-items-center">
+      <KIcon
+        class="mr-2"
+        icon="bot"
+        height="10"
+      />
+      <p class="ma-0">
+        ARTIFICIAL INTELLIGENCE
+      </p>
+    </div>
+  </KBadge>
 </div>
+
+
 
 ```html
 <template>
-  <div class="KBadge-wrapper">
-    <KBadge appearance="danger">DANGER - RADIOACTIVE MATERIAL</KBadge>
-  </div>
+<div class="KBadge-wrapper">
+  <KBadge
+    appearance="custom"
+    background-color="var(--grey-200)"
+    border-color="var(--grey-500)"
+    color="var(--grey-500)"
+    is-bordered
+  >
+    <div class="d-flex aling-items-center">
+      <KIcon
+        class="mr-2"
+        icon="bot"
+        height="10"
+      />
+      <p class="ma-0">
+        ARTIFICIAL INTELLIGENCE
+      </p>
+    </div>
+  </KBadge>
+</div>
 </template>
 
 <style>
 .KBadge-wrapper {
-  --KBadgeBorderRadius: 3px;
-  --KBadgePaddingX: var(--spacing-xxs);
-  --KBadgeDangerBackground: purple;
-  --KBadgeDangerColor: lime;
+  --KBadgeBorderRadius: 22px;
+  --KBadgeFontSize: var(--type-sm);
+  --KBadgePaddingX: var(--spacing-sm);
+  --KBadgePaddingY: var(--spacing-xs);
   --KBadgeMaxWidth: auto;
+
+  p {
+    line-height: 24px;
+  }
+
+  .kong-icon-bot {
+    height: 24px;
+  }
 }
 </style>
 ```
 
 <style lang="scss">
 .KBadge-wrapper {
-  --KBadgeBorderRadius: 3px;
-  --KBadgePaddingX: var(--spacing-xxs);
-  --KBadgeDangerBackground: rgb(222, 53, 11);
-  --KBadgeDangerColor: white;
+  --KBadgeBorderRadius: 22px;
+  --KBadgeFontSize: var(--type-sm);
+  --KBadgePaddingX: var(--spacing-sm);
+  --KBadgePaddingY: var(--spacing-xs);
   --KBadgeMaxWidth: auto;
+
+  p {
+    line-height: 24px;
+  }
+
+  .kong-icon-bot {
+    height: 24px;
+  }
 }
 </style>

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -45,6 +45,7 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="info" is-bordered class="mr-2">INFO</KBadge>
 <KBadge is-bordered class="mr-2">DEFAULT</KBadge>
 <KBadge
+  appearance="custom"
   background-color="var(--purple-100)"
   border-color="var(--purple-400)"
   color="var(--purple-400)"
@@ -60,6 +61,7 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="info" is-bordered>INFO</KBadge>
 <KBadge is-bordered>DEFAULT</KBadge>
 <KBadge
+  appearance="custom"
   background-color="var(--purple-100)"
   border-color="var(--purple-400)"
   color="var(--purple-400)"
@@ -84,7 +86,7 @@ The Badge has two shapes that can be changed with a `shape` property.
 <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 ```
 
-### color, background-color, border-color
+### color, background-color
 
 Using the `custom` appearance in conjunction with `color` and `background-color`:
 
@@ -93,15 +95,6 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="var(--blue-200)" background-color="var(--blue-500)" class="mr-2">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
 <KBadge color="var(--red-500)" background-color="var(--red-300)" class="mr-2">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
-<KBadge
-  background-color="var(--blue-100)"
-  border-color="var(--blue-400)"
-  color="var(--blue-400)"
-  is-bordered
->
-  Production Server
-</KBadge>
-
 
 ```html
 <KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>
@@ -109,13 +102,60 @@ Using the `custom` appearance in conjunction with `color` and `background-color`
 <KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
 <KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+```
+### border-color
+
+Use this prop in conjunction with the `is-bordered` and `appearance="custom"` props to customize the color of the badge border.
+
 <KBadge
-  background-color="var(--blue-100)"
-  border-color="var(--blue-400)"
-  color="var(--blue-400)"
+  appearance="custom"
+  background-color="var(--purple-100)"
+  border-color="var(--purple-400)"
+  color="var(--purple-400)"
   is-bordered
 >
-  Production Server
+  Organization Admin
+</KBadge>
+
+```html
+<KBadge
+  appearance="custom"
+  background-color="var(--purple-100)"
+  border-color="var(--purple-400)"
+  color="var(--purple-400)"
+  is-bordered
+>
+  Organization Admin
+</KBadge>
+```
+
+### hover-color
+
+Use this prop in conjunction with the `dismissable` and `appearance="custom"` props to customize the color of the dismiss button when hovered.
+
+<KBadge
+  appearance="custom"
+  background-color="var(--teal-100)"
+  border-color="var(--teal-400)"
+  color="var(--teal-400)"
+  dismissable
+  hover-color="var(--teal-200)"
+  is-bordered
+>
+  Production
+</KBadge>
+
+```html
+<KBadge
+  appearance="custom"
+  background-color="var(--teal-100)"
+  border-color="var(--teal-400)"
+  color="var(--teal-400)"
+  dismissable
+  hover-color="var(--teal-200)"
+  is-bordered
+>
+  Production
 </KBadge>
 ```
 

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -176,6 +176,9 @@ If you want to show the tooltip regardless of whether the badge text is truncate
 | `--KBadgeWidth`                   | Width of badge text                     |
 | `--KBadgePaddingY`                | Vertical top/bottom spacing             |
 | `--KBadgePaddingX`                | Horizontal left/right spacing           |
+
+<!-- Color variables have been deprecated in favor of props and should not be added back to the docs. -->
+<!--
 | `--KBadgeSuccessColor`            | Text/dismiss icon color of badge        |
 | `--KBadgeSuccessButtonHoverColor` | Hover color of dismiss button           |
 | `--KBadgeSuccessBorder`           | Border of badge (default to background) |
@@ -192,6 +195,7 @@ If you want to show the tooltip regardless of whether the badge text is truncate
 | `--KBadgeDangerButtonHoverColor`  |                                         |
 | `--KBadgeDangerBorder`            |                                         |
 | `--KBadgeDangerBackground`        |                                         |
+-->
 
 An example of theming the danger badge:
 

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -91,7 +91,7 @@ Use this prop to modify the background color of the badge
 ```
 ### borderColor
 
-Use this prop in conjunction with the `is-bordered` to customize the color of the badge border.
+Use this prop in conjunction with the `is-bordered` prop to customize the color of the badge border.
 
 <KBadge
   appearance="custom"
@@ -117,7 +117,7 @@ Use this prop in conjunction with the `is-bordered` to customize the color of th
 
 ### hoverColor
 
-Use this prop in conjunction with the `dismissable` and `appearance="custom"` props to customize the color of the dismiss button when hovered.
+Use this prop in conjunction with the `dismissable` prop to customize the color of the dismiss button when hovered.
 
 <KBadge
   appearance="custom"

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -181,6 +181,12 @@ const badgeCustomStyles = computed(() => {
     styles.color = props.color
   }
 
+  // set border-color to match the text color if is-bordered prop is true and
+  // no border-color is provided
+  if (props.isBordered && !props.borderColor && props.color) {
+    styles.borderColor = props.color
+  }
+
   return styles
 })
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -173,9 +173,9 @@ const isTruncated = computed(() => offsetWidth.value < scrollWidth.value)
 
 const badgeCustomStyles = computed(() => {
   const styles = {} as {
-    backgroundColor: string
-    borderColor: string
-    color: string
+    backgroundColor?: string
+    borderColor?: string
+    color?: string
   }
 
   if (props.backgroundColor) {

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -135,6 +135,9 @@ const props = defineProps({
     default: '',
   },
 
+  /**
+   * The color to apply to the border of badges with custom appearance
+   */
   borderColor: {
     type: String,
     required: false,

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -145,6 +145,15 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+
+  /**
+   * The color to apply to the dismiss button on hover
+   */
+  hoverColor: {
+    type: String,
+    required: false,
+    default: '',
+  },
 })
 
 const emit = defineEmits(['dismissed'])
@@ -264,6 +273,36 @@ watch(badgeText, () => {
     &.is-bordered {
       border-style: solid;
       border-width: 1px;
+    }
+  }
+
+  &.k-badge-custom {
+    color: v-bind('$props.color');
+    background-color: v-bind('$props.backgroundColor');
+    border-color: v-bind('$props.borderColor');
+
+    &.is-bordered {
+      border-style: solid;
+      border-width: 1px;
+    }
+
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close path {
+        stroke: v-bind('$props.color');
+      }
+
+      &:hover {
+        background-color:v-bind('$props.hoverColor');
+      }
+    }
+
+    &:focus {
+      // fall back to backgroundColor if hoverColor is not provided
+      background-color: v-bind('$props.hoverColor || $props.backgroundColor') !important;
+
+      .k-badge-dismiss-button {
+        background-color: v-bind('$props.hoverColor');
+      }
     }
   }
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -4,7 +4,7 @@
     :aria-hidden="hidden ? true : undefined"
     class="k-badge d-inline-flex"
     :class="[ `k-badge-${appearance}`, `k-badge-${shape}`, { 'is-bordered': isBordered } ]"
-    :style="color && backgroundColor && {backgroundColor, color}"
+    :style="badgeCustomStyles"
     :tabindex="hidden ? -1 : 0"
   >
     <component
@@ -68,7 +68,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-defineProps({
+const props = defineProps({
   /**
     * Base styling<br>
     * One of [danger, warning, success etc.]
@@ -135,6 +135,12 @@ defineProps({
     default: '',
   },
 
+  borderColor: {
+    type: String,
+    required: false,
+    default: '',
+  },
+
   isBordered: {
     type: Boolean,
     default: false,
@@ -155,6 +161,28 @@ const offsetWidth = ref(0)
 const scrollWidth = ref(0)
 const truncationCalculated = ref(false)
 const isTruncated = computed(() => offsetWidth.value < scrollWidth.value)
+
+const badgeCustomStyles = computed(() => {
+  const styles = {} as {
+    backgroundColor: string
+    borderColor: string
+    color: string
+  }
+
+  if (props.backgroundColor) {
+    styles.backgroundColor = props.backgroundColor
+  }
+
+  if (props.borderColor) {
+    styles.borderColor = props.borderColor
+  }
+
+  if (props.color) {
+    styles.color = props.color
+  }
+
+  return styles
+})
 
 watch(badgeText, () => {
   // prevent recursion loop


### PR DESCRIPTION
# Summary

Adds new `borderColor` prop to allow customizing badge border color.

I decided against adding a `--KBadgeBorderColor` variable because it seemed difficult to determine a good default without knowing more about the theme of the badge.

## Screenshots
![Screen Shot 2022-12-19 at 3 49 51 PM](https://user-images.githubusercontent.com/2080476/208541810-22aeb8ff-dbf7-4612-bd06-30b8b8a19007.png)
![Screen Shot 2022-12-19 at 3 49 36 PM](https://user-images.githubusercontent.com/2080476/208541813-fc05ce20-3951-4cce-814c-14a63bf75c79.png)

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
