### PR TITLE
fix(ktable): document `sort` event [KHCP-6539]

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -855,6 +855,25 @@ export default {
 
 ### Other Events
 
+#### Sorting
+
+`@sort` - Fired when the user clicks on a sortable column heading
+
+Returns a payload that containing information about the sort action:
+
+```json
+{
+  /** The previous column to sort by's `key` defined in the table headers */
+  prevKey: string,
+  /** The current column to sort by's `key` defined in the table headers */
+  sortColumnKey: string,
+  /** The order by which to sort the column, one of `asc` or `desc` */
+  sortColumnOrder: 'asc' | 'desc'
+}
+```
+
+#### Table Preferences
+
 `@update:table-preferences` - Fired when the user changes the table's `pageSize`, `sortColumnKey`, or `sortColumnOrder`.
 
 Returns a payload that adheres to the `TablePreferences` interface:


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Document KTable `sort` event for [KHCP-6539](https://konghq.atlassian.net/browse/KHCP-6539).

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-6539]: https://konghq.atlassian.net/browse/KHCP-6539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ