### PR TITLE
fix(kprompt): divider style

### DIFF
--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -251,16 +251,17 @@ export default defineComponent({
     }
 
     .divider {
-      color: var(--grey-300);
+      border: none;
+      border-top: 1px solid var(--grey-300);
       /* subtract parents padding from margin to take full width of modal */
       /* use interpolation for the var in calc to not break postcss */
-      margin-left: calc(#{var(--spacing-lg)} * -1);
-      margin-right: calc(#{var(--spacing-lg)} * -1);
+      margin: 16px calc(#{var(--spacing-lg)} * -1) 0;
     }
 
     .k-modal-content {
       .k-modal-header.modal-header {
         display: flex;
+        padding-bottom: var(--spacing-xs);
         width: 100%;
 
         .close-button .k-button {
@@ -279,7 +280,7 @@ export default defineComponent({
           max-height: var(--KPromptMaxHeight, 300px);
           overflow-x: hidden;
           overflow-y: auto;
-          padding-bottom: var(--spacing-lg);
+          padding-bottom: var(--spacing-md);
           text-align: start;
           white-space: normal; // in case inside KTable
           width: 99%;


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
The divider in `KPrompt` has incorrect styles. On the documentation site, the problem won't occur because the divider is getting styles from vitepress:
<img width="1571" alt="image" src="https://user-images.githubusercontent.com/10095631/218966986-687b4c9e-8dba-4f8e-8aa0-713a7f7e2ddc.png">

Without vitepress it looks like this(the divider is darker than expected, and the prompt title is not vertically centered):
<img width="629" alt="image" src="https://user-images.githubusercontent.com/10095631/218967156-c4c2135a-afb2-4783-aded-f2f7d40db26f.png">

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
