### PR TITLE
fix(datetimepicker): allow hiding of clear button [MA-1410]

### DIFF
--- a/docs/components/datetime-picker.md
+++ b/docs/components/datetime-picker.md
@@ -17,6 +17,7 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
 <ClientOnly>
   <KDateTimePicker
     v-model="currentValue0"
+    clear-button
     placeholder="Please select a date"
     mode="date"
     width="250"
@@ -30,6 +31,7 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
   v-model="currentValue"
   @change="newVal => emitVal = newVal"
   :range="false"
+  clear-button
   placeholder="Please select a date"
   mode="date"
   width="250"
@@ -43,6 +45,7 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
 <ClientOnly>
   <KDateTimePicker
     v-model="currentValue1"
+    clear-button
     placeholder="Please select a date and time"
     mode="dateTime"
     :minute-increment="5"
@@ -55,6 +58,7 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
 <KDateTimePicker
   v-model="currentValue"
   @change="newVal => emitVal = newVal"
+  clear-button
   placeholder="Please select a date and time"
   mode="dateTime"
   :minute-increment="5"
@@ -69,6 +73,7 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
 <ClientOnly>
   <KDateTimePicker
     v-model="currentValue2"
+    clear-button
     placeholder="Please select a date range"
     mode="date"
     :range="true"
@@ -80,6 +85,7 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
 <KDateTimePicker
   v-model="currentValue"
   @change="newVal => emitVal = newVal"
+  clear-button
   placeholder="Please select a date range"
   mode="date"
   :range="true"
@@ -93,6 +99,7 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
 <ClientOnly>
   <KDateTimePicker
     v-model="currentValue3"
+    clear-button
     placeholder="Please select a date and time"
     mode="dateTime"
     :minute-increment="5"
@@ -105,6 +112,7 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
 <KDateTimePicker
   v-model="currentValue"
   @change="newVal => emitVal = newVal"
+  clear-button
   placeholder="Please select a date and time"
   mode="dateTime"
   :minute-increment="5"
@@ -331,6 +339,12 @@ currentValue = {
   end: today
 }
 ```
+
+### clearButton
+
+A `Boolean` to show/hide the Clear button.
+
+**default**: `false`
 
 ### icon
 

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -62,6 +62,22 @@ describe('KDateTimePicker', () => {
 
     cy.getTestId(timepickerInput).should('exist')
     cy.getTestId(timepickerInput).find('.kong-icon').should('not.exist')
+    cy.getTestId(clearButton).should('not.exist')
+  })
+
+  it('renders with clear button', () => {
+    mount(KDateTimePicker, {
+      props: {
+        mode: 'date',
+        modelValue: today,
+        clearButton: true,
+        range: false,
+        icon: false,
+      },
+    })
+
+    cy.getTestId(timepickerInput).should('exist')
+    cy.getTestId(clearButton).should('exist')
   })
 
   it('renders a single date picker with placeholder message and correct width', () => {
@@ -73,6 +89,7 @@ describe('KDateTimePicker', () => {
         mode: 'date',
         modelValue: today,
         placeholder: placeholderText,
+        clearButton: true,
         range: false,
         width: width + '',
       },
@@ -142,6 +159,7 @@ describe('KDateTimePicker', () => {
     mount(KDateTimePicker, {
       props: {
         mode: 'date',
+        clearButton: true,
         modelValue: today,
         range: false,
       },
@@ -159,6 +177,7 @@ describe('KDateTimePicker', () => {
       props: {
         mode: 'date',
         modelValue: today,
+        clearButton: true,
         range: false,
       },
     })

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -302,8 +302,6 @@ export default defineComponent({
   },
   emits: ['change', 'update:modelValue'],
   setup(props, { emit }) {
-    console.log(props.clearButton)
-
     // https://vcalendar.io/datepicker.html#model-config
     const modelConfig = { type: 'number' }
     const calendarSelectAttributes = {

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -107,6 +107,7 @@
       >
         <div class="d-flex justify-content-end">
           <KButton
+            v-if="clearButton"
             appearance="btn-link"
             class="action-btn"
             data-testid="k-datetime-picker-clear"
@@ -189,6 +190,11 @@ export default defineComponent({
     DatePicker,
   },
   props: {
+    clearButton: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
     icon: {
       type: Boolean,
       required: false,
@@ -296,6 +302,8 @@ export default defineComponent({
   },
   emits: ['change', 'update:modelValue'],
   setup(props, { emit }) {
+    console.log(props.clearButton)
+
     // https://vcalendar.io/datepicker.html#model-config
     const modelConfig = { type: 'number' }
     const calendarSelectAttributes = {


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-1410

The purpose of the Clear button has recently come into question on Analytics pages where we display Charts or Metrics.  The end user wants to see data displayed, not an empty chart.  Therefore, defaulting to hide the Clear Button.


<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
