### PR TITLE
fix(inputs): support required state [khcp-6528]

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -208,6 +208,10 @@ You can pass any input attribute and it will get properly bound to the element.
 
 KInput will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
 
+:::tip NOTE
+Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.
+:::
+
 <KInput label="Name" required />
 <br>
 <KInput label="Name" overlay-label required />

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -206,7 +206,7 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ### required
 
-KInput will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+KInput will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`required`](/components/label#required) prop for more information.
 
 :::tip NOTE
 Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -51,6 +51,7 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 ```html
 <KInput label="Name" :label-attributes="{   help: 'I use the KLabel `help` prop' }" />
 ```
+
 ### overlayLabel
 
 Enable this prop to overlay the label on the input element's border. Defaults to `false`.
@@ -201,6 +202,19 @@ You can pass any input attribute and it will get properly bound to the element.
 <KInput read-only model-value="read-only"/>
 <KInput type="search" model-value="search"/>
 <KInput type="email" model-value="error" class="input-error"/>
+```
+
+### required
+
+KInput will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+
+<KInput label="Name" required />
+<br>
+<KInput label="Name" overlay-label required />
+
+```html
+<KInput label="Name" required />
+<KInput label="Name" overlay-label required />
 ```
 
 ### v-model

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -83,12 +83,12 @@ Use the `for` attribute to bind a label to an input element for accessibility.
 | :-------------------------------- | :------------------------------- |
 | `--KInputLabelColor`              | Label text color                 |
 | `--KLabelRequiredAsteriskColor`   | Label required '*' color         |
-| `--KInputLabelFont`               |                                  |
-| `--KInputLabelSize`               |                                  |
+| `--KInputLabelFont`               | Label font                       |
+| `--KInputLabelSize`               | Label text size                  |
 | `--KInputLabelWeight`             | Label font weight                |
 | `--KInputCheckboxLabel`           | Checkbox/radio label color       |
-| `--KInputCheckboxLabelFont`       |                                  |
-| `--KInputCheckboxLabelSize`       |                                  |
+| `--KInputCheckboxLabelFont`       | Checkbox/radio font              |
+| `--KInputCheckboxLabelSize`       | Checkbox/radio text size         |
 
 An example of theming the label might look like:
 

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -38,6 +38,16 @@ Use the `info` prop to display information help text.
 <KLabel info="This is an example">Input Title</KLabel>
 ```
 
+### isRequired
+
+Use the `isRequired` prop to indicate requiredness of a field by displaying an `*` after the label.
+
+<KLabel is-required>Name</KLabel>
+
+```html
+<KLabel is-required>Name</KLabel>
+```
+
 ### tooltipAttributes
 
 Use the `tooltipAttributes` prop to configure the **KTooltip's** [props](/components/tooltip) if using the `help` or `info` props.
@@ -66,3 +76,42 @@ Use the `for` attribute to bind a label to an input element for accessibility.
 <KLabel for="service" help="A service is an API that you want to offer">Service Name</KLabel>
 <KInput id="service"/>
 ```
+
+## Theming
+
+| Variable                          | Purpose                          |
+| :-------------------------------- | :------------------------------- |
+| `--KInputLabelColor`              | Label text color                 |
+| `--KLabelRequiredAsteriskColor`   | Label required '*' color         |
+| `--KInputLabelFont`               |                                  |
+| `--KInputLabelSize`               |                                  |
+| `--KInputLabelWeight`             | Label font weight                |
+| `--KInputCheckboxLabel`           | Checkbox/radio label color       |
+| `--KInputCheckboxLabelFont`       |                                  |
+| `--KInputCheckboxLabelSize`       |                                  |
+
+An example of theming the label might look like:
+
+<KLabel for="service" is-required class=custom-label>Service Name</KLabel>
+<KInput id="service"/>
+
+```html
+<template>
+  <KLabel for="service" is-required class=custom-label>Service Name</KLabel>
+  <KInput id="service"/>
+</template>
+
+<style>
+.custom-label {
+  --KInputLabelColor: var(--purple-400);
+  --KLabelRequiredAsteriskColor: var(--red-500);
+}
+</style>
+```
+
+<style lang="scss">
+.custom-label {
+  --KInputLabelColor: var(--purple-400);
+  --KLabelRequiredAsteriskColor: var(--red-500);
+}
+</style>

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -92,12 +92,12 @@ Use the `for` attribute to bind a label to an input element for accessibility.
 
 An example of theming the label might look like:
 
-<KLabel for="service" is-required class=custom-label>Service Name</KLabel>
+<KLabel for="service" required class=custom-label>Service Name</KLabel>
 <KInput id="service"/>
 
 ```html
 <template>
-  <KLabel for="service" is-required class=custom-label>Service Name</KLabel>
+  <KLabel for="service" required class=custom-label>Service Name</KLabel>
   <KInput id="service"/>
 </template>
 

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -38,14 +38,14 @@ Use the `info` prop to display information help text.
 <KLabel info="This is an example">Input Title</KLabel>
 ```
 
-### isRequired
+### required
 
-Use the `isRequired` prop to indicate requiredness of a field by displaying an `*` after the label.
+Use the `required` prop to indicate requiredness of a field by displaying an `*` after the label.
 
-<KLabel is-required>Name</KLabel>
+<KLabel required>Name</KLabel>
 
 ```html
-<KLabel is-required>Name</KLabel>
+<KLabel required>Name</KLabel>
 ```
 
 ### tooltipAttributes

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -583,6 +583,10 @@ You can pass any input attribute and it will get properly bound to the element.
 
 KMultiselect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
 
+:::tip NOTE
+Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.
+:::
+
 <ClientOnly>
   <KMultiselect label="Name" required :items="deepClone(defaultItems)" />
 </ClientOnly>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -579,6 +579,18 @@ You can pass any input attribute and it will get properly bound to the element.
 <KMultiselect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
 ```
 
+### required
+
+KMultiselect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+
+<ClientOnly>
+  <KMultiselect label="Name" required :items="deepClone(defaultItems)" />
+</ClientOnly>
+
+```html
+<KMultiselect label="Name" required :items="items" />
+```
+
 ## Slots
 
 - `item-template` - The template for each item in the dropdown list

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -581,7 +581,7 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ### required
 
-KMultiselect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+KMultiselect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`required`](/components/label#required) prop for more information.
 
 :::tip NOTE
 Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -242,9 +242,9 @@ Adds informational text to the bottom of the dropdown options which remains visi
 
 ### dropdownFooterTextPosition
 
-By default, the dropdown footer text will be stuck to the bottom of the dropdown and will always be visible even if the dropdown content is scrolled. 
+By default, the dropdown footer text will be stuck to the bottom of the dropdown and will always be visible even if the dropdown content is scrolled.
 
-If you want to override the behaviour and have the footer text at the end of the dropdown list, use the value `static`. This ensures the footer text is visible only when the user scrolls to view the bottom of the list. 
+If you want to override the behaviour and have the footer text at the end of the dropdown list, use the value `static`. This ensures the footer text is visible only when the user scrolls to view the bottom of the list.
 
 Accepted values: `sticky` (default) and `static`.
 
@@ -565,6 +565,21 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ```html
 <KSelect disabled placeholder="type something" :items="[{ label: 'test', value: 'test' }]" />
+```
+
+### required
+
+KSelect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+
+<ClientOnly>
+  <KSelect label="Name" required :items="deepClone(defaultItems)" />
+  <br>
+  <KSelect label="Name" required overlay-label :items="deepClone(defaultItems)" />
+</ClientOnly>
+
+```html
+<KSelect label="Name" required :items="items" />
+<KSelect label="Name" required overlay-label :items="items" />
 ```
 
 ## Slots

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -569,7 +569,7 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ### required
 
-KSelect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+KSelect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`required`](/components/label#required) prop for more information.
 
 :::tip NOTE
 Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -571,6 +571,10 @@ You can pass any input attribute and it will get properly bound to the element.
 
 KSelect will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
 
+:::tip NOTE
+Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.
+:::
+
 <ClientOnly>
   <KSelect label="Name" required :items="deepClone(defaultItems)" />
   <br>

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -122,7 +122,7 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ### required
 
-KTextArea will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+KTextArea will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`required`](/components/label#required) prop for more information.
 
 :::tip NOTE
 Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -110,7 +110,29 @@ Boolean value to indicate whether the element has an error and should apply erro
 <KTextArea has-error />
 ```
 
-## v-model
+## Attribute Binding
+
+You can pass any input attribute and it will get properly bound to the element.
+
+<KTextArea label="Name" placeholder="I'm disabled!" disabled />
+
+```html
+<KTextArea label="Name" placeholder="I'm disabled!" disabled />
+```
+
+### required
+
+KTextArea will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
+
+<KTextArea label="Name" required />
+<KTextArea label="Name" overlay-label required />
+
+```html
+<KTextArea label="Name" required />
+<KTextArea label="Name" overlay-label required />
+```
+
+### v-model
 
 `KTextArea` works as regular texarea do using v-model for data binding:
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -124,6 +124,10 @@ You can pass any input attribute and it will get properly bound to the element.
 
 KTextArea will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`isRequired`](/components/label#isrequired) prop for more information.
 
+:::tip NOTE
+Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.
+:::
+
 <KTextArea label="Name" required />
 <KTextArea label="Name" overlay-label required />
 

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -92,6 +92,23 @@ describe('KInput', () => {
     cy.get('.text-on-input label').should('contain.text', label)
   })
 
+  it('renders an asterisk when `overlayLabel` is true and `required` attr is set', () => {
+    const label = 'A label'
+    mount(KInput, {
+      props: {
+        testMode: true,
+        label,
+        overlayLabel: true,
+      },
+      attrs: {
+        required: true,
+      },
+    })
+
+    cy.get('.text-on-input label').should('contain.text', label)
+    cy.get('.text-on-input  .is-required').should('exist')
+  })
+
   it('renders small when size is passed in', () => {
     mount(KInput, {
       props: {

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -14,6 +14,10 @@
           :for="inputId"
         >
           <span>{{ label }}</span>
+          <span
+            v-if="isRequired"
+            class="is-required"
+          >*</span>
         </label>
         <input
           v-bind="modifiedAttrs"
@@ -45,6 +49,7 @@
       <KLabel
         :for="inputId"
         v-bind="labelAttributes"
+        :is-required="isRequired"
       >
         {{ label }}
       </KLabel>
@@ -194,6 +199,7 @@ export default defineComponent({
 
     const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
     const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
+    const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
     const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-input-id-1234' : uuidv1())
     // we need this so we can create a watcher for programmatic changes to the modelValue
     const value = computed({
@@ -218,9 +224,20 @@ export default defineComponent({
       return $attrs
     })
 
-    const charLimitExceeded = computed((): boolean =>
-      !!props.characterLimit && (currValue.value.toString().length ||
-        (!modelValueChanged.value && props.modelValue.toString().length)) > props.characterLimit)
+    const charLimitExceeded = computed((): boolean => {
+      const currValLength = currValue.value.toString().length
+      const modelValLength = props.modelValue.toString().length
+
+      // default to length of currVal
+      let length = currValLength
+
+      // if there is a model value and it hasn't been modified yet, use that instead
+      if (!modelValueChanged.value && modelValLength) {
+        length = modelValLength
+      }
+
+      return !!props.characterLimit && length > props.characterLimit
+    })
 
     const charLimitExceededError = computed((): string => {
       if (!charLimitExceeded.value) {
@@ -297,6 +314,7 @@ export default defineComponent({
       isHovered,
       isDisabled,
       isReadonly,
+      isRequired,
       inputId,
       charLimitExceeded,
       charLimitExceededError,

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -49,7 +49,7 @@
       <KLabel
         :for="inputId"
         v-bind="labelAttributes"
-        :is-required="isRequired"
+        :required="isRequired"
       >
         {{ label }}
       </KLabel>

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -225,8 +225,8 @@ export default defineComponent({
     })
 
     const charLimitExceeded = computed((): boolean => {
-      const currValLength = currValue.value.toString().length
-      const modelValLength = props.modelValue.toString().length
+      const currValLength = currValue.value?.toString().length || 0
+      const modelValLength = props.modelValue?.toString().length || 0
 
       // default to length of currVal
       let length = currValLength

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -13,7 +13,7 @@
           :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled, readonly: isReadonly }"
           :for="inputId"
         >
-          <span>{{ label }}</span>
+          <span>{{ strippedLabel }}</span>
           <span
             v-if="isRequired"
             class="is-required"
@@ -51,7 +51,7 @@
         v-bind="labelAttributes"
         :required="isRequired"
       >
-        {{ label }}
+        {{ strippedLabel }}
       </KLabel>
       <input
         v-bind="modifiedAttrs"
@@ -112,9 +112,10 @@
 
 <script lang="ts">
 import { defineComponent, computed, ref, watch, onMounted, PropType } from 'vue'
-import KLabel from '@/components/KLabel/KLabel.vue'
-import { v1 as uuidv1 } from 'uuid'
 import type { IconPosition, Size, LabelAttributes, SizeRecord, IconPositionRecord } from '@/types'
+import { v1 as uuidv1 } from 'uuid'
+import useUtilities from '@/composables/useUtilities'
+import KLabel from '@/components/KLabel/KLabel.vue'
 
 const sizeRecord: SizeRecord = {
   large: 'large',
@@ -196,11 +197,13 @@ export default defineComponent({
     const isFocused = ref<boolean>(false)
     const isHovered = ref<boolean>(false)
     const icon = ref<HTMLDivElement | null>(null)
+    const { stripRequiredLabel } = useUtilities()
 
     const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
     const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
     const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
     const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-input-id-1234' : uuidv1())
+    const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
     // we need this so we can create a watcher for programmatic changes to the modelValue
     const value = computed({
       get(): string | number {
@@ -316,6 +319,7 @@ export default defineComponent({
       isReadonly,
       isRequired,
       inputId,
+      strippedLabel,
       charLimitExceeded,
       charLimitExceededError,
       modifiedAttrs,

--- a/src/components/KLabel/KLabel.cy.ts
+++ b/src/components/KLabel/KLabel.cy.ts
@@ -38,6 +38,20 @@ describe('KLabel', () => {
     cy.get('.k-input-label .label-tooltip').should('not.be.empty')
   })
 
+  it('renders an asterisk when `isRequired` is true', () => {
+    mount(KLabel, {
+      props: {
+        testMode: true,
+        isRequired: true,
+      },
+      slots: {
+        default: () => 'Full Name',
+      },
+    })
+
+    cy.get('.k-input-label .is-required').should('exist')
+  })
+
   it('renders a tooltip when `info` is provided', () => {
     mount(KLabel, {
       props: {

--- a/src/components/KLabel/KLabel.cy.ts
+++ b/src/components/KLabel/KLabel.cy.ts
@@ -38,11 +38,11 @@ describe('KLabel', () => {
     cy.get('.k-input-label .label-tooltip').should('not.be.empty')
   })
 
-  it('renders an asterisk when `isRequired` is true', () => {
+  it('renders an asterisk when `required` is true', () => {
     mount(KLabel, {
       props: {
         testMode: true,
-        isRequired: true,
+        required: true,
       },
       slots: {
         default: () => 'Full Name',

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -11,6 +11,10 @@
       :test-mode="!!testMode || undefined"
     >
       <slot />
+      <span
+        v-if="isRequired"
+        class="is-required"
+      >*</span>
       <KIcon
         hide-title
         icon="help"
@@ -27,6 +31,10 @@
       :test-mode="!!testMode || undefined"
     >
       <slot />
+      <span
+        v-if="isRequired"
+        class="is-required"
+      >*</span>
       <KIcon
         hide-title
         icon="info"
@@ -35,7 +43,13 @@
       />
     </KTooltip>
 
-    <slot v-else />
+    <span v-else>
+      <slot />
+      <span
+        v-if="isRequired"
+        class="is-required"
+      >*</span>
+    </span>
   </label>
 </template>
 
@@ -59,6 +73,10 @@ export default defineComponent({
     info: {
       type: String,
       default: '',
+    },
+    isRequired: {
+      type: Boolean,
+      default: false,
     },
     tooltipAttributes: {
       type: Object as PropType<TooltipAttributes>,

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -12,7 +12,7 @@
     >
       <slot />
       <span
-        v-if="isRequired"
+        v-if="required"
         class="is-required"
       >*</span>
       <KIcon
@@ -32,7 +32,7 @@
     >
       <slot />
       <span
-        v-if="isRequired"
+        v-if="required"
         class="is-required"
       >*</span>
       <KIcon
@@ -46,7 +46,7 @@
     <span v-else>
       <slot />
       <span
-        v-if="isRequired"
+        v-if="required"
         class="is-required"
       >*</span>
     </span>
@@ -74,7 +74,7 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    isRequired: {
+    required: {
       type: Boolean,
       default: false,
     },

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -9,7 +9,7 @@
       v-bind="labelAttributes"
       :data-testid="labelAttributes['data-testid'] ? labelAttributes['data-testid'] : 'k-multiselect-label'"
       :for="multiselectId"
-      :is-required="isRequired"
+      :required="isRequired"
     >
       {{ label }}
     </KLabel>

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -11,7 +11,7 @@
       :for="multiselectId"
       :required="isRequired"
     >
-      {{ label }}
+      {{ strippedLabel }}
     </KLabel>
     <div
       :id="multiselectId"
@@ -278,7 +278,7 @@ export default {
 
 <script setup lang="ts">
 const attrs = useAttrs()
-const { getSizeFromString, cloneDeep } = useUtilities()
+const { getSizeFromString, cloneDeep, stripRequiredLabel } = useUtilities()
 const SELECTED_ITEMS_SINGLE_LINE_HEIGHT = 34
 
 const props = defineProps({
@@ -414,6 +414,7 @@ const props = defineProps({
 const emit = defineEmits(['selected', 'item:added', 'item:removed', 'input', 'change', 'update:modelValue', 'query-change'])
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
+const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 const defaultKPopAttributes = {
   hideCaret: true,
   placement: 'bottomStart',

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -9,6 +9,7 @@
       v-bind="labelAttributes"
       :data-testid="labelAttributes['data-testid'] ? labelAttributes['data-testid'] : 'k-multiselect-label'"
       :for="multiselectId"
+      :is-required="isRequired"
     >
       {{ label }}
     </KLabel>
@@ -412,6 +413,7 @@ const props = defineProps({
 
 const emit = defineEmits(['selected', 'item:added', 'item:removed', 'input', 'change', 'update:modelValue', 'query-change'])
 
+const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const defaultKPopAttributes = {
   hideCaret: true,
   placement: 'bottomStart',

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -126,9 +126,7 @@ describe('KSelect', () => {
       props: {
         testMode: true,
         label,
-        labelAttributes: {
-          help: 'some help text',
-        },
+        overlayLabel: true,
         items: [{
           label: 'Label 1',
           value: 'label1',

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -120,6 +120,29 @@ describe('KSelect', () => {
     cy.get('.k-input-label .kong-icon-help').should('be.visible')
   })
 
+  it('renders an asterisk when `overlayLabel` is true and `required` attr is set', () => {
+    const label = 'A label'
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        label,
+        labelAttributes: {
+          help: 'some help text',
+        },
+        items: [{
+          label: 'Label 1',
+          value: 'label1',
+        }],
+      },
+      attrs: {
+        required: true,
+      },
+    })
+
+    cy.get('.text-on-input label').should('contain.text', label)
+    cy.get('.text-on-input  .is-required').should('exist')
+  })
+
   it('renders with correct appearance - select', () => {
     mount(KSelect, {
       props: {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -9,7 +9,7 @@
       v-bind="labelAttributes"
       data-testid="k-select-label"
       :for="selectId"
-      :is-required="isRequired"
+      :required="isRequired"
     >
       {{ label }}
     </KLabel>

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -11,7 +11,7 @@
       :for="selectId"
       :required="isRequired"
     >
-      {{ label }}
+      {{ strippedLabel }}
     </KLabel>
     <div
       :id="selectId"
@@ -147,7 +147,7 @@
                 'is-readonly': ($attrs.readonly !== undefined && String($attrs.readonly) !== 'false'),
                 'disabled': ($attrs.disabled !== undefined && String($attrs.disabled) !== 'false')
               }"
-              :label="label && overlayLabel ? label : undefined"
+              :label="label && overlayLabel ? strippedLabel : undefined"
               :model-value="filterStr"
               :overlay-label="overlayLabel"
               :placeholder="selectedItem && appearance === 'select' && !filterIsEnabled ? selectedItem.label : placeholderText"
@@ -264,7 +264,7 @@ export type DropdownFooterTextPosition = 'sticky' | 'static'
 </script>
 
 <script setup lang="ts">
-const { getSizeFromString } = useUtilities()
+const { getSizeFromString, stripRequiredLabel } = useUtilities()
 
 const defaultKPopAttributes = {
   popoverClasses: 'k-select-popover mt-0',
@@ -421,6 +421,7 @@ const attrs = useAttrs()
 const slots = useSlots()
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
+const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 const filterStr = ref('')
 const selectedItem = ref<SelectItem|null>(null)
 const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv1())

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -9,6 +9,7 @@
       v-bind="labelAttributes"
       data-testid="k-select-label"
       :for="selectId"
+      :is-required="isRequired"
     >
       {{ label }}
     </KLabel>
@@ -419,6 +420,7 @@ const emit = defineEmits(['selected', 'input', 'change', 'update:modelValue', 'q
 const attrs = useAttrs()
 const slots = useSlots()
 
+const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const filterStr = ref('')
 const selectedItem = ref<SelectItem|null>(null)
 const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv1())

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -64,6 +64,23 @@ describe('KTextArea', () => {
     cy.get('.text-on-input label').should('contain.text', labelText)
   })
 
+  it('renders an asterisk when `overlayLabel` is true and `required` attr is set', () => {
+    const label = 'A label'
+    mount(KTextArea, {
+      props: {
+        testMode: true,
+        label,
+        overlayLabel: true,
+      },
+      attrs: {
+        required: true,
+      },
+    })
+
+    cy.get('.text-on-input label').should('contain.text', label)
+    cy.get('.text-on-input  .is-required').should('exist')
+  })
+
   it('renders textarea when rows and cols are passed in', () => {
     mount(KTextArea, {
       props: {
@@ -91,7 +108,7 @@ describe('KTextArea', () => {
     cy.get('textarea').type(value2).then(() => {
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'input')
       const emitArray = Cypress.vueWrapper.emitted('input')
-      cy.wrap(String(emitArray[emitArray.length - 1])).should('eq', value2)
+      cy.wrap(String(emitArray?.[emitArray.length - 1])).should('eq', value2)
     })
     cy.get('textarea').should('have.value', value2)
   })

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -77,7 +77,6 @@ describe('KTextArea', () => {
       },
     })
 
-    cy.get('.text-on-input label').should('contain.text', label)
     cy.get('.text-on-input  .is-required').should('exist')
   })
 

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -25,6 +25,10 @@
           :for="textAreaId"
         >
           <span>{{ label }}</span>
+          <span
+            v-if="isRequired"
+            class="is-required"
+          >*</span>
         </label>
         <textarea
           v-bind="modifiedAttrs"
@@ -51,6 +55,7 @@
       <KLabel
         :for="textAreaId"
         v-bind="labelAttributes"
+        :is-required="isRequired"
       >
         {{ label }}
       </KLabel>
@@ -145,6 +150,7 @@ export default defineComponent({
   },
   emits: ['input', 'update:modelValue', 'char-limit-exceeded'],
   setup(props, { attrs, emit }) {
+    const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
     const currValue = ref('') // We need this so that we don't lose the updated value on hover/blur event with label
     const isFocused = ref(false)
     const isHovered = ref(false)
@@ -202,6 +208,7 @@ export default defineComponent({
     }
 
     return {
+      isRequired,
       currValue,
       isFocused,
       isHovered,

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -24,7 +24,7 @@
           :class="{ focused: isFocused, hovered: isHovered }"
           :for="textAreaId"
         >
-          <span>{{ label }}</span>
+          <span>{{ strippedLabel }}</span>
           <span
             v-if="isRequired"
             class="is-required"
@@ -57,7 +57,7 @@
         v-bind="labelAttributes"
         :required="isRequired"
       >
-        {{ label }}
+        {{ strippedLabel }}
       </KLabel>
       <textarea
         v-bind="modifiedAttrs"
@@ -88,8 +88,9 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, watch } from 'vue'
-import KLabel from '@/components/KLabel/KLabel.vue'
 import { v1 as uuidv1 } from 'uuid'
+import useUtilities from '@/composables/useUtilities'
+import KLabel from '@/components/KLabel/KLabel.vue'
 
 const CHARACTER_LIMIT = 2048
 
@@ -150,10 +151,13 @@ export default defineComponent({
   },
   emits: ['input', 'update:modelValue', 'char-limit-exceeded'],
   setup(props, { attrs, emit }) {
+    const { stripRequiredLabel } = useUtilities()
+
     const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
     const currValue = ref('') // We need this so that we don't lose the updated value on hover/blur event with label
     const isFocused = ref(false)
     const isHovered = ref(false)
+    const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
     // we need this so we can create a watcher for programmatic changes to the modelValue
     const value = computed({
       get(): string | number {
@@ -213,6 +217,7 @@ export default defineComponent({
       isFocused,
       isHovered,
       textAreaId,
+      strippedLabel,
       modifiedAttrs,
       charLimitExceeded,
       inputHandler,

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -55,7 +55,7 @@
       <KLabel
         :for="textAreaId"
         v-bind="labelAttributes"
-        :is-required="isRequired"
+        :required="isRequired"
       >
         {{ label }}
       </KLabel>

--- a/src/composables/useUtilities.cy.ts
+++ b/src/composables/useUtilities.cy.ts
@@ -4,7 +4,7 @@
 
 import useUtilities from '@/composables/useUtilities'
 
-const { clientSideSorter, getSizeFromString } = useUtilities()
+const { clientSideSorter, getSizeFromString, stripRequiredLabel } = useUtilities()
 
 describe('Client-side sorting (deprecated in favor of server-side sorting)', () => {
   it('clientSideSorter(): sorts the items by string', () => {
@@ -223,5 +223,30 @@ describe('getSizeFromString(): ', () => {
     const result = getSizeFromString(sizeStr)
 
     expect(result).equal(`${sizeStr}`)
+  })
+})
+
+describe('stripRequiredLabel(): ', () => {
+  it('does not change non-required fields', () => {
+    const label = 'Name**'
+    const result = stripRequiredLabel(label, false)
+
+    expect(result).equal(label)
+  })
+
+  it('correctly modifies required fields with space', () => {
+    const label = 'Name *'
+    const expected = 'Name'
+    const result = stripRequiredLabel(label, true)
+
+    expect(result).equal(expected)
+  })
+
+  it('correctly modifies required fields with no space', () => {
+    const label = 'Name*'
+    const expected = 'Name'
+    const result = stripRequiredLabel(label, true)
+
+    expect(result).equal(expected)
   })
 })

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -255,7 +255,7 @@ export default function useUtilities() {
       return label || ''
     }
 
-    if (label.match(/( )?\*$/gi)) {
+    if (/( )?\*$/gi.test(label)) {
       return label.replace(/\*$/gi, '').trim()
     }
 

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -251,8 +251,8 @@ export default function useUtilities() {
    * @returns the stripped label
    */
   const stripRequiredLabel = (label: string, required: boolean): string => {
-    if (!required) {
-      return label
+    if (!required || !label) {
+      return label || ''
     }
 
     if (label.match(/( )?\*$/gi)) {

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -242,6 +242,26 @@ export default function useUtilities() {
     return JSON.parse(JSON.stringify(val))
   }
 
+  /**
+   * For the label of a `required` input.
+   * If the field is required and the label ends with an '*', strip it out.
+   *
+   * @param label the label to strip
+   * @param required whether or not the field is required
+   * @returns the stripped label
+   */
+  const stripRequiredLabel = (label: string, required: boolean): string => {
+    if (!required) {
+      return label
+    }
+
+    if (label.match(/( )?\*$/gi)) {
+      return label.replace(/\*$/gi, '').trim()
+    }
+
+    return label
+  }
+
   return {
     useRequest,
     useDebounce,
@@ -249,5 +269,6 @@ export default function useUtilities() {
     useSwrvStates,
     getSizeFromString,
     cloneDeep,
+    stripRequiredLabel,
   }
 }

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -14,7 +14,7 @@
   }
 
   .is-required {
-    color: var(--KLabelRequiredAsteriskColor, var(--KInputBorder));
+    color: var(--KLabelRequiredAsteriskColor, var(--KInputBorder, var(--grey-600)));
     font-size: 11px;
     font-weight: 500;
     margin-left: var(--spacing-xxs);

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -13,6 +13,13 @@
     transition: color 0.1s ease;
   }
 
+  .is-required {
+    color: var(--KLabelRequiredAsteriskColor, var(--KInputBorder));
+    font-size: 11px;
+    font-weight: 500;
+    margin-left: var(--spacing-xxs);
+  }
+
   label {
     background-color: var(--KInputBackground, var(--white));
     color: var(--KInputBorder, var(--grey-600));

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -39,15 +39,27 @@
     &.hovered:not(.readonly) {
       color: var(--KInputHover, var(--blue-500));
       transition: color 0.1s ease;
+
+      .is-required {
+        color: var(--KInputHover, var(--blue-500));
+      }
     }
 
     &.focused:not(.readonly) {
       color: var(--KInputFocus, var(--blue-500));
       transition: color 0.1s ease;
+
+      .is-required {
+        color: var(--KInputFocus, var(--blue-500));
+      }
     }
 
     &.disabled {
       color: var(--grey-500);
+
+      .is-required {
+        color: var(--grey-500);
+      }
     }
   }
 }

--- a/src/styles/forms/_labels.scss
+++ b/src/styles/forms/_labels.scss
@@ -7,6 +7,13 @@
   line-height: var(--KInputLabelLineHeight, var(--type-lg, type(lg)));
   margin-bottom: var(--KInputLabelMargin, var(--spacing-xs, spacing(xs)));
 
+  .is-required {
+    color: var(--KLabelRequiredAsteriskColor, var(--KInputLabelColor));
+    font-size: var(--KInputLabelSize, var(--type-sm, type(sm)));
+    font-weight: var(--KInputLabelWeight, 600);
+    margin-left: var(--spacing-xxs);
+  }
+
   .label-tooltip {
     align-items: center;
     display: flex;

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -9,6 +9,6 @@ export type IconPositionRecord = Record<IconPosition, IconPosition>
 export interface LabelAttributes {
   help?: string
   info?: string
-  isRequired?: boolean
+  required?: boolean
   tooltipAttributes?: TooltipAttributes
 }

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -9,5 +9,6 @@ export type IconPositionRecord = Record<IconPosition, IconPosition>
 export interface LabelAttributes {
   help?: string
   info?: string
+  isRequired?: boolean
   tooltipAttributes?: TooltipAttributes
 }


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
**NOTE: This will require changes when adopting in `khcp-ui` to make sure we aren't showing duplicate asterisks anywhere!**
Adoption discussion in this [slack thread](https://kongstrong.slack.com/archives/CTAMPSTNX/p1681327020300829)

Add support for displaying an asterisk to indicate `required` state.
Addressed [KHCP-6528](https://konghq.atlassian.net/browse/KHCP-6528).

Support added for:
- KInput
- KLabel
- KMultiselect
- KSelect
- KTextarea

Doc updates:
- Added `Theming` section to `KLabel`
- Added `Attribute Bindings` section to `KTextarea`

![image](https://user-images.githubusercontent.com/67973710/230986808-f143968e-9de2-4268-b018-7f3720c36091.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-6528]: https://konghq.atlassian.net/browse/KHCP-6528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ