### PR TITLE
fix(kpop): camel case placement

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -355,7 +355,7 @@ export default defineComponent({
       // destroy any previous poppers before creating new one
       this.destroy()
       this.showPopper()
-      const placement = this.placement || 'auto'
+      const placement = (this.placement || 'auto').replace(/[A-Z]/g, '-$&').toLowerCase()
       const popperEl = this.$refs.popper
       const theTarget = (this.target && !this.isSvg && !!document.querySelector(this.target))
         ? document.querySelector(this.target)


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

### Problem

![Kapture 2023-04-21 at 15 59 09](https://user-images.githubusercontent.com/10095631/233578605-f2effbe3-329d-4180-b583-645eb3e58c01.gif)

`KPop` with a two-word `placement` (e.g. `topStart `, `rightEnd `, etc.) has wrong position. This is observed in the `shared-ui-components` [CI](https://github.com/Kong/shared-ui-components/actions/runs/4762038683/jobs/8463884724?pr=760).

### Cause

In `src/components/KPop/KPop.vue`, `this.placement` is a camel case string, but `new Popper()` expects the `placement` field to be a kebab case string. There used to be [a map](https://github.com/Kong/kongponents/blob/1b025bd36523001275908d95ef7bd1253d30cad2/src/components/KPop/KPop.vue#L125-L139) to do the case transformation, but it was removed in #1292.

### Fix

Convert `placement` to kebab case before passing it to `new Popper()`.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
