### PR TITLE
fix(kdropdownitem): not registering KButton locally

### DIFF
--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -22,6 +22,7 @@
 
 <script lang="ts" setup>
 import { DropdownItem, DropdownItemRenderedRecord, DropdownItemRenderedType, DropdownItemType } from '@/types'
+import KButton from '@/components/KButton/KButton.vue'
 import { computed, PropType } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -132,7 +133,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     },
   },
   button: {
-    tag: 'KButton',
+    tag: KButton,
     onClick: handleClick,
     attrs: {
       class: 'k-dropdown-item-trigger btn-link k-button non-visual-button',

--- a/src/types/dropdown-menu.ts
+++ b/src/types/dropdown-menu.ts
@@ -1,4 +1,5 @@
 import { AnyElementOf } from '@/types'
+import { Component } from 'vue'
 
 export interface DropdownItem {
   label: string
@@ -18,7 +19,7 @@ export type DropdownItemType = 'link' | 'button' | 'default'
 export type DropdownItemRenderedType = 'link' | 'router-link' | 'button' | 'div'
 
 export interface DropdownItemRenderedComponent {
-  tag: string
+  tag: string | Component
   onClick?: ((event: Event) => void)
   attrs: {
     class?: string


### PR DESCRIPTION
# Summary

Fixes an issue with KDropdownItem not registering KButton locally which causes the component to be treated as a plain custom element when Kongponents aren’t registered globally.

Fixes #1347.
## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
