### PR TITLE
fix(kcodeblock): allow container to scroll

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -228,16 +228,17 @@ function highlight({ preElement, codeElement, language, code }) {
 ## Theming
 
 
-| Variable                          | Default                   | Purpose                       |
-|:--------------------------------- |:------------------------- |:----------------------------- |
-| `--KCodeBlockBorderRadius`        | `5px`                     | Code block border radius      |
-| `--KCodeBlockFocusColor`          | `var(--blue-500)`         | General focus color           |
-| `--KCodeBlockMatchHighlightColor` | `var(--blue-500)`         | Current match highlight color |
-| `--KCodeBlockColor`               | `var(--black-85)`         | Code block text color         |
-| `--KCodeBlockBackgroundColor`     | `var(--grey-100)`         | Code block background color   |
-| `--KCodeBlockFontSize`            | `var(--type-xs)`          | Code block font size          |
-| `--KCodeBlockFontFamilyMono`      | `var(--font-family-mono)` | Code block font family        |
-| `--KCodeBlockTabSize`             | `2`                       | Tab size for code blocks      |
+| Variable                          | Default                   | Purpose                                                          |
+|:--------------------------------- |:------------------------- |:---------------------------------------------------------------- |
+| `--KCodeBlockBorderRadius`        | `5px`                     | Code block border radius                                         |
+| `--KCodeBlockFocusColor`          | `var(--blue-500)`         | General focus color                                              |
+| `--KCodeBlockMatchHighlightColor` | `var(--blue-500)`         | Current match highlight color                                    |
+| `--KCodeBlockColor`               | `var(--black-85)`         | Code block text color                                            |
+| `--KCodeBlockBackgroundColor`     | `var(--grey-100)`         | Code block background color                                      |
+| `--KCodeBlockFontSize`            | `var(--type-xs)`          | Code block font size                                             |
+| `--KCodeBlockFontFamilyMono`      | `var(--font-family-mono)` | Code block font family                                           |
+| `--KCodeBlockTabSize`             | `2`                       | Tab size for code blocks                                         |
+| `--KCodeBlockMaxHeight`           | `none`                    | Max-height of the code block. Any overflow will be scrollable |
 
 ## Default shortcuts
 

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -3,6 +3,7 @@
     :id="props.id"
     ref="codeBlock"
     class="k-code-block"
+    :class="[`theme-${theme}`]"
     data-testid="k-code-block"
     :style="`--maxLineNumberWidth: ${maxLineNumberWidth}`"
     tabindex="0"
@@ -250,7 +251,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, PropType } from 'vue'
 
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -341,6 +342,15 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+
+  /**
+   * Controls the color scheme of the component. **Default: `light`**.
+   */
+  theme: {
+    type: String as PropType<'light' | 'dark'>,
+    required: false,
+    default: 'light',
   },
 })
 
@@ -723,6 +733,7 @@ $tabSize: 2;
   gap: var(--spacing-sm, spacing(sm));
   min-height: 44px;
   max-height: var(--KCodeBlockMaxHeight, none);
+  overflow: auto;
   padding: var(--spacing-xs, spacing(xs)) 0 var(--spacing-xs, spacing(xs)) var(--spacing-sm, spacing(sm));
   margin-top: 0;
   margin-bottom: 0;

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -250,7 +250,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, PropType } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -3,7 +3,6 @@
     :id="props.id"
     ref="codeBlock"
     class="k-code-block"
-    :class="[`theme-${theme}`]"
     data-testid="k-code-block"
     :style="`--maxLineNumberWidth: ${maxLineNumberWidth}`"
     tabindex="0"
@@ -342,15 +341,6 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
-  },
-
-  /**
-   * Controls the color scheme of the component. **Default: `light`**.
-   */
-  theme: {
-    type: String as PropType<'light' | 'dark'>,
-    required: false,
-    default: 'light',
   },
 })
 


### PR DESCRIPTION
# Summary

Allows the `pre` element to scroll if the max-height is set. Also adds documentation for the `--KCodeBlockMaxHeight` CSS variable.

### Before

> Notice the code overflowing the container and text

![image](https://user-images.githubusercontent.com/2229946/208778318-e9a817ba-907a-411e-9a69-e7a0a32814c4.png)

### After

![image](https://user-images.githubusercontent.com/2229946/208778453-7360dfec-61a0-4ecc-a86c-781b3fd1bb3e.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
