### PR TITLE
docs(badge): render vue component on diff line

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -147,7 +147,9 @@ Use this prop in conjunction with the `dismissable` prop to customize the color 
 
 The `hoverColor` is also utilized if you wrap the `KBadge` with an anchor tag, or add a `@click` listener directly to the component.
 
-<a href="#"><KBadge appearance="success">Anchor Tag</KBadge></a>
+<a href="#">
+  <KBadge appearance="success">Anchor Tag</KBadge>
+</a>
 
 <KLabel>{{ myClicks }} clicks</KLabel><br>
 <KBadge dismissable @click="myClicks++">Click me!</KBadge>


### PR DESCRIPTION
# Summary

Vue components must be rendered on a separate line in the docs

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
