### PR TITLE
feat(kselect, kmultiselect): add dropdown footer text param and slot in KSelect and KMultiselect [KHCP-6007]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -596,7 +596,7 @@ You can use the `empty` slot to customize the look of the dropdown list when the
 
 ### Dropdown Footer Text
 
-Replaces text passed through `dropdownFooterText` param.
+Slot the content of the dropdown footer text. This slot will override the `dropdownFooterText` prop if provided.
 
 <ClientOnly>
   <KMultiselect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)">

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -209,6 +209,18 @@ You can pass a `dropdownMaxHeight` string for the dropdown. By default, the `dro
 <KMultiselect :items="items" dropdown-max-height="150" />
 ```
 
+### dropdownFooterText
+
+Adds informational text to the bottom of the dropdown options which remains visible even if the content is scrolled. Can also be [slotted](#slots).
+
+<ClientOnly>
+  <KMultiselect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
+</ClientOnly>
+
+```html
+<KMultiselect dropdown-footer-text="Dropdown footer text" :items="items" />
+```
+
 ### positionFixed
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `true`. See [`KPop` docs](popover.html#positionfixed) for more information.
@@ -505,18 +517,6 @@ export default {
 </script>
 ```
 
-### dropdownFooterText
-
-Adds text in the bottom of the dropdown, that sticks to the bottom - therefore stays visible even if the content is scrollable. Can also be [slotted](#slots).
-
-<ClientOnly>
-  <KMultiselect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
-</ClientOnly>
-
-```html
-<KMultiselect dropdown-footer-text="Dropdown footer text" :items="items" />
-```
-
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.
@@ -599,7 +599,7 @@ You can use the `empty` slot to customize the look of the dropdown list when the
 Replaces text passed through `dropdownFooterText` param.
 
 <ClientOnly>
-  <KMultiselect dropdownFooterText="Dropdown footer text" :items="deepClone(defaultItemsLongList)">
+  <KMultiselect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)">
     <template #dropdown-footer-text>
       Come as you are
     </template>
@@ -607,7 +607,7 @@ Replaces text passed through `dropdownFooterText` param.
 </ClientOnly>
 
 ```html
-<KMultiselect dropdownFooterText="I am replaceable" :items="items">
+<KMultiselect dropdown-footer-text="I am replaceable" :items="items">
   <template #dropdown-footer-text>
     Come as you are
   </template>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -607,7 +607,7 @@ Replaces text passed through `dropdownFooterText` param.
 </ClientOnly>
 
 ```html
-<KMultiselect dropdownFooterText="I am irreplaceable" :items="items">
+<KMultiselect dropdownFooterText="I am replaceable" :items="items">
   <template #dropdown-footer-text>
     Come as you are
   </template>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -533,6 +533,7 @@ You can pass any input attribute and it will get properly bound to the element.
 
 - `item-template` - The template for each item in the dropdown list
 - `empty` - Slot for the empty state in the dropdown list
+- `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
 
 ### Item Template
 

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -514,7 +514,7 @@ Adds text in the bottom of the dropdown, that sticks to the bottom - therefore s
 </ClientOnly>
 
 ```html
-<KMultiselect dropdownFooterText="Dropdown footer text" :items="items" />
+<KMultiselect dropdown-footer-text="Dropdown footer text" :items="items" />
 ```
 
 ## Attribute Binding

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -510,7 +510,7 @@ export default {
 Adds text in the bottom of the dropdown, that sticks to the bottom - therefore stays visible even if the content is scrollable. Can also be [slotted](#slots).
 
 <ClientOnly>
-  <KMultiselect dropdownFooterText="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
+  <KMultiselect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
 </ClientOnly>
 
 ```html

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -505,6 +505,18 @@ export default {
 </script>
 ```
 
+### dropdownFooterText
+
+Adds text in the bottom of the dropdown, that sticks to the bottom - therefore stays visible even if the content is scrollable. Can also be [slotted](#slots).
+
+<ClientOnly>
+  <KMultiselect dropdownFooterText="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
+</ClientOnly>
+
+```html
+<KMultiselect dropdownFooterText="Dropdown footer text" :items="items" />
+```
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.
@@ -581,16 +593,36 @@ export default defineComponent({
 
 You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
 
+### Dropdown Footer Text
+
+Replaces text passed through `dropdownFooterText` param.
+
+<ClientOnly>
+  <KMultiselect dropdownFooterText="Dropdown footer text" :items="deepClone(defaultItemsLongList)">
+    <template #dropdown-footer-text>
+      Come as you are
+    </template>
+  </KMultiselect>
+</ClientOnly>
+
+```html
+<KMultiselect dropdownFooterText="I am irreplaceable" :items="items">
+  <template #dropdown-footer-text>
+    Come as you are
+  </template>
+</KMultiselect>
+```
+
 ## Events
 
-| Event               | Action       | Returns             |
-| :--------           | :----------- | :------------------ |
-| `selected`          | an item is clicked | array of selected item objects |
-| `update:modelValue` | selections are changed | array of selected item values |
-| `change`            | selections are changed | last item selected/deselected Object or null |
-| `item:added`        | enableItemCreation is true and an item is added | item object being added to selections |
-| `item:removed`      | enableItemCreation is true and an added item is deselected | item object being removed from selections |
-| `query-change`      | filter string is changed | `query` String |
+| Event               | Action                                                     | Returns                                      |
+| :------------------ | :--------------------------------------------------------- | :------------------------------------------- |
+| `selected`          | an item is clicked                                         | array of selected item objects               |
+| `update:modelValue` | selections are changed                                     | array of selected item values                |
+| `change`            | selections are changed                                     | last item selected/deselected Object or null |
+| `item:added`        | enableItemCreation is true and an item is added            | item object being added to selections        |
+| `item:removed`      | enableItemCreation is true and an added item is deselected | item object being removed from selections    |
+| `query-change`      | filter string is changed                                   | `query` String                               |
 
 An example of hooking into events to modify newly created items (`enableItemCreation`) as they are added.
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -577,7 +577,7 @@ You can use the `empty` slot to customize the look of the dropdown list when the
 
 ### Dropdown Footer Text
 
-Replaces text passed through `dropdownFooterText` param.
+Slot the content of the dropdown footer text. This slot will override the `dropdownFooterText` prop if provided.
 
 <ClientOnly>
   <KSelect dropdown-footer-text="I am irreplaceable" :items="deepClone(defaultItemsLongList)">

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -211,6 +211,18 @@ You can pass a `dropdownMaxHeight` string for the dropdown. By default, the `dro
 <KSelect width="250" :items="items" dropdown-max-height="150" />
 ```
 
+### dropdownFooterText
+
+Adds informational text to the bottom of the dropdown options which remains visible even if the content is scrolled. Can also be [slotted](#slots).
+
+<ClientOnly>
+  <KSelect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
+</ClientOnly>
+
+```html
+<KSelect dropdown-footer-text="Dropdown footer text" :items="items" />
+```
+
 ### positionFixed
 
 Use fixed positioning of the popover to avoid content being clipped by parental boundaries - defaults to `true`. See [`KPop` docs](popover.html#positionfixed) for more information.
@@ -478,18 +490,6 @@ When `autosuggest` is enabled, you can use the `loading` prop to show a loading 
 By default, the loading indicator is a spinner icon, and you can implement your own indicator using the `loading` slot.
 See [autosuggest](#autosuggest) for an example.
 
-### dropdownFooterText
-
-Adds text in the bottom of the dropdown, that sticks to the bottom - therefore stays visible even if the content is scrollable. Can also be [slotted](#slots).
-
-<ClientOnly>
-  <KSelect width="250" dropdownFooterText="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
-</ClientOnly>
-
-```html
-<KSelect width="250" dropdownFooterText="Dropdown footer text" :items="items" />
-```
-
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.
@@ -580,7 +580,7 @@ You can use the `empty` slot to customize the look of the dropdown list when the
 Replaces text passed through `dropdownFooterText` param.
 
 <ClientOnly>
-  <KSelect width="250" dropdownFooterText="I am irreplaceable" :items="deepClone(defaultItemsLongList)">
+  <KSelect dropdown-footer-text="I am irreplaceable" :items="deepClone(defaultItemsLongList)">
     <template #dropdown-footer-text>
       Come as you are
     </template>
@@ -588,7 +588,7 @@ Replaces text passed through `dropdownFooterText` param.
 </ClientOnly>
 
 ```html
-<KSelect width="250" dropdownFooterText="I am replaceable" :items="items">
+<KSelect dropdown-footer-text="I am replaceable" :items="items">
   <template #dropdown-footer-text>
     Come as you are
   </template>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -478,6 +478,18 @@ When `autosuggest` is enabled, you can use the `loading` prop to show a loading 
 By default, the loading indicator is a spinner icon, and you can implement your own indicator using the `loading` slot.
 See [autosuggest](#autosuggest) for an example.
 
+### dropdownFooterText
+
+Adds text in the bottom of the dropdown, that sticks to the bottom - therefore stays visible even if the content is scrollable. Can also be [slotted](#slots).
+
+<ClientOnly>
+  <KSelect width="250" dropdownFooterText="Dropdown footer text" :items="deepClone(defaultItemsLongList)" />
+</ClientOnly>
+
+```html
+<KSelect width="250" dropdownFooterText="Dropdown footer text" :items="items" />
+```
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.
@@ -495,6 +507,7 @@ You can pass any input attribute and it will get properly bound to the element.
 - `item-template` - The template for each item in the dropdown list
 - `loading` - Slot for the loading indicator
 - `empty` - Slot for the empty state in the dropdown list
+- `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
 
 ### Item Template
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
@@ -562,14 +575,34 @@ You can use the `loading` slot to customize the loading indicator. Note that thi
 
 You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
 
+### Dropdown Footer Text
+
+Replaces text passed through `dropdownFooterText` param.
+
+<ClientOnly>
+  <KSelect width="250" dropdownFooterText="I am irreplaceable" :items="deepClone(defaultItemsLongList)">
+    <template #dropdown-footer-text>
+      Come as you are
+    </template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect width="250" dropdownFooterText="I am irreplaceable" :items="items">
+  <template #dropdown-footer-text>
+    Come as you are
+  </template>
+</KSelect>
+```
+
 ## Events
 
-| Event     | returns             |
-| :-------- | :------------------ |
-| `selected` | `selectedItem` Object |
-| `input` | `selectedItem` Object or null |
-| `change` | `selectedItem` Object or null |
-| `query-change` | `query` String |
+| Event          | returns                       |
+| :------------- | :---------------------------- |
+| `selected`     | `selectedItem` Object         |
+| `input`        | `selectedItem` Object or null |
+| `change`       | `selectedItem` Object or null |
+| `query-change` | `query` String                |
 
 <script lang="ts">
 import { defineComponent } from 'vue'

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -588,7 +588,7 @@ Replaces text passed through `dropdownFooterText` param.
 </ClientOnly>
 
 ```html
-<KSelect width="250" dropdownFooterText="I am irreplaceable" :items="items">
+<KSelect width="250" dropdownFooterText="I am replaceable" :items="items">
   <template #dropdown-footer-text>
     Come as you are
   </template>

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -401,4 +401,61 @@ describe('KMultiselect', () => {
     cy.getTestId('k-multiselect-selections').get('.k-badge-dismiss-button').first().click()
     cy.getTestId('k-multiselect-selections').should('not.exist')
   })
+
+  it('renders dropdown footer text when prop is passed', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+    const dropdownFooterText = 'Dropdown footer text'
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+        dropdownFooterText,
+      },
+    })
+
+    cy.get('.k-multiselect-input').trigger('click')
+
+    cy.get('.k-multiselect-dropdown-footer-text').should('be.visible').should('contain.text', dropdownFooterText)
+  })
+
+  it('should allow slotting dropdown footer text', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+    const dropdownFooterText = 'Dropdown footer text'
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+        dropdownFooterText: 'This is getting replaced',
+      },
+      slots: {
+        'dropdown-footer-text': dropdownFooterText,
+      },
+    })
+
+    cy.get('.k-multiselect-input').trigger('click')
+
+    cy.get('.k-multiselect-dropdown-footer-text').should('be.visible').should('contain.text', dropdownFooterText)
+  })
 })

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -38,6 +38,7 @@ describe('KMultiselect', () => {
     cy.getTestId(`k-multiselect-item-${vals[1]}`).should('contain.text', labels[1])
     cy.getTestId(`k-multiselect-item-${vals[2]}`).should('contain.text', labels[2])
     cy.get('.k-multiselect-popover').should('be.visible')
+    cy.get('.k-multiselect-dropdown-footer-text').should('not.exist')
   })
 
   it('renders with selected items when focused', () => {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -138,7 +138,7 @@
           <template #content>
             <!-- use @click.stop so we don't close drop down when selecting/deselecting items -->
             <div
-              class="k-multiselect-list ma-0 pa-0"
+              class="k-multiselect-list ma-0 pa-0 p-relative"
               @blur="() => isFocused = false"
               @click.stop
               @focus="isFocused = true"
@@ -190,6 +190,14 @@
                   </div>
                 </template>
               </KMultiselectItem>
+              <div
+                v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
+                class="k-multiselect-dropdown-footer-text p-sticky bottom-0"
+              >
+                <slot name="dropdown-footer-text">
+                  {{ dropdownFooterText }}
+                </slot>
+              </div>
             </div>
             <slot
               v-if="!loading && !sortedItems.length"
@@ -392,6 +400,13 @@ const props = defineProps({
   testMode: {
     type: Boolean,
     default: false,
+  },
+  /**
+     * Dropdown footer text
+     */
+  dropdownFooterText: {
+    type: String,
+    default: '',
   },
 })
 
@@ -999,6 +1014,12 @@ onMounted(() => {
     }
   }
 
+  .k-multiselect-dropdown-footer-text {
+    background-color: color(white);
+    border-top: 1px solid var(--grey-200);
+    color: color(grey-500);
+    padding: 8px;
+  }
 }
 </style>
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -197,7 +197,7 @@
             />
             <div
               v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
-              class="k-multiselect-dropdown-footer-text p-sticky bottom-0"
+              class="k-multiselect-dropdown-footer-text"
             >
               <slot name="dropdown-footer-text">
                 {{ dropdownFooterText }}
@@ -1015,6 +1015,7 @@ onMounted(() => {
   }
 
   .k-multiselect-list {
+    // allows setting a maxHeight on the popover dropdown
     max-height: v-bind('popoverContentMaxHeight');
     overflow-y: auto;
   }

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -138,7 +138,7 @@
           <template #content>
             <!-- use @click.stop so we don't close drop down when selecting/deselecting items -->
             <div
-              class="k-multiselect-list ma-0 pa-0 p-relative"
+              class="k-multiselect-list ma-0 pa-0"
               @blur="() => isFocused = false"
               @click.stop
               @focus="isFocused = true"
@@ -190,19 +190,19 @@
                   </div>
                 </template>
               </KMultiselectItem>
-              <div
-                v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
-                class="k-multiselect-dropdown-footer-text p-sticky bottom-0"
-              >
-                <slot name="dropdown-footer-text">
-                  {{ dropdownFooterText }}
-                </slot>
-              </div>
             </div>
             <slot
               v-if="!loading && !sortedItems.length"
               name="empty"
             />
+            <div
+              v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
+              class="k-multiselect-dropdown-footer-text p-sticky bottom-0"
+            >
+              <slot name="dropdown-footer-text">
+                {{ dropdownFooterText }}
+              </slot>
+            </div>
           </template>
         </KPop>
       </KToggle>
@@ -402,8 +402,8 @@ const props = defineProps({
     default: false,
   },
   /**
-     * Dropdown footer text
-     */
+  * Dropdown footer text
+  */
   dropdownFooterText: {
     type: String,
     default: '',
@@ -1014,11 +1014,17 @@ onMounted(() => {
     }
   }
 
+  .k-multiselect-list {
+    max-height: v-bind('popoverContentMaxHeight');
+    overflow-y: auto;
+  }
+
   .k-multiselect-dropdown-footer-text {
     background-color: color(white);
     border-top: 1px solid var(--grey-200);
     color: color(grey-500);
-    padding: 8px;
+    padding: var(--spacing-xs);
+    padding-bottom: 0;
   }
 }
 </style>
@@ -1087,11 +1093,6 @@ onMounted(() => {
       .select-item-label {
         color: var(--grey-500);
       }
-    }
-
-    .k-popover-content {
-      max-height: v-bind('popoverContentMaxHeight');
-      overflow-y: auto; // Allow setting a maxHeight on the popover dropdown
     }
 
     a {

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -38,6 +38,7 @@ describe('KSelect', () => {
     cy.getTestId(`k-select-item-${vals[1]}`).should('contain.text', labels[1])
     cy.getTestId(`k-select-item-${vals[2]}`).should('contain.text', labels[2])
     cy.get('.k-select-pop-dropdown').should('be.visible')
+    cy.get('.k-select-dropdown-footer-text').should('not.exist')
   })
 
   it('renders with selected item', () => {
@@ -272,5 +273,62 @@ describe('KSelect', () => {
     cy.get('input').should('have.value', labels[0])
     cy.get('.k-select-input .clear-selection-icon').trigger('click')
     cy.get('input').should('have.value', '')
+  })
+
+  it('renders dropdown footer text when prop is passed', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+    const dropdownFooterText = 'Dropdown footer text'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+        dropdownFooterText,
+      },
+    })
+
+    cy.getTestId('k-select-input').trigger('click')
+
+    cy.get('.k-select-dropdown-footer-text').should('be.visible').should('contain.text', dropdownFooterText)
+  })
+
+  it('should allow slotting dropdown footer text', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+    const dropdownFooterText = 'Dropdown footer text'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+        dropdownFooterText: 'This is getting replaced',
+      },
+      slots: {
+        'dropdown-footer-text': dropdownFooterText,
+      },
+    })
+
+    cy.getTestId('k-select-input').trigger('click')
+
+    cy.get('.k-select-dropdown-footer-text').should('be.visible').should('contain.text', dropdownFooterText)
   })
 })

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -159,7 +159,7 @@
             </slot>
             <div
               v-else
-              class="k-select-list ma-0 pa-0"
+              class="k-select-list ma-0 pa-0 p-relative"
             >
               <KSelectItem
                 v-for="item in filteredItems"
@@ -181,6 +181,14 @@
                 class="k-select-empty-item"
                 :item="{ label: 'No results', value: 'no_results' }"
               />
+              <div
+                v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
+                class="k-select-dropdown-footer-text p-sticky bottom-0"
+              >
+                <slot name="dropdown-footer-text">
+                  {{ dropdownFooterText }}
+                </slot>
+              </div>
             </div>
             <slot
               v-if="!loading && !filteredItems.length"
@@ -355,6 +363,13 @@ export default defineComponent({
     testMode: {
       type: Boolean,
       default: false,
+    },
+    /**
+     * Dropdown footer text
+     */
+    dropdownFooterText: {
+      type: String,
+      default: '',
     },
   },
   emits: ['selected', 'input', 'change', 'update:modelValue', 'query-change'],
@@ -914,6 +929,13 @@ export default defineComponent({
       right: 0;
       text-align: center;
       top: 0;
+    }
+
+    .k-select-dropdown-footer-text {
+      background-color: color(white);
+      border-top: 1px solid var(--grey-200);
+      color: color(grey-500);
+      padding: 8px;
     }
   }
 }

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -159,7 +159,7 @@
             </slot>
             <div
               v-else
-              class="k-select-list ma-0 pa-0 p-relative"
+              class="k-select-list ma-0 pa-0"
             >
               <KSelectItem
                 v-for="item in filteredItems"
@@ -181,19 +181,19 @@
                 class="k-select-empty-item"
                 :item="{ label: 'No results', value: 'no_results' }"
               />
-              <div
-                v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
-                class="k-select-dropdown-footer-text p-sticky bottom-0"
-              >
-                <slot name="dropdown-footer-text">
-                  {{ dropdownFooterText }}
-                </slot>
-              </div>
             </div>
             <slot
               v-if="!loading && !filteredItems.length"
               name="empty"
             />
+            <div
+              v-if="$slots['dropdown-footer-text'] || dropdownFooterText"
+              class="k-select-dropdown-footer-text"
+            >
+              <slot name="dropdown-footer-text">
+                {{ dropdownFooterText }}
+              </slot>
+            </div>
           </template>
         </KPop>
       </KToggle>
@@ -901,11 +901,6 @@ export default defineComponent({
       font-style: italic;
     }
 
-    .k-popover-content {
-      max-height: v-bind('popoverContentMaxHeight');
-      overflow-y: auto; // Allow setting a maxHeight on the popover dropdown
-    }
-
     ul {
       margin: 0;
       padding: 0;
@@ -931,11 +926,17 @@ export default defineComponent({
       top: 0;
     }
 
+    .k-select-list {
+      max-height: v-bind('popoverContentMaxHeight');
+      overflow-y: auto;
+    }
+
     .k-select-dropdown-footer-text {
       background-color: color(white);
       border-top: 1px solid var(--grey-200);
       color: color(grey-500);
-      padding: 8px;
+      padding: var(--spacing-xs);
+      padding-bottom: 0;
     }
   }
 }

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -927,6 +927,7 @@ export default defineComponent({
     }
 
     .k-select-list {
+      // allows setting a maxHeight on the popover dropdown
       max-height: v-bind('popoverContentMaxHeight');
       overflow-y: auto;
     }

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -317,18 +317,6 @@ $sides: (top, right, bottom, left);
   place-self: flex-end !important;
 }
 
-/*  Position
-========================================================================== */
-.p-relative {
-  position: relative !important;
-}
-.p-absolute {
-  position: absolute !important;
-}
-.p-sticky {
-  position: sticky !important;
-}
-
 /*  General
 ========================================================================== */
 .cursor-pointer {
@@ -363,18 +351,6 @@ $sides: (top, right, bottom, left);
 }
 .h-screen {
   min-height: 100vh !important;
-}
-.top-0 {
-  top: 0 !important;
-}
-.right-0 {
-  right: 0 !important;
-}
-.bottom-0 {
-  bottom: 0 !important;
-}
-.left-0 {
-  left: 0 !important;
 }
 
 // remove button default styles for elements that act like buttons, but don't look like them

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -317,6 +317,18 @@ $sides: (top, right, bottom, left);
   place-self: flex-end !important;
 }
 
+/*  Position
+========================================================================== */
+.p-relative {
+  position: relative !important;
+}
+.p-absolute {
+  position: absolute !important;
+}
+.p-sticky {
+  position: sticky !important;
+}
+
 /*  General
 ========================================================================== */
 .cursor-pointer {
@@ -351,6 +363,18 @@ $sides: (top, right, bottom, left);
 }
 .h-screen {
   min-height: 100vh !important;
+}
+.top-0 {
+  top: 0 !important;
+}
+.right-0 {
+  right: 0 !important;
+}
+.bottom-0 {
+  bottom: 0 !important;
+}
+.left-0 {
+  left: 0 !important;
 }
 
 // remove button default styles for elements that act like buttons, but don't look like them


### PR DESCRIPTION
# Summary

Ticket: https://konghq.atlassian.net/browse/KHCP-6007

KSelect:
![Screen Shot 2023-02-15 at 8 51 41 AM](https://user-images.githubusercontent.com/36751160/219046075-fe37a737-63cd-4e94-837c-7e0432b064d7.png)

KMultiselect:
![Screen Shot 2023-02-15 at 8 52 04 AM](https://user-images.githubusercontent.com/36751160/219046120-4d97760e-92d4-4898-9303-8e2b4bf0264a.png)

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
