### PR TITLE
fix(kdropdownmenu): allow customizing caret color

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -76,6 +76,27 @@ Use this prop if you would like the KButton to display a dropdown caret to the r
 </KComponent>
 ```
 
+### caretColor
+
+::: tip NOTE
+Use this prop in conjunction with the `showCaret` prop
+:::
+
+Use this prop to customize the color of the caret
+
+<KButton
+  caret-color="var(--blue-300)"
+  show-caret
+>
+  Select Item
+</KButton>
+
+```html
+<KButton caret-color="var(--blue-300)" show-caret>
+  Select Item
+</KButton>
+```
+
 ### isRounded
 
 The buttons are rounded by default. This can be disabled by setting `isRounded` prop to `false`.

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -141,6 +141,32 @@ Use this prop if you would like the trigger button to display the caret.
 />
 ```
 
+### caretColor
+
+::: tip NOTE
+Use this prop in conjunction with the `showCaret` prop
+:::
+
+Use this prop to customize the color of the caret
+
+<ClientOnly>
+  <KDropdownMenu
+    caret-color="var(--steel-300)"
+    label="Select Type"
+    :items="items"
+    show-caret
+  />
+</ClientOnly>
+
+```html
+<KDropdownMenu
+  caret-color="var(--steel-300)"
+  label="Select Type"
+  :items="items"
+  show-caret
+/>
+```
+
 ### icon
 
 A string for the `KIcon` to be displayed on the dropdown button with or in place of the button label.

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -55,7 +55,7 @@
     <KIcon
       v-if="showCaret"
       :class="['caret']"
-      :color="iconColor"
+      :color="caretColor || iconColor"
       icon="chevronDown"
       size="16"
       view-box="2 2 15 15"
@@ -124,6 +124,10 @@ export default defineComponent({
     showCaret: {
       type: Boolean,
       default: false,
+    },
+    caretColor: {
+      type: String,
+      default: undefined,
     },
     isRounded: {
       type: Boolean,

--- a/src/components/KDropdownMenu/KDropdownMenu.vue
+++ b/src/components/KDropdownMenu/KDropdownMenu.vue
@@ -31,6 +31,7 @@
               <KButton
                 v-if="label || icon"
                 :appearance="appearance === 'selectionMenu' ? 'outline' : buttonAppearance"
+                :caret-color="caretColor"
                 class="k-dropdown-btn"
                 data-testid="k-dropdown-btn"
                 :disabled="disabled"
@@ -110,6 +111,10 @@ export default defineComponent({
     buttonAppearance: {
       type: String,
       default: 'primary',
+    },
+    caretColor: {
+      type: String,
+      default: undefined,
     },
     label: {
       type: String,


### PR DESCRIPTION
# Summary

Adds new `caretColor` prop to `KDropdownMenu` and `KButton` components.

## Screenshots
![Screenshot 2023-02-08 at 3 23 36 PM](https://user-images.githubusercontent.com/2080476/217665099-70b0ffcc-904b-4175-afef-0e65605bdb33.png)
![Screenshot 2023-02-08 at 3 23 11 PM](https://user-images.githubusercontent.com/2080476/217665103-0b9729c2-6334-480d-bc8d-e765dfa1c40a.png)

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
