### PR TITLE
fix(kselect): add white-space: nowrap; to item label [KHCP-6433]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -532,7 +532,7 @@ Use this prop to customize selected item element appearance by reusing content p
 <ClientOnly>
   <KSelect reuse-item-template appearance="select" :items="deepClone(defaultItems)">
     <template #item-template="{ item }">
-      <div class="d-inline-flex">
+      <div class="d-inline-flex w-100">
         <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
         <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
         <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -545,7 +545,7 @@ Use this prop to customize selected item element appearance by reusing content p
 ```html
 <KSelect reuse-item-template appearance="select" :items="items">
   <template #item-template="{ item }">
-    <div class="d-inline-flex">
+    <div class="d-inline-flex w-100">
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -638,7 +638,7 @@ export default defineComponent({
 Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated. If present, the slot content takes precedence over the [reuseItemTemplate](#reuseitemtemplate) prop.
 
 ::: tip TIP
-You can use the `.k-select-selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.
+You can use the `.selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.
 :::
 
 <ClientOnly>
@@ -647,10 +647,10 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-      {{ item.label }}
+       <div class="select-item-label">{{ item.label }}</div>
     </template>
     <template #item-template="{ item }">
-      <div class="d-inline-flex">
+      <div class="d-inline-flex w-100">
         <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
         <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
         <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -669,7 +669,7 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
     {{ item.label }}
   </template>
   <template #item-template="{ item }">
-    <div class="d-inline-flex">
+    <div class="d-inline-flex w-100">
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -638,7 +638,7 @@ export default defineComponent({
 Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated. If present, the slot content takes precedence over the [reuseItemTemplate](#reuseitemtemplate) prop.
 
 ::: tip TIP
-You can use the `.selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.
+You can use the `.k-select-selected-item-label` class within the slot to leverage preconfigured styles for selected item title which you're then free to customize.
 :::
 
 <ClientOnly>

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -856,6 +856,12 @@ const onPopoverOpen = () => {
       padding: 10px var(--spacing-md, spacing(md));
       pointer-events: none;
       position: absolute;
+
+      .select-item-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -107,7 +107,10 @@ export default defineComponent({
       font-size: 14px;
       font-weight: 500;
       line-height: 20px;
+      overflow: hidden;
       padding: 8px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       width: auto;
 
       :deep(.select-item-label) {
@@ -115,6 +118,9 @@ export default defineComponent({
         font-size: 14px;
         font-weight: 600;
         margin-bottom: 4px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       :deep(.select-item-desc) {


### PR DESCRIPTION
# Summary

Ticket: https://konghq.atlassian.net/browse/KHCP-6433

Before:
![Screen Shot 2023-03-24 at 4 16 40 PM](https://user-images.githubusercontent.com/36751160/227638831-e4a6d07f-a88f-4308-a558-7973759fead2.png)

After:
![Screen Shot 2023-03-24 at 4 16 59 PM](https://user-images.githubusercontent.com/36751160/227638882-cc3bc84b-3657-4810-870e-3c05df6e63ab.png)

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
