### PR TITLE
fix(kselect): update disabled styles [khcp-5661]

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -90,6 +90,7 @@
               'k-select-input': appearance === 'select',
               'no-filter': !filterIsEnabled,
               'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
+              'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false'),
               'is-open': isToggled.value
             }"
             data-testid="k-select-input"
@@ -131,7 +132,8 @@
                 'cursor-default prevent-pointer-events': !filterIsEnabled,
                 'input-placeholder-dark has-chevron': appearance === 'select',
                 'has-clear': isClearVisible,
-                'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false')
+                'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
+                'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false')
               }"
               :label="label && overlayLabel ? label : undefined"
               :model-value="filterStr"
@@ -729,6 +731,18 @@ export default defineComponent({
 
       &.select-input-container {
         input.k-input.form-control:not([type="checkbox"]):not([type="radio"]):not([type="file"]):read-only {
+          box-shadow: none !important;
+        }
+      }
+    }
+
+      &.select-input-container.disabled {
+      @include input-disabled;
+      box-shadow: none !important;
+      cursor: not-allowed !important;
+
+      &.select-input-container {
+        input.k-input.form-control:not([type="checkbox"]):not([type="radio"]):not([type="file"]):disabled {
           box-shadow: none !important;
         }
       }


### PR DESCRIPTION
Addresses:
[https://konghq.atlassian.net/browse/KHCP-5661](https://konghq.atlassian.net/browse/KHCP-5661)
# Summary

This PR adds the missing `disabled` styles for `KSelect`.

**Before:**
<img width="767" alt="image 834" src="https://user-images.githubusercontent.com/87779967/208897912-199df330-ebf4-458a-a979-021a1a1237a0.png">

**After:**
<img width="767" alt="image 833" src="https://user-images.githubusercontent.com/87779967/208897932-3f218bda-0277-4393-9404-b2c887441881.png">


<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
