### PR TITLE
fix(kpop): fix default max width according to docs

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -187,7 +187,7 @@ export default defineComponent({
      */
     maxWidth: {
       type: String,
-      default: '350',
+      default: 'auto',
     },
     /**
      * The maxHeight of the Popover body - undocumented and only used within KSelect


### PR DESCRIPTION
# Summary

Fix `KPop` default `maxWidth` prop value according to docs:
> The max width of the popover body - by default it is auto.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
