### PR TITLE
feat(kinput): slot tooltip [khcp-7093]

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -317,7 +317,7 @@ If you want to utilize HTML in the input label's tooltip, use the slot.
 ```
 
 :::tip Note:
-By default, when using the `label-tooltip` slot the `info` `KIcon` will be shown, but you can get the `help` icon to display instead by setting the `label-attributes` `help` prop to any non-empty string value.
+When utilizing the `label-tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
 :::
 
 <KInput label="My Tooltip" :label-attributes="{ help: 'true' }">

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -262,9 +262,12 @@ export default defineComponent({
 - `icon` - slot for icon on the left or right of the input (position can be controlled through [prop](#iconposition))
 - `label-tooltip` - slot for tooltip content if input has a label and label has tooltip (note: this slot overrides `help`/`info` content specified in `label-attributes` and is not available with `overlayLabel`)
 
+### `icon`
+
 :::tip TIP
 Whether you choose to use `KIcon` Kongponent or your own SVG, the component's styles will adjust the icon size to match the size of the component.
 :::
+
 
 <KInput placeholder="Search" size="small" class="mb-2">
   <template #icon>
@@ -303,6 +306,8 @@ Whether you choose to use `KIcon` Kongponent or your own SVG, the component's st
   </template>
 </KInput>
 ```
+
+### `label-tooltip`
 
 If you want to utilize HTML in the input label's tooltip, use the slot.
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -44,12 +44,12 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop.
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
 <KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' }"/>
 
 ```html
-<KInput label="Name" :label-attributes="{   help: 'I use the KLabel `help` prop' }" />
+<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 ```
 
 ### overlayLabel
@@ -260,6 +260,7 @@ export default defineComponent({
 ## Slots
 
 - `icon` - slot for icon on the left or right of the input (position can be controlled through [prop](#iconposition))
+- `label-tooltip` - slot for tooltip content if input has a label and label has tooltip (note: this slot is not available for `overlayLabel`)
 
 :::tip TIP
 Whether you choose to use `KIcon` Kongponent or your own SVG, the component's styles will adjust the icon size to match the size of the component.
@@ -300,6 +301,18 @@ Whether you choose to use `KIcon` Kongponent or your own SVG, the component's st
   <template #icon>
     <KIcon icon="search" />
   </template>
+</KInput>
+```
+
+If you want custom HTML in the input label's tooltip, use the slot.
+
+<KInput label="My Tooltip">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KInput>
+
+```html
+<KInput label="My Tooltip">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
 </KInput>
 ```
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -304,7 +304,7 @@ Whether you choose to use `KIcon` Kongponent or your own SVG, the component's st
 </KInput>
 ```
 
-If you want custom HTML in the input label's tooltip, use the slot.
+If you want to utilize HTML in the input label's tooltip, use the slot.
 
 <KInput label="My Tooltip">
   <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -260,7 +260,7 @@ export default defineComponent({
 ## Slots
 
 - `icon` - slot for icon on the left or right of the input (position can be controlled through [prop](#iconposition))
-- `label-tooltip` - slot for tooltip content if input has a label and label has tooltip (note: this slot is not available for `overlayLabel`)
+- `label-tooltip` - slot for tooltip content if input has a label and label has tooltip (note: this slot overrides `help`/`info` content specified in `label-attributes` and is not available with `overlayLabel`)
 
 :::tip TIP
 Whether you choose to use `KIcon` Kongponent or your own SVG, the component's styles will adjust the icon size to match the size of the component.
@@ -312,6 +312,20 @@ If you want to utilize HTML in the input label's tooltip, use the slot.
 
 ```html
 <KInput label="My Tooltip">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KInput>
+```
+
+:::tip Note:
+By default, when using the `label-tooltip` slot the `info` `KIcon` will be shown, but you can get the `help` icon to display instead by setting the `label-attributes` `help` prop to any non-empty string value.
+:::
+
+<KInput label="My Tooltip" :label-attributes="{ help: 'true' }">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KInput>
+
+```html
+<KInput label="My Tooltip" :label-attributes="{ help: 'true' }">
   <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
 </KInput>
 ```

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -79,10 +79,10 @@ Use the `for` attribute to bind a label to an input element for accessibility.
 
 ## Slots
 
-- `tooltip` - Rather than using the `help` or `info` props, if you want to style the tooltip content you can use this slot.
+- `tooltip` - Rather than using the `help` or `info` props, if you need to utilize HTML in the tooltip, you may use the `tooltip` slot.
 
 :::tip Note:
-By default, when using the `tooltip` slot the `info` `KIcon` will be shown, but you can get the `help` icon to display instead by setting the `help` prop to any non-empty string value.
+When utilizing the `label-tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
 :::
 
 <KLabel help="true">

--- a/docs/components/label.md
+++ b/docs/components/label.md
@@ -77,18 +77,41 @@ Use the `for` attribute to bind a label to an input element for accessibility.
 <KInput id="service"/>
 ```
 
+## Slots
+
+- `tooltip` - Rather than using the `help` or `info` props, if you want to style the tooltip content you can use this slot.
+
+:::tip Note:
+By default, when using the `tooltip` slot the `info` `KIcon` will be shown, but you can get the `help` icon to display instead by setting the `help` prop to any non-empty string value.
+:::
+
+<KLabel help="true">
+  My Tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KLabel>
+<KInput />
+
+```html
+<KLabel help="true">
+  My Tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KLabel>
+<KInput />
+```
+
+
 ## Theming
 
-| Variable                          | Purpose                          |
-| :-------------------------------- | :------------------------------- |
-| `--KInputLabelColor`              | Label text color                 |
-| `--KLabelRequiredAsteriskColor`   | Label required '*' color         |
-| `--KInputLabelFont`               | Label font                       |
-| `--KInputLabelSize`               | Label text size                  |
-| `--KInputLabelWeight`             | Label font weight                |
-| `--KInputCheckboxLabel`           | Checkbox/radio label color       |
-| `--KInputCheckboxLabelFont`       | Checkbox/radio font              |
-| `--KInputCheckboxLabelSize`       | Checkbox/radio text size         |
+| Variable                        | Purpose                    |
+| :------------------------------ | :------------------------- |
+| `--KInputLabelColor`            | Label text color           |
+| `--KLabelRequiredAsteriskColor` | Label required '*' color   |
+| `--KInputLabelFont`             | Label font                 |
+| `--KInputLabelSize`             | Label text size            |
+| `--KInputLabelWeight`           | Label font weight          |
+| `--KInputCheckboxLabel`         | Checkbox/radio label color |
+| `--KInputCheckboxLabelFont`     | Checkbox/radio font        |
+| `--KInputCheckboxLabelSize`     | Checkbox/radio text size   |
 
 An example of theming the label might look like:
 

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -84,7 +84,7 @@ describe('KInput', () => {
         label,
       },
       slots: {
-        tooltip: () => h('div', {}, 'This is a tooltip'),
+        'label-tooltip': () => h('div', {}, 'This is a tooltip'),
       },
     })
 

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -74,9 +74,22 @@ describe('KInput', () => {
 
     cy.get('.k-input-label').should('contain.text', label)
     cy.get('.k-input-label .kong-icon-help').should('exist').and('be.visible')
+  })
 
-    // expect(wrapper.find('.k-input-label').element.innerHTML).toContain(labelText)
-    // expect(wrapper.find('.k-input-label .kong-icon-help').exists()).toBeTruthy()
+  it('renders label and tooltip with `label-tooltip` slot applied', () => {
+    const label = 'A label'
+    mount(KInput, {
+      props: {
+        testMode: true,
+        label,
+      },
+      slots: {
+        tooltip: () => h('div', {}, 'This is a tooltip'),
+      },
+    })
+
+    cy.get('.k-input-label').should('contain.text', label)
+    cy.get('.k-input-label .kong-icon-info').should('exist').and('be.visible')
   })
 
   it('renders overlayed label when value is passed', () => {

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -52,6 +52,13 @@
         :required="isRequired"
       >
         {{ strippedLabel }}
+
+        <template
+          v-if="hasLabelTooltip"
+          #tooltip
+        >
+          <slot name="label-tooltip" />
+        </template>
       </KLabel>
       <input
         v-bind="modifiedAttrs"
@@ -111,7 +118,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, watch, onMounted, PropType } from 'vue'
+import { defineComponent, computed, ref, watch, onMounted, PropType, useSlots } from 'vue'
 import type { IconPosition, Size, LabelAttributes, SizeRecord, IconPositionRecord } from '@/types'
 import { v1 as uuidv1 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
@@ -198,12 +205,14 @@ export default defineComponent({
     const isHovered = ref<boolean>(false)
     const icon = ref<HTMLDivElement | null>(null)
     const { stripRequiredLabel } = useUtilities()
+    const slots = useSlots()
 
     const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
     const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
     const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
     const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-input-id-1234' : uuidv1())
     const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
+    const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.help || props.labelAttributes?.info || slots['label-tooltip']))
     // we need this so we can create a watcher for programmatic changes to the modelValue
     const value = computed({
       get(): string | number {
@@ -318,6 +327,7 @@ export default defineComponent({
       isDisabled,
       isReadonly,
       isRequired,
+      hasLabelTooltip,
       inputId,
       strippedLabel,
       charLimitExceeded,

--- a/src/components/KLabel/KLabel.cy.ts
+++ b/src/components/KLabel/KLabel.cy.ts
@@ -1,5 +1,6 @@
 import { mount } from 'cypress/vue'
 import KLabel from '@/components/KLabel/KLabel.vue'
+import { h } from 'vue'
 
 /**
  * ALL TESTS MUST USE testMode: true
@@ -60,6 +61,20 @@ describe('KLabel', () => {
       },
       slots: {
         default: () => 'Full Name',
+      },
+    })
+
+    cy.get('.k-input-label .label-tooltip').should('not.be.empty')
+  })
+
+  it('renders a tooltip when `tooltip` slot is used', () => {
+    mount(KLabel, {
+      props: {
+        testMode: true,
+      },
+      slots: {
+        default: () => 'Full Name',
+        tooltip: () => h('div', {}, 'This is a tooltip'),
       },
     })
 

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -8,10 +8,9 @@
       class="is-required"
     >*</span>
     <KTooltip
-      v-if="help || info"
+      v-if="hasTooltip"
       v-bind="tooltipAttributes"
       class="label-tooltip"
-      :label="help || info"
       position-fixed
       :test-mode="!!testMode || undefined"
     >
@@ -20,48 +19,48 @@
         :icon="help ? 'help' : 'info'"
         size="16"
       />
+      <template #content>
+        <slot name="tooltip">{{ help || info }}</slot>
+      </template>
     </KTooltip>
   </label>
 </template>
 
-<script lang="ts">
-import { defineComponent, PropType } from 'vue'
+<script setup lang="ts">
+import { computed, PropType, useSlots } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import type { TooltipAttributes } from '@/types'
 
-export default defineComponent({
-  name: 'KLabel',
-  components: {
-    KIcon,
-    KTooltip,
+const props = defineProps({
+  help: {
+    type: String,
+    default: '',
   },
-  props: {
-    help: {
-      type: String,
-      default: '',
-    },
-    info: {
-      type: String,
-      default: '',
-    },
-    required: {
-      type: Boolean,
-      default: false,
-    },
-    tooltipAttributes: {
-      type: Object as PropType<TooltipAttributes>,
-      default: () => ({}),
-    },
-    /**
+  info: {
+    type: String,
+    default: '',
+  },
+  required: {
+    type: Boolean,
+    default: false,
+  },
+  tooltipAttributes: {
+    type: Object as PropType<TooltipAttributes>,
+    default: () => ({}),
+  },
+  /**
      * Test mode - for testing only, strips out generated ids
      */
-    testMode: {
-      type: Boolean,
-      default: false,
-    },
+  testMode: {
+    type: Boolean,
+    default: false,
   },
 })
+
+const slots = useSlots()
+
+const hasTooltip = computed((): boolean => !!(props.info || props.help || slots.tooltip))
 </script>
 
 <style lang="scss" scoped>
@@ -80,6 +79,11 @@ export default defineComponent({
 
     :deep(.k-tooltip) {
       font-weight: 400;
+
+      code {
+        background-color: var(--grey-500);
+        color: var(--white);
+      }
     }
   }
 }

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -81,8 +81,8 @@ const hasTooltip = computed((): boolean => !!(props.info || props.help || slots.
       font-weight: 400;
 
       code {
-        background-color: var(--grey-500);
-        color: var(--white);
+        background-color: var(--grey-500, color(grey-500));
+        color: var(--white, #fff);
       }
     }
   }


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Allow slotting a `KInput` label's tooltip content (also support at `KLabel` level) for [KHCP-7093](https://konghq.atlassian.net/browse/KHCP-7093).

![image](https://user-images.githubusercontent.com/67973710/235971657-436746a2-7748-4b99-be92-bdde2a4f93c9.png)


## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-7093]: https://konghq.atlassian.net/browse/KHCP-7093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ