### PR TITLE
fix: revert datetimepicker popover to original width [MA-1654]

### DIFF
--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -604,7 +604,6 @@ $margin: 6px;
     max-height: 90vh;
     overflow: hidden;
     padding: var(--spacing-sm);
-    width: 100% !important;
     &[x-placement^=bottom] {
       margin-top: 2px;
     }

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -602,6 +602,7 @@ $margin: 6px;
 
   .k-popover {
     max-height: 90vh;
+    max-width: 350px;
     overflow: hidden;
     padding: var(--spacing-sm);
     &[x-placement^=bottom] {


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-1654

Deploy Preview:

https://deploy-preview-1339--kongponents.netlify.app/components/datetime-picker.html#custom-date-and-relative-time-frames

`max-width` property applied in kongponents was forcing the timepicker to expand to full width. This PR should fix things both in Kongponents and in consuming apps.

<img width="682" alt="Screenshot 2023-05-01 at 2 09 55 PM" src="https://user-images.githubusercontent.com/103061463/235503571-bbb346ea-09b2-44d9-be81-0b3f3887cb88.png">


## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
