### PR TITLE
fix(kdropdownmenu): divider style

### DIFF
--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -2,7 +2,7 @@
   <li
     class="k-dropdown-item w-100"
     :class="{
-      'has-divider': type !== 'link' && hasDivider,
+      'has-divider': hasDivider,
       'disabled': type === 'default' && disabled,
       'danger': isDangerous,
       'k-dropdown-selected-option': selected
@@ -12,7 +12,7 @@
     <a
       v-if="type === 'link' && to && !!disabled"
       class="k-dropdown-item-trigger"
-      :class="{ 'disabled': disabled, 'has-divider': hasDivider }"
+      :class="{ 'disabled': disabled }"
       data-testid="k-dropdown-item-trigger"
       href="#"
       @click.prevent.stop=""
@@ -22,7 +22,7 @@
     <router-link
       v-else-if="type === 'link' && to"
       class="k-dropdown-item-trigger"
-      :class="{ 'disabled': disabled, 'has-divider': hasDivider }"
+      :class="{ 'disabled': disabled }"
       data-testid="k-dropdown-item-trigger"
       :to="!disabled ? to : routePath"
       @click="handleClick"
@@ -155,31 +155,20 @@ li.k-dropdown-item {
   font-size: 16px;
   line-height: 1;
 
-  &:not(:first-of-type) {
-    &.has-divider,
-    .has-divider {
-      $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
-      $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
-      margin-top: $k-dropdown-item-divider-container-height;
-      position: relative;
+  &:not(:first-of-type).has-divider {
+    $k-dropdown-item-divider-container-height: 24px; // set to the same value as --spacing-lg without the units
+    $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
+    margin-top: $k-dropdown-item-divider-container-height;
+    position: relative;
 
-      &:before {
-        background: var(--grey-200);
-        content: '';
-        display: block;
-        height: 1px;
-        position: absolute;
-        top: $k-dropdown-item-divider-position;
-        width: 100%;
-      }
-    }
-
-    .has-divider {
-      &:before {
-        // negative margins to take the full width if class
-        // is on a child of k-dropdown-item
-        margin-left: calc(var(--spacing-lg) * -1);
-      }
+    &:before {
+      background: var(--grey-200);
+      content: '';
+      display: block;
+      height: 1px;
+      position: absolute;
+      top: $k-dropdown-item-divider-position;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes an expanded background bug when hovering on a `li` element with a nested `a.has-divider` element.

![Kapture 2023-03-09 at 17 40 59](https://user-images.githubusercontent.com/10095631/223983565-e322b122-a9a0-4fb1-a538-7c99c8a14882.gif)


## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
