### PR TITLE
feat(kselect): add selected item slot [KHCP-6336]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -605,7 +605,7 @@ export default defineComponent({
 
 ### Selected Item Template
 
-Use this slot to customize appearance of selected item.
+Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated.
 
 ::: tip TIP
 You can use the `.k-select-selected-item-label` class within the slot as shown in the example below to leverage preconfigured styles for selected item title which you're then free to customize.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -540,10 +540,10 @@ You can pass any input attribute and it will get properly bound to the element.
 ## Slots
 
 - `item-template` - The template for each item in the dropdown list
+- `selected-item` - Slot for customizing selected item appearance
 - `loading` - Slot for the loading indicator
 - `empty` - Slot for the empty state in the dropdown list
 - `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
-- `button-text` - Slot for customizing KSelect button appearance
 
 ### Item Template
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
@@ -603,6 +603,52 @@ export default defineComponent({
 </script>
 ```
 
+### Selected Item
+
+Use this slot to customize appearance of selected item.
+
+::: tip TIP
+You can use the `.k-select-selected-item-label` class within the slot as shown in the example below to leverage preconfigured styles for selected item title which you're then free to customize.
+:::
+
+<ClientOnly>
+  <KSelect autosuggest :items="deepClone(defaultItems)">
+    <template #selected-item="{ item }">
+      <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
+      <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
+      <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+      <span class="k-select-selected-item-label">{{ item.label }}</span>
+    </template>
+    <template #item-template="{ item }">
+      <div class="d-inline-flex">
+        <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
+        <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
+        <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+        <div class="select-item-label">{{ item.label }}</div>
+      </div>
+    </template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect autosuggest :items="items">
+  <template #selected-item="{ item }">
+    <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
+    <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
+    <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+    {{ item.label }}
+  </template>
+  <template #item-template="{ item }">
+    <div class="d-inline-flex">
+      <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
+      <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
+      <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+      <div class="select-item-label">{{ item.label }}</div>
+    </div>
+  </template>
+</KSelect>
+```
+
 ### Loading
 
 You can use the `loading` slot to customize the loading indicator. Note that this only applies when `autoggest` is `true`. See [autosuggest](#autosuggest) for an example of this slot.
@@ -627,48 +673,6 @@ Slot the content of the dropdown footer text. This slot will override the `dropd
 <KSelect dropdown-footer-text="I am replaceable" :items="items">
   <template #dropdown-footer-text>
     Come as you are
-  </template>
-</KSelect>
-```
-
-### Button Text
-
-Use this slot to overwrite `buttonText` prop, should you need to further customize KSelect button.
-
-<ClientOnly>
-  <KSelect appearance="button" button-text="I am overwritten" :items="deepClone(defaultItems)">
-    <template #button-text="{ item }">
-      <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
-      <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
-      <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
-      {{ item.label }}
-    </template>
-    <template #item-template="{ item }">
-      <div class="d-inline-flex">
-        <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
-        <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
-        <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
-        <div class="select-item-label">{{ item.label }}</div>
-      </div>
-    </template>
-  </KSelect>
-</ClientOnly>
-
-```html
-<KSelect appearance="button" button-text="I am overwritten" :items="items">
-  <template #button-text="{ item }">
-    <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
-    <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
-    <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
-    {{ item.label }}
-  </template>
-  <template #item-template="{ item }">
-    <div class="d-inline-flex">
-      <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
-      <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
-      <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
-      <div class="select-item-label">{{ item.label }}</div>
-    </div>
   </template>
 </KSelect>
 ```

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -617,7 +617,7 @@ You can use the `.k-select-selected-item-label` class within the slot as shown i
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-      <span class="k-select-selected-item-label">{{ item.label }}</span>
+      <span class="k-select-selected-item-label">{{ item?.label }}</span>
     </template>
     <template #item-template="{ item }">
       <div class="d-inline-flex">
@@ -636,7 +636,7 @@ You can use the `.k-select-selected-item-label` class within the slot as shown i
     <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
     <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
     <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-    {{ item.label }}
+    <span class="k-select-selected-item-label">{{ item?.label }}</span>
   </template>
   <template #item-template="{ item }">
     <div class="d-inline-flex">

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -608,11 +608,11 @@ export default defineComponent({
 Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated.
 
 ::: tip TIP
-You can use the `.k-select-selected-item-label` class within the slot as shown in the example below to leverage preconfigured styles for selected item title which you're then free to customize.
+You can use the `.k-select-selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.
 :::
 
 <ClientOnly>
-  <KSelect autosuggest :items="deepClone(defaultItems)">
+  <KSelect appearance="select" autosuggest :items="deepClone(defaultItems)">
     <template #selected-item-template="{ item }">
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
@@ -631,7 +631,7 @@ You can use the `.k-select-selected-item-label` class within the slot as shown i
 </ClientOnly>
 
 ```html
-<KSelect autosuggest :items="items">
+<KSelect appearance="select" autosuggest :items="items">
   <template #selected-item-template="{ item }">
     <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
     <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -540,7 +540,7 @@ You can pass any input attribute and it will get properly bound to the element.
 ## Slots
 
 - `item-template` - The template for each item in the dropdown list
-- `selected-item` - Slot for customizing selected item appearance
+- `selected-item-template` - Slot for customizing selected item appearance
 - `loading` - Slot for the loading indicator
 - `empty` - Slot for the empty state in the dropdown list
 - `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
@@ -603,7 +603,7 @@ export default defineComponent({
 </script>
 ```
 
-### Selected Item
+### Selected Item Template
 
 Use this slot to customize appearance of selected item.
 
@@ -613,7 +613,7 @@ You can use the `.k-select-selected-item-label` class within the slot as shown i
 
 <ClientOnly>
   <KSelect autosuggest :items="deepClone(defaultItems)">
-    <template #selected-item="{ item }">
+    <template #selected-item-template="{ item }">
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -632,7 +632,7 @@ You can use the `.k-select-selected-item-label` class within the slot as shown i
 
 ```html
 <KSelect autosuggest :items="items">
-  <template #selected-item="{ item }">
+  <template #selected-item-template="{ item }">
     <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
     <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
     <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -543,6 +543,7 @@ You can pass any input attribute and it will get properly bound to the element.
 - `loading` - Slot for the loading indicator
 - `empty` - Slot for the empty state in the dropdown list
 - `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
+- `button-text` - Slot for customizing KSelect button appearance
 
 ### Item Template
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
@@ -626,6 +627,48 @@ Slot the content of the dropdown footer text. This slot will override the `dropd
 <KSelect dropdown-footer-text="I am replaceable" :items="items">
   <template #dropdown-footer-text>
     Come as you are
+  </template>
+</KSelect>
+```
+
+### Button Text
+
+Use this slot to overwrite `buttonText` prop, should you need to further customize KSelect button.
+
+<ClientOnly>
+  <KSelect appearance="button" button-text="I am overwritten" :items="deepClone(defaultItems)">
+    <template #button-text="{ item }">
+      <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
+      <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
+      <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
+      {{ item.label }}
+    </template>
+    <template #item-template="{ item }">
+      <div class="d-inline-flex">
+        <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
+        <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
+        <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
+        <div class="select-item-label">{{ item.label }}</div>
+      </div>
+    </template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect appearance="button" button-text="I am overwritten" :items="items">
+  <template #button-text="{ item }">
+    <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
+    <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
+    <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
+    {{ item.label }}
+  </template>
+  <template #item-template="{ item }">
+    <div class="d-inline-flex">
+      <span class="mr-1" v-if="item.value === 'cats'">🐈</span>
+      <span class="mr-1" v-if="item.value === 'dogs'">🐕</span>
+      <span class="mr-1" v-if="item.value === 'bunnies'">🐇</span>
+      <div class="select-item-label">{{ item.label }}</div>
+    </div>
   </template>
 </KSelect>
 ```

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -51,7 +51,7 @@ describe('KSelect', () => {
       },
     })
 
-    cy.get('.selected-item-label').should('contain.text', selectedLabel)
+    cy.get('.k-select-selected-item-label').should('contain.text', selectedLabel)
   })
 
   it('renders with disabled item', () => {
@@ -178,7 +178,7 @@ describe('KSelect', () => {
     cy.getTestId(`k-select-item-${vals[1]}`).should('not.be.visible')
 
     cy.getTestId(`k-select-item-${vals[0]}`).eq(1).click({ force: true })
-    cy.get('.selected-item-label').should('contain.text', labels[0])
+    cy.get('.k-select-selected-item-label').should('contain.text', labels[0])
   })
 
   it('ignores clicks on disabled item', () => {
@@ -202,7 +202,7 @@ describe('KSelect', () => {
     cy.getTestId('k-select-input').click()
 
     cy.getTestId(`k-select-item-${vals[0]}`).eq(1).click({ force: true })
-    cy.get('.selected-item-label').should('not.exist')
+    cy.get('.k-select-selected-item-label').should('not.exist')
   })
 
   it('allows slotting content into the items', async () => {
@@ -358,5 +358,56 @@ describe('KSelect', () => {
     cy.get('.k-select-item').eq(2).should('contain.text', items[3].label)
     cy.get('.k-select-item').eq(3).should('contain.text', items[2].label)
     cy.get('.k-select-item').eq(4).should('contain.text', items[4].label)
+  })
+
+  it('allows slotting selected item content', async () => {
+    const selectedItemContent = 'I am slotted baby!'
+    const itemLabel = 'Label 1'
+    const itemValue = 'label1'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: itemLabel,
+          value: itemValue,
+          selected: true,
+        }],
+      },
+      slots: {
+        'selected-item': selectedItemContent,
+      },
+    })
+
+    cy.get('.k-select-item-selection').should('contain.text', selectedItemContent)
+  })
+
+  it.only('displays placeholder correctly when selected item slot is present', async () => {
+    const selectedItemContent = 'I am slotted baby!'
+    const placeholderText = 'Placeholder text'
+    const itemLabel = 'Label 1'
+    const itemValue = 'label1'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        placeholder: placeholderText,
+        appearance: 'select',
+        autosuggest: true,
+        items: [{
+          label: itemLabel,
+          value: itemValue,
+          selected: true,
+        }],
+      },
+      slots: {
+        'selected-item': selectedItemContent,
+      },
+    })
+
+    cy.get('.k-select-input').should('contain.text', selectedItemContent)
+    cy.getTestId('k-select-input').trigger('click')
+    cy.get('.custom-selected-item').should('not.exist')
+    cy.get('input').invoke('attr', 'placeholder').should('contain', placeholderText)
   })
 })

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -375,14 +375,14 @@ describe('KSelect', () => {
         }],
       },
       slots: {
-        'selected-item': selectedItemContent,
+        'selected-item-template': selectedItemContent,
       },
     })
 
     cy.get('.k-select-item-selection').should('contain.text', selectedItemContent)
   })
 
-  it.only('displays placeholder correctly when selected item slot is present', async () => {
+  it('displays placeholder correctly when selected item slot is present', async () => {
     const selectedItemContent = 'I am slotted baby!'
     const placeholderText = 'Placeholder text'
     const itemLabel = 'Label 1'
@@ -401,7 +401,7 @@ describe('KSelect', () => {
         }],
       },
       slots: {
-        'selected-item': selectedItemContent,
+        'selected-item-template': selectedItemContent,
       },
     })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -149,12 +149,23 @@
               :model-value="filterStr"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' && !filterIsEnabled ? selectedItem.label : placeholderText"
+              :type="$slots['selected-item'] ? 'hidden' : ''"
               @blur="onInputBlur"
               @focus="onInputFocus"
               @keypress="onInputKeypress"
               @keyup="(evt: any) => triggerFocus(evt, isToggled)"
               @update:model-value="onQueryChange"
             />
+            <div
+              v-if="$slots['selected-item']"
+              class="d-inline-flex w-100 custom-selected-item"
+              tabindex="0"
+            >
+              <slot
+                :item="selectedItem"
+                name="selected-item"
+              />
+            </div>
           </div>
           <template #content>
             <slot
@@ -703,6 +714,8 @@ const onPopoverOpen = () => {
   overflow-y: auto;
 }
 
+$kSelectChevronIconMarginRight: 10px;
+
 .k-select {
   .k-select-selected-item-label {
     align-self: center;
@@ -762,7 +775,7 @@ const onPopoverOpen = () => {
     }
 
     .kong-icon-chevronDown {
-      margin-right: 10px;
+      margin-right: $kSelectChevronIconMarginRight;
     }
 
     &.cursor-default {
@@ -808,6 +821,11 @@ const onPopoverOpen = () => {
         position: static;
         transform: none;
       }
+    }
+
+    .custom-selected-item {
+      flex: 0 0 calc(100% - (var(--spacing-md, spacing(md)) + $kSelectChevronIconMarginRight));
+      padding: 10px var(--spacing-md, spacing(md));
     }
   }
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -23,7 +23,7 @@
       >
         <slot
           :item="selectedItem"
-          name="selected-item"
+          name="selected-item-template"
         >
           <div
             class="k-select-selected-item-label"
@@ -86,7 +86,7 @@
             >
               <slot
                 :item="selectedItem"
-                name="selected-item"
+                name="selected-item-template"
               >
                 {{ selectButtonText }}
               </slot>
@@ -141,7 +141,7 @@
               :class="{
                 'cursor-default prevent-pointer-events': !filterIsEnabled,
                 'input-placeholder-dark has-chevron': appearance === 'select',
-                'input-placeholder-transparent': appearance === 'select' && $slots['selected-item'] && (!filterIsEnabled || !isToggled.value),
+                'input-placeholder-transparent': appearance === 'select' && $slots['selected-item-template'] && (!filterIsEnabled || !isToggled.value),
                 'has-clear': isClearVisible,
                 'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
                 'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false')
@@ -158,12 +158,12 @@
             />
             <transition name="fade">
               <div
-                v-if="appearance === 'select' && $slots['selected-item'] && (!filterIsEnabled || !isToggled.value)"
+                v-if="appearance === 'select' && $slots['selected-item-template'] && (!filterIsEnabled || !isToggled.value)"
                 class="d-inline-flex w-100 custom-selected-item"
               >
                 <slot
                   :item="selectedItem"
-                  name="selected-item"
+                  name="selected-item-template"
                 />
               </div>
             </transition>

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -141,7 +141,7 @@
               :class="{
                 'cursor-default prevent-pointer-events': !filterIsEnabled,
                 'input-placeholder-dark has-chevron': appearance === 'select',
-                'input-placeholder-transparent': $slots['selected-item'] && (!filterIsEnabled || !isToggled.value),
+                'input-placeholder-transparent': appearance === 'select' && $slots['selected-item'] && (!filterIsEnabled || !isToggled.value),
                 'has-clear': isClearVisible,
                 'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
                 'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false')
@@ -158,7 +158,7 @@
             />
             <transition name="fade">
               <div
-                v-if="$slots['selected-item'] && (!filterIsEnabled || !isToggled.value)"
+                v-if="appearance === 'select' && $slots['selected-item'] && (!filterIsEnabled || !isToggled.value)"
                 class="d-inline-flex w-100 custom-selected-item"
               >
                 <slot

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -206,7 +206,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, computed, watch, PropType, nextTick } from 'vue'
+import { ref, Ref, computed, watch, PropType, nextTick, useAttrs } from 'vue'
 import { v1 as uuidv1 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
 import KButton from '@/components/KButton/KButton.vue'
@@ -218,13 +218,8 @@ import KToggle from '@/components/KToggle'
 import KSelectItems from '@/components/KSelect/KSelectItems.vue'
 import KSelectItem from '@/components/KSelect/KSelectItem.vue'
 
-const { getSizeFromString } = useUtilities()
-
-const defaultKPopAttributes = {
-  popoverClasses: 'k-select-popover mt-0',
-  popoverTimeout: 0,
-  placement: 'bottomStart',
-  hideCaret: true,
+export default {
+  inheritAttrs: false,
 }
 
 export interface SelectItem {
@@ -243,435 +238,406 @@ export interface SelectFilterFnParams {
 
 export type DropdownFooterTextPosition = 'sticky' | 'static'
 
-export default defineComponent({
-  name: 'KSelect',
-  components: {
-    KButton,
-    KIcon,
-    KInput,
-    KLabel,
-    KPop,
-    KSelectItems,
-    KSelectItem,
-    KToggle,
+</script>
+
+<script setup lang="ts">
+const { getSizeFromString } = useUtilities()
+
+const defaultKPopAttributes = {
+  popoverClasses: 'k-select-popover mt-0',
+  popoverTimeout: 0,
+  placement: 'bottomStart',
+  hideCaret: true,
+}
+
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
   },
-  inheritAttrs: false,
-  props: {
-    modelValue: {
-      type: [String, Number],
-      default: '',
-    },
-    kpopAttributes: {
-      type: Object,
-      default: () => ({
-        popoverClasses: '',
-      }),
-    },
-    dropdownMaxHeight: {
-      type: String,
-      default: '300',
-    },
-    label: {
-      type: String,
-      default: '',
-    },
-    overlayLabel: {
-      type: Boolean,
-      default: false,
-    },
-    labelAttributes: {
-      type: Object,
-      default: () => ({}),
-    },
-    /**
+  kpopAttributes: {
+    type: Object,
+    default: () => ({
+      popoverClasses: '',
+    }),
+  },
+  dropdownMaxHeight: {
+    type: String,
+    default: '300',
+  },
+  label: {
+    type: String,
+    default: '',
+  },
+  overlayLabel: {
+    type: Boolean,
+    default: false,
+  },
+  labelAttributes: {
+    type: Object,
+    default: () => ({}),
+  },
+  /**
      * The width of the select and popover's min-width
      */
-    width: {
-      type: String,
-      default: '',
-    },
-    placeholder: {
-      type: String,
-      default: '',
-    },
-    /**
+  width: {
+    type: String,
+    default: '',
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  /**
      * The display style, can be either dropdown, select, or button
      */
-    appearance: {
-      type: String,
-      default: 'dropdown',
-      validator: (value: string) => ['dropdown', 'select', 'button'].includes(value),
-    },
-    /**
+  appearance: {
+    type: String,
+    default: 'dropdown',
+    validator: (value: string) => ['dropdown', 'select', 'button'].includes(value),
+  },
+  /**
      * Override the text displayed on the button if `appearance` is `button` after an item
      * has been selected. By default display the selected item's label
      */
-    buttonText: {
-      type: String,
-      default: '',
-    },
-    /**
+  buttonText: {
+    type: String,
+    default: '',
+  },
+  /**
      * Items are JSON objects with required 'label' and 'value'
      * {
      *  label: 'Item 1',
      *  value: 'item1'
      * }
      */
-    items: {
-      type: Array as PropType<SelectItem[]>,
-      required: false,
-      default: () => [],
-      // Items must have a label & value
-      validator: (items: SelectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
-    },
-    /**
+  items: {
+    type: Array as PropType<SelectItem[]>,
+    required: false,
+    default: () => [],
+    // Items must have a label & value
+    validator: (items: SelectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
+  },
+  /**
      * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
      */
-    positionFixed: {
-      type: Boolean,
-      default: true,
-    },
-    /**
+  positionFixed: {
+    type: Boolean,
+    default: true,
+  },
+  /**
      * Override default filter functionality of case-insensitive search on label
      */
-    filterFunc: {
-      type: Function,
-      default: (params: SelectFilterFnParams) => params.items.filter((item: SelectItem) => item.label?.toLowerCase().includes(params.query?.toLowerCase())),
-    },
-    /**
+  filterFunc: {
+    type: Function,
+    default: (params: SelectFilterFnParams) => params.items.filter((item: SelectItem) => item.label?.toLowerCase().includes(params.query?.toLowerCase())),
+  },
+  /**
      * Control whether the input for `select` and `dropdown` appearances supports filtering.
      */
-    enableFiltering: {
-      type: Boolean,
-      default: null,
-    },
-    /**
+  enableFiltering: {
+    type: Boolean,
+    default: null,
+  },
+  /**
      * A flag for autosuggest mode
      */
-    autosuggest: {
-      type: Boolean,
-      default: false,
-    },
-    /**
+  autosuggest: {
+    type: Boolean,
+    default: false,
+  },
+  /**
      * Loading state in autosuggest
      */
-    loading: {
-      type: Boolean,
-      default: false,
-    },
-    /**
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  /**
      * A flag for clearing selection when appearance is 'select'
      */
-    clearable: {
-      type: Boolean,
-      default: false,
-    },
-    /**
+  clearable: {
+    type: Boolean,
+    default: false,
+  },
+  /**
      * Test mode - for testing only, strips out generated ids
      */
-    testMode: {
-      type: Boolean,
-      default: false,
-    },
-    /**
+  testMode: {
+    type: Boolean,
+    default: false,
+  },
+  /**
      * Dropdown footer text
      */
-    dropdownFooterText: {
-      type: String,
-      default: '',
-    },
-    /**
+  dropdownFooterText: {
+    type: String,
+    default: '',
+  },
+  /**
      * Dropdown footer text position
      * Accepted values: 'sticky' and 'static'
      */
-    dropdownFooterTextPosition: {
-      type: String as PropType<DropdownFooterTextPosition>,
-      default: 'sticky',
-    },
+  dropdownFooterTextPosition: {
+    type: String as PropType<DropdownFooterTextPosition>,
+    default: 'sticky',
   },
-  emits: ['selected', 'input', 'change', 'update:modelValue', 'query-change'],
-  setup(props, { attrs, emit }) {
-    const filterStr = ref('')
-    const selectedItem = ref<SelectItem|null>(null)
-    const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv1())
-    const selectInputId = computed((): string => props.testMode ? 'test-select-input-id-1234' : uuidv1())
-    const selectTextId = computed((): string => props.testMode ? 'test-select-text-id-1234' : uuidv1())
-    const selectItems: Ref<SelectItem[]> = ref([])
-    const initialFocusTriggered: Ref<boolean> = ref(false)
-    const inputFocused: Ref<boolean> = ref(false)
-    const popper = ref(null)
-    // we need this so we can create a watcher for programmatic changes to the modelValue
-    const value = computed({
-      get(): string | number {
-        return props.modelValue
-      },
-      set(newValue: string | number): void {
-        const item = selectItems.value.filter((item: SelectItem) => item.value === newValue)
-        if (item.length) {
-          handleItemSelect(item[0])
-        } else if (!newValue) {
-          clearSelection()
-        }
-      },
-    })
-    const filterIsEnabled = computed((): boolean => {
-      if (props.autosuggest) {
-        return true
-      }
-      if (props.enableFiltering !== null) {
-        // filtering not allowed for `button` appearance
-        return props.appearance === 'button' ? false : props.enableFiltering
-      }
+})
 
-      if (props.appearance === 'dropdown') {
-        return true
-      }
+const emit = defineEmits(['selected', 'input', 'change', 'update:modelValue', 'query-change'])
 
-      return false
-    })
+const attrs = useAttrs()
 
-    const widthValue = computed(() => {
-      let w = ''
-      if (!props.width) {
-        w = '205'
-        if (props.appearance === 'button') {
-          w = '230'
-        }
-      } else {
-        w = props.width
-      }
-
-      return getSizeFromString(w)
-    })
-
-    const widthStyle = computed(() => {
-      return {
-        width: widthValue.value,
-      }
-    })
-
-    const modifiedAttrs = computed(() => {
-      const $attrs = { ...attrs }
-
-      // delete classes because we bind them to the parent
-      delete $attrs.class
-
-      return $attrs
-    })
-
-    const createKPopAttributes = computed(() => {
-      return {
-        ...defaultKPopAttributes,
-        ...props.kpopAttributes,
-        popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-select-pop-${props.appearance}`,
-        width: String(inputWidth.value),
-        maxWidth: String(inputWidth.value),
-        disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
-      }
-    })
-
-    // Calculate the `.k-popover-content` max-height
-    const popoverContentMaxHeight = computed((): string => getSizeFromString(props.dropdownMaxHeight))
-
-    // TypeScript complains if I bind the original object
-    const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
-
-    const filteredItems = computed(() => {
-      // For autosuggest, items don't need to be filtered internally
-      return props.autosuggest ? selectItems.value : props.filterFunc({ items: selectItems.value, query: filterStr.value })
-    })
-
-    const placeholderText = computed((): string => {
-      if (props.placeholder) {
-        return props.placeholder
-      } else if (attrs.placeholder) {
-        return attrs.placeholder as string
-      }
-      if (props.appearance === 'button' || !filterIsEnabled.value) {
-        return 'Select an item'
-      }
-      return 'Filter...'
-    })
-
-    const selectButtonText = computed((): string => {
-      if (props.buttonText && selectedItem.value) {
-        return props.buttonText
-      } else if (selectedItem.value) {
-        return selectedItem.value.label
-      }
-      return placeholderText.value
-    })
-
-    const isClearVisible = computed((): boolean => props.appearance === 'select' && props.clearable && !!selectedItem.value)
-
-    const onInputKeypress = (event: Event) => {
-      // If filters are not enabled, ignore any keypresses
-      if (!filterIsEnabled.value) {
-        event.preventDefault()
-        return false
-      }
-    }
-
-    const handleItemSelect = (item: SelectItem) => {
-      selectItems.value.forEach(anItem => {
-        if (anItem.key === item.key) {
-          anItem.selected = true
-          anItem.key = anItem?.key?.includes('-selected') ? anItem.key : `${anItem.key}-selected`
-          anItem.key += '-selected'
-          selectedItem.value = anItem
-        } else if (anItem.selected) {
-          anItem.selected = false
-          anItem.key = anItem?.key?.replace(/-selected/gi, '')
-        } else {
-          anItem.selected = false
-        }
-      })
-      filterStr.value = props.appearance === 'dropdown' ? '' : item.label
-      emit('selected', item)
-      // this 'input' event must be emitted for v-model binding to work properly
-      emit('input', item.value)
-      emit('change', item)
-      emit('update:modelValue', item.value)
-    }
-
-    const clearSelection = (): void => {
-      selectItems.value.forEach(anItem => {
-        anItem.selected = false
-        anItem.key = anItem?.key?.replace(/-selected/gi, '')
-      })
-      selectedItem.value = null
-      if (props.appearance === 'select') {
-        filterStr.value = ''
-      }
-      // this 'input' event must be emitted for v-model binding to work properly
-      emit('input', null)
-      emit('change', null)
-      emit('update:modelValue', null)
-    }
-
-    const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
-      // Ignore `esc` key
-      if (evt.keyCode === 27) {
-        isToggled.value = false
-        return
-      }
-
-      const inputElem = document.getElementById(selectTextId.value)
-      if (!isToggled.value && inputElem) { // simulate click to trigger dropdown open
-        inputElem.click()
-      }
-    }
-
-    const onQueryChange = (query: string) => {
-      filterStr.value = query
-      emit('query-change', query)
-    }
-
-    const onInputFocus = (): void => {
-      inputFocused.value = true
-      if (!initialFocusTriggered.value) {
-        initialFocusTriggered.value = true
-        emit('query-change', '')
-      }
-    }
-
-    const onInputBlur = (): void => {
-      inputFocused.value = false
-    }
-
-    watch(value, (newVal, oldVal) => {
-      if (newVal !== oldVal) {
-        const item = selectItems.value.filter((item: SelectItem) => item.value === newVal)
-        if (item.length) {
-          handleItemSelect(item[0])
-        } else if (!newVal) {
-          clearSelection()
-        }
-      }
-    })
-
-    watch(() => props.items, (newValue, oldValue) => {
-      // Only trigger the watcher if items actually change
-      if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
-        return
-      }
-
-      selectItems.value = JSON.parse(JSON.stringify(props.items))
-      for (let i = 0; i < selectItems.value.length; i++) {
-        // Ensure each item has a `selected` property
-        if (selectItems.value[i].selected === undefined) {
-          selectItems.value[i].selected = false
-        }
-
-        selectItems.value[i].key = `${selectItems.value[i].label?.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${i}` || `k-select-item-label-${i}`
-        if (selectItems.value[i].value === props.modelValue || selectItems.value[i].selected) {
-          selectItems.value[i].selected = true
-          selectedItem.value = selectItems.value[i]
-          selectItems.value[i].key += '-selected'
-
-          if (props.appearance === 'select' && !inputFocused.value) {
-            filterStr.value = selectedItem.value.label
-          }
-        }
-
-        if (selectedItem.value?.value === selectItems.value[i].value) {
-          selectItems.value[i].selected = true
-        }
-      }
-
-      // Trigger an update to the popper element to cause the popover to redraw
-      // This prevents the popover from displaying "detached" from the KSelect
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      if (popper.value && typeof popper.value.updatePopper === 'function') {
-        nextTick(() => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          popper.value.updatePopper()
-        })
-      }
-    }, { deep: true, immediate: true })
-
-    const inputWidth = ref(0)
-
-    const onPopoverOpen = () => {
-      const inputElem = document.getElementById(selectInputId.value)
-
-      if (inputElem) {
-        inputWidth.value = inputElem.offsetWidth
-      }
-    }
-
-    return {
-      filterStr,
-      selectedItem,
-      selectId,
-      selectInputId,
-      selectTextId,
-      selectItems,
-      modifiedAttrs,
-      popper,
-      boundKPopAttributes,
-      popoverContentMaxHeight,
-      widthValue,
-      widthStyle,
-      filteredItems,
-      placeholderText,
-      selectButtonText,
-      isClearVisible,
-      handleItemSelect,
-      clearSelection,
-      triggerFocus,
-      inputWidth,
-      filterIsEnabled,
-      onInputKeypress,
-      onQueryChange,
-      onInputFocus,
-      onInputBlur,
-      onPopoverOpen,
+const filterStr = ref('')
+const selectedItem = ref<SelectItem|null>(null)
+const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv1())
+const selectInputId = computed((): string => props.testMode ? 'test-select-input-id-1234' : uuidv1())
+const selectTextId = computed((): string => props.testMode ? 'test-select-text-id-1234' : uuidv1())
+const selectItems: Ref<SelectItem[]> = ref([])
+const initialFocusTriggered: Ref<boolean> = ref(false)
+const inputFocused: Ref<boolean> = ref(false)
+const popper = ref(null)
+// we need this so we can create a watcher for programmatic changes to the modelValue
+const value = computed({
+  get(): string | number {
+    return props.modelValue
+  },
+  set(newValue: string | number): void {
+    const item = selectItems.value.filter((item: SelectItem) => item.value === newValue)
+    if (item.length) {
+      handleItemSelect(item[0])
+    } else if (!newValue) {
+      clearSelection()
     }
   },
 })
+const filterIsEnabled = computed((): boolean => {
+  if (props.autosuggest) {
+    return true
+  }
+  if (props.enableFiltering !== null) {
+    // filtering not allowed for `button` appearance
+    return props.appearance === 'button' ? false : props.enableFiltering
+  }
+
+  if (props.appearance === 'dropdown') {
+    return true
+  }
+
+  return false
+})
+
+const widthValue = computed(() => {
+  let w = ''
+  if (!props.width) {
+    w = '205'
+    if (props.appearance === 'button') {
+      w = '230'
+    }
+  } else {
+    w = props.width
+  }
+
+  return getSizeFromString(w)
+})
+
+const widthStyle = computed(() => {
+  return {
+    width: widthValue.value,
+  }
+})
+
+const modifiedAttrs = computed(() => {
+  const $attrs = { ...attrs }
+
+  // delete classes because we bind them to the parent
+  delete $attrs.class
+
+  return $attrs
+})
+
+const createKPopAttributes = computed(() => {
+  return {
+    ...defaultKPopAttributes,
+    ...props.kpopAttributes,
+    popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes.popoverClasses} k-select-pop-${props.appearance}`,
+    width: String(inputWidth.value),
+    maxWidth: String(inputWidth.value),
+    disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
+  }
+})
+
+// Calculate the `.k-popover-content` max-height
+const popoverContentMaxHeight = computed((): string => getSizeFromString(props.dropdownMaxHeight))
+
+// TypeScript complains if I bind the original object
+const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
+
+const filteredItems = computed(() => {
+  // For autosuggest, items don't need to be filtered internally
+  return props.autosuggest ? selectItems.value : props.filterFunc({ items: selectItems.value, query: filterStr.value })
+})
+
+const placeholderText = computed((): string => {
+  if (props.placeholder) {
+    return props.placeholder
+  } else if (attrs.placeholder) {
+    return attrs.placeholder as string
+  }
+  if (props.appearance === 'button' || !filterIsEnabled.value) {
+    return 'Select an item'
+  }
+  return 'Filter...'
+})
+
+const selectButtonText = computed((): string => {
+  if (props.buttonText && selectedItem.value) {
+    return props.buttonText
+  } else if (selectedItem.value) {
+    return selectedItem.value.label
+  }
+  return placeholderText.value
+})
+
+const isClearVisible = computed((): boolean => props.appearance === 'select' && props.clearable && !!selectedItem.value)
+
+const onInputKeypress = (event: Event) => {
+  // If filters are not enabled, ignore any keypresses
+  if (!filterIsEnabled.value) {
+    event.preventDefault()
+    return false
+  }
+}
+
+const handleItemSelect = (item: SelectItem) => {
+  selectItems.value.forEach(anItem => {
+    if (anItem.key === item.key) {
+      anItem.selected = true
+      anItem.key = anItem?.key?.includes('-selected') ? anItem.key : `${anItem.key}-selected`
+      anItem.key += '-selected'
+      selectedItem.value = anItem
+    } else if (anItem.selected) {
+      anItem.selected = false
+      anItem.key = anItem?.key?.replace(/-selected/gi, '')
+    } else {
+      anItem.selected = false
+    }
+  })
+  filterStr.value = props.appearance === 'dropdown' ? '' : item.label
+  emit('selected', item)
+  // this 'input' event must be emitted for v-model binding to work properly
+  emit('input', item.value)
+  emit('change', item)
+  emit('update:modelValue', item.value)
+}
+
+const clearSelection = (): void => {
+  selectItems.value.forEach(anItem => {
+    anItem.selected = false
+    anItem.key = anItem?.key?.replace(/-selected/gi, '')
+  })
+  selectedItem.value = null
+  if (props.appearance === 'select') {
+    filterStr.value = ''
+  }
+  // this 'input' event must be emitted for v-model binding to work properly
+  emit('input', null)
+  emit('change', null)
+  emit('update:modelValue', null)
+}
+
+const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
+  // Ignore `esc` key
+  if (evt.keyCode === 27) {
+    isToggled.value = false
+    return
+  }
+
+  const inputElem = document.getElementById(selectTextId.value)
+  if (!isToggled.value && inputElem) { // simulate click to trigger dropdown open
+    inputElem.click()
+  }
+}
+
+const onQueryChange = (query: string) => {
+  filterStr.value = query
+  emit('query-change', query)
+}
+
+const onInputFocus = (): void => {
+  inputFocused.value = true
+  if (!initialFocusTriggered.value) {
+    initialFocusTriggered.value = true
+    emit('query-change', '')
+  }
+}
+
+const onInputBlur = (): void => {
+  inputFocused.value = false
+}
+
+watch(value, (newVal, oldVal) => {
+  if (newVal !== oldVal) {
+    const item = selectItems.value.filter((item: SelectItem) => item.value === newVal)
+    if (item.length) {
+      handleItemSelect(item[0])
+    } else if (!newVal) {
+      clearSelection()
+    }
+  }
+})
+
+watch(() => props.items, (newValue, oldValue) => {
+  // Only trigger the watcher if items actually change
+  if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
+    return
+  }
+
+  selectItems.value = JSON.parse(JSON.stringify(props.items))
+  for (let i = 0; i < selectItems.value.length; i++) {
+    // Ensure each item has a `selected` property
+    if (selectItems.value[i].selected === undefined) {
+      selectItems.value[i].selected = false
+    }
+
+    selectItems.value[i].key = `${selectItems.value[i].label?.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${i}` || `k-select-item-label-${i}`
+    if (selectItems.value[i].value === props.modelValue || selectItems.value[i].selected) {
+      selectItems.value[i].selected = true
+      selectedItem.value = selectItems.value[i]
+      selectItems.value[i].key += '-selected'
+
+      if (props.appearance === 'select' && !inputFocused.value) {
+        filterStr.value = selectedItem.value.label
+      }
+    }
+
+    if (selectedItem.value?.value === selectItems.value[i].value) {
+      selectItems.value[i].selected = true
+    }
+  }
+
+  // Trigger an update to the popper element to cause the popover to redraw
+  // This prevents the popover from displaying "detached" from the KSelect
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (popper.value && typeof popper.value.updatePopper === 'function') {
+    nextTick(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      popper.value.updatePopper()
+    })
+  }
+}, { deep: true, immediate: true })
+
+const inputWidth = ref(0)
+
+const onPopoverOpen = () => {
+  const inputElem = document.getElementById(selectInputId.value)
+
+  if (inputElem) {
+    inputWidth.value = inputElem.offsetWidth
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -79,7 +79,12 @@
               :style="widthStyle"
               @keyup="evt => triggerFocus(evt, isToggled)"
             >
-              {{ selectButtonText }}
+              <slot
+                :item="selectedItem"
+                name="button-text"
+              >
+                {{ selectButtonText }}
+              </slot>
             </KButton>
           </div>
           <div

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -156,15 +156,17 @@
               @keyup="(evt: any) => triggerFocus(evt, isToggled)"
               @update:model-value="onQueryChange"
             />
-            <div
-              v-if="$slots['selected-item'] && (!filterIsEnabled || !isToggled.value)"
-              class="d-inline-flex w-100 custom-selected-item"
-            >
-              <slot
-                :item="selectedItem"
-                name="selected-item"
-              />
-            </div>
+            <transition name="fade">
+              <div
+                v-if="$slots['selected-item'] && (!filterIsEnabled || !isToggled.value)"
+                class="d-inline-flex w-100 custom-selected-item"
+              >
+                <slot
+                  :item="selectedItem"
+                  name="selected-item"
+                />
+              </div>
+            </transition>
           </div>
           <template #content>
             <slot
@@ -793,10 +795,10 @@ const onPopoverOpen = () => {
 
     &.input-placeholder-transparent {
       input {
-        color: transparent;
+        color: transparent !important;
 
         &::placeholder {
-          color: transparent;
+          color: transparent !important;
         }
       }
     }

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -21,11 +21,16 @@
         class="k-select-item-selection px-3 py-1"
         :class="{ 'overlay-label-item-selection': overlayLabel }"
       >
-        <div
-          class="selected-item-label"
+        <slot
+          :item="selectedItem"
+          name="selected-item"
         >
-          {{ selectedItem.label }}
-        </div>
+          <div
+            class="k-select-selected-item-label"
+          >
+            {{ selectedItem.label }}
+          </div>
+        </slot>
         <button
           class="clear-selection-icon cursor-pointer non-visual-button"
           @click="clearSelection"
@@ -81,7 +86,7 @@
             >
               <slot
                 :item="selectedItem"
-                name="button-text"
+                name="selected-item"
               >
                 {{ selectButtonText }}
               </slot>
@@ -415,6 +420,7 @@ const filterIsEnabled = computed((): boolean => {
   if (props.autosuggest) {
     return true
   }
+
   if (props.enableFiltering !== null) {
     // filtering not allowed for `button` appearance
     return props.appearance === 'button' ? false : props.enableFiltering
@@ -659,12 +665,6 @@ const onPopoverOpen = () => {
       top: -8px;
     }
 
-    .selected-item-label {
-      align-self: center;
-      font-size: 14px;
-      line-height: 16px;
-    }
-
     .clear-selection-icon {
       height: 24px;
       margin-bottom: auto;
@@ -704,6 +704,12 @@ const onPopoverOpen = () => {
 }
 
 .k-select {
+  .k-select-selected-item-label {
+    align-self: center;
+    font-size: 14px;
+    line-height: 16px;
+  }
+
   .k-select-item-selection {
     .clear-selection-icon {
       .kong-icon {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -141,6 +141,7 @@
               :class="{
                 'cursor-default prevent-pointer-events': !filterIsEnabled,
                 'input-placeholder-dark has-chevron': appearance === 'select',
+                'input-placeholder-transparent': $slots['selected-item'] && (!filterIsEnabled || !isToggled.value),
                 'has-clear': isClearVisible,
                 'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
                 'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false')
@@ -149,7 +150,6 @@
               :model-value="filterStr"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' && !filterIsEnabled ? selectedItem.label : placeholderText"
-              :type="$slots['selected-item'] ? 'hidden' : ''"
               @blur="onInputBlur"
               @focus="onInputFocus"
               @keypress="onInputKeypress"
@@ -157,9 +157,8 @@
               @update:model-value="onQueryChange"
             />
             <div
-              v-if="$slots['selected-item']"
+              v-if="$slots['selected-item'] && (!filterIsEnabled || !isToggled.value)"
               class="d-inline-flex w-100 custom-selected-item"
-              tabindex="0"
             >
               <slot
                 :item="selectedItem"
@@ -714,8 +713,6 @@ const onPopoverOpen = () => {
   overflow-y: auto;
 }
 
-$kSelectChevronIconMarginRight: 10px;
-
 .k-select {
   .k-select-selected-item-label {
     align-self: center;
@@ -775,7 +772,7 @@ $kSelectChevronIconMarginRight: 10px;
     }
 
     .kong-icon-chevronDown {
-      margin-right: $kSelectChevronIconMarginRight;
+      margin-right: 10px;
     }
 
     &.cursor-default {
@@ -786,8 +783,22 @@ $kSelectChevronIconMarginRight: 10px;
       pointer-events: none;
     }
 
-    &.input-placeholder-dark::placeholder {
-      color: var(--KInputColor, var(--black-70, rgba(0, 0, 0, 0.7))) !important;
+    &.input-placeholder-dark {
+      input {
+        &::placeholder {
+          color: var(--KInputColor, var(--black-70, rgba(0, 0, 0, 0.7))) !important;
+        }
+      }
+    }
+
+    &.input-placeholder-transparent {
+      input {
+        color: transparent;
+
+        &::placeholder {
+          color: transparent;
+        }
+      }
     }
 
     .k-input.has-chevron {
@@ -824,8 +835,9 @@ $kSelectChevronIconMarginRight: 10px;
     }
 
     .custom-selected-item {
-      flex: 0 0 calc(100% - (var(--spacing-md, spacing(md)) + $kSelectChevronIconMarginRight));
       padding: 10px var(--spacing-md, spacing(md));
+      pointer-events: none;
+      position: absolute;
     }
   }
 


### PR DESCRIPTION
# Summary

Ticket: https://konghq.atlassian.net/browse/KCGW-43

Slot for customizing selected item appearance.

`appearance="dropdown"` (default)

![Screen Shot 2023-02-27 at 4 09 00 PM](https://user-images.githubusercontent.com/36751160/221687170-5255f008-9c0d-409c-9051-e4cc7e971ad5.png)

`appearance="select"`

![Screen Shot 2023-02-27 at 4 10 30 PM](https://user-images.githubusercontent.com/36751160/221687004-6699fce1-efbb-49dd-b8fd-fc8a5bbdb3c7.png)

Also disappears when `autosuggest` prop is `true`

![Screen Shot 2023-02-27 at 4 09 34 PM](https://user-images.githubusercontent.com/36751160/221686858-07482ffd-d3ca-4457-93f8-1c34d982fa73.png)
![Screen Shot 2023-02-27 at 4 09 59 PM](https://user-images.githubusercontent.com/36751160/221687214-29779cb0-f5a5-4705-b659-1d4f5444b779.png)

`appearance="button"`

![Screen Shot 2023-02-27 at 4 11 32 PM](https://user-images.githubusercontent.com/36751160/221687401-2d2d5542-ab46-4e7e-bcd8-ad577f53a456.png)

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
