### PR TITLE
test(component): enable fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,14 +54,14 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: cypress/screenshots/
+          path: cypress/screenshots
 
       - name: Upload Cypress videos (always)
         uses: actions/upload-artifact@v3
-        if: always()
+        if: failure()
         with:
           name: cypress-videos
-          path: cypress/videos/
+          path: cypress/videos
 
       - name: Build components and docs
         run: yarn build

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   component: {
     env: {
       FAIL_FAST_ENABLED: true,
-      FAIL_FAST_STRATEGY: 'run',
+      FAIL_FAST_STRATEGY: 'spec',
     },
     devServer: {
       framework: 'vue',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   component: {
     env: {
       FAIL_FAST_ENABLED: true,
-      FAIL_FAST_STRATEGY: 'spec',
+      FAIL_FAST_STRATEGY: 'run',
     },
     devServer: {
       framework: 'vue',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,15 +2,16 @@ import { defineConfig } from 'cypress'
 import failFast from 'cypress-fail-fast/plugin'
 
 export default defineConfig({
-  env: {
-    FAIL_FAST_ENABLED: true,
-  },
   component: {
+    env: {
+      FAIL_FAST_ENABLED: true,
+      FAIL_FAST_STRATEGY: 'spec',
+    },
     devServer: {
       framework: 'vue',
       bundler: 'vite',
     },
-    setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
+    setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions): Cypress.PluginConfigOptions {
       failFast(on, config)
 
       return config

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'cypress'
+import failFast from 'cypress-fail-fast/plugin'
 
 export default defineConfig({
+  env: {
+    FAIL_FAST_ENABLED: true,
+  },
   component: {
     devServer: {
       framework: 'vue',
       bundler: 'vite',
+    },
+    setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
+      failFast(on, config)
+
+      return config
     },
     viewportHeight: 768,
     viewportWidth: 1366,

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,6 +1,7 @@
 import { mount } from 'cypress/vue'
 import { App, ComputedOptions } from 'vue'
 import Chainable = Cypress.Chainable
+import 'cypress-fail-fast'
 // Import Kongponent styles
 import '@/styles/styles.scss'
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "commitizen": "^4.2.5",
     "copyfiles": "^2.4.1",
     "cypress": "^12.0.2",
+    "cypress-fail-fast": "^7.0.1",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "8.38.0",
     "eslint-config-standard": "^17.0.0",

--- a/src/components/KCatalog/KCatalog.cy.ts
+++ b/src/components/KCatalog/KCatalog.cy.ts
@@ -55,7 +55,7 @@ const largeDataSet = [
  */
 
 describe('KCatalog', () => {
-  function getItems(count) {
+  function getItems(count: number) {
     const myItems = []
 
     for (let i = 0; i < count; i++) {

--- a/src/components/KDropdownMenu/KDropdownMenu.cy.ts
+++ b/src/components/KDropdownMenu/KDropdownMenu.cy.ts
@@ -145,7 +145,7 @@ describe('KDropdownMenu', () => {
     cy.get('.k-dropdown-popover').should('contain.html', itemSlotContent)
   })
 
-  it('correctly renders dividers on all item types', () => {
+  it.only('correctly renders dividers on all item types', () => {
     const itemSlotContent = `
     <KDropdownItem has-divider :item="{ label: 'A link', to: { path: '/' } }" />
     <KDropdownItem has-divider @click="() => {}">
@@ -181,16 +181,19 @@ describe('KDropdownMenu', () => {
     </KDropdownItem>`
 
     mount(KDropdownMenu, {
-      components: {
-        KDropdownItem,
-      },
       props: {
         testMode: true,
         label: 'Click me',
+        class: 'test-dropdown',
       },
       slots: {
         items: itemSlotContent,
         default: h('button', {}, 'hello'),
+      },
+      global: {
+        components: {
+          KDropdownItem,
+        },
       },
     })
 
@@ -198,7 +201,7 @@ describe('KDropdownMenu', () => {
     triggerBtn.click()
     cy.getTestId('k-dropdown-list').should('be.visible')
 
-    cy.get('.k-dropdown-item').should('have.length', 5)
-    cy.get('.has-divider').should('have.length', 5)
+    cy.getTestId('k-dropdown-list').eq(0).find('.k-dropdown-item').should('have.length', 5)
+    cy.getTestId('k-dropdown-list').eq(0).find('.has-divider').should('have.length', 5)
   })
 })

--- a/src/components/KDropdownMenu/KDropdownMenu.cy.ts
+++ b/src/components/KDropdownMenu/KDropdownMenu.cy.ts
@@ -145,7 +145,7 @@ describe('KDropdownMenu', () => {
     cy.get('.k-dropdown-popover').should('contain.html', itemSlotContent)
   })
 
-  it.only('correctly renders dividers on all item types', () => {
+  it('correctly renders dividers on all item types', () => {
     const itemSlotContent = `
     <KDropdownItem has-divider :item="{ label: 'A link', to: { path: '/' } }" />
     <KDropdownItem has-divider @click="() => {}">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,6 +2028,14 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2036,14 +2044,6 @@ chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^5.0.0:
   version "5.1.2"
@@ -2439,6 +2439,13 @@ csstype@^2.6.8:
   version "2.6.21"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
   integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
+
+cypress-fail-fast@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-fail-fast/-/cypress-fail-fast-7.0.1.tgz#9aa0cdbdf92b7ea3712588635f8b35e8f5f10f16"
+  integrity sha512-v68bfFTjPrn3+i+mEFmxC6Z2ble9+k8xIeEGeZJQS0HU8A9Q3oE1LEEv1SAqgyaYL06PKw4ifHw/aydO6rNFaw==
+  dependencies:
+    chalk "4.1.2"
 
 cypress@^12.0.2:
   version "12.9.0"


### PR DESCRIPTION
# Summary

Add the `cypress-fail-fast` plugin.

Note: this will not stop execution of all spec files, but will skip all remaining tests in a spec if one test in the spec fails.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
