### PR TITLE
fix(kdropdownmenu): unscope styles [KHCP-5730]

### DIFF
--- a/.github/workflows/get-changed-files.yml
+++ b/.github/workflows/get-changed-files.yml
@@ -12,6 +12,9 @@ on:
       components-or-docs-or-cypress-files-changed:
         description: Check if src or docs (`src` or `docs` directories) files have changed
         value: ${{ jobs.get-changed-files.outputs.components-or-docs-or-cypress-files-changed }}
+      package-json-yarn-lock-files-changed:
+        description: Check if package.json or yarn.lock files changed
+        value: ${{ jobs.get-changed-files.outputs.package-json-yarn-lock-files-changed }}
 
 jobs:
   get-changed-files:
@@ -21,6 +24,7 @@ jobs:
       component-files-changed: ${{ steps.component-files-changed.outputs.any_modified }}
       docs-files-changed: ${{ steps.docs-files-changed.outputs.any_modified }}
       components-or-docs-or-cypress-files-changed: ${{ steps.components-or-docs-or-cypress-files-changed.outputs.any_modified }}
+      package-json-yarn-lock-files-changed: ${{ steps.package-json-yarn-lock-files-changed.outputs.any_modified }}
 
     steps:
       - uses: actions/checkout@v3
@@ -52,3 +56,12 @@ jobs:
             src/**
             docs/**
             cypress/**
+
+      - name: Check if package.json or yarn.lock files changed
+        uses: tj-actions/changed-files@v34
+        id: package-json-yarn-lock-files-changed
+        # Return 'true' for any directories listed here that changed
+        with:
+          files: |
+            package.json
+            yarn.lock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         - run-tests
       # Only run the publish action (including semantic-release) if files in the /src/ directory changed.
       # Should only run if files in the `src/` directory were changed
-      if: needs.get-changed-files.outputs.component-files-changed == 'true'
+      if: needs.get-changed-files.outputs.component-files-changed == 'true' || needs.get-changed-files.outputs.package-json-yarn-lock-files-changed == 'true'
       runs-on: ubuntu-latest
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
     name: No Build and Publish needed
     needs:
       - get-changed-files
-    if: needs.get-changed-files.outputs.components-or-docs-or-cypress-files-changed == 'false'
+    if: needs.get-changed-files.outputs.components-or-docs-or-cypress-files-changed == 'false' && needs.get-changed-files.outputs.package-json-yarn-lock-files-changed == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Skip new release

--- a/docs/.vitepress/cache/deps/_metadata.json
+++ b/docs/.vitepress/cache/deps/_metadata.json
@@ -1,59 +1,59 @@
 {
-  "hash": "52d8c7d1",
-  "browserHash": "9409d5b4",
+  "hash": "1686dddd",
+  "browserHash": "51587bd7",
   "optimized": {
     "vue": {
       "src": "../../../../node_modules/vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "4dca3537",
+      "fileHash": "3753c7d2",
       "needsInterop": false
     },
     "uuid": {
       "src": "../../../../node_modules/uuid/dist/esm-browser/index.js",
       "file": "uuid.js",
-      "fileHash": "541d0ef4",
+      "fileHash": "de8be901",
       "needsInterop": false
     },
     "date-fns": {
       "src": "../../../../node_modules/date-fns/esm/index.js",
       "file": "date-fns.js",
-      "fileHash": "e45f043e",
+      "fileHash": "dd4aaf79",
       "needsInterop": false
     },
     "date-fns-tz": {
       "src": "../../../../node_modules/date-fns-tz/esm/index.js",
       "file": "date-fns-tz.js",
-      "fileHash": "e73d54c4",
+      "fileHash": "11aebf9f",
       "needsInterop": false
     },
     "v-calendar": {
       "src": "../../../../node_modules/v-calendar/dist/v-calendar.es.js",
       "file": "v-calendar.js",
-      "fileHash": "fb80e3c6",
+      "fileHash": "adedba6c",
       "needsInterop": false
     },
     "focus-trap-vue": {
       "src": "../../../../node_modules/focus-trap-vue/dist/focus-trap-vue.esm-browser.js",
       "file": "focus-trap-vue.js",
-      "fileHash": "499dd66c",
+      "fileHash": "40085e10",
       "needsInterop": false
     },
     "popper.js": {
       "src": "../../../../node_modules/popper.js/dist/esm/popper.js",
       "file": "popper__js.js",
-      "fileHash": "c710084c",
+      "fileHash": "9b55e71a",
       "needsInterop": false
     },
     "swrv": {
       "src": "../../../../node_modules/swrv/esm/index.js",
       "file": "swrv.js",
-      "fileHash": "12680d0a",
+      "fileHash": "4f3b6401",
       "needsInterop": false
     },
     "vue-draggable-next": {
       "src": "../../../../node_modules/vue-draggable-next/dist/vue-draggable-next.esm-bundler.js",
       "file": "vue-draggable-next.js",
-      "fileHash": "e67267a4",
+      "fileHash": "9cdfea8d",
       "needsInterop": false
     }
   },

--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -144,77 +144,78 @@ export default defineComponent({
 })
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+// Must leave this block unscoped as it sometimes causes issues with slotted/nested styles
 @import '@/styles/variables';
 @import '@/styles/functions';
 
-li.k-dropdown-item {
-  display: flex;
-  align-items: center;
-  font-size: 16px;
-  line-height: 1;
+.k-dropdown-menu {
+  li.k-dropdown-item {
+    display: flex;
+    align-items: center;
+    font-size: 16px;
+    line-height: 1;
 
-  &.has-divider {
-    $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
-    $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
-    position: relative;
-    margin-top: $k-dropdown-item-divider-container-height;
+    &.has-divider {
+      $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
+      $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
+      position: relative;
+      margin-top: $k-dropdown-item-divider-container-height;
 
-    &:before {
-      position: absolute;
-      top: $k-dropdown-item-divider-position;
-      display: block;
-      width: 100%;
-      height: 1px;
-      content: '';
-      background: var(--grey-200);
+      &:before {
+        position: absolute;
+        top: $k-dropdown-item-divider-position;
+        display: block;
+        width: 100%;
+        height: 1px;
+        content: '';
+        background: var(--grey-200);
+      }
     }
-  }
 
-  svg {
-    margin-right: 12px;
-  }
+    svg {
+      margin-right: 12px;
+    }
 
-  &:hover {
-    background-color: var(--grey-100);
-  }
+    &:hover {
+      background-color: var(--grey-100);
+    }
 
-  .k-dropdown-item-trigger {
-    width: 100%;
-    padding: var(--spacing-md) var(--spacing-lg);
-    color: var(--black-70);
-    text-align: left;
-    text-decoration: none;
+    .k-dropdown-item-trigger {
+      width: 100%;
+      padding: var(--spacing-md) var(--spacing-lg);
+      color: var(--black-70);
+      text-align: left;
+      text-decoration: none;
 
-    &:disabled,
-    &.disabled {
-      color: var(--grey-400) !important;
-      cursor: not-allowed !important;
+      &:disabled,
+      &.disabled {
+        color: var(--grey-400) !important;
+        cursor: not-allowed !important;
 
-      &:hover {
-        background-color: var(--grey-200) !important;
+        &:hover {
+          background-color: var(--grey-200) !important;
+        }
       }
     }
   }
-}
-</style>
 
-<style lang="scss">
-.k-dropdown-item {
-  a, button {
-    &.k-dropdown-item-trigger {
-      text-decoration: none !important;
+  .k-dropdown-item {
+    a, button {
+      &.k-dropdown-item-trigger {
+        text-decoration: none !important;
+      }
     }
-  }
 
-  &.danger {
-    button:not(:disabled),
-    a:not(:disabled) {
-      color: var(--red-500);
-      transition: all 300ms;
-
-      &:hover {
+    &.danger {
+      button:not(:disabled),
+      a:not(:disabled) {
         color: var(--red-500);
+        transition: all 300ms;
+
+        &:hover {
+          color: var(--red-500);
+        }
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,5 +49,4 @@ const router = createRouter({
 })
 
 app.use(router)
-
 app.mount('#app')


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/2229946/211041569-db4cf6a9-f5e1-4b76-9429-6c827287ff26.png)

Unscope the `KDropdownItem` styles so that they are always properly applied to all dropdown content, regardless of slotted or not, etc.

## PR Checklist

* [ ] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
