### PR TITLE
fix(kpagination): change order so background color styling is applied

### DIFF
--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -453,7 +453,7 @@ export default defineComponent({
     }
 
     &.active {
-      background-color: var(--KPaginationActiveBackgroundColor, var(—-blue-100, color(blue-100)));
+      background-color: var(--KPaginationActiveBackgroundColor, var(--blue-100, color(blue-100)));
       border-color: var(--KPaginationActiveBorderColor, var(--blue-200));
       border-radius: 4px;
       color: var(--KPaginationActiveColor, var(--blue-500));

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -453,8 +453,7 @@ export default defineComponent({
     }
 
     &.active {
-      background-color: var(--blue-100);
-      background-color: var(--KPaginationActiveBackgroundColor, var(--blue-100));
+      background-color: var(--KPaginationActiveBackgroundColor, var(—-blue-100, color(blue-100)));
       border-color: var(--KPaginationActiveBorderColor, var(--blue-200));
       border-radius: 4px;
       color: var(--KPaginationActiveColor, var(--blue-500));

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -453,8 +453,8 @@ export default defineComponent({
     }
 
     &.active {
-      background-color: var(--KPaginationActiveBackgroundColor, var(--blue-100));
       background-color: var(--blue-100);
+      background-color: var(--KPaginationActiveBackgroundColor, var(--blue-100));
       border-color: var(--KPaginationActiveBorderColor, var(--blue-200));
       border-radius: 4px;
       color: var(--KPaginationActiveColor, var(--blue-500));


### PR DESCRIPTION
# Summary
Order needs to be adjusted so that the styling from the CSS var is actually being used. Otherwise in its current order, the default color overrides it even if it is set.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
