### PR TITLE
feat(KCollapse): add support to display tags content [KHCP-5895]

### DIFF
--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -143,6 +143,128 @@ To set the default state (collapsed or expanded) without binding to v-model you 
   I am expanded by default
 </KCollapse>
 ```
+### type
+
+Values: `tags` or `default`. Use this optional prop to specific render the tags(`KBadge`) content.  The trigger icon will automatically appear when the content width is longer than the parent container. If type is setted to tags, only tags related props: `tags`, `tagsAppearance`, and `noCollapse` will take effect.
+
+<KCard title="Tags">
+  <template v-slot:body>
+    <KCollapse
+      type="tags"
+      :tags="complexTags"
+      >
+    </KCollapse>
+  </template>
+</KCard>
+
+```html
+<KCollapse
+  type="tags"
+  :tags="['tag-001', 'tag-002', 'tag-003', 
+  'tag-004', 'tag-005','tag-006', 
+  'BasicAuth', 'WebsiteDesktop', 'AndroidApp', 
+  'iOSApp', 'LinuxVirtualMachine']"
+  >
+</KCollapse>
+```
+
+### tags
+
+Use this prop to provide the tags content of an array.
+
+<KCard title="Tags">
+  <template v-slot:body>
+    <KCollapse
+      type="tags"
+      :tags="['tag-001', 'tag-002', 'tag-003']"
+      >
+    </KCollapse>
+  </template>
+</KCard>
+
+```html
+<KCollapse
+  type="tags"
+  :tags="['tag-001', 'tag-002', 'tag-003']"
+  >
+</KCollapse>
+```
+
+### tagsAppearance
+
+Values: `light` or `default`. Use this optional prop to set the display appearance of the tags.
+
+<KCard title="Tags">
+  <template v-slot:body>
+    <KCollapse
+      type="tags"
+      :tags="complexTags"
+      tags-appearance="light"
+      >
+    </KCollapse>
+  </template>
+</KCard>
+
+```html
+<KCollapse
+  type="tags"
+  :tags="complexTags"
+  tags-appearance="light"
+  >
+</KCollapse>
+```
+
+### noCollapse
+
+Boolean value used to disable the collapse effect on tags.
+
+<KCard title="Tags">
+  <template v-slot:body>
+    <KCollapse
+      type="tags"
+      :tags="complexTags"
+      :no-collapse="true"
+      >
+    </KCollapse>
+  </template>
+</KCard>
+
+```html
+<KCollapse
+  type="tags"
+  :tags="complexTags"
+  :no-collapse="true"
+  >
+</KCollapse>
+```
+
+## Examples
+
+### Rendering tags inside a `KTable`
+
+<KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" >
+  <template v-slot:tags="{rowValue}">
+    <KCollapse
+      type="tags"
+      :tags="rowValue"
+      >
+    </KCollapse>
+  </template>
+</KTable>
+
+```html
+<KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" >
+  <template v-slot:tags="{rowValue}">
+    <KCollapse
+      type="tags"
+      :tags="rowValue"
+      >
+    </KCollapse>
+  </template>
+</KTable>
+```
+
+
 
 ## Slots
 
@@ -262,9 +384,39 @@ import { defineComponent } from 'vue'
 export default defineComponent({
   data() {
     return {
-      myIsCollapsed: true
+      myIsCollapsed: true,
+      tableOptionsHeaders: [
+        { label: 'Name', key: 'name' },
+        { label: 'ID', key: 'id' },
+        { label: 'Tags', key: 'tags' },
+        { key: 'actions', hideLabel: true }
+      ],
+      complexTags: ['tag-001', 'tag-002', 'tag-003', 'tag-004', 'tag-005','tag-006', 'BasicAuth', 'WebsiteDesktop', 'AndroidApp', 'iOSApp', 'LinuxVirtualMachine']
     }
   },
+  methods: {
+    tableOptionsFetcher () {
+      return {
+        data: [
+          {
+            name: 'Basic Auth',
+            id: '517526354743085',
+            tags: ['tag-001', 'tag-002', 'tag-003', 'tag-004', 'tag-005','tag-006'],
+          },
+          {
+            name: 'Website Desktop',
+            id: '328027447731198',
+            tags: ['tag-001', 'tag-002', 'tag-003'],
+
+          },
+          {
+            name: 'Android App',
+            id: '405383051040955',
+          }
+        ]
+      }
+    },
+  }
 })
 </script>
 

--- a/src/components/KCollapse/KCollapse.vue
+++ b/src/components/KCollapse/KCollapse.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="k-collapse w-100">
+    <div v-if="type === 'tags'">
+      <KCollapseItem
+        :no-collapse="noCollapse"
+        :tags="tags"
+        :tags-appearance="tagsAppearance"
+      />
+    </div>
     <div
+      v-else
       class="k-collapse-heading mb-3"
       :class="{
         'd-flex': trailingTrigger,
@@ -78,13 +86,15 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, watch } from 'vue'
+import { defineComponent, computed, ref, watch, PropType } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
+import KCollapseItem from '@/components/KCollapse/KCollapseItem.vue'
 
 export default defineComponent({
   name: 'KCollapse',
   components: {
     KIcon,
+    KCollapseItem,
   },
   props: {
     // Is the KCollapse collapsed? Defaults to true
@@ -110,6 +120,25 @@ export default defineComponent({
       validator: (value: string): boolean => {
         return ['leading', 'trailing'].includes(value)
       },
+    },
+    type: {
+      type: String as PropType<'default' | 'tags'>,
+      required: false,
+      default: 'default',
+    },
+    tags: {
+      type: Array,
+      default: () => [],
+    },
+    tagsAppearance: {
+      type: String as PropType<'default' | 'light'>,
+      required: false,
+      default: 'default',
+    },
+    noCollapse: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   emits: ['toggled', 'update:modelValue'],

--- a/src/components/KCollapse/KCollapseItem.vue
+++ b/src/components/KCollapse/KCollapseItem.vue
@@ -87,36 +87,38 @@ const updateToggleVisibility = () => {
 const handleMoreToggleClick = () => {
   expanded.value = props.noCollapse || !expanded.value
 }
-const getTagLabel = (tag) => {
+const getTagLabel = (tag: any) => {
   if (typeof tag === 'object' && tag !== null && 'label' in tag) {
     return tag.label
   }
   return tag
 }
-const getTagForeground = (tag) => {
+const getTagForeground = (tag: any) => {
   if (typeof tag === 'object' && tag !== null && 'foreground' in tag) {
     return tag.foreground
   }
   return undefined
 }
-const getTagBackground = (tag) => {
+const getTagBackground = (tag: any) => {
   if (typeof tag === 'object' && tag !== null && 'background' in tag) {
     return tag.background
   }
   return undefined
 }
-const getTagIsBordered = (tag) => {
+const getTagIsBordered = (tag: any) => {
   if (typeof tag === 'object' && tag !== null && 'isBordered' in tag) {
     return tag.isBordered
   }
   return undefined
 }
 onMounted(() => {
+  // @ts-ignore
   resizeObserver.value = new ResizeObserver(updateToggleVisibility).observe(tagsContainer.value)
   updateToggleVisibility()
 })
 onBeforeUnmount(() => {
   if (resizeObserver.value) {
+    // @ts-ignore
     resizeObserver.value.unobserve(tagsContainer.value)
   }
 })

--- a/src/components/KCollapse/KCollapseItem.vue
+++ b/src/components/KCollapse/KCollapseItem.vue
@@ -1,0 +1,174 @@
+<template>
+  <div
+    ref="tagsWrapper"
+    :class="{ 'entity-list-tags-wrapper': true, 'expanded': noCollapse || expanded }"
+  >
+    <div
+      ref="tagsContainer"
+      class="tags-container"
+    >
+      <KBadge
+        v-for="tag in tags"
+        :key="getTagLabel(tag)"
+        :background-color="getTagBackground(tag) || defaultBackgroundColor"
+        :color="getTagForeground(tag) || defaultColor"
+        :is-bordered="getTagIsBordered(tag)"
+      >
+        <div>
+          {{ getTagLabel(tag) }}
+        </div>
+      </KBadge>
+    </div>
+    <div
+      v-if="showToggle"
+      class="more-tags-toggle"
+    >
+      <KBadge
+        :background-color="defaultBackgroundColor"
+        :color="defaultColor"
+        @click.stop="handleMoreToggleClick"
+      >
+        <img
+          v-if="!expanded"
+          alt="expand"
+          src="@/components/KIcon/icons/icn-more-horizontal.svg"
+        >
+        <img
+          v-else
+          alt="collapse"
+          src="@/components/KIcon/icons/icn-chevron-up.svg"
+        >
+      </KBadge>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref, computed, PropType } from 'vue'
+const props = defineProps({
+  noCollapse: {
+    type: Boolean,
+    default: false,
+  },
+  tags: {
+    type: Array,
+    default: () => [],
+  },
+  tagsAppearance: {
+    type: String as PropType<'default' | 'light'>,
+    required: false,
+    default: 'default',
+  },
+})
+
+const mapAppearanceToBackgroundColor = {
+  default: 'var(--blue-100)',
+  light: 'var(--grey-200)',
+}
+
+const mapAppearanceToColor = {
+  default: 'var(--blue-500)',
+  light: 'var(--grey-600)',
+}
+
+const defaultBackgroundColor = computed((): string => mapAppearanceToBackgroundColor[props.tagsAppearance])
+const defaultColor = computed((): string => mapAppearanceToColor[props.tagsAppearance])
+
+const expanded = ref<boolean>(false)
+const showToggle = ref<boolean>(false)
+const resizeObserver = ref(null)
+const tagsContainer = ref<HTMLDivElement>()
+const tagsWrapper = ref<HTMLDivElement>()
+const updateToggleVisibility = () => {
+  if (tagsContainer.value && tagsWrapper.value) {
+    showToggle.value = tagsContainer.value.offsetHeight > tagsWrapper.value.offsetHeight && !props.noCollapse
+  }
+}
+const handleMoreToggleClick = () => {
+  expanded.value = props.noCollapse || !expanded.value
+}
+const getTagLabel = (tag) => {
+  if (typeof tag === 'object' && tag !== null && 'label' in tag) {
+    return tag.label
+  }
+  return tag
+}
+const getTagForeground = (tag) => {
+  if (typeof tag === 'object' && tag !== null && 'foreground' in tag) {
+    return tag.foreground
+  }
+  return undefined
+}
+const getTagBackground = (tag) => {
+  if (typeof tag === 'object' && tag !== null && 'background' in tag) {
+    return tag.background
+  }
+  return undefined
+}
+const getTagIsBordered = (tag) => {
+  if (typeof tag === 'object' && tag !== null && 'isBordered' in tag) {
+    return tag.isBordered
+  }
+  return undefined
+}
+onMounted(() => {
+  resizeObserver.value = new ResizeObserver(updateToggleVisibility).observe(tagsContainer.value)
+  updateToggleVisibility()
+})
+onBeforeUnmount(() => {
+  if (resizeObserver.value) {
+    resizeObserver.value.unobserve(tagsContainer.value)
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/variables';
+@import '@/styles/functions';
+.entity-list-tags-wrapper {
+  --KBadgeFontSize: 12px;
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  overflow: hidden;
+  height: 28px;
+  padding: 4px 0;
+  transition: height linear 150ms;
+  &.expanded {
+    height: auto;
+  }
+  .tags-container {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 10px;
+    .k-badge {
+      height: 20px;
+      & > div{
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+  .more-tags-toggle {
+    margin-left: 10px;
+    display: flex;
+    box-sizing: border-box;
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    .k-badge {
+      padding: 4px;
+      height: auto;
+      line-height: 1;
+    }
+    img {
+      max-width: 100%;
+      max-height: 100%;
+      vertical-align: unset;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
# Summary
Ticket: https://konghq.atlassian.net/browse/KHCP-5895

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
![Screenshot 2023-01-24 at 11 27 01 AM](https://user-images.githubusercontent.com/36582129/214390033-c5188e0a-9c54-4604-ac43-f617934f9853.png)
![Screenshot 2023-01-24 at 11 27 19 AM](https://user-images.githubusercontent.com/36582129/214390048-1969bfe4-2e5a-4aaf-be08-060946265cfd.png)
![Screenshot 2023-01-24 at 11 27 50 AM](https://user-images.githubusercontent.com/36582129/214390064-42c3fb8b-e5f9-4a32-8a1b-9d10ea1bb91d.png)




## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
