### PR TITLE
fix(ktooltip): add more placement options from kpop [KHCP-5756]

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -177,19 +177,19 @@ Here are the different options:
 
 ```html
 <template>
-<select v-model="selectedPosition">
-  <option
-    v-for="p in positions"
-    :key="p"
-    :value="p">{{ p }}</option>
-</select>
+  <select v-model="selectedPosition">
+    <option
+      v-for="p in positions"
+      :key="p"
+      :value="p">{{ p }}</option>
+  </select>
 
-<KPop title="Cool header" trigger="hover" :placement="selectedPosition">
-  <KButton>button</KButton>
-  <template v-slot:content>
-    I am placed on the {{ selectedPosition }}!
-  </template>
-</KPop>
+  <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
+    <KButton>button</KButton>
+    <template v-slot:content>
+      I am placed on the {{ selectedPosition }}!
+    </template>
+  </KPop>
 </template>
 
 <script lang="ts">

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -33,12 +33,16 @@ Here you can pass in the text to display in the toolip.
 ### placement
 
 This is where the tooltip will appear - by default it appears on top.
+
 Here are the different options:
 
-- `top`
-- `bottom`
-- `left`
-- `right`
+<ul>
+  <li
+    v-for="p in ['auto', 'top', 'topStart', 'topEnd', 'left', 'leftStart', 'leftEnd', 'right', 'rightStart', 'rightEnd', 'bottom', 'bottomStart', 'bottomEnd']"
+    :key="p">
+    <code>{{ p }}</code>
+  </li>
+</ul>
 
 <div class="d-flex justify-content-around">
   <KTooltip placement="bottom" label="A label that appears on the bottom">
@@ -110,10 +114,10 @@ You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWid
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KTooltipBackground`| Background color
-| `--KTooltipColor`| Color of text
+| Variable               | Purpose          |
+| :--------------------- | :--------------- |
+| `--KTooltipBackground` | Background color |
+| `--KTooltipColor`      | Color of text    |
 
 Example:
 

--- a/src/components/KTooltip/KTooltip.cy.ts
+++ b/src/components/KTooltip/KTooltip.cy.ts
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 
-const positions = ['top', 'right', 'bottom', 'left']
+const positions = ['top', 'topStart', 'topEnd', 'left', 'leftStart', 'leftEnd', 'right', 'rightStart', 'rightEnd', 'bottom', 'bottomStart', 'bottomEnd']
 
 /**
  * ALL TESTS MUST USE testMode: true
@@ -11,7 +11,7 @@ const positions = ['top', 'right', 'bottom', 'left']
  *   testMode: true
  * }
  */
-const rendersCorrectPosition = (variant) => {
+const rendersCorrectPosition = (variant: string) => {
   it(`renders tooltip to the ${variant} side`, () => {
     mount(KTooltip, {
       props: {

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -25,73 +25,61 @@
   </KPop>
 </template>
 
-<script lang="ts">
-import { defineComponent, computed, ref } from 'vue'
+<script setup lang="ts">
+import { computed, ref } from 'vue'
 import KPop, { placements } from '@/components/KPop/KPop.vue'
 
-export default defineComponent({
-  name: 'KTooltip',
-  components: { KPop },
-  inheritAttrs: false,
-  props: {
-    /**
+const props = defineProps({
+  /**
      * Text to show in tooltip
      */
-    label: {
-      type: String,
-      required: false,
-      default: '',
-    },
+  label: {
+    type: String,
+    required: false,
+    default: '',
+  },
 
-    /**
+  /**
      * Define which side the tooltip displays
      */
-    placement: {
-      type: String,
-      default: 'bottom',
-      validator: (value: string):boolean => {
-        return Object.keys(placements).includes(value)
-      },
+  placement: {
+    type: String,
+    default: 'bottom',
+    validator: (value: string):boolean => {
+      return Object.keys(placements).includes(value)
     },
-    /**
+  },
+  /**
      * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
      */
-    positionFixed: {
-      type: Boolean,
-      default: false,
-    },
-    /**
+  positionFixed: {
+    type: Boolean,
+    default: false,
+  },
+  /**
      * Set the max-width of the ktooltip
      */
-    maxWidth: {
-      type: String,
-      default: 'auto',
-    },
-    /**
+  maxWidth: {
+    type: String,
+    default: 'auto',
+  },
+  /**
      * Test mode - for testing only, strips out generated ids
      */
-    testMode: {
-      type: Boolean,
-      default: false,
-    },
+  testMode: {
+    type: Boolean,
+    default: false,
   },
+})
 
-  setup(props) {
-    const className = ref('')
-    const computedClass = computed((): any => {
-      return {
-        top: 'mb-2',
-        right: 'ml-2',
-        bottom: 'mt-2',
-        left: 'mr-2',
-      }[props.placement]
-    })
-
-    return {
-      className,
-      computedClass,
-    }
-  },
+const className = ref('')
+const computedClass = computed((): any => {
+  return {
+    top: 'mb-2',
+    right: 'ml-2',
+    bottom: 'mt-2',
+    left: 'mr-2',
+  }[props.placement]
 })
 </script>
 

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -27,7 +27,7 @@
 
 <script lang="ts">
 import { defineComponent, computed, ref } from 'vue'
-import KPop from '@/components/KPop/KPop.vue'
+import KPop, { placements } from '@/components/KPop/KPop.vue'
 
 export default defineComponent({
   name: 'KTooltip',
@@ -44,14 +44,13 @@ export default defineComponent({
     },
 
     /**
-     * Define which side the tooltip displays<br>
-     * 'top' | 'bottom' | 'left' | 'right'
+     * Define which side the tooltip displays
      */
     placement: {
       type: String,
       default: 'bottom',
       validator: (value: string):boolean => {
-        return ['top', 'bottom', 'left', 'right'].includes(value)
+        return Object.keys(placements).includes(value)
       },
     },
     /**


### PR DESCRIPTION
# Summary

Ticket: https://konghq.atlassian.net/browse/KHCP-5756

All of these values from KPop should be included in the validator/accepted values in KTooltip

```ts
export const placements = {
  auto: 'auto',
  top: 'top',
  topStart: 'top-start',
  topEnd: 'top-end',
  left: 'left',
  leftStart: 'left-start',
  leftEnd: 'left-end',
  right: 'right',
  rightStart: 'right-start',
  rightEnd: 'right-end',
  bottom: 'bottom',
  bottomStart: 'bottom-start',
  bottomEnd: 'bottom-end',
}
```

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
