### PR TITLE
fix(kskeleton): documentation [khcp-5659]

### DIFF
--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -135,7 +135,7 @@ Used for controlling the progress indicator.
 Defaults to `false`, you can use this prop to hide the progress indicator.
 
 <div>
-  <KButton class="mr-2 mb-2" @click="clickNoProgress()">Click for no progress indicator</KButton>
+  <KButton class="mr-2" @click="clickNoProgress()">Click for no progress indicator</KButton>
   <KButton @click="clicked()">Click for default progress behavior</KButton>
   <KSkeleton
     v-if="loadingNone"

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -8,7 +8,7 @@
 
 - `type`
 
-There are 5 different types of loading states that KSkeleton supports: Card, Table, Form, Spinner and a generic loading state. Defaults to a generic loading state. The following example shows a Form type KSKeleton.
+There are 6 different types of loading states that KSkeleton supports: `card`, `table`, `form`, `spinner`, `fullscreen-kong`, and a generic loading state. Defaults to a generic loading state. The following example shows a `form` type KSKeleton.
 
 <KSkeleton type="form" />
 
@@ -126,23 +126,42 @@ This loading state is used for a spinner, which can be used for a wide variety o
 
 The full screen loading state is used to display a full screen loader typically during initial render of an app to avoid any FOUC (Flash Of Unstyled Content) while the app tries to figure out if you are able to access the route and also to perform any expensive querying on first load.
 
+### progress
+
+Used for controlling the progress indicator.
+
 <div>
   <KButton @click="clicked()" class="mr-2">click for default progress behavior</KButton>
   <KButton @click="clickProgress()">click me to simulate progress manually</KButton>
   <KSkeleton
     v-if="loading"
     type="fullscreen-kong"
-    :delay-milliseconds="0" />
+    :delay-milliseconds="0"
+  />
   <KSkeleton
     v-if="loadingManually"
     type="fullscreen-kong"
     :progress="progress"
-    :delay-milliseconds="0" />
+    :delay-milliseconds="0"
+  />
 </div>
 
 ```html
   <KButton @click="clicked()">click for default progress behavior</KButton>
-  <KSkeleton v-if="loading" type="fullscreen-kong" :delay-milliseconds="0" />
+  <KButton @click="clickProgress()">click me to simulate progress manually</KButton>
+
+  <KSkeleton
+    v-if="loading"
+    type="fullscreen-kong"
+    :delay-milliseconds="0"
+  />
+
+  <KSkeleton
+    v-if="loadingManually"
+    type="fullscreen-kong"
+    :progress="progress"
+    :delay-milliseconds="0"
+  />
 ```
 
 ## KSkeletonBox

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -130,37 +130,57 @@ The full screen loading state is used to display a full screen loader typically 
 
 Used for controlling the progress indicator.
 
+### hideProgress
+
+Defaults to `false`, you can use this prop to hide the progress indicator.
+
 <div>
-  <KButton @click="clicked()" class="mr-2">click for default progress behavior</KButton>
-  <KButton @click="clickProgress()">click me to simulate progress manually</KButton>
+  <KButton
+  class="mr-2 mb-2" @click="clickNoProgress()">Click for no progress indicator</KButton>
+  <KButton class="mr-2 mb-2" @click="clicked()">Click for default progress behavior</KButton>
+  <KButton @click="clickProgress()">Click me to simulate progress manually</KButton>
+  <KSkeleton
+    v-if="loadingNone"
+    :delay-milliseconds="0"
+    hide-progress
+    type="fullscreen-kong"
+  />
   <KSkeleton
     v-if="loading"
-    type="fullscreen-kong"
     :delay-milliseconds="0"
+    type="fullscreen-kong"
   />
   <KSkeleton
     v-if="loadingManually"
-    type="fullscreen-kong"
-    :progress="progress"
     :delay-milliseconds="0"
+    :progress="progress"
+    type="fullscreen-kong"
   />
 </div>
 
 ```html
-  <KButton @click="clicked()">click for default progress behavior</KButton>
-  <KButton @click="clickProgress()">click me to simulate progress manually</KButton>
+  <KButton @click="clickNoProgress()">Click for no progress indicator</KButton>
+  <KButton @click="clicked()" class="mr-2">Click for default progress behavior</KButton>
+  <KButton @click="clickProgress()">Click me to simulate progress manually</KButton>
+
+  <KSkeleton
+    v-if="loadingNone"
+    :delay-milliseconds="0"
+    hide-progress
+    type="fullscreen-kong"
+  />
 
   <KSkeleton
     v-if="loading"
-    type="fullscreen-kong"
     :delay-milliseconds="0"
+    type="fullscreen-kong"
   />
 
   <KSkeleton
     v-if="loadingManually"
-    type="fullscreen-kong"
-    :progress="progress"
     :delay-milliseconds="0"
+    :progress="progress"
+    type="fullscreen-kong"
   />
 ```
 
@@ -317,6 +337,7 @@ export default defineComponent({
   data () {
     return {
       loading: false,
+      loadingNone: false,
       loadingButton: false,
       loadingManually: false,
       loadingTheming: false,
@@ -328,6 +349,13 @@ export default defineComponent({
       this.loading = true
       setTimeout(() => {
         this.loading = false
+      }, 1000)
+    },
+
+    clickNoProgress() {
+      this.loadingNone = true
+      setTimeout(() => {
+        this.loadingNone = false
       }, 1000)
     },
 

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -135,10 +135,8 @@ Used for controlling the progress indicator.
 Defaults to `false`, you can use this prop to hide the progress indicator.
 
 <div>
-  <KButton
-  class="mr-2 mb-2" @click="clickNoProgress()">Click for no progress indicator</KButton>
-  <KButton class="mr-2 mb-2" @click="clicked()">Click for default progress behavior</KButton>
-  <KButton @click="clickProgress()">Click me to simulate progress manually</KButton>
+  <KButton class="mr-2 mb-2" @click="clickNoProgress()">Click for no progress indicator</KButton>
+  <KButton @click="clicked()">Click for default progress behavior</KButton>
   <KSkeleton
     v-if="loadingNone"
     :delay-milliseconds="0"
@@ -150,6 +148,29 @@ Defaults to `false`, you can use this prop to hide the progress indicator.
     :delay-milliseconds="0"
     type="fullscreen-kong"
   />
+</div>
+
+```html
+<KButton @click="clickNoProgress()">Click for no progress indicator</KButton>
+<KButton @click="clicked()">Click for default progress behavior</KButton>
+
+<KSkeleton
+  v-if="loadingNone"
+  :delay-milliseconds="0"
+  hide-progress
+  type="fullscreen-kong"
+/>
+
+<KSkeleton
+  v-if="loading"
+  :delay-milliseconds="0"
+  type="fullscreen-kong"
+/>
+```
+
+<div>
+  <KButton @click="clickProgress()">Click me to simulate progress manually</KButton>
+
   <KSkeleton
     v-if="loadingManually"
     :delay-milliseconds="0"
@@ -159,22 +180,8 @@ Defaults to `false`, you can use this prop to hide the progress indicator.
 </div>
 
 ```html
-  <KButton @click="clickNoProgress()">Click for no progress indicator</KButton>
-  <KButton @click="clicked()" class="mr-2">Click for default progress behavior</KButton>
+<template>
   <KButton @click="clickProgress()">Click me to simulate progress manually</KButton>
-
-  <KSkeleton
-    v-if="loadingNone"
-    :delay-milliseconds="0"
-    hide-progress
-    type="fullscreen-kong"
-  />
-
-  <KSkeleton
-    v-if="loading"
-    :delay-milliseconds="0"
-    type="fullscreen-kong"
-  />
 
   <KSkeleton
     v-if="loadingManually"
@@ -182,6 +189,24 @@ Defaults to `false`, you can use this prop to hide the progress indicator.
     :progress="progress"
     type="fullscreen-kong"
   />
+</template>
+
+<script setup lang="ts">
+  const loadingManually = ref(false)
+  const progress = ref(0)
+
+  const clickProgress = () => {
+    progress.value = 0
+    loadingManually.value = true
+    const interval = setInterval(() => {
+      progress.value = progress.value + 20
+      if (progress.value >= 100) {
+        loadingManually.value = false
+        clearInterval(interval)
+      }
+    }, 500)
+  },
+</script>
 ```
 
 ## KSkeletonBox

--- a/src/components/KSkeleton/CardSkeleton.vue
+++ b/src/components/KSkeleton/CardSkeleton.vue
@@ -71,7 +71,7 @@ $borderColor: #e6e6e6;
 .skeleton-card {
   display: flex;
   flex-direction: column;
-  height: 324px;
+  min-height: 324px;
   padding: 16px;
   overflow: hidden;
   border: 1px solid $borderColor;

--- a/src/components/KSkeleton/FullScreenKongSkeleton.vue
+++ b/src/components/KSkeleton/FullScreenKongSkeleton.vue
@@ -13,6 +13,7 @@
           class="progress-bar"
           role="progressbar"
           :style="{ width: `${progression}%` }"
+          title="Loading"
         />
       </div>
     </div>

--- a/src/components/KSkeleton/FullScreenKongSkeleton.vue
+++ b/src/components/KSkeleton/FullScreenKongSkeleton.vue
@@ -8,7 +8,10 @@
         alt="Loading"
         :src="loaderImage"
       >
-      <div class="progress">
+      <div
+        v-if="!hideProgress"
+        class="progress"
+      >
         <div
           class="progress-bar"
           role="progressbar"
@@ -30,6 +33,10 @@ export default defineComponent({
     progress: {
       type: Number,
       default: null,
+    },
+    hideProgress: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props) {

--- a/src/components/KSkeleton/KSkeleton.vue
+++ b/src/components/KSkeleton/KSkeleton.vue
@@ -33,6 +33,7 @@
 
     <FullScreenKongSkeleton
       v-else-if="type === 'fullscreen-kong'"
+      :hide-progress="hideProgress"
       :progress="progress"
     />
 
@@ -88,6 +89,10 @@ export default defineComponent({
       type: Number,
       required: false,
       default: null,
+    },
+    hideProgress: {
+      type: Boolean,
+      default: false,
     },
     cardCount: {
       type: Number,


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
- Adjust documentation
- Set card to have min-height instead of explicit height
- Fix axe linter warning
- Add `hideProgress` prop

Addresses [KHCP-5659](https://konghq.atlassian.net/browse/KHCP-5659).

Fixed card issue:
![image](https://user-images.githubusercontent.com/67973710/208721838-7e5e84eb-e6d2-4152-86f1-bb3c6475630b.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
