### PR TITLE
feat(ktextarea): add prop to allow resizing of textarea

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -98,7 +98,7 @@ Boolean value to indicate whether the element has an error and should apply erro
 
 ### isResizable
 
-Boolean value to allow manually resizing a textarea
+Boolean value to allow vertically resizing a textarea
 
 <KTextArea is-resizable />
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -96,6 +96,16 @@ Boolean value to indicate whether the element has an error and should apply erro
 <KTextArea has-error />
 ```
 
+### isResizable
+
+Boolean value to allow manually resizing a textarea
+
+<KTextArea is-resizable />
+
+```html
+<KTextArea is-resizable />
+```
+
 ## v-model
 
 `KTextArea` works as regular texarea do using v-model for data binding:

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -50,20 +50,34 @@ Enable this prop to overlay the label on the input element's border. Defaults to
 <KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
 ```
 
-### size
+### cols
 
-You can specify `rows`, `cols` for the textarea size.
+You can specify `cols` to adjust the horizontal size of the textarea
 
-<KTextArea label="Size" :rows="3" :cols="20" placeholder="I'm labelled and customized!" />
-<br>
-<KTextArea :rows="8" :cols="25" placeholder="rows:8, cols:25" />
+<KTextArea :cols="12" placeholder="cols:12" />
 
 ```html
-<template>
-  <KTextArea label="Size" :rows="3" :cols="20" placeholder="I'm labelled and customized!" />
-  <br>
-  <KTextArea :rows="8" :cols="25" placeholder="rows:8, cols:25" />
-</template>
+<KTextArea :cols="12" placeholder="cols:12" />
+```
+
+### rows
+
+You can specify `rows` to adjust the vertical size of the textarea
+
+<KTextArea :rows="12" placeholder="rows:12" />
+
+```html
+<KTextArea :rows="12" placeholder="rows:12" />
+```
+
+### isResizable
+
+Boolean value to allow vertically resizing using the drag handle in the right-hand corner of the textarea
+
+<KTextArea is-resizable />
+
+```html
+<KTextArea is-resizable />
 ```
 
 ### characterLimit
@@ -94,16 +108,6 @@ Boolean value to indicate whether the element has an error and should apply erro
 
 ```html
 <KTextArea has-error />
-```
-
-### isResizable
-
-Boolean value to allow vertically resizing a textarea
-
-<KTextArea is-resizable />
-
-```html
-<KTextArea is-resizable />
 ```
 
 ## v-model

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -132,4 +132,14 @@ describe('KTextArea', () => {
 
     cy.get('.char-limit').should('not.exist')
   })
+
+  it('should have `is-resizable` class when is-resizable prop is enabled', () => {
+    mount(KTextArea, {
+      props: {
+        isResizable: true,
+      },
+    })
+
+    cy.get('textarea').should('have.class', 'is-resizable')
+  })
 })

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -232,7 +232,7 @@ export default defineComponent({
     resize: none;
 
     &.is-resizable {
-      resize: both;
+      resize: vertical;
     }
 
     &:focus::placeholder {

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -7,6 +7,7 @@
       v-if="!label"
       v-bind="modifiedAttrs"
       class="form-control k-input style-body-lg"
+      :class="[isResizable ? 'is-resizable' : undefined]"
       :cols="cols"
       :rows="rows"
       :value="getValue()"
@@ -30,6 +31,7 @@
           :id="textAreaId"
           :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
           class="form-control k-input style-body-lg"
+          :class="[isResizable ? 'is-resizable' : undefined]"
           :cols="cols"
           :rows="rows"
           :value="getValue()"
@@ -57,6 +59,7 @@
         :id="textAreaId"
         :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
         class="form-control k-input style-body-lg"
+        :class="[isResizable ? 'is-resizable' : undefined]"
         :cols="cols"
         :rows="rows"
         :value="getValue()"
@@ -132,6 +135,10 @@ export default defineComponent({
      * Test mode - for testing only, strips out generated ids
      */
     testMode: {
+      type: Boolean,
+      default: false,
+    },
+    isResizable: {
       type: Boolean,
       default: false,
     },
@@ -223,6 +230,10 @@ export default defineComponent({
   textarea.form-control {
     font-family: var(--font-family-sans);
     resize: none;
+
+    &.is-resizable {
+      resize: both;
+    }
 
     &:focus::placeholder {
       color: transparent;

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -232,6 +232,7 @@ export default defineComponent({
     resize: none;
 
     &.is-resizable {
+      min-height: 50px;
       resize: vertical;
     }
 


### PR DESCRIPTION
# Summary

Adds `is-resizable` prop to allow manually resizing of a textarea

![Screenshot 2023-01-27 at 3 26 26 PM](https://user-images.githubusercontent.com/2080476/215218213-0a10c436-116c-4442-9bd7-7c48e1b0cd9f.png)


<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
