### PR TITLE
feat(kmultiselect): collapsedContext [ma-1456]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -202,6 +202,18 @@ Use this prop to customize the number of rows of selections to display when the 
 <KMultiselect :selected-row-count="1" :items="items" />
 ```
 
+### collapsedContext
+
+By default, we try to keep the KMultiselect display slim. This means that KMultiselect only takes up a single line when it doesn't have focus. You can set `collapsedContext` to `true` if you want to continue to see the selections even when KMultiselect doesn't have focus.
+
+<ClientOnly>
+  <KMultiselect :selected-row-count="1" collapsed-context :items="deepClone(defaultItemsCollapse)" />
+</ClientOnly>
+
+```html
+<KMultiselect :selected-row-count="1"  collapsed-context :items="items" />
+```
+
 ### expandSelected
 
 By default, we try to keep the KMultiselect display slim. This means that KMultiselect only takes up a single line when it doesn't have focus, and when focused, if the selected entries would display beyond the `selectedRowCount` we collapse them into the additional count badge. You can set `expandSelected` to `true` if you want to continue to see the selections even when KMultiselect doesn't have focus. Instead of collapsing additional selections into the additional count badge we will allow you to scroll through all of your selections.
@@ -240,9 +252,9 @@ Adds informational text to the bottom of the dropdown options which remains visi
 
 ### dropdownFooterTextPosition
 
-By default, the dropdown footer text will be stuck to the bottom of the dropdown and will always be visible even if the dropdown content is scrolled. 
+By default, the dropdown footer text will be stuck to the bottom of the dropdown and will always be visible even if the dropdown content is scrolled.
 
-If you want to override the behaviour and have the footer text at the end of the dropdown list, use the value `static`. This ensures the footer text is visible only when the user scrolls to view the bottom of the list. 
+If you want to override the behaviour and have the footer text at the end of the dropdown list, use the value `static`. This ensures the footer text is visible only when the user scrolls to view the bottom of the list.
 
 Accepted values: `sticky` (default) and `static`.
 

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -204,13 +204,16 @@ Use this prop to customize the number of rows of selections to display when the 
 
 ### collapsedContext
 
-By default, we try to keep the KMultiselect display slim. This means that KMultiselect only takes up a single line when it doesn't have focus. You can set `collapsedContext` to `true` if you want to continue to see the selections even when KMultiselect doesn't have focus.
+By default, we try to keep the KMultiselect display slim. This means that KMultiselect only takes up a single line when it doesn't have focus. You can set `collapsedContext` to `true` if you want to continue to see the selections even when KMultiselect doesn't have focus. Note: the `selectedRowCount` determines the maximum number of rows the KMultiselect will take up when collapsed.
 
 <ClientOnly>
+  <KMultiselect collapsed-context :items="deepClone(defaultItemsManySelected)" />
+  <br>
   <KMultiselect :selected-row-count="1" collapsed-context :items="deepClone(defaultItemsCollapse)" />
 </ClientOnly>
 
 ```html
+<KMultiselect collapsed-context :items="items" />
 <KMultiselect :selected-row-count="1" collapsed-context :items="items" />
 ```
 

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -211,7 +211,7 @@ By default, we try to keep the KMultiselect display slim. This means that KMulti
 </ClientOnly>
 
 ```html
-<KMultiselect :selected-row-count="1"  collapsed-context :items="items" />
+<KMultiselect :selected-row-count="1" collapsed-context :items="items" />
 ```
 
 ### expandSelected

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -351,6 +351,36 @@ describe('KMultiselect', () => {
     cy.getTestId('k-multiselect-selections').should('exist')
   })
 
+  it('always shows selections when collapsedContext is true', () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        collapsedContext: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+          selected: true,
+        }, {
+          label: labels[1],
+          value: vals[1],
+          selected: true,
+        }],
+      },
+    })
+
+    cy.getTestId('k-multiselect-selections').should('exist')
+
+    cy.getTestId('k-multiselect-selections').should('contain.text', labels[0])
+    cy.getTestId('k-multiselect-selections').should('contain.text', labels[1])
+
+    cy.get('.k-multiselect-chevron-icon').click()
+
+    cy.getTestId('k-multiselect-selections').should('exist')
+  })
+
   it('can clear all selections when focused', () => {
     const labels = ['Label 1', 'Label 2']
     const vals = ['label1', 'label2']

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -38,11 +38,11 @@
             @click="handleFilterClick"
           >
             <div
-              v-if="selectedItems.length && (isToggled.value || expandSelected)"
+              v-if="selectedItems.length && (isToggled.value || expandSelected || collapsedContext)"
               :id="multiselectSelectedItemsId"
               :key="key"
               class="k-multiselect-selections"
-              :class="{ 'scrollable my-2': expandSelected }"
+              :class="{ 'scrollable my-2': expandSelected, 'mb-2': collapsedContext && !isToggled.value }"
               data-testid="k-multiselect-selections"
               :style="!expandSelected ? numericWidthStyle : nonSlimStyle"
             >
@@ -109,7 +109,7 @@
               :style="numericWidthStyle"
             >
               <KInput
-                v-if="!expandSelected || (expandSelected && (!selectedItems.length || isToggled.value))"
+                v-if="(!expandSelected && !collapsedContext) || ((expandSelected || collapsedContext) && (!selectedItems.length || isToggled.value))"
                 :id="multiselectTextId"
                 v-bind="modifiedAttrs"
                 autocapitalize="off"
@@ -339,6 +339,14 @@ const props = defineProps({
   selectedRowCount: {
     type: Number,
     default: 2,
+  },
+  /**
+   * Determines whether to show total selected count (false), or
+   * row(s) of selections when collapsed
+   */
+  collapsedContext: {
+    type: Boolean,
+    default: false,
   },
   /**
    * Determines whether or not to hide the selections when not focused,


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add support for seeing my selections when collapsed (like `expandSelections`), but still allowing for a maximum row count and collapsing extra entries into the `+n` badge.
Address [MA-1456](https://konghq.atlassian.net/browse/MA-1456).

![image](https://user-images.githubusercontent.com/67973710/225342249-34bd5e63-0630-4f2e-be7f-fbf1b384e226.png)



## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[MA-1456]: https://konghq.atlassian.net/browse/MA-1456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ