### PR TITLE
feat(codeBlock): add useSingleLine prop

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -217,7 +217,7 @@ Sets the display theme of the component.
 />
 ```
 
-### useSingleLine
+### isSingleLine
 
 * **Type**: `boolean`
 * **Required**: no
@@ -231,21 +231,21 @@ Line numbers will not be displayed and the code will not be searchable when this
 
 <ClientOnly>
   <KCodeBlock
-    id="code-block-use-single-line"
+    id="code-block-is-single-line"
     :code="cert"
     language="plaintext"
     theme="dark"
-    use-single-line
+    is-single-line
   />
 </ClientOnly>
 
 ```html
 <KCodeBlock
-  id="code-block-use-single-line"
+  id="code-block-is-single-line"
   :code="cert"
   language="plaintext"
   theme="dark"
-  use-single-line
+  is-single-line
 />
 ```
 

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -217,6 +217,38 @@ Sets the display theme of the component.
 />
 ```
 
+### useSingleLine
+
+* **Type**: `boolean`
+* **Required**: no
+* **Default**: `false`
+
+The code passed into the component will be displayed on a single line.
+
+::: tip NOTE
+Line numbers will not be displayed and the code will not be searchable when this prop is enabled.
+:::
+
+<ClientOnly>
+  <KCodeBlock
+    id="code-block-use-single-line"
+    :code="cert"
+    language="plaintext"
+    theme="dark"
+    use-single-line
+  />
+</ClientOnly>
+
+```html
+<KCodeBlock
+  id="code-block-use-single-line"
+  :code="cert"
+  language="plaintext"
+  theme="dark"
+  use-single-line
+/>
+```
+
 ## Events
 
 ### code-block-render
@@ -399,4 +431,27 @@ const code = `{
     "./types"
   ]
 }`
+
+const cert = `-----BEGIN CERTIFICATE-----
+MIIDlDCCAn6gAwIBAgIBATALBgkqhkiG9w0BAQ0wNDEyMAkGA1UEBhMCVVMwJQYD
+VQQDHh4AawBvAG4AbgBlAGMAdAAtAGQAZQBmAGEAdQBsAHQwHhcNMjMwMTAzMTg1
+NDQxWhcNMzMwMTAzMTg1NDQxWjA0MTIwCQYDVQQGEwJVUzAlBgNVBAMeHgBrAG8A
+bgBuAGUAYwB0AC0AZABlAGYAYQB1AGwAdDCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBAJ1dzsZKtwFniWQaxIEqrs2EH95fWQ4Jie+79jJL1unRJJu5oDnR
+5ontJZhPFSDdGZ1ZXhjQXIzaUk3BoFn7Zel7X25hzUdlKHoOTPf/KA7+isdvS89j
+nGoC5vHtXQmgzNFRdCjeKDOmfa/Arff7+41SNTT+DNitZun+V3diePoatotOT3tv
+puNqc5EjHLEGOdBwxSkO7qCvzsqOcFyBshT8AzFKU8aapErlILOIJKJIYHoAkS/A
+cUfm/MNNMzPBBI3p1jZKXnWCwXMWUi8jZvsALYwn8E65GE07jW2O+n9hWzC43yTu
+DYW0U8vcoTsdPmsZByIFDfERaxavQiEuhf0CAwEAAaOBtDCBsTASBgNVHRMBAf8E
+CDAGAQH/AgEDMAsGA1UdDwQEAwIABjAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB
+BQUHAwIwFwYJKwYBBAGCNxQCBAoMCGNlcnRUeXBlMCMGCSsGAQQBgjcVAgQWBBQB
+AQEBAQEBAQEBAQEBAQEBAQEBATAcBgkrBgEEAYI3FQcEDzANBgUpAQEBAQIBCgIB
+FDATBgkrBgEEAYI3FQEEBgIEABQACjALBgkqhkiG9w0BAQ0DggEBABGVFc6DTlx7
+SuKgT3OhQS94VyECnJjyk2eR6/MaZYvgw0Iz8nOyg7xTtj7DKl/uyHdJWwYn5R70
++YGF7GGbkk6rkRuHEVT+dhyYwO9fKzBZkLNnzdp900VSmTubx4j6WN0+gmQS0dLW
+uyBQdUiKvE/ZTjWHUAIYb3244VRRHBRLs3s40f2mJjBZ3Zm6XUxGtsnYudWOh4cv
+nYKRWqogwSBtKPYAe115DLDULxe86Cu5neYTt5/kU7VjnLxhOhguWTIrGMSV0Jle
+Rl1IG8evLu2zWxN3wb451/Kf5lRFLUjfjuLD8tHMlpwVIxoHct9GuKV4W14cf2Q/
+cWMCwpGsAAE=
+-----END CERTIFICATE-----`
 </script>

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -77,6 +77,40 @@ Shows an actions bar with a search input and related action buttons.
 />
 ```
 
+### isSingleLine
+
+* **Type**: `boolean`
+* **Required**: no
+* **Default**: `false`
+
+The code passed into the component will be displayed on a single line.
+
+::: tip NOTE
+Please keep the following in mind when using `isSingleLine`:
+- Line numbers will not be displayed
+- Code will not be searchable
+- Long code snippets will be truncated to allow for responsive design
+- Multi-line code snippets will have `\n` stripped out to allow displaying the code on a single line. Code copied by clicking the copy button will contain any `\n` in the original code.
+:::
+
+<ClientOnly>
+  <KCodeBlock
+    id="code-block-is-single-line"
+    :code="cert"
+    is-single-line
+    language="plaintext"
+  />
+</ClientOnly>
+
+```html
+<KCodeBlock
+  id="code-block-is-single-line"
+  :code="cert"
+  is-single-line
+  language="plaintext"
+/>
+```
+
 ### isProcessing
 
 * **Type**: `boolean`
@@ -214,40 +248,6 @@ Sets the display theme of the component.
   language="json"
   theme="dark"
   is-searchable
-/>
-```
-
-### isSingleLine
-
-* **Type**: `boolean`
-* **Required**: no
-* **Default**: `false`
-
-The code passed into the component will be displayed on a single line.
-
-::: tip NOTE
-Please keep the following in mind when using `isSingleLine`:
-- Line numbers will not be displayed
-- Code will not be searchable
-- Long code snippets will be truncated to allow for responsive design
-- Multi-line code snippets will have `\n` stripped out to allow displaying the code on a single line. Code copied by clicking the copy button will contain any `\n` in the original code.
-:::
-
-<ClientOnly>
-  <KCodeBlock
-    id="code-block-is-single-line"
-    :code="cert"
-    is-single-line
-    language="plaintext"
-  />
-</ClientOnly>
-
-```html
-<KCodeBlock
-  id="code-block-is-single-line"
-  :code="cert"
-  is-single-line
-  language="plaintext"
 />
 ```
 

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -89,7 +89,6 @@ The code passed into the component will be displayed on a single line.
 Please keep the following in mind when using `isSingleLine`:
 - Line numbers will not be displayed
 - Code will not be searchable
-- Long code snippets will be truncated to allow for responsive design
 - Multi-line code snippets will have `\n` stripped out to allow displaying the code on a single line. Code copied by clicking the copy button will contain any `\n` in the original code.
 :::
 

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -226,16 +226,19 @@ Sets the display theme of the component.
 The code passed into the component will be displayed on a single line.
 
 ::: tip NOTE
-Line numbers will not be displayed and the code will not be searchable when this prop is enabled.
+Please keep the following in mind when using `isSingleLine`:
+- Line numbers will not be displayed
+- Code will not be searchable
+- Long code snippets will be truncated to allow for responsive design
+- Multi-line code snippets will have `\n` stripped out to allow displaying the code on a single line. Code copied by clicking the copy button will contain any `\n` in the original code.
 :::
 
 <ClientOnly>
   <KCodeBlock
     id="code-block-is-single-line"
     :code="cert"
-    language="plaintext"
-    theme="dark"
     is-single-line
+    language="plaintext"
   />
 </ClientOnly>
 
@@ -243,9 +246,8 @@ Line numbers will not be displayed and the code will not be searchable when this
 <KCodeBlock
   id="code-block-is-single-line"
   :code="cert"
-  language="plaintext"
-  theme="dark"
   is-single-line
+  language="plaintext"
 />
 ```
 

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -173,9 +173,9 @@ describe('KCodeBlock', () => {
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'href').should('equal', `#${id}-L2`)
   })
 
-  it('has the `use-single-line` class when props.useSingleLine is true', () => {
-    renderComponent({ id: 'code-block', useSingleLine: true })
+  it('has the `is-single-line` class when props.isSingleLine is true', () => {
+    renderComponent({ id: 'code-block', isSingleLine: true })
 
-    cy.get('pre.k-highlighted-code-block').should('have.class', 'use-single-line')
+    cy.get('pre.k-highlighted-code-block').should('have.class', 'is-single-line')
   })
 })

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -172,4 +172,10 @@ describe('KCodeBlock', () => {
     cy.get('.k-code-block').trigger('keydown', { code: 'F3' })
     cy.get('.k-line-is-highlighted-match .k-line-anchor').invoke('attr', 'href').should('equal', `#${id}-L2`)
   })
+
+  it('has the `use-single-line` class when props.useSingleLine is true', () => {
+    renderComponent({ id: 'code-block', useSingleLine: true })
+
+    cy.get('pre.k-highlighted-code-block').should('have.class', 'use-single-line')
+  })
 })

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1195,30 +1195,13 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-code-block-content {
   pre.k-highlighted-code-block.is-single-line {
     display: flex;
-    padding: var(--spacing-sm, spacing(sm)) 0 var(--spacing-sm, spacing(sm)) var(--spacing-sm, spacing(sm));
+    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xxl, spacing(xxl)) var(--spacing-sm, spacing(sm)) var(--spacing-sm, spacing(sm));
 
     code {
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      overflow: auto;
       line-height: 29px;
       margin-right: 20px;
-    }
-
-    &.show-copy-button {
-      code {
-        @media (max-width: $viewport-sm) {
-          max-width: 50ch;
-        }
-
-        @media (min-width: $viewport-sm) {
-          max-width: 70ch;
-        }
-
-        @media (min-width: $viewport-lg) {
-          max-width: 78ch;
-        }
-      }
     }
 
     + .k-code-block-copy-button {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -9,7 +9,7 @@
     tabindex="0"
   >
     <div
-      v-if="isSearchable && !useSingleLine"
+      v-if="isSearchable && !isSingleLine"
       class="k-code-block-actions"
     >
       <p
@@ -194,7 +194,7 @@
         data-testid="k-code-block-filtered-code-block"
       >
         <span
-          v-if="!useSingleLine"
+          v-if="!isSingleLine"
           class="k-line-number-rows"
         >
           <span
@@ -216,13 +216,13 @@
         v-else
         class="k-highlighted-code-block"
         :class="{
-          'use-single-line': useSingleLine,
+          'is-single-line': isSingleLine,
           'show-copy-button': showCopyButton
         }"
         data-testid="k-code-block-highlighted-code-block"
       >
         <span
-          v-if="!useSingleLine"
+          v-if="!isSingleLine"
           class="k-line-number-rows"
         >
           <span
@@ -376,7 +376,7 @@ const props = defineProps({
   /**
    * Displays the code on a single line. **Default: `false`**.
    */
-  useSingleLine: {
+  isSingleLine: {
     type: Boolean,
     required: false,
     default: false,
@@ -448,7 +448,7 @@ const filteredCode = computed(function() {
     })
     .join('\n')
 })
-const finalCode = computed(() => props.useSingleLine ? codeRef.value?.replace('\n', '') : props.code)
+const finalCode = computed(() => props.isSingleLine ? codeRef.value?.replace('\n', '') : props.code)
 
 watch(() => props.code, async function() {
   // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.
@@ -1194,7 +1194,7 @@ $dark-focusColor: var(--green-500, color(green-500));
 }
 
 .k-code-block-content {
-  pre.k-highlighted-code-block.use-single-line {
+  pre.k-highlighted-code-block.is-single-line {
     display: flex;
     min-height: 46px;
 

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -794,10 +794,10 @@ $dark-focusColor: var(--green-500, color(green-500));
   display: grid;
   grid-template-columns: var(--maxLineNumberWidth) 1fr;
   gap: var(--spacing-sm, spacing(sm));
-  min-height: 44px;
+  min-height: 56px;
   max-height: var(--KCodeBlockMaxHeight, none);
   overflow: auto;
-  padding: var(--spacing-xs, spacing(xs)) 0 var(--spacing-xs, spacing(xs)) var(--spacing-sm, spacing(sm));
+  padding: var(--spacing-md, spacing(md)) 0 var(--spacing-md, spacing(md)) var(--spacing-sm, spacing(sm));
   margin-top: 0;
   margin-bottom: 0;
   background-color: var(--KCodeBlockBackgroundColor, $light-backgroundColor);
@@ -1196,7 +1196,7 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-code-block-content {
   pre.k-highlighted-code-block.is-single-line {
     display: flex;
-    min-height: 46px;
+    padding: var(--spacing-sm, spacing(sm)) 0 var(--spacing-sm, spacing(sm)) var(--spacing-sm, spacing(sm));
 
     code {
       white-space: nowrap;
@@ -1223,7 +1223,7 @@ $dark-focusColor: var(--green-500, color(green-500));
     }
 
     + .k-code-block-copy-button {
-      top: var(--spacing-xxs, 4px);
+      top: var(--spacing-xs, 4px);
     }
   }
 }

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1195,13 +1195,15 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-code-block-content {
   pre.k-highlighted-code-block.is-single-line {
     display: flex;
-    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xxl, spacing(xxl)) var(--spacing-sm, spacing(sm)) var(--spacing-sm, spacing(sm));
+    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xxl, spacing(xxl)) 0 0;
 
     code {
       white-space: nowrap;
       overflow: auto;
       line-height: 29px;
       margin-right: 20px;
+      padding-bottom: var(--spacing-xs, spacing(xs));
+      padding-left: var(--spacing-sm, spacing(sm));
     }
 
     + .k-code-block-copy-button {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -271,7 +271,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, PropType, toRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, PropType } from 'vue'
 
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -413,7 +413,6 @@ const codeBlockCopyButton = ref<typeof KButton | null>(null)
 const numberOfMatches = ref(0)
 const matchingLineNumbers = ref<number[]>([])
 const currentLineIndex = ref<null | number>(null)
-const codeRef = toRef(props, 'code')
 
 const totalLines = computed(() => {
   let length: number
@@ -448,7 +447,7 @@ const filteredCode = computed(function() {
     })
     .join('\n')
 })
-const finalCode = computed(() => props.isSingleLine ? codeRef.value?.replace('\n', '') : props.code)
+const finalCode = computed(() => props.isSingleLine ? props.code?.replace('\n', '') : props.code)
 
 watch(() => props.code, async function() {
   // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1221,14 +1221,9 @@ $dark-focusColor: var(--green-500, color(green-500));
         }
       }
     }
-  }
 
-  .k-code-block-copy-button {
-    top: var(--spacing-xxs, 4px);
-
-    &.k-button {
-      color: var(--steel-300, color(steel-300));
-      background-color: var(--black-500, color(black-500));
+    + .k-code-block-copy-button {
+      top: var(--spacing-xxs, 4px);
     }
   }
 }


### PR DESCRIPTION
# Summary

- Adds a new `useSingleLine` prop, which will display the code passed into the CodeBlock component on a single line. We have a number of use cases and requirements for this in Konnect.
- Adds docs for the new prop
- Adds a test that verifies the new class is added

**Notes:**
- Line numbers will not be displayed and code will not be searchable when `useSingleLine` is enabled
- I'd thought about adding a prop to allow toggling wether or not the content on the single line gets truncated after a certain length, but decided to truncate by default for now. Happy to change this if anyone thinks truncation should be able to be toggled by default.

### Screenshots
**Docs addition**
<img width="715" alt="Screenshot 2023-01-03 at 3 30 33 PM" src="https://user-images.githubusercontent.com/2080476/210452663-f30fb9b2-b36a-42a8-9c06-21b496f0e54c.png">

**With copy button**
<img width="715" alt="Screenshot 2023-01-03 at 3 37 34 PM" src="https://user-images.githubusercontent.com/2080476/210452987-b8210f70-aabd-462f-9486-7e0b33263fd1.png">

**Without copy button**
<img width="715" alt="Screenshot 2023-01-03 at 3 37 51 PM" src="https://user-images.githubusercontent.com/2080476/210452985-57a41d4c-47bb-417b-88e0-93fa7fdcaa73.png">




<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
