### PR TITLE
fix(kmultiselect): dismissable badge [khcp-5995]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -45,7 +45,7 @@ You can specify `disabledTooltipText` property to customize the disabled tooltip
     value: 'dogs',
     selected: true,
     disabled: true,
-    disabledTooltipText: 'This item is locked and can not be removed'
+    disabledTooltipText: 'This item is locked and cannot be removed'
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -743,7 +743,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is locked and can not be removed'
+        disabledTooltipText: 'This item is locked and cannot be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -800,7 +800,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is locked and can not be removed'
+        disabledTooltipText: 'This item is locked and cannot be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -830,7 +830,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is locked and can not be removed'
+        disabledTooltipText: 'This item is locked and cannot be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies'

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -42,7 +42,8 @@ If an item is specified with `selected: true` and `disabled: true`, then the ite
     label: 'Dogs',
     value: 'dogs',
     selected: true,
-    disabled: true
+    disabled: true,
+    disabledTooltipText: 'This selection is dismissible'
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -739,7 +740,8 @@ export default defineComponent({
         label: 'Dogs',
         value: 'dogs',
         selected: true,
-        disabled: true
+        disabled: true,
+        disabledTooltipText: 'This selection is dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -795,8 +797,8 @@ export default defineComponent({
         label: 'Dogs',
         value: 'dogs',
         selected: true,
-        selected: true,
-        disabled: true
+        disabled: true,
+        disabledTooltipText: 'This selection is dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -825,7 +827,8 @@ export default defineComponent({
         label: 'Dogs',
         value: 'dogs',
         selected: true,
-        disabled: true
+        disabled: true,
+        disabledTooltipText: 'This selection is dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies'

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -24,7 +24,10 @@ An array of items containing a `label` and `value`.
 You may also specify:
 - a certain item is `selected` by default
 - a certain item is `disabled`
-- if a certain item has `selected: true` and `disabled: true`, then KBadge for that item is not dismissable
+
+:::tip TIP
+If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item.
+:::
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -24,7 +24,7 @@ An array of items containing a `label` and `value`.
 You may also specify:
 - a certain item is `selected` by default
 - a certain item is `disabled`
-- a certain item is readonly by using `isReadonly` property
+- if a certain item has `selected: true` and `disabled: true`, then KBadge for that item is not dismissable
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />
@@ -38,7 +38,8 @@ You may also specify:
   }, {
     label: 'Dogs',
     value: 'dogs',
-    isReadonly: true
+    selected: true,
+    disabled: true
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -268,7 +269,8 @@ export default defineComponent({
       }, {
         label: 'Dogs',
         value: 'dogs',
-        isReadonly: true
+        selected: true,
+        disabled: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -616,7 +618,8 @@ const myItems = ref([
   {
     label: '200',
     value: 200,
-    isReadonly: true
+    selected: true,
+    disabled: true
   },
   {
     label: '400',
@@ -705,7 +708,8 @@ export default defineComponent({
       }, {
         label: 'Dogs',
         value: 'dogs',
-        isReadonly: true
+        selected: true,
+        disabled: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -731,7 +735,8 @@ export default defineComponent({
       }, {
         label: 'Dogs',
         value: 'dogs',
-        isReadonly: true
+        selected: true,
+        disabled: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -758,7 +763,8 @@ export default defineComponent({
       }, {
         label: 'Dogs',
         value: 'dogs',
-        isReadonly: true
+        selected: true,
+        disabled: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -786,7 +792,8 @@ export default defineComponent({
         label: 'Dogs',
         value: 'dogs',
         selected: true,
-        isReadonly: true
+        selected: true,
+        disabled: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -814,7 +821,8 @@ export default defineComponent({
       }, {
         label: 'Dogs',
         value: 'dogs',
-        isReadonly: true
+        selected: true,
+        disabled: true
       }, {
         label: 'Bunnies',
         value: 'bunnies'
@@ -835,7 +843,8 @@ export default defineComponent({
       myEventItems: [{
         label: '200',
         value: 200,
-        isReadonly: true
+        selected: true,
+        disabled: true
       },
       {
         label: '400',

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -26,7 +26,7 @@ You may also specify:
 - a certain item is `disabled`
 
 :::tip TIP
-If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item. `disabledTooltipText` can be used to specify the description for this item.
+If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item.
 :::
 
 <ClientOnly>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -43,7 +43,7 @@ If an item is specified with `selected: true` and `disabled: true`, then the ite
     value: 'dogs',
     selected: true,
     disabled: true,
-    disabledTooltipText: 'This selection is dismissible'
+    disabledTooltipText: 'This selection is non-dismissible'
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -741,7 +741,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This selection is dismissible'
+        disabledTooltipText: 'This selection is non-dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -798,7 +798,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This selection is dismissible'
+        disabledTooltipText: 'This selection is non-dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -828,7 +828,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This selection is dismissible'
+        disabledTooltipText: 'This selection is non-dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies'

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -28,7 +28,7 @@ You may also specify:
 :::tip TIP
 If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item.
 
-You can specify `disabledTooltipText` property to customize the disabled tooltip label. Defaults to `This item cannot be removed`.
+You can specify `disabledTooltipText` property to customize the disabled tooltip that appears when hovering over the lock icon. Defaults to `This item cannot be removed`.
 :::
 
 <ClientOnly>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -26,7 +26,7 @@ You may also specify:
 - a certain item is `disabled`
 
 :::tip TIP
-If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item.
+If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item. `disabledTooltipText` can be used to specify the description for this item.
 :::
 
 <ClientOnly>
@@ -43,7 +43,7 @@ If an item is specified with `selected: true` and `disabled: true`, then the ite
     value: 'dogs',
     selected: true,
     disabled: true,
-    disabledTooltipText: 'This selection is non-dismissible'
+    disabledTooltipText: 'This item is non-dismissible'
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -741,7 +741,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This selection is non-dismissible'
+        disabledTooltipText: 'This item is non-dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -798,7 +798,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This selection is non-dismissible'
+        disabledTooltipText: 'This item is non-dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -828,7 +828,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This selection is non-dismissible'
+        disabledTooltipText: 'This item is non-dismissible'
       }, {
         label: 'Bunnies',
         value: 'bunnies'

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -24,6 +24,7 @@ An array of items containing a `label` and `value`.
 You may also specify:
 - a certain item is `selected` by default
 - a certain item is `disabled`
+- a certain item is readonly by using `isReadonly` property
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsWithDisabled)" />
@@ -36,7 +37,8 @@ You may also specify:
     selected: true
   }, {
     label: 'Dogs',
-    value: 'dogs'
+    value: 'dogs',
+    isReadonly: true
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -265,7 +267,8 @@ export default defineComponent({
         selected: true
       }, {
         label: 'Dogs',
-        value: 'dogs'
+        value: 'dogs',
+        isReadonly: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -612,7 +615,8 @@ import { ref } from 'vue'
 const myItems = ref([
   {
     label: '200',
-    value: 200
+    value: 200,
+    isReadonly: true
   },
   {
     label: '400',
@@ -700,7 +704,8 @@ export default defineComponent({
         selected: true
       }, {
         label: 'Dogs',
-        value: 'dogs'
+        value: 'dogs',
+        isReadonly: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -725,7 +730,8 @@ export default defineComponent({
         selected: true
       }, {
         label: 'Dogs',
-        value: 'dogs'
+        value: 'dogs',
+        isReadonly: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -751,7 +757,8 @@ export default defineComponent({
         selected: true
       }, {
         label: 'Dogs',
-        value: 'dogs'
+        value: 'dogs',
+        isReadonly: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -778,7 +785,8 @@ export default defineComponent({
       }, {
         label: 'Dogs',
         value: 'dogs',
-        selected: true
+        selected: true,
+        isReadonly: true
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -805,7 +813,8 @@ export default defineComponent({
         value: 'cats'
       }, {
         label: 'Dogs',
-        value: 'dogs'
+        value: 'dogs',
+        isReadonly: true
       }, {
         label: 'Bunnies',
         value: 'bunnies'
@@ -825,7 +834,8 @@ export default defineComponent({
       }],
       myEventItems: [{
         label: '200',
-        value: 200
+        value: 200,
+        isReadonly: true
       },
       {
         label: '400',

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -45,7 +45,7 @@ You can specify `disabledTooltipText` property to customize the disabled tooltip
     value: 'dogs',
     selected: true,
     disabled: true,
-    disabledTooltipText: 'This item is non-dismissible'
+    disabledTooltipText: 'This item is locked and can not be removed'
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -743,7 +743,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is non-dismissible'
+        disabledTooltipText: 'This item is locked and can not be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -800,7 +800,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is non-dismissible'
+        disabledTooltipText: 'This item is locked and can not be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -830,7 +830,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is non-dismissible'
+        disabledTooltipText: 'This item is locked and can not be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies'

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -27,6 +27,8 @@ You may also specify:
 
 :::tip TIP
 If an item is specified with `selected: true` and `disabled: true`, then the item will be selected, disabled in the dropdown list, and the dismiss button will be removed, meaning a user cannot remove the selected item.
+
+You can specify `disabledTooltipText` property to customize the disabled tooltip label. Defaults to `This item cannot be removed`.
 :::
 
 <ClientOnly>

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -13,6 +13,7 @@
     <component
       :is="truncationTooltip && (forceTooltip || isTruncated) ? 'KTooltip' : 'div'"
       class="k-badge-text truncate"
+      :position-fixed="truncationTooltip && (forceTooltip || isTruncated) ? true : undefined"
     >
       <template #content>
         {{ truncationTooltip }}

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -55,7 +55,7 @@
                   'mt-2': !expandSelected,
                   'resize-badge':(item.selected && item.disabled)
                 }"
-                :dismissable="!(item.selected && item.disabled)"
+                :dismissable="item.selected && !item.disabled"
                 shape="rectangular"
                 :truncation-tooltip="item.label"
                 @click.stop
@@ -215,7 +215,7 @@
           v-for="item, idx in visibleSelectedItemsStaging"
           :key="`${item.key ? item.key : idx}-badge`"
           class="mr-1 mt-2"
-          :dismissable="!(item.selected && item.disabled)"
+          :dismissable="item.selected && !item.disabled"
           hidden
           shape="rectangular"
         >

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -833,6 +833,7 @@ watch(() => props.items, (newValue, oldValue) => {
       unfilteredItems.value[i].selected = false
     }
 
+    // If an item is `selected` and `disabled`, provide fallback tooltip text if not provided
     if (unfilteredItems.value[i].selected === true && unfilteredItems.value[i].disabled === true && !unfilteredItems.value[i].disabledTooltipText) {
       unfilteredItems.value[i].disabledTooltipText = 'This item cannot be removed'
     }

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -254,6 +254,7 @@ export interface MultiselectItem {
   key?: string
   selected?: boolean
   disabled?: boolean
+  disabledTooltipText?: string
   custom?: boolean
 }
 
@@ -830,6 +831,10 @@ watch(() => props.items, (newValue, oldValue) => {
     // Ensure each item has a `selected` property
     if (unfilteredItems.value[i].selected === undefined) {
       unfilteredItems.value[i].selected = false
+    }
+
+    if (unfilteredItems.value[i].selected === true && unfilteredItems.value[i].disabled === true && !unfilteredItems.value[i].disabledTooltipText) {
+      unfilteredItems.value[i].disabledTooltipText = 'This item cannot be removed'
     }
 
     unfilteredItems.value[i].key = `${unfilteredItems.value[i].label?.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${i}` || `k-multiselect-item-label-${i}`

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -479,10 +479,12 @@ const createKPopAttributes = computed(() => {
     popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-multiselect-pop`,
     width: numericWidth.value + 'px',
     maxWidth: numericWidth.value + 'px',
-    maxHeight: String(props.dropdownMaxHeight),
     disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
   }
 })
+
+// Calculate the `.k-popover-content` max-height
+const popoverContentMaxHeight = computed((): string => getSizeFromString(props.dropdownMaxHeight))
 
 // TypeScript complains if I bind the original object
 const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
@@ -1043,7 +1045,6 @@ onMounted(() => {
   .k-multiselect-popover {
     box-sizing: border-box;
     margin-top: 2px !important;
-    overflow: auto !important; // Allow setting a maxHeight on the popover dropdown
     width: 100%;
 
     &[x-placement^="top"] {
@@ -1065,6 +1066,11 @@ onMounted(() => {
       .select-item-label {
         color: var(--grey-500);
       }
+    }
+
+    .k-popover-content {
+      max-height: v-bind('popoverContentMaxHeight');
+      overflow-y: auto; // Allow setting a maxHeight on the popover dropdown
     }
 
     a {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -251,7 +251,7 @@ export interface MultiselectItem {
   selected?: boolean
   disabled?: boolean
   custom?: boolean
-  isReadonly?: boolean // To be able to remove the KButton in the KBadge
+  isReadonly?: boolean // To be able to remove the KButton in KBadge
 }
 
 export interface MultiselectFilterFnParams {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -51,7 +51,7 @@
                 :key="`${item.key ? item.key : idx}-badge`"
                 class="mr-1"
                 :class="!expandSelected ? 'mt-2' : 'my-1'"
-                :dismissable="!item.isReadonly"
+                :dismissable="!(item.selected && item.disabled)"
                 shape="rectangular"
                 :truncation-tooltip="item.label"
                 @click.stop
@@ -211,7 +211,7 @@
           v-for="item, idx in visibleSelectedItemsStaging"
           :key="`${item.key ? item.key : idx}-badge`"
           class="mr-1 mt-2"
-          :dismissable="!item.isReadonly"
+          :dismissable="!(item.selected && item.disabled)"
           hidden
           shape="rectangular"
         >
@@ -251,7 +251,6 @@ export interface MultiselectItem {
   selected?: boolean
   disabled?: boolean
   custom?: boolean
-  isReadonly?: boolean // To be able to remove the KButton in KBadge
 }
 
 export interface MultiselectFilterFnParams {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -51,7 +51,7 @@
                 :key="`${item.key ? item.key : idx}-badge`"
                 class="mr-1"
                 :class="!expandSelected ? 'mt-2' : 'my-1'"
-                dismissable
+                :dismissable="!item.isReadonly"
                 shape="rectangular"
                 :truncation-tooltip="item.label"
                 @click.stop
@@ -211,7 +211,7 @@
           v-for="item, idx in visibleSelectedItemsStaging"
           :key="`${item.key ? item.key : idx}-badge`"
           class="mr-1 mt-2"
-          dismissable
+          :dismissable="!item.isReadonly"
           hidden
           shape="rectangular"
         >
@@ -251,6 +251,7 @@ export interface MultiselectItem {
   selected?: boolean
   disabled?: boolean
   custom?: boolean
+  isReadonly?: boolean // To be able to remove the KButton in the KBadge
 }
 
 export interface MultiselectFilterFnParams {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -50,7 +50,11 @@
                 v-for="item, idx in visibleSelectedItems"
                 :key="`${item.key ? item.key : idx}-badge`"
                 class="mr-1"
-                :class="!expandSelected ? 'mt-2' : 'my-1'"
+                :class="{
+                  'my-1': expandSelected,
+                  'mt-2': !expandSelected,
+                  'resize-badge':(item.selected && item.disabled)
+                }"
                 :dismissable="!(item.selected && item.disabled)"
                 shape="rectangular"
                 :truncation-tooltip="item.label"
@@ -891,6 +895,10 @@ onMounted(() => {
     box-sizing: border-box;
     padding-left: 16px;
     padding-right: 23px;
+
+    .resize-badge {
+      padding: 5px;
+    }
 
     &.scrollable {
       overflow-y: auto;

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -142,8 +142,8 @@ const handleClick = (): void => {
       height: var(--spacing-lg);
 
       &.kong-icon.kong-icon-lock {
-        padding-left: var(--spacing-xxs);
         height: 14px;
+        padding-left: var(--spacing-xxs);
       }
     }
 

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -17,18 +17,12 @@
       >
         <span class="k-multiselect-item-label mr-2">
           <slot name="content">{{ item.label }}
-            <div
-              v-if="(item.selected && item.disabled)"
-              class="select-item-desc"
-            >
-              {{ item.disabledTooltipText }}
-            </div>
           </slot>
         </span>
         <span class="k-multiselect-selected-icon-container">
           <KTooltip
             v-if="item.selected && item.disabled"
-            :label="item.disabledTooltipText || disabledTooltipText"
+            :label="item.disabledTooltipText"
             placement="left"
           >
             <KIcon
@@ -59,11 +53,6 @@ const props = defineProps({
     default: null,
     // Items must have a label and value
     validator: (item: Record<string, string | number | boolean>): boolean => item.label !== undefined && item.value !== undefined,
-  },
-  disabledTooltipText: {
-    type: String,
-    // Default tooltip text
-    default: 'This item is readonly',
   },
 })
 

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -63,7 +63,7 @@ const props = defineProps({
   disabledTooltipText: {
     type: String,
     // Default tooltip text
-    default: 'This option is readonly',
+    default: 'This item is readonly',
   },
 })
 
@@ -143,6 +143,7 @@ const handleClick = (): void => {
 
       &.kong-icon.kong-icon-lock {
         padding-left: var(--spacing-xxs);
+        height: 14px;
       }
     }
 

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -16,11 +16,30 @@
         @click="handleClick"
       >
         <span class="k-multiselect-item-label mr-2">
-          <slot name="content">{{ item.label }}</slot>
+          <slot name="content">{{ item.label }}
+            <div
+              v-if="(item.selected && item.disabled)"
+              class="select-item-desc"
+            >
+              {{ item.disabledTooltipText }}
+            </div>
+          </slot>
         </span>
         <span class="k-multiselect-selected-icon-container">
+          <KTooltip
+            v-if="item.selected && item.disabled"
+            :label="item.disabledTooltipText || disabledTooltipText"
+            placement="left"
+          >
+            <KIcon
+              class="selected-item-icon"
+              color="var(--blue-200)"
+              icon="lock"
+              size="14"
+            />
+          </KTooltip>
           <KIcon
-            v-if="item.selected"
+            v-else-if="item.selected"
             class="selected-item-icon"
             color="var(--blue-200)"
             icon="check"
@@ -40,6 +59,11 @@ const props = defineProps({
     default: null,
     // Items must have a label and value
     validator: (item: Record<string, string | number | boolean>): boolean => item.label !== undefined && item.value !== undefined,
+  },
+  disabledTooltipText: {
+    type: String,
+    // Default tooltip text
+    default: 'This option is readonly',
   },
 })
 
@@ -105,29 +129,33 @@ const handleClick = (): void => {
         color: var(--grey-600);
         font-size: 14px;
         font-weight: 600;
-        margin-bottom: 4px;
+        margin-bottom: var(--spacing-xxs);
       }
 
       :deep(.select-item-desc) {
         color: var(--grey-500);
-        font-size: 12px;
+        font-size: var(--spacing-sm);
         font-weight: 400;
       }
     }
     .selected-item-icon {
-      height: 24px;
+      height: var(--spacing-lg);
+
+      &.kong-icon.kong-icon-lock {
+        padding-left: var(--spacing-xxs);
+      }
     }
 
     .kong-icon:not(.selected-item-icon) {
-      margin-right: 12px;
+      margin-right: var(--spacing-sm);
     }
 
     .k-multiselect-selected-icon-container {
-      height: 24px;
+      height: var(--spacing-lg);
       margin-bottom: auto;
       margin-left: auto;
       margin-top: auto;
-      width: 24px;
+      width: var(--spacing-lg);
     }
 
     &:not(:disabled):hover {

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -28,6 +28,7 @@
             <KIcon
               class="selected-item-icon"
               color="var(--blue-200)"
+              hide-title
               icon="lock"
               size="14"
             />

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -434,10 +434,12 @@ export default defineComponent({
         popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-select-pop-${props.appearance}`,
         width: String(inputWidth.value),
         maxWidth: String(inputWidth.value),
-        maxHeight: String(props.dropdownMaxHeight),
         disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
       }
     })
+
+    // Calculate the `.k-popover-content` max-height
+    const popoverContentMaxHeight = computed((): string => getSizeFromString(props.dropdownMaxHeight))
 
     // TypeScript complains if I bind the original object
     const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
@@ -618,6 +620,7 @@ export default defineComponent({
       modifiedAttrs,
       popper,
       boundKPopAttributes,
+      popoverContentMaxHeight,
       widthValue,
       widthStyle,
       filteredItems,
@@ -851,7 +854,6 @@ export default defineComponent({
   .k-select-popover {
     box-sizing: border-box;
     margin-top: 2px !important;
-    overflow: auto !important; // Allow setting a maxHeight on the popover dropdown
     width: 100%;
 
     &[x-placement^="top"] {
@@ -882,6 +884,11 @@ export default defineComponent({
     .k-select-empty-item button:hover {
       color: var(--grey-500);
       font-style: italic;
+    }
+
+    .k-popover-content {
+      max-height: v-bind('popoverContentMaxHeight');
+      overflow-y: auto; // Allow setting a maxHeight on the popover dropdown
     }
 
     ul {


### PR DESCRIPTION
# Summary
Addresses:
[https://konghq.atlassian.net/browse/KHCP-5995](https://konghq.atlassian.net/browse/KHCP-5995)

Updates KMultiselect so that user can have an option of whether KBadge for an item should be dismissable or not.
![image 942](https://user-images.githubusercontent.com/87779967/216389939-eb7ff3bc-d8ce-48ee-92be-a49b8d658cdb.png)
![image 945](https://user-images.githubusercontent.com/87779967/216397611-f14886be-c4fc-48c1-8530-28107c353a55.png)
![image 946](https://user-images.githubusercontent.com/87779967/216400053-80e191ba-01e1-4ab7-b02f-47256a305d0e.png)

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
