### PR TITLE
feat(kbadge): add clickable prop [khcp-5737]

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -117,7 +117,7 @@ Use this prop in conjunction with the `is-bordered` prop to customize the color 
 
 ### hoverColor
 
-Use this prop in conjunction with the `dismissable` prop to customize the color of the dismiss button when hovered.
+Use this prop in conjunction with the `dismissable` and `clickable` props to customize the color of the badge/dismiss button when hovered.
 
 <KBadge
   appearance="custom"
@@ -145,10 +145,28 @@ Use this prop in conjunction with the `dismissable` prop to customize the color 
 </KBadge>
 ```
 
+### clickable
+
+Use this prop if you want the badge to be clickable. The hover color of the badge is determined by the badge type and uses the same theming variables as the badge text. Clicking the badge will trigger a `clicked` event.
+
+<KLabel>{{ myClicks }} clicks</KLabel>
+<br>
+<KBadge clickable @clicked="myClicks++">Click me!</KBadge>
+
+```html
+<KLabel>{{ myClicks }} clicks</KLabel>
+<KBadge
+  clickable
+  @clicked="myClicks++"
+>
+  Click me!
+</KBadge>
+```
+
 ### dismissable
 
 Use this prop if you want the badge to be dismissable. If the badge text is long enough to need truncation, the label will truncate; the dismiss button is always visible.
-The color of the dismiss button is determined by the badge type and uses the same theming variables as the badge text.
+The color of the dismiss button is determined by the badge type and uses the same theming variables as the badge text. Clicking the dismiss button will trigger a `dismissed` event.
 
 <KBadge dismissable class="mr-2">Close me</KBadge>
 <KBadge dismissable shape="rectangular">No, close me!</KBadge>
@@ -189,6 +207,13 @@ If you want to show the tooltip regardless of whether the badge text is truncate
 ```html
 <KBadge appearance="success">SUCCESS</KBadge>
 ```
+
+## Events
+
+| Event                 | Action              |
+| :--------             | :------------------ |
+| `clicked`             | When `clickable` is true and you click the badge |
+| `dismissed`           | When `dismissable` is true and you click the dismiss button |
 
 ## Theming
 
@@ -248,8 +273,6 @@ An example of theming a custom badge:
   </KBadge>
 </div>
 
-
-
 ```html
 <template>
 <div class="KBadge-wrapper">
@@ -292,6 +315,12 @@ An example of theming a custom badge:
 }
 </style>
 ```
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const myClicks = ref(0)
+</script>
 
 <style lang="scss">
 .KBadge-wrapper {

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -147,17 +147,17 @@ Use this prop in conjunction with the `dismissable` and `clickable` props to cus
 
 ### clickable
 
-Use this prop if you want the badge to be clickable. The hover color of the badge is determined by the badge type and uses the same theming variables as the badge text. Clicking the badge will trigger a `clicked` event.
+Use this prop if you want the badge to be clickable. The hover color of the badge is determined by the badge type and uses the same theming variables as the badge text. Clicking the badge will trigger a `click` event.
 
 <KLabel>{{ myClicks }} clicks</KLabel>
 <br>
-<KBadge clickable @clicked="myClicks++">Click me!</KBadge>
+<KBadge clickable @click="myClicks++">Click me!</KBadge>
 
 ```html
 <KLabel>{{ myClicks }} clicks</KLabel>
 <KBadge
   clickable
-  @clicked="myClicks++"
+  @click="myClicks++"
 >
   Click me!
 </KBadge>
@@ -212,7 +212,7 @@ If you want to show the tooltip regardless of whether the badge text is truncate
 
 | Event                 | Action              |
 | :--------             | :------------------ |
-| `clicked`             | When `clickable` is true and you click the badge |
+| `click`               | When `clickable` is true and you click the badge |
 | `dismissed`           | When `dismissable` is true and you click the dismiss button |
 
 ## Theming

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -210,7 +210,6 @@ If you want to show the tooltip regardless of whether the badge text is truncate
 
 | Event                 | Action              |
 | :--------             | :------------------ |
-| `click`               | When `clickable` is true and you click the badge |
 | `dismissed`           | When `dismissable` is true and you click the dismiss button |
 
 ## Theming

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -117,7 +117,7 @@ Use this prop in conjunction with the `is-bordered` prop to customize the color 
 
 ### hoverColor
 
-Use this prop in conjunction with the `dismissable` and `clickable` props to customize the color of the badge/dismiss button when hovered.
+Use this prop in conjunction with the `dismissable` prop to customize the color of the badge/dismiss button when hovered.
 
 <KBadge
   appearance="custom"
@@ -145,20 +145,18 @@ Use this prop in conjunction with the `dismissable` and `clickable` props to cus
 </KBadge>
 ```
 
-### clickable
+The `hoverColor` is also utilized if you wrap the `KBadge` with an anchor tag, or add a `@click` listener directly to the component.
 
-Use this prop if you want the badge to be clickable. The hover color of the badge is determined by the badge type and uses the same theming variables as the badge text. Clicking the badge will trigger a `click` event.
+<a href="#"><KBadge appearance="success">Anchor Tag</KBadge></a>
 
-<KLabel>{{ myClicks }} clicks</KLabel>
-<br>
-<KBadge clickable @click="myClicks++">Click me!</KBadge>
+<KLabel>{{ myClicks }} clicks</KLabel><br>
+<KBadge @click="myClicks++">Click me!</KBadge>
 
 ```html
-<KLabel>{{ myClicks }} clicks</KLabel>
-<KBadge
-  clickable
-  @click="myClicks++"
->
+<a href="#"><KBadge appearance="success">Anchor Tag</KBadge></a>
+
+<KLabel>{{ myClicks }} clicks</KLabel><br>
+<KBadge @click="myClicks++">
   Click me!
 </KBadge>
 ```
@@ -320,6 +318,10 @@ An example of theming a custom badge:
 import { ref } from 'vue'
 
 const myClicks = ref(0)
+
+const testClick = () => {
+  console.log('you clicked')
+}
 </script>
 
 <style lang="scss">

--- a/src/components/KBadge/KBadge.cy.ts
+++ b/src/components/KBadge/KBadge.cy.ts
@@ -120,7 +120,7 @@ describe('KBadge', () => {
 
     cy.get('.k-badge').click()
     // emit clicked event
-    cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'clicked')
+    cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'click')
   })
 
   it('handles custom colors', () => {

--- a/src/components/KBadge/KBadge.cy.ts
+++ b/src/components/KBadge/KBadge.cy.ts
@@ -104,6 +104,23 @@ describe('KBadge', () => {
     cy.getTestId('k-badge-dismiss-button').should('exist')
     cy.getTestId('k-badge-dismiss-button').click()
     cy.get('.k-badge').should('not.exist')
+    // emit dismissed event
+    cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'dismissed')
+  })
+
+  it('renders clickable badge', () => {
+    mount(KBadge, {
+      props: {
+        clickable: true,
+      },
+      slots: {
+        default: () => 'Hello!',
+      },
+    })
+
+    cy.get('.k-badge').click()
+    // emit clicked event
+    cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'clicked')
   })
 
   it('handles custom colors', () => {

--- a/src/components/KBadge/KBadge.cy.ts
+++ b/src/components/KBadge/KBadge.cy.ts
@@ -102,27 +102,8 @@ describe('KBadge', () => {
     })
 
     cy.getTestId('k-badge-dismiss-button').should('exist')
-    cy.getTestId('k-badge-dismiss-button').click().then(() => {
-      // emit dismissed event
-      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'dismissed')
-      cy.get('.k-badge').should('not.exist')
-    })
-  })
-
-  it('renders clickable badge', () => {
-    mount(KBadge, {
-      props: {
-        clickable: true,
-      },
-      slots: {
-        default: () => 'Hello!',
-      },
-    })
-
-    cy.get('.k-badge').click().then(() => {
-      // emit clicked event
-      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'click')
-    })
+    cy.getTestId('k-badge-dismiss-button').click()
+    cy.get('.k-badge').should('not.exist')
   })
 
   it('handles custom colors', () => {

--- a/src/components/KBadge/KBadge.cy.ts
+++ b/src/components/KBadge/KBadge.cy.ts
@@ -102,10 +102,11 @@ describe('KBadge', () => {
     })
 
     cy.getTestId('k-badge-dismiss-button').should('exist')
-    cy.getTestId('k-badge-dismiss-button').click()
-    cy.get('.k-badge').should('not.exist')
-    // emit dismissed event
-    cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'dismissed')
+    cy.getTestId('k-badge-dismiss-button').click().then(() => {
+      // emit dismissed event
+      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'dismissed')
+      cy.get('.k-badge').should('not.exist')
+    })
   })
 
   it('renders clickable badge', () => {
@@ -118,9 +119,10 @@ describe('KBadge', () => {
       },
     })
 
-    cy.get('.k-badge').click()
-    // emit clicked event
-    cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'click')
+    cy.get('.k-badge').click().then(() => {
+      // emit clicked event
+      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'click')
+    })
   })
 
   it('handles custom colors', () => {

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -172,14 +172,14 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['clicked', 'dismissed'])
+const emit = defineEmits(['click', 'dismissed'])
 
 const badgeText = ref(null)
 const isDismissed = ref(false)
 
 const handleClick = (): void => {
   if (props.clickable) {
-    emit('clicked')
+    emit('click')
   }
 }
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -5,11 +5,10 @@
     class="k-badge d-inline-flex"
     :class="[ `k-badge-${appearance}`, `k-badge-${shape}`, {
       'is-bordered': isBordered,
-      'clickable': clickable
+      'clickable': isClickable
     } ]"
     :style="badgeCustomStyles"
     :tabindex="hidden ? -1 : 0"
-    @click="handleClick"
   >
     <component
       :is="truncationTooltip && (forceTooltip || isTruncated) ? 'KTooltip' : 'div'"
@@ -45,7 +44,7 @@
 </template>
 
 <script lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, useAttrs } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
@@ -98,13 +97,6 @@ const props = defineProps({
    * or not the badge text is truncated.
    */
   forceTooltip: {
-    type: Boolean,
-    default: false,
-  },
-  /**
-   * Badge responds to clicks
-   */
-  clickable: {
     type: Boolean,
     default: false,
   },
@@ -172,16 +164,13 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['click', 'dismissed'])
+const emit = defineEmits(['dismissed'])
+
+const attrs = useAttrs()
+const isClickable = computed((): boolean => !!attrs.onClick)
 
 const badgeText = ref(null)
 const isDismissed = ref(false)
-
-const handleClick = (): void => {
-  if (props.clickable) {
-    emit('click')
-  }
-}
 
 const handleDismiss = (): void => {
   isDismissed.value = true
@@ -317,6 +306,11 @@ watch(badgeText, () => {
     cursor: pointer;
   }
 
+  a &,
+  &.clickable {
+    user-select: none;
+  }
+
   .k-badge-text {
     align-self: center;
     width: var(--KBadgeWidth, auto);
@@ -363,6 +357,8 @@ watch(badgeText, () => {
       }
     }
 
+    a &:hover,
+    a:focus &,
     &.clickable:hover,
     &:focus {
       // fall back to backgroundColor if hoverColor is not provided
@@ -385,6 +381,8 @@ watch(badgeText, () => {
       }
     }
 
+    a &:hover,
+    a:focus &,
     &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeDefaultButtonHoverColor, var(--blue-200, color(blue-200)));
@@ -406,6 +404,8 @@ watch(badgeText, () => {
       }
     }
 
+    a &:hover,
+    a:focus &,
     &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeSuccessButtonHoverColor, var(--green-200, color(green-200)));
@@ -427,6 +427,8 @@ watch(badgeText, () => {
       }
     }
 
+    a &:hover,
+    a:focus &,
     &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeDangerButtonHoverColor, var(--red-200, color(red-200)));
@@ -448,6 +450,8 @@ watch(badgeText, () => {
       }
     }
 
+    a &:hover,
+    a:focus &,
     &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeInfoButtonHoverColor, var(--blue-300, color(blue-300)));
@@ -469,6 +473,8 @@ watch(badgeText, () => {
       }
     }
 
+    a &:hover,
+    a:focus &,
     &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, color(yellow-200)));

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -3,9 +3,13 @@
     v-if="!isDismissed"
     :aria-hidden="hidden ? true : undefined"
     class="k-badge d-inline-flex"
-    :class="[ `k-badge-${appearance}`, `k-badge-${shape}`, { 'is-bordered': isBordered } ]"
+    :class="[ `k-badge-${appearance}`, `k-badge-${shape}`, {
+      'is-bordered': isBordered,
+      'clickable': clickable
+    } ]"
     :style="badgeCustomStyles"
     :tabindex="hidden ? -1 : 0"
+    @click="handleClick"
   >
     <component
       :is="truncationTooltip && (forceTooltip || isTruncated) ? 'KTooltip' : 'div'"
@@ -97,7 +101,16 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-
+  /**
+   * Badge responds to clicks
+   */
+  clickable: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * Adds a dismiss button to the badge
+   */
   dismissable: {
     type: Boolean,
     default: false,
@@ -159,12 +172,18 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['dismissed'])
+const emit = defineEmits(['clicked', 'dismissed'])
 
 const badgeText = ref(null)
 const isDismissed = ref(false)
 
-const handleDismiss = () => {
+const handleClick = (): void => {
+  if (props.clickable) {
+    emit('clicked')
+  }
+}
+
+const handleDismiss = (): void => {
   isDismissed.value = true
   emit('dismissed')
 }
@@ -279,36 +298,6 @@ watch(badgeText, () => {
     }
   }
 
-  &.k-badge-custom {
-    color: v-bind('$props.color');
-    background-color: v-bind('$props.backgroundColor');
-    border-color: v-bind('$props.borderColor');
-
-    &.is-bordered {
-      border-style: solid;
-      border-width: 1px;
-    }
-
-    .k-badge-dismiss-button {
-      .kong-icon.kong-icon-close path {
-        stroke: v-bind('$props.color');
-      }
-
-      &:hover {
-        background-color:v-bind('$props.hoverColor');
-      }
-    }
-
-    &:focus {
-      // fall back to backgroundColor if hoverColor is not provided
-      background-color: v-bind('$props.hoverColor || $props.backgroundColor') !important;
-
-      .k-badge-dismiss-button {
-        background-color: v-bind('$props.hoverColor');
-      }
-    }
-  }
-
   &.k-badge-rectangular {
     border-radius: var(--KBadgeBorderRadius, 4px);
 
@@ -322,6 +311,10 @@ watch(badgeText, () => {
 
   &.k-badge-rounded {
     border-radius: var(--KBadgeBorderRadius, 25px);
+  }
+
+  &.clickable {
+    cursor: pointer;
   }
 
   .k-badge-text {
@@ -350,6 +343,37 @@ watch(badgeText, () => {
 @import '@/styles/functions';
 
 .k-badge {
+   &.k-badge-custom {
+    color: v-bind('$props.color');
+    background-color: v-bind('$props.backgroundColor');
+    border-color: v-bind('$props.borderColor');
+
+    &.is-bordered {
+      border-style: solid;
+      border-width: 1px;
+    }
+
+    .k-badge-dismiss-button {
+      .kong-icon.kong-icon-close path {
+        stroke: v-bind('$props.color');
+      }
+
+      &:hover {
+        background-color:v-bind('$props.hoverColor');
+      }
+    }
+
+    &.clickable:hover,
+    &:focus {
+      // fall back to backgroundColor if hoverColor is not provided
+      background-color: v-bind('$props.hoverColor || $props.backgroundColor') !important;
+
+      .k-badge-dismiss-button {
+        background-color: v-bind('$props.hoverColor');
+      }
+    }
+  }
+
   &.k-badge-default {
     .k-badge-dismiss-button {
       .kong-icon.kong-icon-close path {
@@ -361,6 +385,7 @@ watch(badgeText, () => {
       }
     }
 
+    &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeDefaultButtonHoverColor, var(--blue-200, color(blue-200)));
 
@@ -381,6 +406,7 @@ watch(badgeText, () => {
       }
     }
 
+    &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeSuccessButtonHoverColor, var(--green-200, color(green-200)));
 
@@ -401,6 +427,7 @@ watch(badgeText, () => {
       }
     }
 
+    &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeDangerButtonHoverColor, var(--red-200, color(red-200)));
 
@@ -421,6 +448,7 @@ watch(badgeText, () => {
       }
     }
 
+    &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeInfoButtonHoverColor, var(--blue-300, color(blue-300)));
 
@@ -441,6 +469,7 @@ watch(badgeText, () => {
       }
     }
 
+    &.clickable:hover,
     &:focus {
       background-color: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, color(yellow-200)));
 


### PR DESCRIPTION
# Summary

Add styles for clickable `KBadge` items.
Addresses [KHCP-5737](https://konghq.atlassian.net/browse/KHCP-5737).


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-5738]: https://konghq.atlassian.net/browse/KHCP-5738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KHCP-5737]: https://konghq.atlassian.net/browse/KHCP-5737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ