### PR TITLE
fix(kinputswitch): fix position for enabledIcon in KInputSwitch with labelPosition left [KHCP-6412]

### DIFF
--- a/docs/components/input-switch.md
+++ b/docs/components/input-switch.md
@@ -102,6 +102,19 @@ Display a check icon when switch is enabled
   enabled-icon
 />
 
+Display a check icon when switch is enabled with label positioned to the left
+
+```html
+<KInputSwitch v-model="enabledIconChecked" :label="enabledIconChecked ? 'Enabled' : 'Disabled'" labelPosition="left" enabled-icon />
+```
+
+<KInputSwitch
+  v-model="enabledIconChecked"
+  :label="enabledIconChecked ? 'Enabled' : 'Disabled'"
+  labelPosition="left"
+  enabled-icon
+/>
+
 ## Slots
 
 - `label`

--- a/src/components/KInputSwitch/KInputSwitch.vue
+++ b/src/components/KInputSwitch/KInputSwitch.vue
@@ -171,9 +171,16 @@ export default defineComponent({
 .k-input-switch {
   position: relative;
 
-  .kong-icon {
+  .has-label-left + .kong-icon{
+    margin-left: 8px;
+  }
+
+  .has-label-right + .kong-icon {
     left: 57px;
     position: absolute;
+  }
+
+  .kong-icon {
     top: 1px;
     transform: translateX(-54px);
   }


### PR DESCRIPTION
# Summary

When labelPosition is left in KInputSwitch, use `position:relative` and `margin-left` on KIcon for proper positioning 
[KHCP-6412]

https://konghq.atlassian.net/browse/KHCP-6412

<img width="1292" alt="Screenshot 2023-03-16 at 2 16 23 AM" src="https://user-images.githubusercontent.com/2568272/225570966-ac6f930f-7bef-41d0-87a5-44a3bff5428e.png">

<img width="1282" alt="Screenshot 2023-03-16 at 2 17 02 AM" src="https://user-images.githubusercontent.com/2568272/225570971-bb30ecc0-8e1d-45b7-afc5-cded4aa0b465.png">

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-6412]: https://konghq.atlassian.net/browse/KHCP-6412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ