### PR TITLE
feat(kskeleton): add a generic fullscreen spinner loader (TDX-2940)

### DIFF
--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -8,7 +8,7 @@
 
 - `type`
 
-There are 6 different types of loading states that KSkeleton supports: `card`, `table`, `form`, `spinner`, `fullscreen-kong`, and a generic loading state. Defaults to a generic loading state. The following example shows a `form` type KSKeleton.
+There are 6 different types of loading states that KSkeleton supports: `card`, `table`, `form`, `spinner`, `fullscreen-kong`, `fullscreen-generic`, and a generic loading state. Defaults to a generic loading state. The following example shows a `form` type KSKeleton.
 
 <KSkeleton type="form" />
 
@@ -140,13 +140,13 @@ Defaults to `false`, you can use this prop to hide the progress indicator.
   <KSkeleton
     v-if="loadingNone"
     :delay-milliseconds="0"
-    hide-progress
     type="fullscreen-kong"
   />
+  <!-- Generic Spinner example -->
   <KSkeleton
     v-if="loading"
     :delay-milliseconds="0"
-    type="fullscreen-kong"
+    type="fullscreen-generic"
   />
 </div>
 
@@ -337,6 +337,7 @@ And another example:
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--KSkeletonFullScreenMargin`        | Margin around full screen variant. Useful for when you want to show full screen loader under header or next to sidebar since the full screen component has fixed position. |
 | `--KSkeletonFullScreenProgressColor` | Progress bar fill color.                                                                                                                                                   |
+| `--KSkeletonFullScreenSpinnerColor` | Generic spinner icon fill color.                                                                                                                                                   |
 | `--KSkeletonCardWidth`               | Width of the card. Default is 33%                                                                                                                                          |
 
 ### Examples

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -8,7 +8,7 @@
 
 - `type`
 
-There are 6 different types of loading states that KSkeleton supports: `card`, `table`, `form`, `spinner`, `fullscreen-kong`, `fullscreen-generic`, and a generic loading state. Defaults to a generic loading state. The following example shows a `form` type KSKeleton.
+There are 7 different types of loading states that KSkeleton supports: `card`, `table`, `form`, `spinner`, `fullscreen-kong`, `fullscreen-generic`, and a generic loading state. Defaults to a generic loading state. The following example shows a `form` type KSKeleton.
 
 <KSkeleton type="form" />
 

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -164,7 +164,7 @@ Defaults to `false`, you can use this prop to hide the progress indicator.
 <KSkeleton
   v-if="loading"
   :delay-milliseconds="0"
-  type="fullscreen-kong"
+  type="fullscreen-generic"
 />
 ```
 

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -336,6 +336,7 @@ And another example:
 | Variable                             | Purpose                                                                                                                                                                    |
 | :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--KSkeletonFullScreenMargin`        | Margin around full screen variant. Useful for when you want to show full screen loader under header or next to sidebar since the full screen component has fixed position. |
+| `--KSkeletonFullScreenProgressBackgroundColor` | Progress bar background color.                                                                                                                                                   |
 | `--KSkeletonFullScreenProgressColor` | Progress bar fill color.                                                                                                                                                   |
 | `--KSkeletonFullScreenSpinnerColor` | Generic spinner icon fill color.                                                                                                                                                   |
 | `--KSkeletonCardWidth`               | Width of the card. Default is 33%                                                                                                                                          |

--- a/src/components/KSkeleton/FullScreenGenericSpinner.vue
+++ b/src/components/KSkeleton/FullScreenGenericSpinner.vue
@@ -1,0 +1,135 @@
+<template>
+  <div
+    class="fullscreen-loading-container"
+    data-testid="full-screen-loader"
+  >
+    <div>
+      <div
+        class="loader"
+      />
+      <div
+        v-if="!hideProgress"
+        class="progress"
+      >
+        <div
+          class="progress-bar"
+          role="progressbar"
+          :style="{ width: `${progression}%` }"
+          title="Loading"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted, onUnmounted } from 'vue'
+
+export default defineComponent({
+  name: 'FullScreenGenericSpinner',
+  props: {
+    progress: {
+      type: Number,
+      default: null,
+    },
+    hideProgress: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props) {
+    const timer = ref(0)
+    const progressInternal = ref(0)
+    const progression = computed(() => props.progress !== null ? props.progress : progressInternal.value)
+
+    onMounted(() => {
+      // If progress is user determined, don't fire interval to simulate progress
+      if (props.progress) {
+        return
+      }
+      timer.value = setInterval(() => {
+        if (progressInternal.value >= 100) {
+          clearInterval(timer.value)
+          progressInternal.value = 100
+        }
+        progressInternal.value = Math.min(progressInternal.value + Math.ceil((Math.random() * 10) * 30), 100)
+      }, 200)
+    })
+
+    onUnmounted(() => {
+      clearInterval(timer.value)
+    })
+
+    return {
+      timer,
+      progressInternal,
+      progression,
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/variables';
+@import '@/styles/functions';
+.fullscreen-loading-container {
+  align-items: center;
+  background: var(--white, color(white));
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  left: 0;
+  margin: var(--KSkeletonFullScreenMargin, 0);
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 10500;
+
+  .progress {
+    background-color: var(--grey-200, color(grey-200));
+    border-radius: 8px;
+    margin-top: 16px;
+    max-width: 350px;
+
+    .progress-bar {
+      background-color: var(--KSkeletonFullScreenProgressColor, var(--blue-500, color(blue-500)));
+      border-radius: 8px;
+      height: 5px;
+    }
+  }
+
+  .loader {
+    :after {
+      border-radius: 50%;
+      width: 183px;
+      height: 183px;
+    }
+    border-radius: 50%;
+    width: 183px;
+    height: 183px;
+    margin: 60px auto;
+    font-size: 10px;
+    position: relative;
+    text-indent: -9999em;
+    border-top: 1.1em solid var(--grey-200, color(grey-200));
+    border-right: 1.1em solid var(--grey-200, color(grey-200));
+    border-bottom: 1.1em solid var(--grey-200, color(grey-200));
+    border-left: 1.1em solid var(--KSkeletonFullScreenSpinnerColor, var(--blue-500, color(blue-500)));
+    transform: translateZ(0);
+    animation: spinnerAnimation 1.4s infinite linear;
+  }
+
+  @keyframes spinnerAnimation {
+    0% {
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+      transform: rotate(360deg);
+    }
+  }
+
+}
+</style>

--- a/src/components/KSkeleton/FullScreenGenericSpinner.vue
+++ b/src/components/KSkeleton/FullScreenGenericSpinner.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     class="fullscreen-loading-container"
-    data-testid="full-screen-loader"
+    data-testid="full-screen-spinner-loader"
   >
     <div>
       <div
-        class="loader"
+        class="spinner-loader"
       />
       <div
         v-if="!hideProgress"
@@ -71,23 +71,12 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/mixins';
 @import '@/styles/functions';
 .fullscreen-loading-container {
-  align-items: center;
-  background: var(--white, color(white));
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  left: 0;
-  margin: var(--KSkeletonFullScreenMargin, 0);
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 10500;
-
+  @include fullscreen-loading-container;
   .progress {
-    background-color: var(--grey-200, color(grey-200));
+    background-color: var(--KSkeletonFullScreenProgressBackgroundColor, var(--grey-200, color(grey-200)));
     border-radius: 8px;
     margin-top: 16px;
     max-width: 350px;
@@ -99,13 +88,12 @@ export default defineComponent({
     }
   }
 
-  .loader {
+  .spinner-loader {
     :after {
       border-radius: 50%;
       height: 183px;
       width: 183px;
     }
-    -webkit-animation: spinnerAnimation 1.4s infinite linear;
     animation: spinnerAnimation 1.4s infinite linear;
     border-bottom: 10px solid var(--grey-200, color(grey-200));
     border-left: 10px solid var(--KSkeletonFullScreenSpinnerColor, var(--blue-500, color(blue-500)));
@@ -116,33 +104,23 @@ export default defineComponent({
     height: 183px;
     margin: 60px auto;
     position: relative;
-    -ms-transform: translateZ(0);
-    -webkit-transform: translateZ(0);
     transform: translateZ(0);
     width: 183px;
   }
 
 @-webkit-keyframes spinnerAnimation {
   0% {
-    -ms-transform: rotate(0deg);
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -ms-transform: rotate(360deg);
-    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }
 @keyframes spinnerAnimation {
   0% {
-    -ms-transform: rotate(0deg);
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
-    -ms-transform: rotate(360deg);
-    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }

--- a/src/components/KSkeleton/FullScreenGenericSpinner.vue
+++ b/src/components/KSkeleton/FullScreenGenericSpinner.vue
@@ -102,34 +102,50 @@ export default defineComponent({
   .loader {
     :after {
       border-radius: 50%;
-      width: 183px;
       height: 183px;
+      width: 183px;
     }
+    -webkit-animation: spinnerAnimation 1.4s infinite linear;
+    animation: spinnerAnimation 1.4s infinite linear;
+    border-bottom: 10px solid var(--grey-200, color(grey-200));
+    border-left: 10px solid var(--KSkeletonFullScreenSpinnerColor, var(--blue-500, color(blue-500)));
     border-radius: 50%;
-    width: 183px;
+    border-right: 10px solid var(--grey-200, color(grey-200));
+    border-top: 10px solid var(--grey-200, color(grey-200));
+    font-size: 10px;
     height: 183px;
     margin: 60px auto;
-    font-size: 10px;
     position: relative;
-    text-indent: -9999em;
-    border-top: 1.1em solid var(--grey-200, color(grey-200));
-    border-right: 1.1em solid var(--grey-200, color(grey-200));
-    border-bottom: 1.1em solid var(--grey-200, color(grey-200));
-    border-left: 1.1em solid var(--KSkeletonFullScreenSpinnerColor, var(--blue-500, color(blue-500)));
+    -ms-transform: translateZ(0);
+    -webkit-transform: translateZ(0);
     transform: translateZ(0);
-    animation: spinnerAnimation 1.4s infinite linear;
+    width: 183px;
   }
 
-  @keyframes spinnerAnimation {
-    0% {
-      -webkit-transform: rotate(0deg);
-      transform: rotate(0deg);
-    }
-    100% {
-      -webkit-transform: rotate(360deg);
-      transform: rotate(360deg);
-    }
+@-webkit-keyframes spinnerAnimation {
+  0% {
+    -ms-transform: rotate(0deg);
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
   }
+  100% {
+    -ms-transform: rotate(360deg);
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes spinnerAnimation {
+  0% {
+    -ms-transform: rotate(0deg);
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -ms-transform: rotate(360deg);
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
 
 }
 </style>

--- a/src/components/KSkeleton/FullScreenKongSkeleton.vue
+++ b/src/components/KSkeleton/FullScreenKongSkeleton.vue
@@ -74,23 +74,13 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/mixins';
 @import '@/styles/functions';
 .fullscreen-loading-container {
-  align-items: center;
-  background: var(--white, color(white));
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  left: 0;
-  margin: var(--KSkeletonFullScreenMargin, 0);
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 10500;
+  @include fullscreen-loading-container;
 
   .progress {
-    background-color: var(--grey-200, color(grey-200));
+    background-color: var(--KSkeletonFullScreenProgressBackgroundColor, var(--grey-200, color(grey-200)));
     border-radius: 8px;
     margin-top: 16px;
     max-width: 350px;

--- a/src/components/KSkeleton/KSkeleton.cy.ts
+++ b/src/components/KSkeleton/KSkeleton.cy.ts
@@ -64,5 +64,17 @@ describe('KSkeleton', () => {
 
       cy.get('[role="progressbar"]').should('be.visible')
     })
+
+    it('renders full screen generic loader with progress bar', () => {
+      mount(KSkeleton, {
+        props: {
+          type: 'fullscreen-generic',
+        },
+      })
+
+      cy.getTestId('full-screen-spinner-loader').should('be.visible')
+
+      cy.get('[role="progressbar"]').should('be.visible')
+    })
   })
 })

--- a/src/components/KSkeleton/KSkeleton.vue
+++ b/src/components/KSkeleton/KSkeleton.vue
@@ -37,6 +37,12 @@
       :progress="progress"
     />
 
+    <FullScreenGenericSpinner
+      v-else-if="type === 'fullscreen-generic'"
+      :hide-progress="hideProgress"
+      :progress="progress"
+    />
+
     <KIcon
       v-else-if="type === 'spinner'"
       color="#000"
@@ -55,6 +61,7 @@ import CardSkeleton from '@/components/KSkeleton/CardSkeleton.vue'
 import TableSkeleton from '@/components/KSkeleton/TableSkeleton.vue'
 import FormSkeleton from '@/components/KSkeleton/FormSkeleton.vue'
 import FullScreenKongSkeleton from '@/components/KSkeleton/FullScreenKongSkeleton.vue'
+import FullScreenGenericSpinner from '@/components/KSkeleton/FullScreenGenericSpinner.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 
 export default defineComponent({
@@ -65,6 +72,7 @@ export default defineComponent({
     TableSkeleton,
     FormSkeleton,
     FullScreenKongSkeleton,
+    FullScreenGenericSpinner,
     KIcon,
   },
   props: {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -51,3 +51,18 @@
   font-style: italic;
   transition: all 0.1s ease;
 }
+
+@mixin fullscreen-loading-container {
+  align-items: center;
+  background: var(--white, color(white));
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  left: 0;
+  margin: var(--KSkeletonFullScreenMargin, 0);
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 10500;
+}


### PR DESCRIPTION
# Summary
Adds a generic loading screen for the `KSkeleton` full screen loader, without the Kong gruceo branding.
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
