### PR TITLE
fix(ktreelist): item selection [khcp-6355]

### DIFF
--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -230,8 +230,17 @@ const checkMove = (target: any): boolean => {
   return true
 }
 
-const onStartDrag = (): void => {
+const onStartDrag = (draggedItem: any): void => {
+  const draggedItemId = draggedItem.item?._underlying_vm_?.id || ''
+  const listItem = internalList.value.find((item: TreeListItem) => item.id === draggedItemId)
+
   dragging.value = true
+
+  if (listItem) {
+    // trigger item selection on drag event
+    emit('selected', listItem)
+  }
+
   setDragCursor(true)
 }
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Trigger item selection when drag-n-drop is initiated to fix the issue of having difficulty triggering the selection event.
Addresses [KHCP-6355](https://konghq.atlassian.net/browse/KHCP-6355).

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-6355]: https://konghq.atlassian.net/browse/KHCP-6355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ