### PR TITLE
fix(ktreelist): emit target when firing each of @change and @child-change in KTreeList [KHCP-5950]

### DIFF
--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -202,7 +202,8 @@ You can pass a `width` string for the entire tree. By default it will take the f
 <div>
   <KLabel>Selected: </KLabel> {{ mySelection && mySelection.name || '' }}
   <br>
-  <KLabel>Items: </KLabel> {{ eventItems }}
+  <KLabel>Items:</KLabel>
+  <pre class="json hide-from-percy">{{ JSON.stringify(eventItems) }}</pre>
   <KTreeList
     :items="eventItems"
     class="mt-3"

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -193,9 +193,9 @@ You can pass a `width` string for the entire tree. By default it will take the f
 ## Events
 
 - `@change` - emitted when there is a change to the root level items
-  - returns `items` - an array of tree items
+  - returns `items` - an array of tree items; `target` - the changed item
 - `@child-change` - emitted when an item is added or removed at the non-root level
-  - returns `parent` - id of the parent item; `children` - an array of tree items
+  - returns `parent` - id of the parent item; `children` - an array of tree items; `target` - the changed item
   - **Note:** two separate `child-change` events will fire if an item is moved from one parent to another
 - `@selected` - emitted when you click (and don't drag) an item; returns the selected item's data
 
@@ -229,7 +229,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
 
   const mySelection = ref(null)
   const handleChildChange = (data) => {
-    const { parentId, children } = data
+    const { parentId, children, target } = data
     const changedParent = myItems.value.filter(item => item.id === parentId)?.[0]
     changedParent.children = children
   }
@@ -479,7 +479,7 @@ const reset = () => {
 }
 
 const handleChildChange = (data) => {
-  const { parentId, children } = data
+  const { parentId, children, target } = data
   const changedParent = eventItems.value.filter(item => item.id === parentId)?.[0]
   changedParent.children = children
 }

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -98,12 +98,14 @@ export const getMaximumDepth = ({ children = [] }): number => {
 
 <script setup lang="ts">
 export interface ChangeEvent {
-  items: TreeListItem[]
+  items: TreeListItem[],
+  target: TreeListItem
 }
 
 export interface ChildChangeEvent {
   parent: string,
-  children: TreeListItem[]
+  children: TreeListItem[],
+  target: TreeListItem
 }
 
 export interface DropEvent {
@@ -179,15 +181,17 @@ const getElementChildren = (item: TreeListItem): TreeListItem[] => {
   return item.children as TreeListItem[]
 }
 
-const handleChangeEvent = (): void => {
+const handleChangeEvent = (item: TreeListItem): void => {
   if (props.parentId) {
     emit('child-change', {
       parent: props.parentId,
       children: internalList.value,
+      target: item,
     })
   } else {
     emit('change', {
       items: internalList.value,
+      target: item,
     })
   }
 }

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -76,12 +76,14 @@ const treeListIsValid = (items: TreeListItem[]): boolean => {
 
 <script lang="ts" setup>
 export interface ChangeEvent {
-  items: TreeListItem[]
+  items: TreeListItem[],
+  target: TreeListItem
 }
 
 export interface ChildChangeEvent {
   parent: string,
-  children: TreeListItem[]
+  children: TreeListItem[],
+  target: TreeListItem
 }
 
 const props = defineProps({


### PR DESCRIPTION

# Summary
https://konghq.atlassian.net/browse/KHCP-5950

Added `target` to be emitted upon `@change` and `@child-change` events in KTreeList

<img width="1390" alt="Screenshot 2023-01-30 at 6 22 19 AM" src="https://user-images.githubusercontent.com/2568272/215503250-aa12b218-7161-4300-98d6-5584d7d37c0b.png">

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
