### PR TITLE
fix(KTable): loosen types passed to slots in KTable

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -634,7 +634,7 @@ const fetchData = async () => {
     sortColumnOrder: sortColumnOrder.value,
     offset: offset.value,
   })
-  data.value = res.data as any[]
+  data.value = res.data as Record<string, any>[]
   total.value = props.paginationTotalItems || res.total || res.data?.length
 
   if (props.paginationType === 'offset') {

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -625,7 +625,7 @@ const fetchData = async () => {
     sortColumnOrder: sortColumnOrder.value,
     offset: offset.value,
   })
-  data.value = res.data as Record<string, any>[]
+  data.value = res.data as any[]
   total.value = props.paginationTotalItems || res.total || res.data?.length
 
   if (props.paginationType === 'offset') {

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -522,6 +522,11 @@ const hasInitialized = ref(false)
 const nextPageClicked = ref(false)
 const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
 
+/**
+ * Utilize a helper function to generate the column slot name.
+ * This helps TypeScript infer the slot name in the template section so that the slot props can be resolved.
+ * @param {string} columnKey The column.key
+ */
 const getColumnSlotName = (columnKey: string): TableColumnSlotName => {
   return `column-${columnKey}`
 }

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -528,7 +528,7 @@ const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
  * @param row The object to strip the type from
  */
 const getGeneric = (row: Record<string, any>) => {
-  return row as unknown as Object
+  return row as unknown as any
 }
 
 /**

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -122,7 +122,7 @@
               <span class="d-flex align-items-center">
                 <slot
                   :column="getGeneric(column)"
-                  :name="`column-${column.key}`"
+                  :name="getColumnSlotName(column.key)"
                 >
                   <span :class="{'sr-only': column.hideLabel}">
                     {{ column.label ? column.label : column.key }}
@@ -202,7 +202,7 @@ import KSkeleton from '@/components/KSkeleton/KSkeleton.vue'
 import KPagination from '@/components/KPagination/KPagination.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import useUtilities from '@/composables/useUtilities'
-import type { TablePreferences, TablePaginationType, TableHeader } from '@/types'
+import type { TablePreferences, TablePaginationType, TableHeader, TableColumnSlotName } from '@/types'
 
 const { useDebounce, useRequest } = useUtilities()
 
@@ -521,6 +521,10 @@ const isClickable = ref(false)
 const hasInitialized = ref(false)
 const nextPageClicked = ref(false)
 const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
+
+const getColumnSlotName = (columnKey: string): TableColumnSlotName => {
+  return `column-${columnKey}`
+}
 
 /**
  * To avoid requiring the consuming app to typecast if they want to use `row` or `column`

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -121,7 +121,7 @@
             >
               <span class="d-flex align-items-center">
                 <slot
-                  :column="column"
+                  :column="getGeneric(column)"
                   :name="`column-${column.key}`"
                 >
                   <span :class="{'sr-only': column.hideLabel}">
@@ -523,12 +523,12 @@ const nextPageClicked = ref(false)
 const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
 
 /**
- * To avoid requiring the consuming app to typecast if they want to use `row`,
- * we will strip the types to something generic before we put it in the slot for use.
- * @param row The object to strip the type from
+ * To avoid requiring the consuming app to typecast if they want to use `row` or `column`
+ * we strip the types to something generic before we put it in the slot for use.
+ * @param obj The object to strip the type from
  */
-const getGeneric = (row: Record<string, any>) => {
-  return row as unknown as any
+const getGeneric = (obj: Record<string, any>): any => {
+  return obj as unknown as any
 }
 
 /**

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -159,7 +159,7 @@
             >
               <slot
                 :name="value.key"
-                :row="row"
+                :row="getGeneric(row)"
                 :row-key="rowIndex"
                 :row-value="row[value.key]"
               >
@@ -521,6 +521,15 @@ const isClickable = ref(false)
 const hasInitialized = ref(false)
 const nextPageClicked = ref(false)
 const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
+
+/**
+ * To avoid requiring the consuming app to type cast if they want to use row,
+ * we will strip the types to something generic before we put it in the slot for use.
+ * @param row The object to strip the type from
+ */
+const getGeneric = (row: Record<string, any>) => {
+  return row as unknown as Object
+}
 
 /**
  * Grabs listeners from attrs matching a prefix to attach the

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -523,7 +523,7 @@ const nextPageClicked = ref(false)
 const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
 
 /**
- * To avoid requiring the consuming app to type cast if they want to use row,
+ * To avoid requiring the consuming app to typecast if they want to use `row`,
  * we will strip the types to something generic before we put it in the slot for use.
  * @param row The object to strip the type from
  */

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -16,3 +16,5 @@ export interface TableHeader {
   hideLabel?: boolean
   useSortHandlerFn?: boolean
 }
+
+export type TableColumnSlotName = `column-${string}`

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -17,4 +17,10 @@ export interface TableHeader {
   useSortHandlerFn?: boolean
 }
 
+/**
+ * Provide a type interface for KTable `column-*` slot names.
+ *
+ * This helps TypeScript infer the slot name in the template section so that
+ * the slot props can be resolved.
+ */
 export type TableColumnSlotName = `column-${string}`


### PR DESCRIPTION
# Summary

Return a typeof `any` for `row` and `column` slot props to prevent having to explicitly typecast in host applications. Also adds a column slot name type interface to properly resolve the slots in the template along with the corresponding slot props.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
