### PR TITLE
feat(ktabs): accept route to generate router-links

### DIFF
--- a/docs/.vitepress/components/RouterLink.vue
+++ b/docs/.vitepress/components/RouterLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="typeof to === 'string' ? to : to.path"><slot /></a>
+  <a :href="typeof to === 'string' ? to : (to.path ?? to.name)"><slot /></a>
 </template>
 
 <script setup>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -24,6 +24,7 @@ export default {
 
     // Stub the <router-link> component; it doesn't exist in VitePress
     ctx.app.component('RouterLink', RouterLink)
+    ctx.app.component('RouterView', () => ({ name: 'RouterView', template: '<!-- router-view -->' }))
 
     // Register all Kongponents
     ctx.app.use(Kongponents)

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -55,8 +55,11 @@ export default defineComponent({
 export interface Tab {
   hash: string
   title: string
+  route?: RouteLocationNamedRaw
 }
 ```
+
+When providing the `route` property on tabs, `KTabs` will automatically use `router-link` to create tabs with links.
 
 ```html
 <template>
@@ -218,6 +221,46 @@ export default defineComponent({
 </script>
 ```
 
+### Navigation using `router-link`s
+
+<KTabs
+  v-model:model-value="navTabs[0].hash"
+  :tabs="navTabs"
+/>
+
+```html
+<template>
+  <KTabs
+    v-model:model-value="activeTabHash"
+    :tabs="tabs"
+  />
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+// Importing `route` in your app may vary and is excluded in this example.
+
+const tabs = [
+  {
+    hash: '#pictures',
+    title: 'Pictures',
+    route: { name: 'picture-list-view' },
+  },
+  {
+    hash: '#movies',
+    title: 'Movies',
+    route: { name: 'movie-list-view' },
+  },
+]
+
+const activeTabHash = computed(() => {
+  const activeTab = tabs.value.find((tab) => tab.routeName === route.name)
+
+  return activeTab !== undefined ? activeTab.hash : tabs.value[0].hash
+})
+</script>
+```
+
 ## Theming
 
 | Variable | Purpose
@@ -284,6 +327,18 @@ export default {
         { hash: '#pictures', title: 'Pictures' },
         { hash: '#movies', title: 'Movies' },
         { hash: '#books', title: 'Books' },
+      ],
+      navTabs: [
+        {
+          hash: '#pictures',
+          title: 'Pictures',
+          route: { name: 'picture-list-view' },
+        },
+        {
+          hash: '#movies',
+          title: 'Movies',
+          route: { name: 'movie-list-view' },
+        },
       ],
     }
   }

--- a/src/components/KTabs/KTabs.cy.ts
+++ b/src/components/KTabs/KTabs.cy.ts
@@ -7,6 +7,8 @@ const TABS = [
   { hash: '#books', title: 'Books' },
 ]
 
+const NAV_TABS = TABS.map((tab) => ({ ...tab, route: { name: tab.hash.substring(1) } }))
+
 describe('KTabs', () => {
   it('first tab is set if hash not found', () => {
     mount(KTabs, {
@@ -40,5 +42,18 @@ describe('KTabs', () => {
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'changed')
       cy.wrap(Cypress.vueWrapper.emitted('changed')[0][0]).should('eq', '#movies')
     })
+  })
+
+  it('uses links when providing route property', () => {
+    mount(KTabs, {
+      props: {
+        tabs: NAV_TABS,
+      },
+    })
+
+    // This *should* assert that the item has an “href” attribute, but since this Cypress doesn’t set-up vue-router, the rendered router-link element will be treated as an undefined custom element with its `to` prop represented as a prop
+    cy.get('.tab-item')
+      .eq(2)
+      .should('have.attr', 'to')
   })
 })

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -4,26 +4,45 @@
       aria-label="Tabs"
       role="tablist"
     >
-      <li
+      <template
         v-for="(tab, i) in tabs"
-        :id="`${tab.hash.replace('#','')}-tab`"
         :key="tab.hash"
-        :aria-controls="`panel-${i}`"
-        :aria-selected="activeTab === tab.hash ? 'true' : 'false'"
-        class="tab-item"
-        :class="{ active: activeTab === tab.hash }"
-        role="tab"
-        tabindex="0"
-        @click="handleTabChange(tab.hash)"
-        @keydown.enter.prevent="handleTabChange(tab.hash)"
-        @keydown.space.prevent="handleTabChange(tab.hash)"
       >
-        <div class="tab-link">
-          <slot :name="`${tab.hash.replace('#','')}-anchor`">
-            {{ tab.title }}
-          </slot>
-        </div>
-      </li>
+        <router-link
+          v-if="tab.route !== undefined"
+          :id="`${tab.hash.replace('#','')}-tab`"
+          class="tab-item"
+          :class="{ active: activeTab === tab.hash }"
+          :to="tab.route"
+          @click="handleTabChange(tab.hash)"
+        >
+          <div class="tab-link">
+            <slot :name="`${tab.hash.replace('#','')}-anchor`">
+              {{ tab.title }}
+            </slot>
+          </div>
+        </router-link>
+
+        <li
+          v-else
+          :id="`${tab.hash.replace('#','')}-tab`"
+          :aria-controls="`panel-${i}`"
+          :aria-selected="activeTab === tab.hash ? 'true' : 'false'"
+          class="tab-item"
+          :class="{ active: activeTab === tab.hash }"
+          role="tab"
+          tabindex="0"
+          @click="handleTabChange(tab.hash)"
+          @keydown.enter.prevent="handleTabChange(tab.hash)"
+          @keydown.space.prevent="handleTabChange(tab.hash)"
+        >
+          <div class="tab-link">
+            <slot :name="`${tab.hash.replace('#','')}-anchor`">
+              {{ tab.title }}
+            </slot>
+          </div>
+        </li>
+      </template>
     </ul>
 
     <div
@@ -38,7 +57,9 @@
       <slot
         v-if="activeTab === tab.hash"
         :name="tab.hash.replace('#','')"
-      />
+      >
+        <router-view v-if="tab.route !== undefined" />
+      </slot>
     </div>
   </div>
 </template>
@@ -128,6 +149,10 @@ export default defineComponent({
       &:hover {
         border-bottom: 4px solid var(--KTabBottomBorderColor, var(--teal-300, color(teal-300)));
         .tab-link { color: var(--KTabsActiveColor, var(--black-500, color(black-500))); }
+      }
+
+      &:hover {
+        text-decoration: none;
       }
     }
 

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -1,4 +1,7 @@
+import type { RouteLocationNamedRaw } from 'vue-router'
+
 export interface Tab {
   hash: string
   title: string
+  route?: RouteLocationNamedRaw
 }


### PR DESCRIPTION
# Summary

**feat(ktabs): accept route to generate router-links**

Adds support for a new optional `route` property on the `props.tabs` elements. When provided, `KTabs` will use a `router-link` components instead of the `li` element to render actual links in the tabs. It will also automatically add the `router-view` component in the tab content containers.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
