### PR TITLE
feat(kmultiselect): allow item creation [khcp-5569]

### DIFF
--- a/docs/.vitepress/theme/index.scss
+++ b/docs/.vitepress/theme/index.scss
@@ -9,6 +9,14 @@ body {
   font-family: "Inter", Helvetica, Arial, sans-serif;
 }
 
+pre.json {
+  font-size: var(--type-sm);
+  white-space: pre-wrap;
+  padding: 16px;
+  background-color: var(--grey-200);
+  border-radius: 8px;
+}
+
 .VPContent {
   // Tables
   table {

--- a/docs/components/datetime-picker.md
+++ b/docs/components/datetime-picker.md
@@ -522,13 +522,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss">
-pre.json {
-  font-size: var(--type-sm);
-  white-space: pre-wrap;
-  padding: 16px;
-  background-color: var(--grey-200);
-  border-radius: 8px;
-}
-</style>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -566,8 +566,8 @@ You can use the `empty` slot to customize the look of the dropdown list when the
 | `selected`          | an item is clicked | array of selected item objects |
 | `update:modelValue` | selections are changed | array of selected item values |
 | `change`            | selections are changed | last item selected/deselected Object or null |
-| `added`             | enableItemCreation is true and an item is added | item object being added to selections |
-| `removed`           | enableItemCreation is true and an added item is deselected | item object being removed from selections |
+| `item:added`             | enableItemCreation is true and an item is added | item object being added to selections |
+| `item:removed`           | enableItemCreation is true and an added item is deselected | item object being removed from selections |
 | `query-change`      | filter string is changed | `query` String |
 
 <script lang="ts">

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -59,18 +59,26 @@ An array of items containing a `label` and `value`. You may also specify:
 
 ### enableItemCreation
 
-`KMultiselect` offers the ability to add custom items to the list by typing the `label` you want to add and pressing `Enter` (which will automatically select it). Newly created items will have a randomly generated id for the `value` to ensure uniqueness. This action triggers an `added` event containing the newly added item data. Deselecting the item will completely remove it from the list. This action triggers a `removed` event containing the removed item's data.
+`KMultiselect` can offer users the ability to add custom items to the list by typing the item they want to and then clicking the `... (New value)` item at the bottom of the list, which will also automatically select it.
+
+Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. This action triggers an `item:added` event containing the added item data.
+
+Deselecting the item will completely remove it from the list and trigger a `item:removed` event containing the removed item's data.
+
+:::tip NOTE
+You cannot add an item if the `label` matches the `label` of a pre-existing item. In that scenario the `... (New value)` item will not be displayed.
+:::
 
 <ClientOnly>
-  <KLabel>Value:</KLabel> {{ mySelections }}
-  <br>
-  <KLabel>Added Items:</KLabel> {{ addedItems }}
+  <KLabel>Value:</KLabel> <pre class="json ma-0">{{ JSON.stringify(mySelections) }}</pre>
+  <KLabel>Added Items:</KLabel> <pre class="json ma-0">{{ JSON.stringify(addedItems) }}</pre>
   <KMultiselect
     v-model="mySelections"
     :items="deepClone(defaultItems)"
     enable-item-creation
-    @added="(item) => trackNewItems(item, true)"
-    @removed="(item) => trackNewItems(item, false)"
+    class="mt-2"
+    @item:added="(item) => trackNewItems(item, true)"
+    @item:removed="(item) => trackNewItems(item, false)"
   />
 </ClientOnly>
 
@@ -82,8 +90,8 @@ An array of items containing a `label` and `value`. You may also specify:
     v-model="mySelections"
     :items="items"
     enable-item-creation
-    @added="(item) => trackNewItems(item, true)"
-    @removed="(item) => trackNewItems(item, false)"
+    @item:added="(item) => trackNewItems(item, true)"
+    @item:removed="(item) => trackNewItems(item, false)"
   />
 </template>
 
@@ -229,8 +237,8 @@ See [autosuggest](#autosuggest) for more details.
 `KMultiselect` works as regular inputs do using v-model for data binding:
 
 <ClientOnly>
-  <KLabel>Value:</KLabel> {{ myVal }}
-  <KMultiselect v-model="myVal" :items="deepClone(defaultItems)" />
+  <KLabel>Value:</KLabel> <pre class="json ma-0">{{ JSON.stringify(myVal) }}</pre>
+  <KMultiselect v-model="myVal" :items="deepClone(defaultItems)" class="mt-2" />
   <br>
   <KButton @click="clearIt">Clear</KButton>
 </ClientOnly>
@@ -295,12 +303,13 @@ When using `autosuggest`, you **MUST** use `v-model` otherwise the Multiselect c
 :::
 
 <ClientOnly>
-  <KLabel>Value:</KLabel> {{ myAutoVal }}
+  <KLabel>Value:</KLabel> <pre class="json ma-0">{{ JSON.stringify(myAutoVal) }}</pre>
   <KMultiselect
     v-model="myAutoVal"
     autosuggest
     :items="itemsForAutosuggest"
     :loading="loading"
+    class="mt-2"
     @query-change="onQueryChange"
   >
     <template v-slot:item-template="{ item }">

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -66,7 +66,7 @@ You may also specify:
 
 Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. It will also have an attribute `custom` set to `true`. This action triggers an `item:added` event containing the added item data.
 
-Deselecting the item will completely remove it from the list and trigger a `item:removed` event containing the removed item's data.
+Deselecting the item will completely remove it from the list and underlying data, and trigger a `item:removed` event containing the removed item's data.
 
 :::tip NOTE
 You cannot add an item if the `label` matches the `label` of a pre-existing item. In that scenario the `... (New value)` item will not be displayed.
@@ -99,7 +99,7 @@ You cannot add an item if the `label` matches the `label` of a pre-existing item
 </template>
 
 <script setup lang="ts">
-  const mySelections = ref([])
+  const mySelections = ref(['cats','bunnies'])
   const addedItems = ref([])
 
   const trackNewItems = (item, added) => {

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -19,9 +19,12 @@
 
 ### items
 
-An array of items containing a `label` and `value`. You may also specify:
-- a certain items are `selected` by default
-- a certain items are `disabled`
+An array of items containing a `label` and `value`.
+
+You may also specify:
+- a certain item is `selected` by default
+- a certain item is `disabled`
+- a certain item is `added` (see [`enableItemCreation`](#enableitemcreation) for more information)
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />
@@ -61,7 +64,7 @@ An array of items containing a `label` and `value`. You may also specify:
 
 `KMultiselect` can offer users the ability to add custom items to the list by typing the item they want to and then clicking the `... (New value)` item at the bottom of the list, which will also automatically select it.
 
-Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. This action triggers an `item:added` event containing the added item data.
+Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. It will also have an attribute `added` set to `true`. This action triggers an `item:added` event containing the added item data.
 
 Deselecting the item will completely remove it from the list and trigger a `item:removed` event containing the removed item's data.
 
@@ -575,9 +578,80 @@ You can use the `empty` slot to customize the look of the dropdown list when the
 | `selected`          | an item is clicked | array of selected item objects |
 | `update:modelValue` | selections are changed | array of selected item values |
 | `change`            | selections are changed | last item selected/deselected Object or null |
-| `item:added`             | enableItemCreation is true and an item is added | item object being added to selections |
-| `item:removed`           | enableItemCreation is true and an added item is deselected | item object being removed from selections |
+| `item:added`        | enableItemCreation is true and an item is added | item object being added to selections |
+| `item:removed`      | enableItemCreation is true and an added item is deselected | item object being removed from selections |
 | `query-change`      | filter string is changed | `query` String |
+
+An example of hooking into events to modify newly created items (`enableItemCreation`) as they are added.
+
+<ClientOnly>
+  <KLabel>myItems:</KLabel> <pre class="json ma-0">{{ JSON.stringify(myEventItems) }}</pre>
+  <KMultiselect
+    :items="myEventItems"
+    enable-item-creation
+    @item:added="item => handleAddedItem(item, true)"
+    @item:removed="item => handleAddedItem(item, false)"
+    @selected="handleSelection"
+  />
+</ClientOnly>
+
+```html
+<template>
+  <KMultiselect
+    :items="myItems"
+    enable-item-creation
+    @item:added="item => handleAddedItem(item, true)"
+    @item:removed="item => handleAddedItem(item, false)"
+    @selected="handleSelection"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const myItems = ref([
+  {
+    label: '200',
+    value: 200
+  },
+  {
+    label: '400',
+    value: 400
+  },
+  {
+    label: '401',
+    value: 401
+  },
+  {
+    label: '404',
+    value: 404
+  },
+  {
+    label: '500',
+    value: 500
+  },
+])
+
+const handleAddedItem = (item, added) => {
+  if (added) { // addition
+    item.added = true
+    // mutate added items in some way
+    item.value = `${item.label}-overridden`
+    myItems.value.push(item)
+  } else { // removal
+    myItems.value = myItems.value.filter(anItem => anItem.value !== item.value)
+  }
+}
+
+const handleSelection = (selectedItems) => {
+  // updated selected state
+  myItems.value.forEach(item => {
+    const itemSelected = selectedItems.filter(sItem => sItem.value === item.value).length
+    item.selected = itemSelected ? true : false
+  })
+}
+</script>
+```
 
 <script lang="ts">
 import { defineComponent } from 'vue'
@@ -749,6 +823,26 @@ export default defineComponent({
         label: 'A long & truncated item',
         value: 'long'
       }],
+      myEventItems: [{
+        label: '200',
+        value: 200
+      },
+      {
+        label: '400',
+        value: 400
+      },
+      {
+        label: '401',
+        value: 401
+      },
+      {
+        label: '404',
+        value: 404
+      },
+      {
+        label: '500',
+        value: 500
+      }],
       defaultItemsForAutosuggest: [],
       itemsForAutosuggest: [],
       loading: false,
@@ -826,7 +920,24 @@ export default defineComponent({
             .map(item => Object.assign({}, item));
         this.loadingForDebounced = false;
       }, 200);
-    }, 400)
+    }, 400),
+    handleAddedItem (item, added) {
+      if (added) { // addition
+        item.added = true
+        // mutate added items in some way
+        item.value = `${item.label}-overridden`
+        this.myEventItems.push(item)
+      } else { // removal
+        this.myEventItems = this.myEventItems.filter(anItem => anItem.value !== item.value)
+      }
+    },
+    handleSelection (selectedItems) {
+      // updated selected state
+      this.myEventItems.forEach(item => {
+        const itemSelected = selectedItems.filter(sItem => sItem.value === item.value).length
+        item.selected = itemSelected ? true : false
+      })
+    }
   },
   computed: {
     defaultItemsLongList () {

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -24,7 +24,6 @@ An array of items containing a `label` and `value`.
 You may also specify:
 - a certain item is `selected` by default
 - a certain item is `disabled`
-- a certain item is `custom` (see [`enableItemCreation`](#enableitemcreation) for more information)
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />
@@ -62,14 +61,14 @@ You may also specify:
 
 ### enableItemCreation
 
-`KMultiselect` can offer users the ability to add custom items to the list by typing the item they want to and then clicking the `... (New value)` item at the bottom of the list, which will also automatically select it.
+`KMultiselect` can offer users the ability to add custom items to the list by typing the item they want to and then clicking the `... (Add new value)` item at the bottom of the list, which will also automatically select it.
 
 Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. It will also have an attribute `custom` set to `true`. This action triggers an `item:added` event containing the added item data.
 
 Deselecting the item will completely remove it from the list and underlying data, and trigger a `item:removed` event containing the removed item's data.
 
 :::tip NOTE
-You cannot add an item if the `label` matches the `label` of a pre-existing item. In that scenario the `... (New value)` item will not be displayed.
+You cannot add an item if the `label` matches the `label` of a pre-existing item. In that scenario the `... (Add new value)` item will not be displayed.
 :::
 
 <ClientOnly>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -24,7 +24,7 @@ An array of items containing a `label` and `value`.
 You may also specify:
 - a certain item is `selected` by default
 - a certain item is `disabled`
-- a certain item is `added` (see [`enableItemCreation`](#enableitemcreation) for more information)
+- a certain item is `custom` (see [`enableItemCreation`](#enableitemcreation) for more information)
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />
@@ -64,7 +64,7 @@ You may also specify:
 
 `KMultiselect` can offer users the ability to add custom items to the list by typing the item they want to and then clicking the `... (New value)` item at the bottom of the list, which will also automatically select it.
 
-Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. It will also have an attribute `added` set to `true`. This action triggers an `item:added` event containing the added item data.
+Newly created items will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. It will also have an attribute `custom` set to `true`. This action triggers an `item:added` event containing the added item data.
 
 Deselecting the item will completely remove it from the list and trigger a `item:removed` event containing the removed item's data.
 
@@ -589,6 +589,7 @@ An example of hooking into events to modify newly created items (`enableItemCrea
   <KMultiselect
     :items="myEventItems"
     enable-item-creation
+    class="mt-2"
     @item:added="item => handleAddedItem(item, true)"
     @item:removed="item => handleAddedItem(item, false)"
     @selected="handleSelection"
@@ -634,7 +635,7 @@ const myItems = ref([
 
 const handleAddedItem = (item, added) => {
   if (added) { // addition
-    item.added = true
+    item.custom = true
     // mutate added items in some way
     item.value = `${item.label}-overridden`
     myItems.value.push(item)
@@ -923,7 +924,7 @@ export default defineComponent({
     }, 400),
     handleAddedItem (item, added) {
       if (added) { // addition
-        item.added = true
+        item.custom = true
         // mutate added items in some way
         item.value = `${item.label}-overridden`
         this.myEventItems.push(item)

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -57,6 +57,21 @@ An array of items containing a `label` and `value`. You may also specify:
 />
 ```
 
+### enableItemCreation
+
+`KMultiselect` offers the ability to add custom items to the list by typing the `label` you want to add and pressing `Enter` (which will automatically select it). Deselecting the item will completely remove it from the list.
+
+<ClientOnly>
+  <KMultiselect :items="deepClone(defaultItems)" enable-item-creation />
+</ClientOnly>
+
+```html
+<KMultiselect
+  :items="items"
+  enable-item-creation
+/>
+```
+
 ### label
 
 The label for the select.

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -486,14 +486,6 @@ const handleChildChange = (data) => {
 </script>
 
 <style scoped lang="scss">
-pre.json {
-  font-size: var(--type-sm);
-  white-space: pre-wrap;
-  padding: 16px;
-  background-color: var(--grey-200);
-  border-radius: 8px;
-}
-
 .slot-example :deep(.k-tree-item) .k-tree-item-icon {
   line-height: 1.4;
 }

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -190,9 +190,13 @@ describe('KMultiselect', () => {
 
     cy.getTestId(`k-multiselect-item-${vals[0]}`).should('contain.text', labels[0])
     cy.getTestId(`k-multiselect-item-${vals[1]}`).should('contain.text', labels[1])
-
+    // no adding a label that already exists
+    cy.get('input').type(labels[0])
+    cy.getTestId('k-multiselect-add-item').should('not.exist')
+    cy.get('input').clear()
+    // add new item
     cy.get('input').type(newItem)
-    cy.get('input').type('{enter}')
+    cy.getTestId('k-multiselect-add-item').should('contain.text', newItem).click()
     // search is cleared
     cy.get('input').should('not.contain.text', newItem)
     // item displays in selections
@@ -200,6 +204,8 @@ describe('KMultiselect', () => {
     // item displays when searching
     cy.get('input').type(newItem)
     cy.get('.k-multiselect-item .k-multiselect-item-label').should('contain.text', newItem)
+    // no adding a label that already exists
+    cy.getTestId('k-multiselect-add-item').should('not.exist')
     // item gone when dismissed
     cy.getTestId('k-multiselect-selections').get('.k-badge-dismiss-button').first().click()
     // removed from selections
@@ -207,7 +213,7 @@ describe('KMultiselect', () => {
     // gone when searching
     cy.get('input').clear()
     cy.get('input').type(newItem)
-    cy.get('.k-multiselect-item .k-multiselect-item-label').should('not.contain.text', newItem)
+    cy.get('.k-multiselect-item .selected .k-multiselect-item-label').should('not.exist')
   })
 
   it('ignores clicks on disabled item', () => {

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -167,6 +167,49 @@ describe('KMultiselect', () => {
     cy.getTestId('k-multiselect-selections').should('contain.text', labels[0])
   })
 
+  it('allows adding an item with enableItemCreation', () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+    const newItem = 'Rock me'
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }],
+        enableItemCreation: true,
+      },
+    })
+
+    cy.get('.k-multiselect-input').click()
+
+    cy.getTestId(`k-multiselect-item-${vals[0]}`).should('contain.text', labels[0])
+    cy.getTestId(`k-multiselect-item-${vals[1]}`).should('contain.text', labels[1])
+
+    cy.get('input').type(newItem)
+    cy.get('input').type('{enter}')
+    // search is cleared
+    cy.get('input').should('not.contain.text', newItem)
+    // item displays in selections
+    cy.getTestId('k-multiselect-selections').should('contain.text', newItem)
+    // item displays when searching
+    cy.get('input').type(newItem)
+    cy.get('.k-multiselect-item .k-multiselect-item-label').should('contain.text', newItem)
+    // item gone when dismissed
+    cy.getTestId('k-multiselect-selections').get('.k-badge-dismiss-button').first().click()
+    // removed from selections
+    cy.getTestId('k-multiselect-selections').should('not.to.exist')
+    // gone when searching
+    cy.get('input').clear()
+    cy.get('input').type(newItem)
+    cy.get('.k-multiselect-item .k-multiselect-item-label').should('not.contain.text', newItem)
+  })
+
   it('ignores clicks on disabled item', () => {
     const labels = ['Label 1', 'Label 2']
     const vals = ['label1', 'label2']

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -216,6 +216,42 @@ describe('KMultiselect', () => {
     cy.get('.k-multiselect-item .selected .k-multiselect-item-label').should('not.exist')
   })
 
+  it('clears added items when clicking clear all with enableItemCreation', () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+    const newItem = 'Rock me'
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }],
+        enableItemCreation: true,
+      },
+    })
+
+    cy.get('.k-multiselect-input').click()
+
+    cy.getTestId(`k-multiselect-item-${vals[0]}`).should('contain.text', labels[0])
+    cy.getTestId(`k-multiselect-item-${vals[1]}`).should('contain.text', labels[1])
+
+    // add new item
+    cy.get('input').type(newItem)
+    cy.getTestId('k-multiselect-add-item').should('contain.text', newItem).click()
+    // item displays in selections
+    cy.getTestId('k-multiselect-selections').should('contain.text', newItem)
+    cy.getTestId('k-multiselect-clear-icon').click()
+    // cleared
+    cy.getTestId('k-multiselect-selections').should('not.to.exist')
+    cy.get('input').type(newItem)
+    cy.get('.k-multiselect-item .selected .k-multiselect-item-label').should('not.exist')
+  })
+
   it('ignores clicks on disabled item', () => {
     const labels = ['Label 1', 'Label 2']
     const vals = ['label1', 'label2']

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -16,7 +16,7 @@
       :id="multiselectId"
       data-testid="k-multiselect-container"
     >
-      <KToggle v-slot="{ toggle, isToggled }">
+      <KToggle v-slot="{ isToggled, toggle }">
         <KPop
           ref="popper"
           v-bind="boundKPopAttributes"
@@ -26,17 +26,8 @@
           :position-fixed="positionFixed"
           :target="`[id='${multiselectInputId}']`"
           :test-mode="!!testMode || undefined"
-          @closed="() => {
-            if (isToggled.value) {
-              toggle()
-              sortItems()
-            }
-            filterStr = ''
-          }"
-          @opened="() => {
-            filterStr = ''
-            toggle()
-          }"
+          @closed="() => handleToggle(false, isToggled, toggle)"
+          @opened="() => handleToggle(true, isToggled, toggle)"
         >
           <div
             ref="multiselectRef"
@@ -134,6 +125,7 @@
                 }"
                 @focus="onInputFocus"
                 @keyup="(evt: any) => triggerFocus(evt, isToggled)"
+                @keyup.enter="(evt: any) => handleAddItem(evt)"
                 @mouseenter="() => isHovered = true"
                 @mouseleave="() => isHovered = false"
                 @update:model-value="onQueryChange"
@@ -175,7 +167,7 @@
                     No results found
                   </div>
                   <div class="select-item-desc">
-                    Please adjust the criteria and try again
+                    {{ enableItemCreation ? 'You can still add this value by pressing “enter”' : 'Please adjust the criteria and try again' }}
                   </div>
                 </template>
               </KMultiselectItem>
@@ -225,7 +217,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, computed, watch, PropType, nextTick, onMounted } from 'vue'
+import { ref, Ref, computed, watch, PropType, nextTick, onMounted, useAttrs } from 'vue'
 import { v1 as uuidv1 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
 import KBadge from '@/components/KBadge/KBadge.vue'
@@ -236,16 +228,6 @@ import KLabel from '@/components/KLabel/KLabel.vue'
 import KPop from '@/components/KPop/KPop.vue'
 import KToggle from '@/components/KToggle'
 import KMultiselectItem from '@/components/KMultiselect/KMultiselectItem.vue'
-
-const { getSizeFromString, cloneDeep } = useUtilities()
-const SELECTED_ITEMS_SINGLE_LINE_HEIGHT = 34
-
-const defaultKPopAttributes = {
-  hideCaret: true,
-  placement: 'bottomStart',
-  popoverTimeout: 0,
-  popoverClasses: 'k-multiselect-popover mt-0',
-}
 
 export interface MultiselectItem {
   label: string
@@ -260,564 +242,587 @@ export interface MultiselectFilterFnParams {
   query: string
 }
 
-export default defineComponent({
-  name: 'KMultiselect',
-  components: {
-    KBadge,
-    KButton,
-    KIcon,
-    KInput,
-    KLabel,
-    KPop,
-    KMultiselectItem,
-    KToggle,
-  },
+export default {
   inheritAttrs: false,
-  props: {
-    modelValue: {
-      type: Array as PropType<string[]>,
-      default: () => [],
-    },
-    label: {
-      type: String,
-      default: '',
-    },
-    labelAttributes: {
-      type: Object,
-      default: () => ({}),
-    },
-    placeholder: {
-      type: String,
-      default: '',
-    },
-    kpopAttributes: {
-      type: Object,
-      default: () => ({
-        popoverClasses: '',
-      }),
-    },
-    dropdownMaxHeight: {
-      type: String,
-      default: '300',
-    },
-    /**
-     * The width of the multiselect and popover's min-width
-     */
-    width: {
-      type: String,
-      default: '',
-    },
-    /**
-     * Number of rows of selections to show when focused
-     */
-    selectedRowCount: {
-      type: Number,
-      default: 2,
-    },
-    /**
-     * Determines whether or not to hide the selections when not focused,
-     * and whether or not to move items displayed beyond the selectedRowCount
-     * into a +n badge, or allow the sections to be scrollable.
-     */
-    expandSelected: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * Items are JSON objects with required 'label' and 'value'
-     * {
-     *  label: 'Item 1',
-     *  value: 'item1'
-     * }
-     */
-    items: {
-      type: Array as PropType<MultiselectItem[]>,
-      default: () => [],
-      // Items must have a label & value
-      validator: (items: MultiselectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
-    },
-    /**
-     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
-     */
-    positionFixed: {
-      type: Boolean,
-      default: true,
-    },
-    /**
-     * Override default filter functionality of case-insensitive search on label
-     */
-    filterFunc: {
-      type: Function,
-      default: (params: MultiselectFilterFnParams) => params.items.filter((item: MultiselectItem) => item.label.toLowerCase().includes(params.query.toLowerCase())),
-    },
-    /**
-     * A flag for autosuggest mode
-     */
-    autosuggest: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * Loading state in autosuggest
-     */
-    loading: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * Test mode - for testing only, strips out generated ids
-     */
-    testMode: {
-      type: Boolean,
-      default: false,
-    },
+}
+</script>
+
+<script setup lang="ts">
+const attrs = useAttrs()
+const { getSizeFromString, cloneDeep } = useUtilities()
+const SELECTED_ITEMS_SINGLE_LINE_HEIGHT = 34
+
+const props = defineProps({
+  modelValue: {
+    type: Array as PropType<string[]>,
+    default: () => [],
   },
-  emits: ['selected', 'input', 'change', 'update:modelValue', 'query-change'],
-  setup(props, { attrs, emit }) {
-    // keys and ids
-    const key = ref(0)
-    const stagingKey = ref(0)
-    const multiselectId = computed((): string => props.testMode ? 'test-multiselect-id-1234' : uuidv1())
-    const multiselectInputId = computed((): string => props.testMode ? 'test-multiselect-input-id-1234' : uuidv1())
-    const multiselectTextId = computed((): string => props.testMode ? 'test-multiselect-text-id-1234' : uuidv1())
-    const multiselectSelectedItemsId = computed((): string => props.testMode ? 'test-multiselect-selected-id-1234' : uuidv1())
-    const multiselectSelectedItemsStagingId = computed((): string => props.testMode ? 'test-multiselect-selected-staging-id-1234' : uuidv1())
-    const multiselectRef = ref(null)
-    const selectionBottomRef = ref(null)
-    // filter and selection
-    const selectionsMaxHeight = computed((): number => {
-      return props.selectedRowCount * SELECTED_ITEMS_SINGLE_LINE_HEIGHT
-    })
-    const filterStr = ref('')
-    const popper = ref(null)
-    const unfilteredItems: Ref<MultiselectItem[]> = ref([])
-    const sortedItems: Ref<MultiselectItem[]> = ref([])
-    const selectedItems = ref<MultiselectItem[]>([])
-    const visibleSelectedItemsStaging = ref<MultiselectItem[]>([])
-    const invisibleSelectedItemsStaging = ref<MultiselectItem[]>([])
-    const visibleSelectedItems = ref<MultiselectItem[]>([])
-    const invisibleSelectedItems = ref<MultiselectItem[]>([])
-    const hiddenItemsTooltip = computed(() => invisibleSelectedItems.value.map(item => item.label).join(', '))
-    // state
-    const initialFocusTriggered: Ref<boolean> = ref(false)
-    const isHovered = ref(false)
-    const isFocused = ref(false)
-    const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
-    const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
+  label: {
+    type: String,
+    default: '',
+  },
+  labelAttributes: {
+    type: Object,
+    default: () => ({}),
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  kpopAttributes: {
+    type: Object,
+    default: () => ({
+      popoverClasses: '',
+    }),
+  },
+  dropdownMaxHeight: {
+    type: String,
+    default: '300',
+  },
+  /**
+   * The width of the multiselect and popover's min-width
+   */
+  width: {
+    type: String,
+    default: '',
+  },
+  /**
+   * Number of rows of selections to show when focused
+   */
+  selectedRowCount: {
+    type: Number,
+    default: 2,
+  },
+  /**
+   * Determines whether or not to hide the selections when not focused,
+   * and whether or not to move items displayed beyond the selectedRowCount
+   * into a +n badge, or allow the sections to be scrollable.
+   */
+  expandSelected: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Items are JSON objects with required 'label' and 'value'
+   * {
+   *  label: 'Item 1',
+   *  value: 'item1'
+   * }
+   */
+  items: {
+    type: Array as PropType<MultiselectItem[]>,
+    default: () => [],
+    // Items must have a label & value
+    validator: (items: MultiselectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
+  },
+  /**
+   * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+   */
+  positionFixed: {
+    type: Boolean,
+    default: true,
+  },
+  /**
+   * Override default filter functionality of case-insensitive search on label
+   */
+  filterFunc: {
+    type: Function,
+    default: (params: MultiselectFilterFnParams) => params.items.filter((item: MultiselectItem) => item.label.toLowerCase().includes(params.query.toLowerCase())),
+  },
+  /**
+   * A flag for autosuggest mode
+   */
+  autosuggest: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Allow creating new items
+   */
+  enableItemCreation: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Loading state in autosuggest
+   */
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Test mode - for testing only, strips out generated ids
+   */
+  testMode: {
+    type: Boolean,
+    default: false,
+  },
+})
 
-    // we need this so we can create a watcher for programmatic changes to the modelValue
-    const value = computed({
-      get(): string[] {
-        return props.modelValue
-      },
-      set(newValue: string[]): void {
-        const items = unfilteredItems.value.filter((item: MultiselectItem) => newValue.includes(item.value))
+const emit = defineEmits(['selected', 'added', 'input', 'change', 'update:modelValue', 'query-change'])
 
-        if (items.length) {
-          handleMultipleItemsSelect(items)
-        } else if (!newValue.length) {
-          clearSelection()
-        }
-      },
-    })
+const defaultKPopAttributes = {
+  hideCaret: true,
+  placement: 'bottomStart',
+  popoverTimeout: 0,
+  popoverClasses: 'k-multiselect-popover mt-0',
+}
 
-    const modifiedAttrs = computed(() => {
-      const $attrs = { ...attrs }
+// keys and ids
+const key = ref(0)
+const stagingKey = ref(0)
+const multiselectId = computed((): string => props.testMode ? 'test-multiselect-id-1234' : uuidv1())
+const multiselectInputId = computed((): string => props.testMode ? 'test-multiselect-input-id-1234' : uuidv1())
+const multiselectTextId = computed((): string => props.testMode ? 'test-multiselect-text-id-1234' : uuidv1())
+const multiselectSelectedItemsId = computed((): string => props.testMode ? 'test-multiselect-selected-id-1234' : uuidv1())
+const multiselectSelectedItemsStagingId = computed((): string => props.testMode ? 'test-multiselect-selected-staging-id-1234' : uuidv1())
+const multiselectRef = ref(null)
+const selectionBottomRef = ref(null)
+// filter and selection
+const selectionsMaxHeight = computed((): number => {
+  return props.selectedRowCount * SELECTED_ITEMS_SINGLE_LINE_HEIGHT
+})
+const filterStr = ref('')
+const popper = ref(null)
+const unfilteredItems: Ref<MultiselectItem[]> = ref([])
+const addedItems: Ref<MultiselectItem[]> = ref([])
+const sortedItems: Ref<MultiselectItem[]> = ref([])
+const selectedItems = ref<MultiselectItem[]>([])
+const visibleSelectedItemsStaging = ref<MultiselectItem[]>([])
+const invisibleSelectedItemsStaging = ref<MultiselectItem[]>([])
+const visibleSelectedItems = ref<MultiselectItem[]>([])
+const invisibleSelectedItems = ref<MultiselectItem[]>([])
+const hiddenItemsTooltip = computed(() => invisibleSelectedItems.value.map(item => item.label).join(', '))
+// state
+const initialFocusTriggered: Ref<boolean> = ref(false)
+const isHovered = ref(false)
+const isFocused = ref(false)
+const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
+const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
 
-      // delete classes because we bind them to the parent
-      delete $attrs.class
+// we need this so we can create a watcher for programmatic changes to the modelValue
+const value = computed({
+  get(): string[] {
+    return props.modelValue
+  },
+  set(newValue: string[]): void {
+    const items = unfilteredItems.value.filter((item: MultiselectItem) => newValue.includes(item.value))
 
-      return $attrs
-    })
-
-    const createKPopAttributes = computed(() => {
-      return {
-        ...defaultKPopAttributes,
-        ...props.kpopAttributes,
-        popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-multiselect-pop`,
-        width: numericWidth.value + 'px',
-        maxWidth: numericWidth.value + 'px',
-        maxHeight: String(props.dropdownMaxHeight),
-        disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
-      }
-    })
-
-    // TypeScript complains if I bind the original object
-    const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
-
-    const widthValue = computed(() => {
-      let w = ''
-      if (!props.width) {
-        w = '300'
-      } else {
-        w = props.width
-      }
-
-      return getSizeFromString(w)
-    })
-
-    const widthStyle = computed(() => {
-      return {
-        width: widthValue.value,
-      }
-    })
-
-    const numericWidthStyle = computed(() => {
-      return {
-        width: numericWidth.value + 'px',
-      }
-    })
-
-    const nonSlimStyle = computed(() => {
-      return {
-        width: (numericWidth.value - 30) + 'px',
-        maxHeight: selectionsMaxHeight.value + 'px',
-        paddingRight: 0,
-      }
-    })
-
-    const getPlaceholderText = (isOpen?: boolean): string => {
-      if (selectedItems.value.length && !isOpen) {
-        if (selectedItems.value.length === 1) {
-          return `${selectedItems.value.length} item selected`
-        }
-        return `${selectedItems.value.length} items selected`
-      }
-
-      if (props.placeholder) {
-        return props.placeholder
-      } else if (attrs.placeholder) {
-        return String(attrs.placeholder || '')
-      }
-
-      return 'Filter...'
+    if (items.length) {
+      handleMultipleItemsSelect(items)
+    } else if (!newValue.length) {
+      clearSelection()
     }
+  },
+})
 
-    const filteredItems = computed(() => {
-      // For autosuggest, items don't need to be filtered internally
-      return props.autosuggest ? unfilteredItems.value : props.filterFunc({ items: unfilteredItems.value, query: filterStr.value })
-    })
+const modifiedAttrs = computed(() => {
+  const $attrs = { ...attrs }
 
-    const handleFilterClick = (evt: any) => {
-      if (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') {
-        evt.stopPropagation()
-      }
+  // delete classes because we bind them to the parent
+  delete $attrs.class
+
+  return $attrs
+})
+
+const createKPopAttributes = computed(() => {
+  return {
+    ...defaultKPopAttributes,
+    ...props.kpopAttributes,
+    popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-multiselect-pop`,
+    width: numericWidth.value + 'px',
+    maxWidth: numericWidth.value + 'px',
+    maxHeight: String(props.dropdownMaxHeight),
+    disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
+  }
+})
+
+// TypeScript complains if I bind the original object
+const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
+
+const widthValue = computed(() => {
+  let w = ''
+  if (!props.width) {
+    w = '300'
+  } else {
+    w = props.width
+  }
+
+  return getSizeFromString(w)
+})
+
+const widthStyle = computed(() => {
+  return {
+    width: widthValue.value,
+  }
+})
+
+const numericWidthStyle = computed(() => {
+  return {
+    width: numericWidth.value + 'px',
+  }
+})
+
+const nonSlimStyle = computed(() => {
+  return {
+    width: (numericWidth.value - 30) + 'px',
+    maxHeight: selectionsMaxHeight.value + 'px',
+    paddingRight: 0,
+  }
+})
+
+const getPlaceholderText = (isOpen?: boolean): string => {
+  if (selectedItems.value.length && !isOpen) {
+    if (selectedItems.value.length === 1) {
+      return `${selectedItems.value.length} item selected`
     }
+    return `${selectedItems.value.length} items selected`
+  }
 
-    // make sure we don't grow past the max height of the selected items box
-    // do the check off screen in the staging area so the UI doesn't jump
-    const stageSelections = () => {
-      // set timeout required to push the calculation to the end of the update lifecycle event queue
-      setTimeout(() => {
-        const elem = document.getElementById(multiselectSelectedItemsStagingId.value)
+  if (props.placeholder) {
+    return props.placeholder
+  } else if (attrs.placeholder) {
+    return String(attrs.placeholder || '')
+  }
 
-        if (props.expandSelected) {
-          // if it's expanded don't do calculcations, because we will display all
-          stagingKey.value++
-          return
-        }
+  return 'Filter...'
+}
 
-        if (elem) {
-          const height = elem.clientHeight
-          if (height > selectionsMaxHeight.value) {
-            const item = visibleSelectedItemsStaging.value.pop()
-            if (item) {
-              invisibleSelectedItemsStaging.value.push(item)
-            }
-          }
-          stagingKey.value++
-        }
-      }, 0)
-    }
+const filteredItems = computed(() => {
+  // For autosuggest, items don't need to be filtered internally
+  return props.autosuggest ? unfilteredItems.value.concat(addedItems.value) : props.filterFunc({ items: unfilteredItems.value.concat(addedItems.value), query: filterStr.value })
+})
 
-    // handles programmatic selections
-    const handleMultipleItemsSelect = (items: MultiselectItem[]) => {
-      items.forEach(itemToSelect => {
-        const selectedItem = unfilteredItems.value.filter(anItem => anItem.value === itemToSelect.value)[0]
-        selectedItem.selected = true
-        selectedItem.key = selectedItem?.key?.includes('-selected') ? selectedItem.key : `${selectedItem.key}-selected`
-        // if it isn't already in selectedItems, add it
-        if (!selectedItems.value.filter(anItem => anItem.value === selectedItem.value).length) {
-          selectedItems.value.push(selectedItem)
-          visibleSelectedItemsStaging.value.push(selectedItem)
-        }
-      })
+const handleFilterClick = (evt: any) => {
+  if (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') {
+    evt.stopPropagation()
+  }
+}
 
-      stageSelections()
-    }
-
-    // handle item select/deselect from dropdown
-    const handleItemSelect = (item: MultiselectItem) => {
-      let selectedItem = unfilteredItems.value.filter(anItem => anItem.value === item.value)?.[0] || null
-
-      // if it wasn't in unfilteredItems, we are probably filtering with autosuggest, so get it from selectedItems
-      if (selectedItem === null) {
-        selectedItem = selectedItems.value.filter(anItem => anItem.value === item.value)?.[0] || null
-      }
-      // if we still couldn't find it, bail
-      if (selectedItem === null) {
-        return
-      }
-
-      // if clicked item is already selected
-      if (selectedItem.selected) {
-        selectedItems.value = selectedItems.value.filter(anItem => anItem.value !== item.value)
-        // remove item from visibility arrays
-        if (visibleSelectedItemsStaging.value.filter(anItem => anItem.value === item.value).length) {
-          visibleSelectedItemsStaging.value = visibleSelectedItemsStaging.value.filter(anItem => anItem.value !== item.value)
-        } else if (invisibleSelectedItemsStaging.value.filter(anItem => anItem.value === item.value).length) {
-          invisibleSelectedItemsStaging.value = invisibleSelectedItemsStaging.value.filter(anItem => anItem.value !== item.value)
-        }
-        // deselect item
-        selectedItem.selected = false
-        selectedItem.key = selectedItem.key?.replace(/-selected/gi, '')
-
-        // if some items are hidden grab the first hidden one and add it into the visible array
-        if (invisibleSelectedItemsStaging.value.length) {
-          const item = invisibleSelectedItemsStaging.value.pop()
-          if (item) {
-            visibleSelectedItemsStaging.value.push(item)
-          }
-        }
-      } else { // newly selected item
-        selectedItem.selected = true
-        selectedItem.key = selectedItem.key?.includes('-selected') ? selectedItem.key : `${selectedItem.key}-selected`
-        selectedItems.value.push(selectedItem)
-        visibleSelectedItemsStaging.value.push(selectedItem)
-
-        if (props.expandSelected) {
-          // if expanded, scroll new selections into view
-          scrollSmoothlyToBottom()
-        }
-      }
-
-      stageSelections()
-      const selectedVals = selectedItems.value.map(anItem => anItem.value)
-
-      emit('selected', selectedItems.value)
-      emit('change', item)
-      emit('update:modelValue', selectedVals)
-    }
-
-    const scrollSmoothlyToBottom = () => {
-      setTimeout(() => {
-        // @ts-ignore
-        selectionBottomRef.value?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest',
-        })
-      }, 200)
-    }
-
-    // sort dropdown items. Selected items displayed before unselected items
-    const sortItems = () => {
-      const selItems = filteredItems.value.filter((item: MultiselectItem) => item.selected)
-      const unselItems = filteredItems.value.filter((item: MultiselectItem) => !item.selected)
-
-      sortedItems.value = selItems.concat(unselItems)
-    }
-
-    const clearSelection = (): void => {
-      unfilteredItems.value.forEach(anItem => {
-        anItem.selected = false
-        anItem.key = anItem?.key?.replace(/-selected/gi, '')
-      })
-      selectedItems.value = []
-      visibleSelectedItemsStaging.value = []
-      invisibleSelectedItemsStaging.value = []
+const handleToggle = (open: boolean, isToggled: Ref<boolean>, toggle: Function) => {
+  if (open) {
+    if (!isToggled.value) { // not already open
       filterStr.value = ''
-      stageSelections()
-
-      emit('selected', [])
-      emit('change', null)
-      emit('update:modelValue', [])
-      emit('query-change', '')
-    }
-
-    const onQueryChange = (query: string) => {
-      filterStr.value = query
-      emit('query-change', query)
-    }
-
-    const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
-      // Ignore `esc` key
-      if (evt.keyCode === 27) {
-        isToggled.value = false
-        return
-      }
-
-      const inputElem = document.getElementById(multiselectTextId.value)
-      if (!isToggled.value && inputElem) {
-        // simulate click to trigger dropdown open
-        inputElem.click()
-      }
-    }
-
-    const onInputFocus = (): void => {
-      isFocused.value = true
-      if (!initialFocusTriggered.value) {
-        initialFocusTriggered.value = true
-        emit('query-change', '')
-      }
-    }
-
-    // whenever staging key is changed, we're ready to actually draw the selections
-    watch(stagingKey, () => {
-      // set timeout required to push the calculation to the end of the update lifecycle event queue
-      setTimeout(() => {
-        const elem = document.getElementById(multiselectSelectedItemsStagingId.value)
-
-        if (props.expandSelected) {
-          // if expanded, don't do all the calculations because we are going to display
-          // everything
-          visibleSelectedItems.value = cloneDeep(visibleSelectedItemsStaging.value)
-          invisibleSelectedItems.value = []
-          key.value++
-          return
-        }
-
-        if (elem) {
-          const height = elem.clientHeight
-          if (height > selectionsMaxHeight.value) {
-            const item = visibleSelectedItemsStaging.value.pop()
-            if (item) {
-              invisibleSelectedItemsStaging.value.push(item)
-            }
-            stagingKey.value++
-          } else {
-            visibleSelectedItems.value = cloneDeep(visibleSelectedItemsStaging.value)
-            invisibleSelectedItems.value = cloneDeep(invisibleSelectedItemsStaging.value)
-            key.value++
-          }
-        }
-      }, 0)
-    })
-
-    // make the popper recalculate it's position whenever the selections display
-    // is updated in case we've grown a line
-    watch(key, () => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      if (popper.value && typeof popper.value.updatePopper === 'function') {
-        nextTick(() => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          popper.value.updatePopper()
-        })
-      }
-    })
-
-    // If filtered items change, re-sort them
-    watch(filteredItems, () => {
+      toggle()
       sortItems()
+    }
+  } else {
+    if (isToggled.value) { // not already closed
+      filterStr.value = ''
+      toggle()
+    }
+  }
+}
+
+// make sure we don't grow past the max height of the selected items box
+// do the check off screen in the staging area so the UI doesn't jump
+const stageSelections = () => {
+  // set timeout required to push the calculation to the end of the update lifecycle event queue
+  setTimeout(() => {
+    const elem = document.getElementById(multiselectSelectedItemsStagingId.value)
+
+    if (props.expandSelected) {
+      // if it's expanded don't do calculcations, because we will display all
+      stagingKey.value++
+      return
+    }
+
+    if (elem) {
+      const height = elem.clientHeight
+      if (height > selectionsMaxHeight.value) {
+        const item = visibleSelectedItemsStaging.value.pop()
+        if (item) {
+          invisibleSelectedItemsStaging.value.push(item)
+        }
+      }
+      stagingKey.value++
+    }
+  }, 0)
+}
+
+// handles programmatic selections
+const handleMultipleItemsSelect = (items: MultiselectItem[]) => {
+  items.forEach(itemToSelect => {
+    let selectedItem = unfilteredItems.value.filter(anItem => anItem.value === itemToSelect.value)?.[0] || null
+
+    // if it wasn't in unfilteredItems, check newly added items if enabled
+    if (selectedItem === null && props.enableItemCreation) {
+      selectedItem = addedItems.value.filter(anItem => anItem.value === itemToSelect.value)?.[0] || null
+    }
+
+    selectedItem.selected = true
+    selectedItem.key = selectedItem?.key?.includes('-selected') ? selectedItem.key : `${selectedItem.key}-selected`
+    // if it isn't already in selectedItems, add it
+    if (!selectedItems.value.filter(anItem => anItem.value === selectedItem.value).length) {
+      selectedItems.value.push(selectedItem)
+      visibleSelectedItemsStaging.value.push(selectedItem)
+    }
+  })
+
+  stageSelections()
+}
+
+// handle item select/deselect from dropdown
+const handleItemSelect = (item: MultiselectItem, isNew?: boolean) => {
+  let selectionIsAdded = false // true if selected item is added, not from items passed in
+  let selectedItem = isNew ? item : unfilteredItems.value.filter(anItem => anItem.value === item.value)?.[0] || null
+
+  // if it wasn't in unfilteredItems, check newly added items if enabled
+  if (selectedItem === null && props.enableItemCreation) {
+    selectedItem = addedItems.value.filter(anItem => anItem.value === item.value)?.[0] || null
+    selectionIsAdded = true
+  }
+
+  // if still not found, we are probably filtering with autosuggest, so get it from selectedItems
+  if (selectedItem === null) {
+    selectedItem = selectedItems.value.filter(anItem => anItem.value === item.value)?.[0] || null
+  }
+  // if we still couldn't find it, bail
+  if (selectedItem === null) {
+    return
+  }
+
+  // if clicked item is already selected
+  if (selectedItem.selected) {
+    selectedItems.value = selectedItems.value.filter(anItem => anItem.value !== item.value)
+    // remove item from visibility arrays
+    if (visibleSelectedItemsStaging.value.filter(anItem => anItem.value === item.value).length) {
+      visibleSelectedItemsStaging.value = visibleSelectedItemsStaging.value.filter(anItem => anItem.value !== item.value)
+    } else if (invisibleSelectedItemsStaging.value.filter(anItem => anItem.value === item.value).length) {
+      invisibleSelectedItemsStaging.value = invisibleSelectedItemsStaging.value.filter(anItem => anItem.value !== item.value)
+    }
+    // deselect item
+    selectedItem.selected = false
+    selectedItem.key = selectedItem.key?.replace(/-selected/gi, '')
+
+    // if some items are hidden grab the first hidden one and add it into the visible array
+    if (invisibleSelectedItemsStaging.value.length) {
+      const itemToShow = invisibleSelectedItemsStaging.value.pop()
+      if (itemToShow) {
+        visibleSelectedItemsStaging.value.push(itemToShow)
+      }
+    }
+
+    // if it's an added item, remove it from list when it is deselected
+    if (selectionIsAdded) {
+      addedItems.value = addedItems.value.filter(anItem => anItem.value !== item.value)
+    }
+  } else { // newly selected item
+    selectedItem.selected = true
+    selectedItem.key = selectedItem.key?.includes('-selected') ? selectedItem.key : `${selectedItem.key}-selected`
+    selectedItems.value.push(selectedItem)
+    visibleSelectedItemsStaging.value.push(selectedItem)
+    // track it if it's a newly added item
+    if (isNew) {
+      addedItems.value.push(selectedItem)
+    }
+
+    if (props.expandSelected) {
+      // if expanded, scroll new selections into view
+      scrollSmoothlyToBottom()
+    }
+  }
+
+  stageSelections()
+  const selectedVals = selectedItems.value.map(anItem => anItem.value)
+
+  emit('selected', selectedItems.value)
+  emit('change', item)
+  emit('update:modelValue', selectedVals)
+}
+
+// add an item with `enter`
+const handleAddItem = (evt: any): void => {
+  evt.stopPropagation()
+  if (!props.enableItemCreation || !filterStr.value) {
+    // do nothing if not enabled or no label
+    return
+  }
+
+  const item:MultiselectItem = {
+    label: filterStr.value + '',
+    value: props.testMode ? `test-multiselect-added-item-${addedItems.value.length + 1}` : uuidv1(),
+    key: `${filterStr.value.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${addedItems.value.length + 1}`,
+  }
+  emit('added', item)
+
+  handleItemSelect(item, true)
+  filterStr.value = ''
+}
+
+const scrollSmoothlyToBottom = () => {
+  setTimeout(() => {
+    // @ts-ignore
+    selectionBottomRef.value?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
     })
+  }, 200)
+}
 
-    // watch for programmatic changes to model
-    watch(value, (newVal, oldVal) => {
-      if (JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
-        const items = unfilteredItems.value.filter((item: MultiselectItem) => newVal.includes(item.value))
-        if (items.length) {
-          handleMultipleItemsSelect(items)
-        } else if (!newVal.length) {
-          clearSelection()
+// sort dropdown items. Selected items displayed before unselected items
+const sortItems = () => {
+  const selItems = filteredItems.value.filter((item: MultiselectItem) => item.selected)
+  const unselItems = filteredItems.value.filter((item: MultiselectItem) => !item.selected)
+
+  sortedItems.value = selItems.concat(unselItems)
+}
+
+const clearSelection = (): void => {
+  unfilteredItems.value.forEach(anItem => {
+    anItem.selected = false
+    anItem.key = anItem?.key?.replace(/-selected/gi, '')
+  })
+  selectedItems.value = []
+  visibleSelectedItemsStaging.value = []
+  invisibleSelectedItemsStaging.value = []
+  filterStr.value = ''
+  stageSelections()
+
+  emit('selected', [])
+  emit('change', null)
+  emit('update:modelValue', [])
+  emit('query-change', '')
+}
+
+const onQueryChange = (query: string) => {
+  filterStr.value = query
+  emit('query-change', query)
+}
+
+const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
+  // `esc` key closes
+  if (evt.keyCode === 27) {
+    isToggled.value = false
+    return
+  }
+
+  const inputElem = document.getElementById(multiselectTextId.value)
+  if (!isToggled.value && inputElem) {
+    // simulate click to trigger dropdown open
+    inputElem.click()
+  }
+}
+
+const onInputFocus = (): void => {
+  isFocused.value = true
+  if (!initialFocusTriggered.value) {
+    initialFocusTriggered.value = true
+    emit('query-change', '')
+  }
+}
+
+// whenever staging key is changed, we're ready to actually draw the selections
+watch(stagingKey, () => {
+  // set timeout required to push the calculation to the end of the update lifecycle event queue
+  setTimeout(() => {
+    const elem = document.getElementById(multiselectSelectedItemsStagingId.value)
+
+    if (props.expandSelected) {
+      // if expanded, don't do all the calculations because we are going to display
+      // everything
+      visibleSelectedItems.value = cloneDeep(visibleSelectedItemsStaging.value)
+      invisibleSelectedItems.value = []
+      key.value++
+      return
+    }
+
+    if (elem) {
+      const height = elem.clientHeight
+      if (height > selectionsMaxHeight.value) {
+        const item = visibleSelectedItemsStaging.value.pop()
+        if (item) {
+          invisibleSelectedItemsStaging.value.push(item)
         }
+        stagingKey.value++
+      } else {
+        visibleSelectedItems.value = cloneDeep(visibleSelectedItemsStaging.value)
+        invisibleSelectedItems.value = cloneDeep(invisibleSelectedItemsStaging.value)
+        key.value++
       }
-    })
+    }
+  }, 0)
+})
 
-    watch(() => props.items, (newValue, oldValue) => {
-      // Only trigger the watcher if items actually change
-      if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
-        return
-      }
-
-      unfilteredItems.value = cloneDeep(props.items)
-      for (let i = 0; i < unfilteredItems.value.length; i++) {
-        // Ensure each item has a `selected` property
-        if (unfilteredItems.value[i].selected === undefined) {
-          unfilteredItems.value[i].selected = false
-        }
-
-        unfilteredItems.value[i].key = `${unfilteredItems.value[i].label?.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${i}` || `k-multiselect-item-label-${i}`
-        if (props.modelValue.includes(unfilteredItems.value[i].value) || unfilteredItems.value[i].selected) {
-          const selectedItem = unfilteredItems.value[i]
-          selectedItem.selected = true
-          selectedItem.key = selectedItem.key?.includes('-selected') ? selectedItem.key : `${selectedItem.key}-selected`
-          // if it isn't already in the selectedItems array, add it
-          if (!selectedItems.value.filter(anItem => anItem.value === selectedItem.value).length) {
-            selectedItems.value.push(selectedItem)
-          }
-          // if it isn't already in the selectedItems array, add it
-          if (!visibleSelectedItemsStaging.value.filter(anItem => anItem.value === selectedItem.value).length) {
-            visibleSelectedItemsStaging.value.push(selectedItem)
-          }
-        }
-
-        stageSelections()
-      }
-
-      // Trigger an update to the popper element to cause the popover to redraw
-      // This prevents the popover from displaying "detached" from the KSelect
+// make the popper recalculate it's position whenever the selections display
+// is updated in case we've grown a line
+watch(key, () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (popper.value && typeof popper.value.updatePopper === 'function') {
+    nextTick(() => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      if (popper.value && typeof popper.value.updatePopper === 'function') {
-        nextTick(() => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          popper.value.updatePopper()
-        })
-      }
-    }, { deep: true, immediate: true })
-
-    const numericWidth = ref<number>(300)
-    onMounted(() => {
-      // @ts-ignore
-      numericWidth.value = multiselectRef.value?.clientWidth || 300
+      popper.value.updatePopper()
     })
+  }
+})
 
-    return {
-      // keys and ids
-      key,
-      stagingKey,
-      multiselectId,
-      multiselectInputId,
-      multiselectTextId,
-      multiselectSelectedItemsStagingId,
-      multiselectSelectedItemsId,
-      multiselectRef,
-      selectionBottomRef,
-      // text
-      getPlaceholderText,
-      filterStr,
-      // items
-      unfilteredItems,
-      sortedItems,
-      selectedItems,
-      invisibleSelectedItemsStaging,
-      visibleSelectedItemsStaging,
-      invisibleSelectedItems,
-      visibleSelectedItems,
-      hiddenItemsTooltip,
-      // style and attributes
-      widthStyle,
-      numericWidthStyle,
-      nonSlimStyle,
-      modifiedAttrs,
-      isHovered,
-      isFocused,
-      isDisabled,
-      isReadonly,
-      popper,
-      boundKPopAttributes,
-      // functions
-      sortItems,
-      handleFilterClick,
-      handleItemSelect,
-      clearSelection,
-      triggerFocus,
-      onQueryChange,
-      onInputFocus,
+// If filtered items change, re-sort them
+watch(filteredItems, () => {
+  sortItems()
+})
+
+// watch for programmatic changes to model
+watch(value, (newVal, oldVal) => {
+  if (JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
+    const items = unfilteredItems.value.filter((item: MultiselectItem) => newVal.includes(item.value))
+    if (items.length) {
+      handleMultipleItemsSelect(items)
+    } else if (!newVal.length) {
+      clearSelection()
     }
-  },
+  }
+})
+
+watch(() => props.items, (newValue, oldValue) => {
+  // Only trigger the watcher if items actually change
+  if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
+    return
+  }
+
+  unfilteredItems.value = cloneDeep(props.items)
+  for (let i = 0; i < unfilteredItems.value.length; i++) {
+    // Ensure each item has a `selected` property
+    if (unfilteredItems.value[i].selected === undefined) {
+      unfilteredItems.value[i].selected = false
+    }
+
+    unfilteredItems.value[i].key = `${unfilteredItems.value[i].label?.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${i}` || `k-multiselect-item-label-${i}`
+    if (props.modelValue.includes(unfilteredItems.value[i].value) || unfilteredItems.value[i].selected) {
+      const selectedItem = unfilteredItems.value[i]
+      selectedItem.selected = true
+      selectedItem.key = selectedItem.key?.includes('-selected') ? selectedItem.key : `${selectedItem.key}-selected`
+      // if it isn't already in the selectedItems array, add it
+      if (!selectedItems.value.filter(anItem => anItem.value === selectedItem.value).length) {
+        selectedItems.value.push(selectedItem)
+      }
+      // if it isn't already in the selectedItems array, add it
+      if (!visibleSelectedItemsStaging.value.filter(anItem => anItem.value === selectedItem.value).length) {
+        visibleSelectedItemsStaging.value.push(selectedItem)
+      }
+    }
+
+    stageSelections()
+  }
+
+  // Trigger an update to the popper element to cause the popover to redraw
+  // This prevents the popover from displaying "detached" from the KSelect
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (popper.value && typeof popper.value.updatePopper === 'function') {
+    nextTick(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      popper.value.updatePopper()
+    })
+  }
+}, { deep: true, immediate: true })
+
+const numericWidth = ref<number>(300)
+onMounted(() => {
+  // @ts-ignore
+  numericWidth.value = multiselectRef.value?.clientWidth || 300
 })
 </script>
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -359,7 +359,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['selected', 'added', 'input', 'change', 'update:modelValue', 'query-change'])
+const emit = defineEmits(['selected', 'added', 'removed', 'input', 'change', 'update:modelValue', 'query-change'])
 
 const defaultKPopAttributes = {
   hideCaret: true,
@@ -606,6 +606,7 @@ const handleItemSelect = (item: MultiselectItem, isNew?: boolean) => {
     // if it's an added item, remove it from list when it is deselected
     if (selectionIsAdded) {
       addedItems.value = addedItems.value.filter(anItem => anItem.value !== item.value)
+      emit('removed', item)
     }
   } else { // newly selected item
     selectedItem.selected = true

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -159,6 +159,7 @@
                 v-if="enableItemCreation && uniqueFilterStr"
                 key="k-multiselect-new-item"
                 class="k-multiselect-empty-item"
+                data-testid="k-multiselect-add-item"
                 :item="{ label: `${filterStr} (New value)`, value: 'add_item' }"
                 @selected="handleAddItem"
               />
@@ -166,6 +167,7 @@
                 v-if="!sortedItems.length && !$slots.empty && !enableItemCreation"
                 key="k-multiselect-empty-state"
                 class="k-multiselect-empty-item"
+                data-testid="k-multiselect-empty-item"
                 :item="{ label: 'No results found', value: 'no_results' }"
               >
                 <template #content>

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -441,12 +441,7 @@ const createKPopAttributes = computed(() => {
 const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
 
 const widthValue = computed(() => {
-  let w = ''
-  if (!props.width) {
-    w = '300'
-  } else {
-    w = props.width
-  }
+  const w = props.width ? props.width : '300'
 
   return getSizeFromString(w)
 })
@@ -546,7 +541,7 @@ const handleMultipleItemsSelect = (items: MultiselectItem[]) => {
     let selectedItem = unfilteredItems.value.filter(anItem => anItem.value === itemToSelect.value)?.[0] || null
 
     // if it wasn't in unfilteredItems, check newly added items if enabled
-    if (selectedItem === null && props.enableItemCreation) {
+    if (props.enableItemCreation && selectedItem === null) {
       selectedItem = addedItems.value.filter(anItem => anItem.value === itemToSelect.value)?.[0] || null
     }
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -158,11 +158,18 @@
               <KMultiselectItem
                 v-if="enableItemCreation && uniqueFilterStr"
                 key="k-multiselect-new-item"
-                class="k-multiselect-empty-item"
+                class="k-multiselect-new-item"
                 data-testid="k-multiselect-add-item"
-                :item="{ label: `${filterStr} (New value)`, value: 'add_item' }"
+                :item="{ label: `${filterStr} (Add new value)`, value: 'add_item' }"
                 @selected="handleAddItem"
-              />
+              >
+                <template #content>
+                  <div class="select-item-description">
+                    {{ filterStr }}
+                    <span class="select-item-new-indicator">(Add new value)</span>
+                  </div>
+                </template>
+              </KMultiselectItem>
               <KMultiselectItem
                 v-if="!sortedItems.length && !$slots.empty && !enableItemCreation"
                 key="k-multiselect-empty-state"
@@ -966,6 +973,16 @@ onMounted(() => {
       }
     }
   }
+
+  .k-multiselect-new-item {
+    word-break: break-word;
+
+    .select-item-new-indicator {
+      font-weight: 600;
+      font-style: italic;
+    }
+  }
+
 }
 </style>
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -243,7 +243,7 @@ export interface MultiselectItem {
   key?: string
   selected?: boolean
   disabled?: boolean
-  added?: boolean
+  custom?: boolean
 }
 
 export interface MultiselectFilterFnParams {
@@ -593,7 +593,7 @@ const handleItemSelect = (item: MultiselectItem, isNew?: boolean) => {
   let selectedItem = isNew ? item : unfilteredItems.value.filter(anItem => anItem.value === item.value)?.[0] || null
 
   // if it wasn't in unfilteredItems, check newly added items if enabled
-  if (props.enableItemCreation && selectedItem?.added) {
+  if (props.enableItemCreation && selectedItem?.custom) {
     selectionIsAdded = true
   }
 
@@ -639,7 +639,7 @@ const handleItemSelect = (item: MultiselectItem, isNew?: boolean) => {
     visibleSelectedItemsStaging.value.push(selectedItem)
     // track it if it's a newly added item
     if (isNew) {
-      selectedItem.added = true
+      selectedItem.custom = true
       unfilteredItems.value.push(selectedItem)
     }
 
@@ -699,13 +699,13 @@ const clearSelection = (): void => {
     anItem.selected = false
     anItem.key = anItem?.key?.replace(/-selected/gi, '')
 
-    if (anItem.added) {
+    if (anItem.custom) {
       // we must emit that we are removing each item before we actually clear them since this is our only reference
       emit('item:removed', anItem)
     }
   })
   // clear added entries
-  unfilteredItems.value = unfilteredItems.value.filter(anItem => !anItem.added)
+  unfilteredItems.value = unfilteredItems.value.filter(anItem => !anItem.custom)
   selectedItems.value = []
   visibleSelectedItemsStaging.value = []
   invisibleSelectedItemsStaging.value = []

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -31,35 +31,27 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
 import KIcon from '@/components/KIcon/KIcon.vue'
 
-export default defineComponent({
-  name: 'MultiselectItem',
-  components: { KIcon },
-  props: {
-    item: {
-      type: Object,
-      default: null,
-      // Items must have a label and value
-      validator: (item: Record<string, string | number | boolean>): boolean => item.label !== undefined && item.value !== undefined,
-    },
-  },
-  emits: ['selected'],
-  setup(props, { emit }) {
-    const handleClick = (): void => {
-      if (props.item.disabled) {
-        return
-      }
-      emit('selected', props.item)
-    }
-
-    return {
-      handleClick,
-    }
+const props = defineProps({
+  item: {
+    type: Object,
+    default: null,
+    // Items must have a label and value
+    validator: (item: Record<string, string | number | boolean>): boolean => item.label !== undefined && item.value !== undefined,
   },
 })
+
+const emit = defineEmits(['selected'])
+
+const handleClick = (): void => {
+  if (props.item.disabled) {
+    return
+  }
+
+  emit('selected', props.item)
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -99,6 +99,7 @@ const handleClick = (): void => {
       font-weight: 500;
       line-height: 20px;
       color: var(--grey-600);
+      word-break: break-word;
 
       :deep(.select-item-label) {
         margin-bottom: 4px;

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -6,8 +6,8 @@
     :aria-controls="$slots.default ? popoverId : undefined"
     :aria-expanded="$slots.default ? (!!isOpen || undefined) : undefined"
     :role="$slots.default ? 'button' : null"
-    @keydown.enter="(e: any) => handleClick(e)"
-    @keydown.esc="hidePopper"
+    @keyup.enter.stop.prevent="showPopper"
+    @keyup.esc="hidePopper"
   >
     <slot>
       <KButton


### PR DESCRIPTION
# Summary

- Add support for item creation via `enableItemCreation` prop.
- Emit 2 new events `item:added` and `item:removed`.
- Add validation to confirm the uniqueness of item values.
- Addresses [KHCP-5569](https://konghq.atlassian.net/browse/KHCP-5569).
- Also changes behavior of `KPop` on `Enter` to always open the popover instead of toggling (hit `Esc` to close popover), this fixes an issue where hitting `Enter` would cause the KPop to show and then immediately hide itself.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-5569]: https://konghq.atlassian.net/browse/KHCP-5569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ