### PR TITLE
fix(kselect): remove scrollbar when the last item is selected

### DIFF
--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -136,7 +136,7 @@ export default defineComponent({
       width: 24px;
 
       .kong-icon {
-        display: inline;
+        display: flex;
         position: relative;
         right: 0;
         top: 0;


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
I tried to fix this problem in https://github.com/Kong/kongponents/pull/1151, and at that time the [PR preview](https://deploy-preview-1151--kongponents.netlify.app/components/select.html) looked good (there was no scrollbar):

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/10095631/221793286-d4bf609d-7eb3-43ed-8e9c-cf8fcbd4a567.png">

But after KM and Konnect have upgraded to the latest `@kong/kongponents`, the problem persists:

<img width="1716" alt="image" src="https://user-images.githubusercontent.com/10095631/221792852-cbb40b55-1f9a-47b6-9d25-a7f57f818d34.png">
<p align="center"><i>KM</i></p>

<img width="1699" alt="image" src="https://user-images.githubusercontent.com/10095631/221792974-8ee91813-65bf-42ad-bb97-8d10fed41f5b.png">
<p align="center"><i>Konnect</i></p>

Changing the display to `flex` should work.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
