### PR TITLE
feat(kcodeblock): dark theme [KHCP-5231]

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -6,10 +6,6 @@ Searching highlights matching lines within the code while filtering shows only m
 
 Searching and filtering can happen by exact matches (the default) and by matching regular expressions. The search-related UI controls can also be interacted with [using keyboard shortcuts](#default-shortcuts).
 
-::: danger EXPERIMENTAL COMPONENT
-`KCodeBlock` is an experimental component. The component’s design and overall look and feel may change until it is in stable status.
-:::
-
 <ClientOnly>
   <KCodeBlock
     id="code-block-default"

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -191,6 +191,36 @@ You might need to turn this off for sites that already constantly use the fragme
 />
 ```
 
+### theme
+
+* **Type**: `string`
+* **Required**: no
+* **Default**: `light`
+
+Sets the display theme of the component.
+
+**Note**: [Additional theming options](#theming) are available via CSS variables.
+
+<ClientOnly>
+  <KCodeBlock
+    id="code-block-dark-theme"
+    :code="code"
+    language="json"
+    theme="dark"
+    is-searchable
+  />
+</ClientOnly>
+
+```html
+<KCodeBlock
+  id="code-block-dark-theme"
+  :code="code"
+  language="json"
+  theme="dark"
+  is-searchable
+/>
+```
+
 ## Events
 
 ### code-block-render

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -3,6 +3,7 @@
     :id="props.id"
     ref="codeBlock"
     class="k-code-block"
+    :class="[`theme-${theme}`]"
     data-testid="k-code-block"
     :style="`--maxLineNumberWidth: ${maxLineNumberWidth}`"
     tabindex="0"
@@ -227,7 +228,7 @@
       <KButton
         v-if="props.showCopyButton"
         ref="codeBlockCopyButton"
-        appearance="outline"
+        appearance="btn-link"
         class="k-code-block-copy-button"
         data-testid="k-code-block-copy-button"
         :is-rounded="false"
@@ -237,9 +238,9 @@
         @click="copyCode"
       >
         <KIcon
-          color="currentColor"
+          :color="theme === 'light' ? 'currentColor' : 'var(--steel-300)'"
           icon="copy"
-          size="16"
+          size="18"
           :title="`Copy (${ALT_SHORTCUT_LABEL}+C)`"
         />
 
@@ -250,7 +251,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, PropType } from 'vue'
 
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -341,6 +342,15 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
+  },
+
+  /**
+   * Controls the color scheme of the component. **Default: `light`**.
+   */
+  theme: {
+    type: String as PropType<'light' | 'dark'>,
+    required: false,
+    default: 'light',
   },
 })
 
@@ -695,26 +705,42 @@ async function copyCode(): Promise<void> {
 @import '@/styles/variables';
 @import '@/styles/functions';
 
-$borderRadius: 3px;
-$focusColor: var(--blue-500, color(blue-500));
-$matchHighlightColor: var(--blue-500, color(blue-500));
-$color: var(--black-85, color(black-85));
-$backgroundColor: var(--grey-100, color(grey-100));
+// shared
+$borderRadius: 8px;
 $fontSize: var(--type-xs, type(xs));
 $fontFamilyMono: var(--font-family-mono, font(mono));
 $tabSize: 2;
 
+// theme-light
+$light-color: var(--black-85, color(black-85));
+$light-backgroundColor: var(--grey-100, color(grey-100));
+$light-focusColor: var(--blue-500, color(blue-500));
+
+// theme-dark
+$dark-color: var(--green-200, color(green-200));
+$dark-backgroundColor: var(--black-500, color(black-500));
+$dark-focusColor: var(--blue-500, color(blue-500));
+
 .k-code-block {
-  color: var(--KCodeBlockColor, $color);
+  color: var(--KCodeBlockColor, $light-color);
   border-radius: var(--KCodeBlockBorderRadius, $borderRadius);
+
+  &.theme-dark {
+    color: var(--KCodeBlockColor, $dark-color);
+  }
 }
 
 .k-code-block pre,
 .k-code-block code {
   font-family: var(--KCodeBlockFontFamilyMono, $fontFamilyMono);
   font-size: var(--KCodeBlockFontSize, $fontSize);
-  color: var(--KCodeBlockColor, $color);
+  color: var(--KCodeBlockColor, $light-color);
   tab-size: var(--KCodeBlockTabSize, $tabSize);
+}
+
+.k-code-block.theme-dark pre,
+.k-code-block.theme-dark code {
+  color: var(--KCodeBlockColor, $dark-color);
 }
 
 .k-code-block pre {
@@ -723,22 +749,33 @@ $tabSize: 2;
   gap: var(--spacing-sm, spacing(sm));
   min-height: 44px;
   max-height: var(--KCodeBlockMaxHeight, none);
+  overflow: auto;
   padding: var(--spacing-xs, spacing(xs)) 0 var(--spacing-xs, spacing(xs)) var(--spacing-sm, spacing(sm));
   margin-top: 0;
   margin-bottom: 0;
-  background-color: var(--KCodeBlockBackgroundColor, $backgroundColor);
+  background-color: var(--KCodeBlockBackgroundColor, $light-backgroundColor);
   border-radius: var(--KCodeBlockBorderRadius, $borderRadius);
+}
+
+.k-code-block.theme-dark pre {
+  background-color: var(--KCodeBlockBackgroundColor, $dark-backgroundColor);
 }
 
 .k-code-block pre:focus-visible {
   isolation: isolate;
-  outline: 2px solid var(--KCodeBlockFocusColor, $focusColor);
+  outline: 2px solid var(--KCodeBlockFocusColor, $light-focusColor);
   outline-offset: -2px;
+}
+
+.k-code-block.theme-dark pre:focus-visible {
+  outline: 2px solid var(--KCodeBlockFocusColor, $dark-focusColor);
 }
 
 .k-code-block-actions + .k-code-block-content > pre {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+  border-bottom-left-radius: $borderRadius;
+  border-bottom-right-radius: $borderRadius;
 }
 
 .k-code-block code {
@@ -752,7 +789,11 @@ $tabSize: 2;
 .k-code-block:focus-visible {
   isolation: isolate;
   outline: none;
-  box-shadow: 0 0 0 2px var(--KCodeBlockFocusColor, $focusColor);
+  box-shadow: 0 0 0 2px var(--KCodeBlockFocusColor, $light-focusColor);
+}
+
+.k-code-block.theme-dark:focus-visible {
+  box-shadow: 0 0 0 2px var(--KCodeBlockFocusColor, $dark-focusColor);
 }
 
 .k-code-block-actions {
@@ -766,6 +807,11 @@ $tabSize: 2;
   border-bottom: 1px solid var(--grey-300, color(grey-300));
   border-top-left-radius: var(--KCodeBlockBorderRadius, $borderRadius);
   border-top-right-radius: var(--KCodeBlockBorderRadius, $borderRadius);
+}
+
+.theme-dark .k-code-block-actions {
+  background-color: #060d19;
+  border-bottom: 1px solid var(--black-400, color(black-400));
 }
 
 .k-code-block-actions .k-button {
@@ -843,6 +889,10 @@ $tabSize: 2;
   color: var(--grey-500, color(grey-500));
 }
 
+.theme-dark .k-code-block-search-results:not(.k-code-block-search-results-has-query) {
+  color: var(--steel-300, color(steel-300));
+}
+
 .k-code-block-search-error,
 .k-code-block-search-results {
   margin-top: 0;
@@ -883,9 +933,14 @@ $tabSize: 2;
 }
 
 .k-clear-query-button:focus {
-  border-color: var(--KButtonOutlineBorder, $focusColor);
+  border-color: var(--KButtonOutlineBorder, $light-focusColor);
   outline: none;
-  box-shadow: 0 0 0 2px var(--white, color(white)), 0 0 0 4px var(--KButtonOutlineBorder, $focusColor);
+  box-shadow: 0 0 0 2px var(--white, color(white)), 0 0 0 4px var(--KButtonOutlineBorder, $light-focusColor);
+}
+
+.theme-dark .k-clear-query-button:focus {
+  border-color: var(--KButtonOutlineBorder, $dark-focusColor);
+  box-shadow: 0 0 0 2px var(--white, color(white)), 0 0 0 4px var(--KButtonOutlineBorder, $dark-focusColor);
 }
 
 .k-code-block-content {
@@ -894,7 +949,7 @@ $tabSize: 2;
 
 .k-code-block-copy-button {
   position: absolute;
-  top: var(--spacing-xs, spacing(xs));
+  top: var(--spacing-md, spacing(md));
   right: var(--spacing-md, spacing(md));
   z-index: 2;
   display: block;
@@ -932,6 +987,11 @@ $tabSize: 2;
   color: var(--grey-500, color(grey-500));
 }
 
+.theme-dark .k-line-number-rows,
+.theme-dark .k-line-number-rows a {
+  color: var(--steel-300, color(steel-300));
+}
+
 .k-line {
   // For some reason, `.k-line` elements are otherwise sized way too large.
   display: inline-flex;
@@ -949,7 +1009,11 @@ $tabSize: 2;
 
 .k-line-is-highlighted-match::before {
   background-color: hsl(220, 18%, 35%, 0.2);
-  border-left: 5px solid var(--KCodeBlockMatchHighlightColor, $focusColor);
+  border-left: 5px solid var(--KCodeBlockMatchHighlightColor, $light-focusColor);
+}
+
+.theme-dark .k-line-is-highlighted-match::before {
+  border-left: 5px solid var(--KCodeBlockMatchHighlightColor, $dark-focusColor);
 }
 
 .k-line-anchor:not([href]) {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -18,7 +18,11 @@
           'k-code-block-search-results-has-query': query !== '',
         }"
       >
-        <template v-if="numberOfMatches === 0">
+        <template v-if="query === '' && numberOfMatches === 0">
+          &nbsp;
+        </template>
+
+        <template v-else-if="numberOfMatches === 0">
           No results
         </template>
 
@@ -91,25 +95,6 @@
           />
         </button>
       </div>
-
-      <!-- <p
-        class="k-code-block-search-results"
-        :class="{
-          'k-code-block-search-results-has-query': query !== '',
-        }"
-      >
-        <template v-if="numberOfMatches === 0">
-          No results
-        </template>
-
-        <template v-else-if="typeof currentLineIndex === 'number' && !isShowingFilteredCode">
-          {{ currentLineIndex + 1 }} of {{ numberOfMatches }}
-        </template>
-
-        <template v-else>
-          {{ numberOfMatches }} results
-        </template>
-      </p> -->
 
       <div class="k-search-actions">
         <KButton
@@ -917,11 +902,11 @@ $dark-focusColor: var(--green-500, color(green-500));
 }
 
 .k-search-container:hover {
-  border-color: var(--KInputHover, var(--blue-200, color(blue-200)));
+  border-color: var(--KInputHover, var(--steel-200, color(steel-200)));
 }
 
 .k-search-container:focus-within {
-  border-color: var(--KInputFocus, var(--blue-400, color(blue-400)));
+  border-color: var(--KInputFocus, var(--steel-400, color(steel-400)));
 }
 
 .theme-dark .k-search-container:focus-within {
@@ -931,6 +916,7 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-code-block-search-input {
   flex-grow: 1;
   width: 0;
+  height: 32px;
   padding: 0 var(--spacing-xs, spacing(xs));
   margin: 0;
   font: inherit;
@@ -955,7 +941,8 @@ $dark-focusColor: var(--green-500, color(green-500));
   align-self: center;
   // Sets the minimum width to 12 characters which is the length of the string “1234 results” which should be reasonably safe in order to avoid having layout elements jump around.
   min-width: 12ch;
-  text-align: center;
+  text-align: right;
+  padding-right: var(--spacing-sm, spacing(sm));
 }
 
 .k-code-block-search-results:not(.k-code-block-search-results-has-query) {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -15,7 +15,7 @@
       <div class="k-search-container">
         <KIcon
           class="k-search-icon"
-          color="currentColor"
+          :color="theme === 'light' ? 'currentColor' : 'var(--steel-300)'"
           data-testid="k-code-block-search-icon"
           icon="search"
           size="20"
@@ -47,7 +47,7 @@
         <KIcon
           class="k-is-processing-icon"
           :class="{ 'k-is-processing-icon-is-visible': isProcessing }"
-          color="var(--grey-400)"
+          :color="theme === 'light' ? 'var(--grey-400)' : 'var(--steel-300)'"
           data-testid="k-code-block-is-processing-icon"
           icon="spinner"
         />
@@ -65,7 +65,7 @@
 
           <KIcon
             class="k-clear-icon"
-            color="currentColor"
+            :color="theme === 'light' ? 'var(--grey-400)' : 'var(--steel-300)'"
             data-testid="k-code-block-clear-icon"
             icon="clear"
             size="20"
@@ -94,7 +94,7 @@
 
       <div class="k-search-actions">
         <KButton
-          :appearance="isRegExpMode ? 'secondary' : 'outline'"
+          :appearance="isRegExpMode ? 'action-active secondary' : 'outline'"
           :aria-pressed="isRegExpMode"
           class="k-regexp-mode-button"
           data-testid="k-code-block-regexp-mode-button"
@@ -110,7 +110,7 @@
         </KButton>
 
         <KButton
-          :appearance="isFilterMode ? 'secondary' : 'outline'"
+          :appearance="isFilterMode ? 'action-active secondary' : 'outline'"
           :aria-pressed="isFilterMode"
           class="k-filter-mode-button"
           data-testid="k-code-block-filter-mode-button"
@@ -719,7 +719,7 @@ $light-focusColor: var(--blue-500, color(blue-500));
 // theme-dark
 $dark-color: var(--green-200, color(green-200));
 $dark-backgroundColor: var(--black-500, color(black-500));
-$dark-focusColor: var(--blue-500, color(blue-500));
+$dark-focusColor: var(--green-500, color(green-500));
 
 .k-code-block {
   color: var(--KCodeBlockColor, $light-color);
@@ -810,12 +810,36 @@ $dark-focusColor: var(--blue-500, color(blue-500));
 }
 
 .theme-dark .k-code-block-actions {
-  background-color: #060d19;
+  color: #fff;
+  background-color: var(--black-500, color(black-500));
   border-bottom: 1px solid var(--black-400, color(black-400));
 }
 
 .k-code-block-actions .k-button {
   align-self: stretch;
+}
+
+.theme-dark .k-code-block-actions .k-button {
+  color: var(--steel-300, color(steel-300));
+  border-color: var(--steel-300, color(steel-300));
+  background-color: $dark-backgroundColor;
+
+  &:hover {
+    color: $dark-backgroundColor;
+    border-color: var(--steel-300, color(steel-300));
+    background-color: var(--steel-300, color(steel-300));
+
+    &:disabled {
+      background-color: $dark-backgroundColor;
+    }
+  }
+
+  // Since the .theme-dark * .k-buttons don't have the `secondary` class, add additional theme styles
+  &.action-active {
+    color: $dark-backgroundColor;
+    border-color: var(--steel-400, color(steel-400));
+    background-color: var(--steel-400, color(steel-400));
+  }
 }
 
 .k-is-processing-icon {
@@ -853,12 +877,21 @@ $dark-focusColor: var(--blue-500, color(blue-500));
   transition: border 0.1s ease;
 }
 
+.theme-dark .k-search-container {
+  background-color: $dark-backgroundColor;
+  border: 1px solid var(--KInputBorder, var(--steel-300, color(steel-300)));
+}
+
 .k-search-container:hover {
   border-color: var(--KInputHover, var(--blue-200, color(blue-200)));
 }
 
 .k-search-container:focus-within {
   border-color: var(--KInputFocus, var(--blue-400, color(blue-400)));
+}
+
+.theme-dark .k-search-container:focus-within {
+  border-color: var(--KInputFocus, var(--steel-300, color(steel-300)));
 }
 
 .k-code-block-search-input {
@@ -871,6 +904,11 @@ $dark-focusColor: var(--blue-500, color(blue-500));
   background-color: transparent;
   border: none;
   appearance: none;
+}
+
+.theme-dark .k-code-block-search-input {
+  color: #fff;
+  background-color: $dark-backgroundColor;
 }
 
 .k-code-block-search-input:focus {
@@ -1005,6 +1043,10 @@ $dark-focusColor: var(--blue-500, color(blue-500));
   pointer-events: none;
   content: '\A0';
   background-color: hsl(220, 18%, 35%, 0.1);
+}
+
+.theme-dark .k-line-is-match::before {
+  background-color: hsl(220, 18%, 35%, 0.3);
 }
 
 .k-line-is-highlighted-match::before {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -232,7 +232,7 @@
       <KButton
         v-if="props.showCopyButton"
         ref="codeBlockCopyButton"
-        appearance="btn-link"
+        appearance="outline"
         class="k-code-block-copy-button"
         data-testid="k-code-block-copy-button"
         :is-rounded="false"
@@ -242,7 +242,7 @@
         @click="copyCode"
       >
         <KIcon
-          :color="theme === 'light' ? 'var(--steel-500)' : 'var(--steel-300)'"
+          color="currentColor"
           icon="copy"
           size="18"
           :title="`Copy (${ALT_SHORTCUT_LABEL}+C)`"
@@ -1009,10 +1009,46 @@ $dark-focusColor: var(--green-500, color(green-500));
 
 .k-code-block-copy-button {
   position: absolute;
-  top: var(--spacing-md, spacing(md));
+  top: var(--spacing-xs, spacing(xs));
   right: var(--spacing-md, spacing(md));
   z-index: 2;
   display: block;
+
+  &.k-button {
+    background-color: transparent;
+    border-color: transparent;
+
+    &:hover {
+      background-color: var(--steel-100, color(steel-100));
+      border-color: transparent !important;
+    }
+
+    &:active,
+    &:hover:active {
+      color: #fff;
+      background-color: var(--steel-500, color(steel-500));
+      border-color: var(--steel-500, color(steel-500));
+    }
+  }
+}
+
+.theme-dark .k-code-block-copy-button {
+
+  &.k-button {
+    color: var(--steel-300, color(steel-300));
+
+    &:hover {
+      background-color: rgba(#fff, 0.1);
+      border-color: transparent !important;
+    }
+
+    &:active,
+    &:hover:active {
+      color: $dark-backgroundColor;
+      background-color: var(--steel-300, color(steel-300));
+      border-color: var(--steel-300, color(steel-300));
+    }
+  }
 }
 
 .k-code-block-copy-button[data-tooltip-text]::after {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -12,10 +12,29 @@
       v-if="isSearchable"
       class="k-code-block-actions"
     >
+      <p
+        class="k-code-block-search-results"
+        :class="{
+          'k-code-block-search-results-has-query': query !== '',
+        }"
+      >
+        <template v-if="numberOfMatches === 0">
+          No results
+        </template>
+
+        <template v-else-if="typeof currentLineIndex === 'number' && !isShowingFilteredCode">
+          {{ currentLineIndex + 1 }} of {{ numberOfMatches }}
+        </template>
+
+        <template v-else>
+          {{ numberOfMatches }} {{ numberOfMatches === 1 ? 'result' : 'results' }}
+        </template>
+      </p>
+
       <div class="k-search-container">
         <KIcon
           class="k-search-icon"
-          :color="theme === 'light' ? 'currentColor' : 'var(--steel-400)'"
+          :color="theme === 'light' ? 'var(--steel-500)' : 'var(--steel-400)'"
           data-testid="k-code-block-search-icon"
           icon="search"
           size="20"
@@ -47,7 +66,7 @@
         <KIcon
           class="k-is-processing-icon"
           :class="{ 'k-is-processing-icon-is-visible': isProcessing }"
-          :color="theme === 'light' ? 'var(--steel -400)' : 'var(--steel-400)'"
+          :color="theme === 'light' ? 'var(--steel-500)' : 'var(--steel-400)'"
           data-testid="k-code-block-is-processing-icon"
           icon="spinner"
         />
@@ -73,7 +92,7 @@
         </button>
       </div>
 
-      <p
+      <!-- <p
         class="k-code-block-search-results"
         :class="{
           'k-code-block-search-results-has-query': query !== '',
@@ -90,11 +109,11 @@
         <template v-else>
           {{ numberOfMatches }} results
         </template>
-      </p>
+      </p> -->
 
       <div class="k-search-actions">
         <KButton
-          :appearance="isRegExpMode ? 'action-active secondary' : 'outline'"
+          :appearance="isRegExpMode ? 'action-active' : 'outline'"
           :aria-pressed="isRegExpMode"
           class="k-regexp-mode-button"
           data-testid="k-code-block-regexp-mode-button"
@@ -110,7 +129,7 @@
         </KButton>
 
         <KButton
-          :appearance="isFilterMode ? 'action-active secondary' : 'outline'"
+          :appearance="isFilterMode ? 'action-active' : 'outline'"
           :aria-pressed="isFilterMode"
           class="k-filter-mode-button"
           data-testid="k-code-block-filter-mode-button"
@@ -238,7 +257,7 @@
         @click="copyCode"
       >
         <KIcon
-          :color="theme === 'light' ? 'currentColor' : 'var(--steel-300)'"
+          :color="theme === 'light' ? 'var(--steel-500)' : 'var(--steel-300)'"
           icon="copy"
           size="18"
           :title="`Copy (${ALT_SHORTCUT_LABEL}+C)`"
@@ -712,7 +731,7 @@ $fontFamilyMono: var(--font-family-mono, font(mono));
 $tabSize: 2;
 
 // theme-light
-$light-color: var(--blue-700, color(blue-700));
+$light-color: var(--steel-700, color(blue-700));
 $light-backgroundColor: var(--grey-100, color(grey-100));
 $light-focusColor: var(--blue-500, color(blue-500));
 
@@ -724,6 +743,12 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-code-block {
   color: var(--KCodeBlockColor, $light-color);
   border-radius: var(--KCodeBlockBorderRadius, $borderRadius);
+
+  &.theme-light {
+    --KButtonOutlineColor: var(--steel-500, color(steel-500));
+    --KButtonOutlineBorder: var(--steel-500, color(steel-500));
+    --KButtonOutlineHoverBorder: var(--steel-700, color(steel-700));
+  }
 
   &.theme-dark {
     color: var(--KCodeBlockColor, $dark-color);
@@ -817,6 +842,12 @@ $dark-focusColor: var(--green-500, color(green-500));
 
 .k-code-block-actions .k-button {
   align-self: stretch;
+
+  &.action-active {
+    color: #fff;
+    border-color: var(--steel-500, color(steel-500));
+    background-color: var(--steel-500, color(steel-500));
+  }
 }
 
 .theme-dark .k-code-block-actions .k-button {
@@ -826,19 +857,18 @@ $dark-focusColor: var(--green-500, color(green-500));
 
   &:hover {
     color: $dark-backgroundColor;
-    border-color: var(--steel-300, color(steel-300));
-    background-color: var(--steel-300, color(steel-300));
+    border-color: var(--steel-400, color(steel-400));
+    background-color: var(--steel-400, color(steel-400));
 
     &:disabled {
       background-color: $dark-backgroundColor;
     }
   }
 
-  // Since the .theme-dark * .k-buttons don't have the `secondary` class, add additional theme styles
   &.action-active {
     color: $dark-backgroundColor;
-    border-color: var(--steel-400, color(steel-400));
-    background-color: var(--steel-400, color(steel-400));
+    border-color: var(--steel-300, color(steel-300));
+    background-color: var(--steel-300, color(steel-300));
   }
 }
 
@@ -859,7 +889,7 @@ $dark-focusColor: var(--green-500, color(green-500));
   visibility: hidden;
 }
 
-.k-regexp-mode-button {
+.k-button.k-regexp-mode-button {
   font-family: var(--KCodeBlockFontFamilyMono, $fontFamilyMono);
 }
 
@@ -1077,6 +1107,10 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-matched-term {
   font-weight: 900;
   color: var(--teal-500, color(teal-500));
+}
+
+.theme-dark .k-matched-term {
+  color: var(--green-500, color(green-500));
 }
 
 .k-code-block .k-button.small {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -15,7 +15,7 @@
       <div class="k-search-container">
         <KIcon
           class="k-search-icon"
-          :color="theme === 'light' ? 'currentColor' : 'var(--steel-300)'"
+          :color="theme === 'light' ? 'currentColor' : 'var(--steel-400)'"
           data-testid="k-code-block-search-icon"
           icon="search"
           size="20"
@@ -47,7 +47,7 @@
         <KIcon
           class="k-is-processing-icon"
           :class="{ 'k-is-processing-icon-is-visible': isProcessing }"
-          :color="theme === 'light' ? 'var(--grey-400)' : 'var(--steel-300)'"
+          :color="theme === 'light' ? 'var(--steel -400)' : 'var(--steel-400)'"
           data-testid="k-code-block-is-processing-icon"
           icon="spinner"
         />
@@ -65,7 +65,7 @@
 
           <KIcon
             class="k-clear-icon"
-            :color="theme === 'light' ? 'var(--grey-400)' : 'var(--steel-300)'"
+            :color="theme === 'light' ? 'var(--steel-500)' : 'var(--steel-400)'"
             data-testid="k-code-block-clear-icon"
             icon="clear"
             size="20"
@@ -712,7 +712,7 @@ $fontFamilyMono: var(--font-family-mono, font(mono));
 $tabSize: 2;
 
 // theme-light
-$light-color: var(--black-85, color(black-85));
+$light-color: var(--blue-700, color(blue-700));
 $light-backgroundColor: var(--grey-100, color(grey-100));
 $light-focusColor: var(--blue-500, color(blue-500));
 
@@ -812,7 +812,7 @@ $dark-focusColor: var(--green-500, color(green-500));
 .theme-dark .k-code-block-actions {
   color: #fff;
   background-color: var(--black-500, color(black-500));
-  border-bottom: 1px solid var(--black-400, color(black-400));
+  border-bottom: 1px solid var(--steel-700, color(steel-700));
 }
 
 .k-code-block-actions .k-button {
@@ -875,11 +875,15 @@ $dark-focusColor: var(--green-500, color(green-500));
   border: 1px solid var(--KInputBorder, var(--grey-300, color(grey-300)));
   border-radius: 3px;
   transition: border 0.1s ease;
+
+  &:focus {
+    border: 1px solid var(--KInputBorder, var(--grey-300, color(grey-300)));
+  }
 }
 
 .theme-dark .k-search-container {
-  background-color: $dark-backgroundColor;
-  border: 1px solid var(--KInputBorder, var(--steel-300, color(steel-300)));
+  background-color: var(--steel-700, color(steel-700));
+  border: none;
 }
 
 .k-search-container:hover {
@@ -908,10 +912,11 @@ $dark-focusColor: var(--green-500, color(green-500));
 
 .theme-dark .k-code-block-search-input {
   color: #fff;
-  background-color: $dark-backgroundColor;
+  background-color: var(--steel-700, color(steel-700));
 }
 
-.k-code-block-search-input:focus {
+.k-code-block-search-input:focus,
+.k-code-block-search-input:focus-visible {
   // Focus styles are managed by `.k-search-container`
   outline: none;
 }
@@ -1022,7 +1027,7 @@ $dark-focusColor: var(--green-500, color(green-500));
 
 .k-line-number-rows,
 .k-line-number-rows a {
-  color: var(--grey-500, color(grey-500));
+  color: var(--steel-500, color(steel-500));
 }
 
 .theme-dark .k-line-number-rows,


### PR DESCRIPTION
# Summary

Add a new `theme` prop to `KCodeBlock` that accepts `light` (default) or `dark`

## Themes

### Light

![image](https://user-images.githubusercontent.com/2229946/208935017-46550717-cdfe-40c8-a5b0-3a0c77192f63.png)

### Dark

![image](https://user-images.githubusercontent.com/2229946/208935062-e2abe90a-d5e2-458b-bdd4-e9a8c0ca1f88.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
