### PR TITLE
revert(kselect): add white-space: nowrap; to item label [KHCP-6433]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -532,7 +532,7 @@ Use this prop to customize selected item element appearance by reusing content p
 <ClientOnly>
   <KSelect reuse-item-template appearance="select" :items="deepClone(defaultItems)">
     <template #item-template="{ item }">
-      <div class="d-inline-flex w-100">
+      <div class="d-inline-flex">
         <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
         <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
         <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -545,7 +545,7 @@ Use this prop to customize selected item element appearance by reusing content p
 ```html
 <KSelect reuse-item-template appearance="select" :items="items">
   <template #item-template="{ item }">
-    <div class="d-inline-flex w-100">
+    <div class="d-inline-flex">
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -647,10 +647,10 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-       <div class="select-item-label">{{ item.label }}</div>
+      {{ item.label }}
     </template>
     <template #item-template="{ item }">
-      <div class="d-inline-flex w-100">
+      <div class="d-inline-flex">
         <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
         <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
         <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
@@ -669,7 +669,7 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
     {{ item.label }}
   </template>
   <template #item-template="{ item }">
-    <div class="d-inline-flex w-100">
+    <div class="d-inline-flex">
       <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
       <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
       <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -856,12 +856,6 @@ const onPopoverOpen = () => {
       padding: 10px var(--spacing-md, spacing(md));
       pointer-events: none;
       position: absolute;
-
-      .select-item-label {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
     }
   }
 

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -107,10 +107,7 @@ export default defineComponent({
       font-size: 14px;
       font-weight: 500;
       line-height: 20px;
-      overflow: hidden;
       padding: 8px;
-      text-overflow: ellipsis;
-      white-space: nowrap;
       width: auto;
 
       :deep(.select-item-label) {
@@ -118,9 +115,6 @@ export default defineComponent({
         font-size: 14px;
         font-weight: 600;
         margin-bottom: 4px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
       }
 
       :deep(.select-item-desc) {


### PR DESCRIPTION
Revert #1240 

This reverts commit ef81956fc8c232645b50f95add0aa91b697e1ec5.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
