### PR TITLE
fix(kdropdownmenu): divider display

### DIFF
--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -409,6 +409,13 @@ There are 3 primary item types:
       Disabled button
     </KDropdownItem>
     <KDropdownItem
+      :item="{ label: 'You are here 2', to: { path: '/components/dropdown-menu.html' } }"
+      disabled
+      @click="clickHandler"
+    >
+      Disabled to link
+    </KDropdownItem>
+    <KDropdownItem
       has-divider
       is-dangerous
       class="d-inline-block"

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -356,7 +356,7 @@ There are 3 primary item types:
   <KDropdownMenu label="Variety">
     <template #items>
       <KDropdownItem :item="youAreHere" />
-      <KDropdownItem @click="clickHandler('Button clicked!')">
+      <KDropdownItem has-divider @click="clickHandler('Button clicked!')">
         A button
       </KDropdownItem>
       <KDropdownItem
@@ -399,7 +399,7 @@ There are 3 primary item types:
 <KDropdownMenu label="Variety">
   <template #items>
     <KDropdownItem :item="{ label: 'You are here', to: { path: '/components/dropdown-menu.html' } }" />
-    <KDropdownItem @click="clickHandler">
+    <KDropdownItem has-divider @click="clickHandler">
       A button
     </KDropdownItem>
     <KDropdownItem

--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -155,20 +155,31 @@ li.k-dropdown-item {
   font-size: 16px;
   line-height: 1;
 
-  &.has-divider {
-    $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
-    $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
-    margin-top: $k-dropdown-item-divider-container-height;
-    position: relative;
+  &:not(:first-of-type) {
+    &.has-divider,
+    .has-divider {
+      $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
+      $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
+      margin-top: $k-dropdown-item-divider-container-height;
+      position: relative;
 
-    &:before {
-      background: var(--grey-200);
-      content: '';
-      display: block;
-      height: 1px;
-      position: absolute;
-      top: $k-dropdown-item-divider-position;
-      width: 100%;
+      &:before {
+        background: var(--grey-200);
+        content: '';
+        display: block;
+        height: 1px;
+        position: absolute;
+        top: $k-dropdown-item-divider-position;
+        width: 100%;
+      }
+    }
+
+    .has-divider {
+      &:before {
+        // negative margins to take the full width if class
+        // is on a child of k-dropdown-item
+        margin-left: calc(var(--spacing-lg) * -1);
+      }
     }
   }
 

--- a/src/components/KDropdownMenu/KDropdownMenu.cy.ts
+++ b/src/components/KDropdownMenu/KDropdownMenu.cy.ts
@@ -1,6 +1,7 @@
 import { mount } from 'cypress/vue'
 import { h } from 'vue'
 import KDropdownMenu from '@/components/KDropdownMenu/KDropdownMenu.vue'
+import KDropdownItem from '@/components/KDropdownMenu/KDropdownItem.vue'
 
 const defaultMenuItems = [
   { label: 'Props' },
@@ -142,5 +143,62 @@ describe('KDropdownMenu', () => {
 
     triggerBtn.should('contain.html', triggerSlotContent)
     cy.get('.k-dropdown-popover').should('contain.html', itemSlotContent)
+  })
+
+  it('correctly renders dividers on all item types', () => {
+    const itemSlotContent = `
+    <KDropdownItem has-divider :item="{ label: 'A link', to: { path: '/' } }" />
+    <KDropdownItem has-divider @click="() => {}">
+      A button
+    </KDropdownItem>
+    <KDropdownItem
+      has-divider
+      disabled
+      @click="() => {}"
+    >
+      Disabled button
+    </KDropdownItem>
+    <KDropdownItem
+      :item="{ label: 'You are here 2', to: { path: '/' } }"
+      has-divider
+      disabled
+      @click="() => {}"
+    >
+      Disabled link
+    </KDropdownItem>
+    <KDropdownItem
+      has-divider
+      is-dangerous
+      class="d-inline-block"
+    >
+      <a
+        href="http://www.google.com"
+        rel="noopener"
+        target="_blank"
+      >
+        Custom item
+      </a>
+    </KDropdownItem>`
+
+    mount(KDropdownMenu, {
+      components: {
+        KDropdownItem,
+      },
+      props: {
+        testMode: true,
+        label: 'Click me',
+      },
+      slots: {
+        items: itemSlotContent,
+        default: h('button', {}, 'hello'),
+      },
+    })
+
+    const triggerBtn = cy.getTestId('k-dropdown-trigger')
+    triggerBtn.click()
+    cy.getTestId('k-dropdown-list').should('be.visible')
+
+    cy.get('.k-dropdown-item').should('have.length', 5)
+    cy.get('.has-divider').should('have.length', 5)
   })
 })


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Fix an issue where the divider wasn't correctly rendering for each of the different item types.

![image](https://user-images.githubusercontent.com/67973710/223855596-62acce39-815e-45d9-8192-92331a7d2823.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
