### PR TITLE
fix(kcodeblock): minor code block issues

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -429,7 +429,8 @@ const code = `{
   },
   "include": [
     "./src",
-    "./types"
+    "./types",
+    "./particularly-long-value-that-will-inadvertently-cause-scrolling-for-narrower-containers"
   ]
 }`
 

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -793,6 +793,23 @@ $dark-focusColor: var(--green-500, color(green-500));
   padding: var(--spacing-md, spacing(md)) 0 0 var(--spacing-sm, spacing(sm));
 }
 
+.k-code-block pre.is-single-line {
+  grid-template-columns: auto;
+  padding: var(--spacing-sm, spacing(sm)) var(--spacing-xxl, spacing(xxl)) 0 0;
+
+  code {
+    line-height: 29px;
+    margin-right: 20px;
+    overflow-x: auto;
+    padding-bottom: var(--spacing-xs, spacing(xs));
+    padding-left: var(--spacing-sm, spacing(sm));
+  }
+
+  + .k-code-block-copy-button {
+    top: var(--spacing-xs, spacing(xs));
+  }
+}
+
 .k-code-block.theme-dark pre {
   background-color: var(--KCodeBlockBackgroundColor, $dark-backgroundColor);
 }
@@ -1161,8 +1178,6 @@ $dark-focusColor: var(--green-500, color(green-500));
 </style>
 
 <style lang="scss">
-@import '@/styles/variables';
-
 .k-matched-term {
   color: var(--teal-500, color(teal-500));
   font-weight: 900;
@@ -1181,25 +1196,5 @@ $dark-focusColor: var(--green-500, color(green-500));
   align-items: center;
   display: inline-flex;
   justify-content: center;
-}
-
-.k-code-block-content {
-  pre.k-highlighted-code-block.is-single-line {
-    grid-template-columns: auto;
-    padding: var(--spacing-sm, spacing(sm)) var(--spacing-xxl, spacing(xxl)) 0 0;
-
-    code {
-      line-height: 29px;
-      margin-right: 20px;
-      overflow-x: auto;
-      padding-bottom: var(--spacing-xs, spacing(xs));
-      padding-left: var(--spacing-sm, spacing(sm));
-      white-space: nowrap;
-    }
-
-    + .k-code-block-copy-button {
-      top: var(--spacing-xs, spacing(xs));
-    }
-  }
 }
 </style>

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :id="props.id"
+    :id="id"
     ref="codeBlock"
     class="k-code-block"
     :class="[`theme-${theme}`]"
@@ -46,13 +46,13 @@
 
         <label
           class="k-code-block-search-label"
-          :for="`${props.id}-search-input`"
+          :for="`${id}-search-input`"
         >
           <span class="k-visually-hidden">Search</span>
         </label>
 
         <input
-          :id="`${props.id}-search-input`"
+          :id="`${id}-search-input`"
           ref="codeBlockSearchInput"
           class="k-code-block-search-input"
           data-testid="k-code-block-search-input"
@@ -205,7 +205,7 @@
             <a
               :id="`${linePrefix}-L${line}`"
               class="k-line-anchor"
-              :href="props.showLineNumberLinks ? `#${linePrefix}-L${line}` : undefined"
+              :href="showLineNumberLinks ? `#${linePrefix}-L${line}` : undefined"
             >{{ line }}</a>
           </span>
         </span>
@@ -237,7 +237,7 @@
             <a
               :id="`${linePrefix}-L${line}`"
               class="k-line-anchor"
-              :href="props.showLineNumberLinks ? `#${linePrefix}-L${line}` : undefined"
+              :href="showLineNumberLinks ? `#${linePrefix}-L${line}` : undefined"
             >{{ line }}</a>
           </span>
         </span>
@@ -246,7 +246,7 @@
       <!-- eslint-enable vue/no-v-html -->
 
       <KButton
-        v-if="props.showCopyButton"
+        v-if="showCopyButton"
         ref="codeBlockCopyButton"
         appearance="outline"
         class="k-code-block-copy-button"

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -790,7 +790,7 @@ $dark-focusColor: var(--green-500, color(green-500));
   max-height: var(--KCodeBlockMaxHeight, none);
   min-height: 56px;
   overflow: auto;
-  padding: var(--spacing-md, spacing(md)) 0 var(--spacing-md, spacing(md)) var(--spacing-sm, spacing(sm));
+  padding: var(--spacing-md, spacing(md)) 0 0 var(--spacing-sm, spacing(sm));
 }
 
 .k-code-block.theme-dark pre {
@@ -817,9 +817,10 @@ $dark-focusColor: var(--green-500, color(green-500));
 .k-code-block code {
   // This is an essential performance regression prevention in scenarios where the code block content is being syntax-highlighted using PrismJS (see https://github.com/PrismJS/prism/issues/2062). I’ve observed noticeable performance issues as recent as October 2022.
   display: block;
-
   // This element will act as a grid item whose minimum width is initially `auto` which in turn can cause the CSS box to overflow which is not desirable here.
   min-width: 0;
+  overflow-x: auto;
+  padding-bottom: var(--spacing-sm, spacing(sm));
 }
 
 .k-code-block:focus-visible {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -414,17 +414,7 @@ const numberOfMatches = ref(0)
 const matchingLineNumbers = ref<number[]>([])
 const currentLineIndex = ref<null | number>(null)
 
-const totalLines = computed(() => {
-  let length: number
-
-  if (props.code?.includes('\n') && props.code.split('\n')?.length) {
-    length = props.code.split('\n').length
-  } else {
-    length = 1
-  }
-
-  return Array.from({ length }, (_, index) => index + 1)
-})
+const totalLines = computed(() => Array.from({ length: props.code.split('\n').length }, (_, index) => index + 1))
 const maxLineNumberWidth = computed(() => totalLines.value[totalLines.value.length - 1].toString().length + 'ch')
 const linePrefix = computed(() => props.id.toLowerCase().replace(/\s+/g, '-'))
 const isProcessing = computed(() => props.isProcessing || isProcessingInternally.value)
@@ -447,7 +437,7 @@ const filteredCode = computed(function() {
     })
     .join('\n')
 })
-const finalCode = computed(() => props.isSingleLine ? props.code?.replace('\n', '') : props.code)
+const finalCode = computed(() => props.isSingleLine ? props.code.replaceAll('\n', '') : props.code)
 
 watch(() => props.code, async function() {
   // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.
@@ -607,7 +597,7 @@ function updateMatchingLineNumbers() {
   regExpError.value = null
 
   // Avoids searching when one can expect a very large number of results. The numbers here are determined purely by gut feel and not by any scientific reasoning. Feel free to tweak them.
-  const isSmallEnoughForCostlySearch = query.value.length >= 3 || props.code?.length < 1000
+  const isSmallEnoughForCostlySearch = query.value.length >= 3 || props.code.length < 1000
   const shouldPerformSearch = query.value.length > 0 && (isRegExpMode.value || (!isRegExpMode.value && isSmallEnoughForCostlySearch))
   let totalMatchingLineNumbers: number[] = []
 
@@ -1200,14 +1190,14 @@ $dark-focusColor: var(--green-500, color(green-500));
     code {
       line-height: 29px;
       margin-right: 20px;
-      overflow: auto;
+      overflow-x: auto;
       padding-bottom: var(--spacing-xs, spacing(xs));
       padding-left: var(--spacing-sm, spacing(sm));
       white-space: nowrap;
     }
 
     + .k-code-block-copy-button {
-      top: var(--spacing-xs, 4px);
+      top: var(--spacing-xs, spacing(xs));
     }
   }
 }


### PR DESCRIPTION
# Summary

* **fix(kcodeblock): not replacing all new lines in single line mode**

  Fixes an issue with the code block component not replacing all new line characters when 
 `props.isSingleLine` is `true`.

  **Dev note**: With this change, it’s no longer necessary to set `white-space: nowrap` on the `code` element.

  **Dev note**: Replaces access of `props.code` via optional chaining with direct access as `props.code` is required and of type `String`. It is not expected to ever be `undefined` or `null`.

  **Dev note**: As an aside, it’s not required to special case the computation of `totalLines`; hence, the previous version of the computation was restored. It behaves correctly for the empty string, strings without new line characters, and strings with new line characters.
* **fix(kcodeblock): scrolling moving line numbers out of view**

  Fixes horizontal scrolling of code to cause the line numbers to be scrolled out of view.
* **refactor(kcodeblock): moves styles into scoped block**

  Moves some styles from the unscoped style block into the scoped style block which were unintentionally placed there.
* **refactor(kcodeblock): always accesses props using `props.`**

## Comment

I’d rather have favored an implementation of a single line mode that expects `props.code` to come preformatted (i.e. as a string without new line characters) as also suggested/asked about by Adam in https://github.com/Kong/kongponents/pull/1027#issuecomment-1370301538, but changing this now would be a breaking change.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
