### PR TITLE
feat(modals): doc differences prompt vs modal

### DIFF
--- a/docs/.vitepress/theme/_overrides.scss
+++ b/docs/.vitepress/theme/_overrides.scss
@@ -1,5 +1,9 @@
 // Theme overrides; all should be nested inside of the `.vp-doc` class
 .vp-doc {
+  --vp-custom-block-info-border: var(--blue-600, #003694);
+  --vp-custom-block-info-text: var(--blue-500, #1155cb);
+  --vp-custom-block-info-bg: var(--blue-100, #f2f6fe);
+
   .kong-card li + li {
     margin-top: 0;
   }

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,7 +1,7 @@
 # Modal
 
 ::: info
-Are you looking for a modal with a close icon, left-aligned text, and divider lines at the top and bottom of the modal? Try [KPrompt](/components/prompt.html) instead.
+Are you looking for a modal with a close icon, left-aligned text, right-aligned actions, and divider lines at the top and bottom of the modal? Try [KPrompt](/components/prompt.html) instead.
 :::
 
 The **KModal** component is used for displaying general information to a user that must be acknowledged before continuing.

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,6 +1,10 @@
 # Modal
 
-The **KModal** component is used to show content on top of existing UI. Typically used when confirming changes or while during a delete action.
+::: info
+Are you looking for a modal with a close icon, left-aligned text, and divider lines at the top and bottom of the modal? Try [KPrompt](/components/prompt.html) instead.
+:::
+
+The **KModal** component is used for displaying general information to a user that must be acknowledged before continuing.
 
 <KButton appearance="primary" @click="defaultIsOpen = true">Open Modal</KButton>
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,7 +1,7 @@
 # Modal
 
 ::: info
-Are you looking for a modal with a close icon, left-aligned text, right-aligned actions, and divider lines at the top and bottom of the modal? Try [KPrompt](/components/prompt.html) instead.
+Are you looking for a modal with a close icon, left-aligned text, right-aligned action buttons, and divider lines at the top and bottom of the modal? Try [KPrompt](/components/prompt.html) instead.
 :::
 
 The **KModal** component is used for displaying general information to a user that must be acknowledged before continuing.

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -1,5 +1,9 @@
 # Prompt
 
+::: info
+Are you looking for a modal with no close icon, centered text, and the ability to display an image in the header of the modal? Try [KModal](/components/modal.html) instead.
+:::
+
 The **KPrompt** component is used to display a dialog that prompts a user to take an action.
 
 <KButton appearance="primary" @click="defaultIsOpen = true">Prompt</KButton>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Document the differences between `KPrompt` and `KModal`.

![image](https://user-images.githubusercontent.com/67973710/231559077-d7d8a051-47a8-416f-8beb-82ca98c4d57b.png)

![image](https://user-images.githubusercontent.com/67973710/231558047-78818068-140d-4543-bf71-0f94dc172bb8.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
