### PR TITLE
fix(ktable): only emit table prefs when user changes

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -781,6 +781,9 @@ export default defineComponent({
       } else if (props.paginationType !== 'offset') {
         revalidate()
       }
+
+      // Emit an event whenever one of the tablePreferences are updated
+      emitTablePreferences()
     }
     const pageChangeHandler = ({ page: newPage }: Record<string, number>) => {
       page.value = newPage
@@ -790,6 +793,9 @@ export default defineComponent({
       offset.value = null
       pageSize.value = newPageSize
       page.value = 1
+
+      // Emit an event whenever one of the tablePreferences are updated
+      emitTablePreferences()
     }
     const scrollHandler = (event: any) => {
       if (event && event.target && event.target.scrollTop) {
@@ -808,10 +814,10 @@ export default defineComponent({
       sortColumnOrder: sortColumnOrder.value as 'asc' | 'desc',
     }))
 
-    // Emit an event whenever the tablePreferences are updated
-    watch(tablePreferences, (tablePrefs: TablePreferences) => {
-      emit('update:table-preferences', tablePrefs)
-    })
+    const emitTablePreferences = (): void => {
+      // Emit an event whenever one of the tablePreferences are updated
+      emit('update:table-preferences', tablePreferences.value)
+    }
 
     const getNextOffsetHandler = (): void => {
       page.value++


### PR DESCRIPTION
# Summary

The previous logic was emitting the `update:table-preferences` event on component mount when the values were set instead of just upon user interaction.
## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
