### PR TITLE
fix(kmodalfullscreen): fix header layout on small screen

### DIFF
--- a/src/components/KModalFullscreen/KModalFullscreen.vue
+++ b/src/components/KModalFullscreen/KModalFullscreen.vue
@@ -362,9 +362,9 @@ $fullscreen-modal-padding: 64px;
   padding-top: 0;
 
   .body-header {
-    font-size: 32px;
+    font-size: var(--type-xxxl, type(xxxl));
     font-weight: 600;
-    line-height: 32px;
+    line-height: var(--type-xxxl, type(xxxl));
     margin-bottom: -4px;
   }
 
@@ -372,7 +372,7 @@ $fullscreen-modal-padding: 64px;
     color: var(--grey-600);
     font-size: 14px;
     font-weight: 400;
-    line-height: 22px;
+    line-height: var(--type-xl, type(xl));
     margin-top: var(--spacing-md);
   }
 }

--- a/src/components/KModalFullscreen/KModalFullscreen.vue
+++ b/src/components/KModalFullscreen/KModalFullscreen.vue
@@ -229,7 +229,7 @@ onUnmounted(() => {
 <style lang="scss" scoped>
 @import '@/styles/variables';
 @import '@/styles/functions';
-$screen-md: 992px;
+$kmodalfullscreen-viewport-md: 992px;
 $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-dialog {
@@ -243,14 +243,14 @@ $fullscreen-modal-padding: 64px;
   width: 100vw;
   z-index: 9999;
 
-  @media (min-width: ($viewport-md)) {
+  @media (min-width: $viewport-md) {
     padding-top: $fullscreen-modal-padding;
   }
 
   &.has-footer {
     padding-bottom: $fullscreen-modal-padding * 2;
 
-    @media (min-width: ($viewport-md)) {
+    @media (min-width: $viewport-md) {
       padding-bottom: $fullscreen-modal-padding;
     }
     .k-modal-fullscreen-header {
@@ -278,7 +278,7 @@ $fullscreen-modal-padding: 64px;
     font-weight: var(--KModalFullscreenHeaderWeight, 600);
     justify-content: space-between;
 
-    @media (min-width: ($viewport-md)) {
+    @media (min-width: $viewport-md) {
       flex-direction: row;
     }
   }
@@ -305,7 +305,7 @@ $fullscreen-modal-padding: 64px;
   margin-bottom: var(--spacing-xs, spacing(xs));
   position: relative;
 
-  @media (min-width: ($viewport-md)) {
+  @media (min-width: $viewport-md) {
     justify-content: flex-start;
     margin-bottom: 0;
     margin-left: 36px;
@@ -326,7 +326,7 @@ $fullscreen-modal-padding: 64px;
     margin-left: var(--spacing-md, spacing(md));
   }
 
-  @media (min-width: ($viewport-md)) {
+  @media (min-width: $viewport-md) {
     justify-content: flex-end;
   }
 }
@@ -337,12 +337,12 @@ $fullscreen-modal-padding: 64px;
   padding-left: var(--spacing-lg);
   padding-right: var(--spacing-lg);
 
-  @media (min-width: ($viewport-md)) {
+  @media (min-width: $viewport-md) {
     padding-left: 120px;
     padding-right: 120px;
   }
 
-  @media (min-width: ($screen-md)) {
+  @media (min-width: $kmodalfullscreen-viewport-md) {
     padding-left: 230px;
     padding-right: 230px;
   }
@@ -350,7 +350,7 @@ $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-body {
   padding-bottom: var(--spacing-lg);
-  @media (min-width: ($viewport-md)) {
+  @media (min-width: $viewport-md) {
     padding-bottom: $fullscreen-modal-padding;
   }
 }
@@ -399,7 +399,7 @@ $fullscreen-modal-padding: 64px;
     margin-left: var(--spacing-md, spacing(md));
   }
 
-  @media (min-width: ($viewport-md)) {
+  @media (min-width: $viewport-md) {
     margin-left: auto;
   }
 }

--- a/src/components/KModalFullscreen/KModalFullscreen.vue
+++ b/src/components/KModalFullscreen/KModalFullscreen.vue
@@ -243,14 +243,14 @@ $fullscreen-modal-padding: 64px;
   width: 100vw;
   z-index: 9999;
 
-  @media (min-width: ($viewport-md + 1px)) {
+  @media (min-width: ($viewport-md)) {
     padding-top: $fullscreen-modal-padding;
   }
 
   &.has-footer {
     padding-bottom: $fullscreen-modal-padding * 2;
 
-    @media (min-width: ($viewport-md + 1px)) {
+    @media (min-width: ($viewport-md)) {
       padding-bottom: $fullscreen-modal-padding;
     }
     .k-modal-fullscreen-header {
@@ -337,12 +337,12 @@ $fullscreen-modal-padding: 64px;
   padding-left: var(--spacing-lg);
   padding-right: var(--spacing-lg);
 
-  @media (min-width: ($viewport-md + 1px)) {
+  @media (min-width: ($viewport-md)) {
     padding-left: 120px;
     padding-right: 120px;
   }
 
-  @media (min-width: ($screen-md + 1px)) {
+  @media (min-width: ($screen-md)) {
     padding-left: 230px;
     padding-right: 230px;
   }
@@ -350,7 +350,7 @@ $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-body {
   padding-bottom: var(--spacing-lg);
-  @media (min-width: ($viewport-md + 1px)) {
+  @media (min-width: ($viewport-md)) {
     padding-bottom: $fullscreen-modal-padding;
   }
 }

--- a/src/components/KModalFullscreen/KModalFullscreen.vue
+++ b/src/components/KModalFullscreen/KModalFullscreen.vue
@@ -273,9 +273,14 @@ $fullscreen-modal-padding: 64px;
   .k-modal-fullscreen-header-description {
     color: var(--KModalFullscreenHeaderColor, var(--black-500, color(black-500)));
     display: flex;
+    flex-direction: column;
     font-size: var(--KModalFullscreenHeaderSize, 20px);
     font-weight: var(--KModalFullscreenHeaderWeight, 600);
     justify-content: space-between;
+
+    @media only screen and (min-width: ($viewport-md)) {
+      flex-direction: row;
+    }
   }
 }
 
@@ -296,12 +301,20 @@ $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-title {
   display: inline-flex;
-  margin-left: 36px;
+  justify-content: center;
+  margin-bottom: var(--spacing-xs, spacing(xs));
   position: relative;
+
+  @media only screen and (min-width: ($viewport-md)) {
+    justify-content: flex-start;
+    margin-bottom: 0;
+    margin-left: 36px;
+  }
 }
 
 .k-modal-fullscreen-action {
   display: inline-flex;
+  justify-content: center;
   margin-right: var(--spacing-xl, spacing(xl));
 
   & button,
@@ -311,6 +324,10 @@ $fullscreen-modal-padding: 64px;
     height: 40px;
     line-height: 13px;
     margin-left: var(--spacing-md, spacing(md));
+  }
+
+  @media only screen and (min-width: ($viewport-md)) {
+    justify-content: flex-end;
   }
 }
 
@@ -377,11 +394,13 @@ $fullscreen-modal-padding: 64px;
 }
 
 .k-modal-fullscreen-action-buttons {
-  margin-left: auto;
-
   button,
   :deep(button) {
     margin-left: var(--spacing-md, spacing(md));
+  }
+
+  @media only screen and (min-width: ($viewport-md)) {
+    margin-left: auto;
   }
 }
 </style>

--- a/src/components/KModalFullscreen/KModalFullscreen.vue
+++ b/src/components/KModalFullscreen/KModalFullscreen.vue
@@ -243,14 +243,14 @@ $fullscreen-modal-padding: 64px;
   width: 100vw;
   z-index: 9999;
 
-  @media only screen and (min-width: ($viewport-md + 1px)) {
+  @media (min-width: ($viewport-md + 1px)) {
     padding-top: $fullscreen-modal-padding;
   }
 
   &.has-footer {
     padding-bottom: $fullscreen-modal-padding * 2;
 
-    @media only screen and (min-width: ($viewport-md + 1px)) {
+    @media (min-width: ($viewport-md + 1px)) {
       padding-bottom: $fullscreen-modal-padding;
     }
     .k-modal-fullscreen-header {
@@ -278,7 +278,7 @@ $fullscreen-modal-padding: 64px;
     font-weight: var(--KModalFullscreenHeaderWeight, 600);
     justify-content: space-between;
 
-    @media only screen and (min-width: ($viewport-md)) {
+    @media (min-width: ($viewport-md)) {
       flex-direction: row;
     }
   }
@@ -305,7 +305,7 @@ $fullscreen-modal-padding: 64px;
   margin-bottom: var(--spacing-xs, spacing(xs));
   position: relative;
 
-  @media only screen and (min-width: ($viewport-md)) {
+  @media (min-width: ($viewport-md)) {
     justify-content: flex-start;
     margin-bottom: 0;
     margin-left: 36px;
@@ -326,7 +326,7 @@ $fullscreen-modal-padding: 64px;
     margin-left: var(--spacing-md, spacing(md));
   }
 
-  @media only screen and (min-width: ($viewport-md)) {
+  @media (min-width: ($viewport-md)) {
     justify-content: flex-end;
   }
 }
@@ -337,12 +337,12 @@ $fullscreen-modal-padding: 64px;
   padding-left: var(--spacing-lg);
   padding-right: var(--spacing-lg);
 
-  @media only screen and (min-width: ($viewport-md + 1px)) {
+  @media (min-width: ($viewport-md + 1px)) {
     padding-left: 120px;
     padding-right: 120px;
   }
 
-  @media only screen and (min-width: ($screen-md + 1px)) {
+  @media (min-width: ($screen-md + 1px)) {
     padding-left: 230px;
     padding-right: 230px;
   }
@@ -350,7 +350,7 @@ $fullscreen-modal-padding: 64px;
 
 .k-modal-fullscreen-body {
   padding-bottom: var(--spacing-lg);
-  @media only screen and (min-width: ($viewport-md + 1px)) {
+  @media (min-width: ($viewport-md + 1px)) {
     padding-bottom: $fullscreen-modal-padding;
   }
 }
@@ -399,7 +399,7 @@ $fullscreen-modal-padding: 64px;
     margin-left: var(--spacing-md, spacing(md));
   }
 
-  @media only screen and (min-width: ($viewport-md)) {
+  @media (min-width: ($viewport-md)) {
     margin-left: auto;
   }
 }


### PR DESCRIPTION
# Summary

Fixes KModalFullscreen header layout on small screen.

Before:
![Screen Shot 2023-04-20 at 4 22 48 PM](https://user-images.githubusercontent.com/36751160/233482270-ad0a6151-1bb7-40bd-b84c-810176818d44.png)

After:
![Screen Shot 2023-04-20 at 4 21 27 PM](https://user-images.githubusercontent.com/36751160/233482194-d3440d50-a591-4422-aba3-a6fef85039ac.png)

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
