### PR TITLE
chore: catch and fail CI when PR preview publishing fails [KHCP-7061]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version  --yes --amend
 
           npm_instructions=""
-          rm .npmrc
+
           pkg=$(npm publish  --no-git-checks --access public --report-summary --tag "${tag}" | grep "+ "| sed 's/+ //')
 
           if [[ -z "${pkg}" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,14 @@ jobs:
           yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version  --yes --amend
 
           npm_instructions=""
+          rm .npmrc
           pkg=$(npm publish  --no-git-checks --access public --report-summary --tag "${tag}" | grep "+ "| sed 's/+ //')
+
+          if [[ -z "${pkg}" ]]; then
+            echo "Error publishing package"
+            exit -1
+          fi
+
           npm_instructions="@$(echo ${pkg}|cut -d'@' -f2)@${tag}"
 
           echo "npm_instructions<<EOF" >> $GITHUB_ENV


### PR DESCRIPTION
# Summary

when PR preview publish fails - entire PR ci should fail

![image](https://user-images.githubusercontent.com/4562608/233197278-4d11db3b-3589-4820-9408-c0bcda5d7e95.png)
