### PR TITLE
fix(kbadge): dismissable should not trigger @click [MA-1213]

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -150,7 +150,7 @@ The `hoverColor` is also utilized if you wrap the `KBadge` with an anchor tag, o
 <a href="#"><KBadge appearance="success">Anchor Tag</KBadge></a>
 
 <KLabel>{{ myClicks }} clicks</KLabel><br>
-<KBadge @click="myClicks++">Click me!</KBadge>
+<KBadge dismissable @click="myClicks++">Click me!</KBadge>
 
 ```html
 <a href="#"><KBadge appearance="success">Anchor Tag</KBadge></a>

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -32,6 +32,7 @@
       :is-rounded="shape === 'rounded'"
       :tabindex="hidden ? -1 : 0"
       @click="handleDismiss"
+      @click.stop
     >
       <KIcon
         :color="color"


### PR DESCRIPTION
# Summary

Needed to ensure that clicking on the "x" is does not also trigger the badge's `@click` listener

Bug explained by this screencap:
https://www.loom.com/share/d813c27a5367448fbcbc4ad00601ff81

Test the "Click Me!" example in this section
https://deploy-preview-1045--kongponents.netlify.app/components/badge.html#hovercolor
  
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
