### PR TITLE
fix(klabel): tooltip trigger

### DIFF
--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -2,54 +2,25 @@
   <label
     class="k-input-label"
   >
+    <slot />
+    <span
+      v-if="required"
+      class="is-required"
+    >*</span>
     <KTooltip
-      v-if="help"
+      v-if="help || info"
       v-bind="tooltipAttributes"
       class="label-tooltip"
-      :label="help"
+      :label="help || info"
       position-fixed
       :test-mode="!!testMode || undefined"
     >
-      <slot />
-      <span
-        v-if="required"
-        class="is-required"
-      >*</span>
       <KIcon
         hide-title
-        icon="help"
+        :icon="help ? 'help' : 'info'"
         size="16"
       />
     </KTooltip>
-
-    <KTooltip
-      v-else-if="info"
-      v-bind="tooltipAttributes"
-      class="label-tooltip"
-      :label="info"
-      position-fixed
-      :test-mode="!!testMode || undefined"
-    >
-      <slot />
-      <span
-        v-if="required"
-        class="is-required"
-      >*</span>
-      <KIcon
-        hide-title
-        icon="info"
-        size="16"
-        view-box="0 0 16 16"
-      />
-    </KTooltip>
-
-    <span v-else>
-      <slot />
-      <span
-        v-if="required"
-        class="is-required"
-      >*</span>
-    </span>
   </label>
 </template>
 
@@ -103,6 +74,7 @@ export default defineComponent({
       &.kong-icon-help,
       &.kong-icon-info {
         cursor: pointer;
+        height: 16px;
       }
     }
 

--- a/src/styles/forms/_labels.scss
+++ b/src/styles/forms/_labels.scss
@@ -1,6 +1,6 @@
 .k-input-label {
   color: var(--KInputLabelColor, var(--black-85));
-  display: inline-block;
+  display: inline-flex;
   font-family: var(--KInputLabelFont, var(--font-family-sans, font(sans)));
   font-size: var(--KInputLabelSize, var(--type-sm, type(sm)));
   font-weight: var(--KInputLabelWeight, 600);


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a bug that the help/info tooltip only appears when hovering over the `*` mark.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
