### PR TITLE
fix(kdropdownitem): add hasDivider to KDropdownItem type [KHCP-6613]

### DIFF
--- a/src/types/dropdown-menu.ts
+++ b/src/types/dropdown-menu.ts
@@ -4,6 +4,7 @@ export interface DropdownItem {
   to?: string | object
   value?: string | number
   selected?: boolean
+  hasDivider?: boolean
 }
 
 export type Appearance = 'menu' | 'selectionMenu';


### PR DESCRIPTION
# Summary

Adds `hasDivider` optional boolean type to `DropdownItem` so that it can be specified with a divider in `KDropdownItem`

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
