### PR TITLE
fix(codeBlock): fix display styling

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1194,8 +1194,8 @@ $dark-focusColor: var(--green-500, color(green-500));
 
 .k-code-block-content {
   pre.k-highlighted-code-block.is-single-line {
-    display: flex;
     padding: var(--spacing-sm, spacing(sm)) var(--spacing-xxl, spacing(xxl)) 0 0;
+    grid-template-columns: auto;
 
     code {
       white-space: nowrap;


### PR DESCRIPTION
# Summary

I ran across an issue when using the `is-single-line` prop where the code block would extend beyond it's intended container:

![Screenshot 2023-01-27 at 9 49 02 AM](https://user-images.githubusercontent.com/2080476/215146784-be7e594a-c781-4de2-8b5c-d99cca79265b.png)

For the fix itself, there seem to be a few workable options for the `grid-template-columns` value: `auto`, `100%` and `fit-content(100%)` all seem to work fine. I went with `auto`, but please let me know if one of the other options are better or if there is a different solution that would be more suitable.


<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
