### PR TITLE
fix(table): fetcher called twice on load

### DIFF
--- a/src/components/KTable/KTable.cy.ts
+++ b/src/components/KTable/KTable.cy.ts
@@ -484,11 +484,12 @@ describe('KTable', () => {
           searchInput: '',
         },
       })
-
-      // wait for initial fetcher call
-      cy.get('@fetcher', { timeout: 1000 })
+        .get('@fetcher')
         .should('have.callCount', 1) // fetcher's 1st call
         .should('returned', { data: [{ query: '' }] })
+        .wait(1000)
+        .get('@fetcher')
+        .should('have.callCount', 1) // ensure fetcher is NOT called twice on load
         .then(() => cy.wrap(Cypress.vueWrapper.setProps({ searchInput: 'some-keyword' })))
 
       // fetcher call should be delayed (> 350ms for search func + 500ms for revalidate func)

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -647,6 +647,7 @@ export default defineComponent({
     })
 
     const fetchData = async () => {
+      console.warn('fetchData')
       const searchInput = props.searchInput
 
       isTableLoading.value = true
@@ -864,8 +865,9 @@ export default defineComponent({
       }
     }, { immediate: true })
 
-    watch(query, (newQuery) => {
-      if (newQuery === '') {
+    watch(() => [query.value, page.value, pageSize.value], ([newQuery, /* newPage */, /* newPageSize */, oldQuery]) => {
+      // Check if the new query is empty and ensure this watch() is triggered by query change
+      if (newQuery === '' && newQuery !== oldQuery) {
         // Immediately triggers the revalidate, ...
         // 1) on the 1st time (query is empty)
         // 2) after clearing the input (query becomes empty)
@@ -874,10 +876,6 @@ export default defineComponent({
         // Triggers a debounced revalidate
         debouncedRevalidate()
       }
-    }, { deep: true, immediate: true })
-
-    watch(() => [page.value, pageSize.value], () => {
-      debouncedRevalidate()
     }, { deep: true, immediate: true })
 
     onMounted(() => {


### PR DESCRIPTION
# Summary

This PR fixes an issue with KTable where the fetcher was called twice on load.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
