### PR TITLE
fix(kmenu): divider style

### DIFF
--- a/src/components/KMenu/KMenuDivider.vue
+++ b/src/components/KMenu/KMenuDivider.vue
@@ -18,6 +18,12 @@ export default defineComponent({
 @import '@/styles/functions';
 
 .k-menu-item-divider {
-  padding: 0 19px 0 19px;
+  padding: 0 19px;
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--grey-300);
+    margin: 16px 0;
+  }
 }
 </style>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Similar to https://github.com/Kong/kongponents/pull/1118, the divider in `KMenu` is also affected by vitepress style.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
