### PR TITLE
feat(kselect): add reuse item template prop

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -635,7 +635,7 @@ export default defineComponent({
 
 ### Selected Item Template
 
-Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated. If present, overwrites [reuseItemTemplate](#reuseitemtemplate) prop.
+Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated. If present, the slot content takes precedence over the [reuseItemTemplate](#reuseitemtemplate) prop.
 
 ::: tip TIP
 You can use the `.k-select-selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.
@@ -647,7 +647,7 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-      {{ item?.label }}
+      {{ item.label }}
     </template>
     <template #item-template="{ item }">
       <div class="d-inline-flex">
@@ -666,7 +666,7 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
     <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
     <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
     <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-    {{ item?.label }}
+    {{ item.label }}
   </template>
   <template #item-template="{ item }">
     <div class="d-inline-flex">

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -635,7 +635,7 @@ export default defineComponent({
 
 ### Selected Item Template
 
-Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated.
+Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated. If present, overwrites [reuseItemTemplate](#reuseitemtemplate) prop.
 
 ::: tip TIP
 You can use the `.k-select-selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -525,6 +525,36 @@ When `autosuggest` is enabled, you can use the `loading` prop to show a loading 
 By default, the loading indicator is a spinner icon, and you can implement your own indicator using the `loading` slot.
 See [autosuggest](#autosuggest) for an example.
 
+### reuseItemTemplate
+
+Use this prop to customize selected item element appearance by reusing content passed through [item-template](#item-template) slot. **Note:** this prop only applies when `appearance` prop is `select` (use [selected-item-template](#selected-item-template) slot in other cases).
+
+<ClientOnly>
+  <KSelect reuse-item-template appearance="select" :items="deepClone(defaultItems)">
+    <template #item-template="{ item }">
+      <div class="d-inline-flex">
+        <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
+        <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
+        <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+        <div class="select-item-label">{{ item.label }}</div>
+      </div>
+    </template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect reuse-item-template appearance="select" :items="items">
+  <template #item-template="{ item }">
+    <div class="d-inline-flex">
+      <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
+      <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
+      <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+      <div class="select-item-label">{{ item.label }}</div>
+    </div>
+  </template>
+</KSelect>
+```
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.
@@ -617,7 +647,7 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-      <span class="k-select-selected-item-label">{{ item?.label }}</span>
+      {{ item?.label }}
     </template>
     <template #item-template="{ item }">
       <div class="d-inline-flex">
@@ -636,7 +666,7 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
     <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
     <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
     <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-    <span class="k-select-selected-item-label">{{ item?.label }}</span>
+    {{ item?.label }}
   </template>
   <template #item-template="{ item }">
     <div class="d-inline-flex">

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -227,6 +227,30 @@ describe('KSelect', () => {
     cy.getTestId(`k-select-item-${itemValue}`).should('contain.text', itemSlotContent)
   })
 
+  it('reuses item template slot for selected item element when prop is true', async () => {
+    const itemSlotContent = 'I am slotted baby!'
+    const itemLabel = 'Label 1'
+    const itemValue = 'label1'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        appearance: 'select',
+        items: [{
+          label: itemLabel,
+          value: itemValue,
+          selected: true,
+        }],
+        reuseItemTemplate: true,
+      },
+      slots: {
+        'item-template': h('span', {}, itemSlotContent),
+      },
+    })
+
+    cy.get('.k-select-input').should('contain.text', itemSlotContent)
+  })
+
   it('works in autosuggest mode', () => {
     const onQueryChange = cy.spy().as('onQueryChange')
     mount(KSelect, {
@@ -387,6 +411,7 @@ describe('KSelect', () => {
     const placeholderText = 'Placeholder text'
     const itemLabel = 'Label 1'
     const itemValue = 'label1'
+    const itemSlotContent = 'I am overwritten by selected-item slot'
 
     mount(KSelect, {
       props: {
@@ -399,9 +424,11 @@ describe('KSelect', () => {
           value: itemValue,
           selected: true,
         }],
+        reuseItemTemplate: true,
       },
       slots: {
         'selected-item-template': selectedItemContent,
+        'item-template': itemSlotContent,
       },
     })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -166,7 +166,6 @@
                   name="selected-item-template"
                 >
                   <slot
-                    class="select-item-label select-item-desc"
                     :item="selectedItem"
                     name="item-template"
                   />
@@ -301,8 +300,8 @@ const props = defineProps({
     default: () => ({}),
   },
   /**
-  * The width of the select and popover's min-width
-  */
+   * The width of the select and popover's min-width
+   */
   width: {
     type: String,
     default: '',
@@ -312,28 +311,28 @@ const props = defineProps({
     default: '',
   },
   /**
-  * The display style, can be either dropdown, select, or button
-  */
+   * The display style, can be either dropdown, select, or button
+   */
   appearance: {
     type: String,
     default: 'dropdown',
     validator: (value: string) => ['dropdown', 'select', 'button'].includes(value),
   },
   /**
-  * Override the text displayed on the button if `appearance` is `button` after an item
-  * has been selected. By default display the selected item's label
-  */
+   * Override the text displayed on the button if `appearance` is `button` after an item
+   * has been selected. By default display the selected item's label
+   */
   buttonText: {
     type: String,
     default: '',
   },
   /**
-  * Items are JSON objects with required 'label' and 'value'
-  * {
-  *  label: 'Item 1',
-  *  value: 'item1'
-  * }
-  */
+   * Items are JSON objects with required 'label' and 'value'
+   * {
+   *  label: 'Item 1',
+   *  value: 'item1'
+   * }
+   */
   items: {
     type: Array as PropType<SelectItem[]>,
     required: false,
@@ -342,73 +341,73 @@ const props = defineProps({
     validator: (items: SelectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
   },
   /**
-  * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
-  */
+   * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+   */
   positionFixed: {
     type: Boolean,
     default: true,
   },
   /**
-  * Override default filter functionality of case-insensitive search on label
-  */
+   * Override default filter functionality of case-insensitive search on label
+   */
   filterFunc: {
     type: Function,
     default: (params: SelectFilterFnParams) => params.items.filter((item: SelectItem) => item.label?.toLowerCase().includes(params.query?.toLowerCase())),
   },
   /**
-  * Control whether the input for `select` and `dropdown` appearances supports filtering.
-  */
+   * Control whether the input for `select` and `dropdown` appearances supports filtering.
+   */
   enableFiltering: {
     type: Boolean,
     default: null,
   },
   /**
-  * A flag for autosuggest mode
-  */
+   * A flag for autosuggest mode
+   */
   autosuggest: {
     type: Boolean,
     default: false,
   },
   /**
-  * Loading state in autosuggest
-  */
+   * Loading state in autosuggest
+   */
   loading: {
     type: Boolean,
     default: false,
   },
   /**
-  * A flag for clearing selection when appearance is 'select'
-  */
+   * A flag for clearing selection when appearance is `select`
+   */
   clearable: {
     type: Boolean,
     default: false,
   },
   /**
-  * Test mode - for testing only, strips out generated ids
-  */
+   * Test mode - for testing only, strips out generated ids
+   */
   testMode: {
     type: Boolean,
     default: false,
   },
   /**
-  * Dropdown footer text
-  */
+   * Dropdown footer text
+   */
   dropdownFooterText: {
     type: String,
     default: '',
   },
   /**
-  * Dropdown footer text position
-  * Accepted values: 'sticky' and 'static'
-  */
+   * Dropdown footer text position
+   * Accepted values: 'sticky' and 'static'
+   */
   dropdownFooterTextPosition: {
     type: String as PropType<DropdownFooterTextPosition>,
     default: 'sticky',
   },
   /**
-  * If true and item-template is passed, will display item-template content inside selected-slot-template
-  * Only applies when appearance prop is select.
-  */
+   * If true and item-template is passed, will display item-template content inside selected-slot-template
+   * Only applies when appearance prop is `select`.
+   */
   reuseItemTemplate: {
     type: Boolean,
     default: false,

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -141,7 +141,7 @@
               :class="{
                 'cursor-default prevent-pointer-events': !filterIsEnabled,
                 'input-placeholder-dark has-chevron': appearance === 'select',
-                'input-placeholder-transparent': hasCustomSelectedItemSlot && (!filterIsEnabled || !isToggled.value),
+                'input-placeholder-transparent': hasCustomSelectedItem && (!filterIsEnabled || !isToggled.value),
                 'has-clear': isClearVisible,
                 'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
                 'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false')
@@ -158,7 +158,7 @@
             />
             <transition name="fade">
               <div
-                v-if="hasCustomSelectedItemSlot && (!filterIsEnabled || !isToggled.value)"
+                v-if="hasCustomSelectedItem && (!filterIsEnabled || !isToggled.value)"
                 class="d-inline-flex w-100 custom-selected-item"
               >
                 <slot
@@ -534,7 +534,7 @@ const selectButtonText = computed((): string => {
 
 const isClearVisible = computed((): boolean => props.appearance === 'select' && props.clearable && !!selectedItem.value)
 
-const hasCustomSelectedItemSlot = computed((): boolean => !!(selectedItem.value && props.appearance === 'select' && (slots['selected-item-template'] || (props.reuseItemTemplate && slots['item-template']))))
+const hasCustomSelectedItem = computed((): boolean => !!(selectedItem.value && props.appearance === 'select' && (slots['selected-item-template'] || (props.reuseItemTemplate && slots['item-template']))))
 
 const onInputKeypress = (event: Event) => {
   // If filters are not enabled, ignore any keypresses

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -301,8 +301,8 @@ const props = defineProps({
     default: () => ({}),
   },
   /**
-     * The width of the select and popover's min-width
-     */
+  * The width of the select and popover's min-width
+  */
   width: {
     type: String,
     default: '',
@@ -312,28 +312,28 @@ const props = defineProps({
     default: '',
   },
   /**
-     * The display style, can be either dropdown, select, or button
-     */
+  * The display style, can be either dropdown, select, or button
+  */
   appearance: {
     type: String,
     default: 'dropdown',
     validator: (value: string) => ['dropdown', 'select', 'button'].includes(value),
   },
   /**
-     * Override the text displayed on the button if `appearance` is `button` after an item
-     * has been selected. By default display the selected item's label
-     */
+  * Override the text displayed on the button if `appearance` is `button` after an item
+  * has been selected. By default display the selected item's label
+  */
   buttonText: {
     type: String,
     default: '',
   },
   /**
-     * Items are JSON objects with required 'label' and 'value'
-     * {
-     *  label: 'Item 1',
-     *  value: 'item1'
-     * }
-     */
+  * Items are JSON objects with required 'label' and 'value'
+  * {
+  *  label: 'Item 1',
+  *  value: 'item1'
+  * }
+  */
   items: {
     type: Array as PropType<SelectItem[]>,
     required: false,
@@ -342,69 +342,73 @@ const props = defineProps({
     validator: (items: SelectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
   },
   /**
-     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
-     */
+  * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+  */
   positionFixed: {
     type: Boolean,
     default: true,
   },
   /**
-     * Override default filter functionality of case-insensitive search on label
-     */
+  * Override default filter functionality of case-insensitive search on label
+  */
   filterFunc: {
     type: Function,
     default: (params: SelectFilterFnParams) => params.items.filter((item: SelectItem) => item.label?.toLowerCase().includes(params.query?.toLowerCase())),
   },
   /**
-     * Control whether the input for `select` and `dropdown` appearances supports filtering.
-     */
+  * Control whether the input for `select` and `dropdown` appearances supports filtering.
+  */
   enableFiltering: {
     type: Boolean,
     default: null,
   },
   /**
-     * A flag for autosuggest mode
-     */
+  * A flag for autosuggest mode
+  */
   autosuggest: {
     type: Boolean,
     default: false,
   },
   /**
-     * Loading state in autosuggest
-     */
+  * Loading state in autosuggest
+  */
   loading: {
     type: Boolean,
     default: false,
   },
   /**
-     * A flag for clearing selection when appearance is 'select'
-     */
+  * A flag for clearing selection when appearance is 'select'
+  */
   clearable: {
     type: Boolean,
     default: false,
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+  * Test mode - for testing only, strips out generated ids
+  */
   testMode: {
     type: Boolean,
     default: false,
   },
   /**
-     * Dropdown footer text
-     */
+  * Dropdown footer text
+  */
   dropdownFooterText: {
     type: String,
     default: '',
   },
   /**
-     * Dropdown footer text position
-     * Accepted values: 'sticky' and 'static'
-     */
+  * Dropdown footer text position
+  * Accepted values: 'sticky' and 'static'
+  */
   dropdownFooterTextPosition: {
     type: String as PropType<DropdownFooterTextPosition>,
     default: 'sticky',
   },
+  /**
+  * If true and item-template is passed, will display item-template content inside selected-slot-template
+  * Only applies when appearance prop is select.
+  */
   reuseItemTemplate: {
     type: Boolean,
     default: false,


### PR DESCRIPTION
# Summary

- fixes bug where placeholder doesn't appear when using `selected-item-template` slot && selection is empty
- adds `reuseItemTemplate` prop, which allows customizing selected item element without repeating code

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
