### PR TITLE
fix(kpop): stop document click event propagation only when event is about to hide popper

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -405,22 +405,27 @@ export default defineComponent({
       this.updatePopper()
     },
     handleClick(e) {
-      e.stopPropagation()
+      const hidePopperAndStopPropagation = () => {
+        // Stop event propagation only when the click event is about to hide popper
+        e.stopPropagation()
+        this.hidePopper()
+      }
+
       if (this.reference && this.reference.contains(e.target)) {
         if (this.isOpen) {
-          this.hidePopper()
+          hidePopperAndStopPropagation()
         } else {
           this.createInstance()
         }
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target) && this.onPopoverClick) {
         const isOpen = this.onPopoverClick()
         if (isOpen !== undefined) {
-          isOpen ? this.showPopper() : this.hidePopper()
+          isOpen ? this.showPopper() : hidePopperAndStopPropagation()
         }
       } else if (this.$refs.popper && this.$refs.popper.contains(e.target)) {
         this.showPopper()
       } else if (this.isOpen) {
-        this.hidePopper()
+        hidePopperAndStopPropagation()
       }
     },
     bindEvents() {


### PR DESCRIPTION
# Summary

This fixes the issue where other document click event listeners were not being fired because the stopPropagation() was always being called no matter what was the actual action of the click.

Most UI libraries use document-bound click listeners for execution optimization reasons, and this behavior caused them to not work anymore.

stopPropagation() should only be called when the click event is hiding the popper.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
