### PR TITLE
feat(inputs): add label tooltip slot support

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -151,7 +151,7 @@ The label for the select.
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop.
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
 <ClientOnly>
   <KMultiselect label="Name" :label-attributes="{
@@ -597,11 +597,48 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 
 ## Slots
 
+- `label-tooltip` - slot for tooltip content if multiselect has a label and label has tooltip (note: this slot overrides `help`/`info` content specified in `label-attributes`)
 - `item-template` - The template for each item in the dropdown list
 - `empty` - Slot for the empty state in the dropdown list
 - `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
 
-### Item Template
+### `label-tooltip`
+
+If you want to utilize HTML in the multiselect label's tooltip, use the slot.
+
+<ClientOnly>
+  <KMultiselect label="My Tooltip" :items="deepClone(defaultItems)">
+    <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+  </KMultiselect>
+</ClientOnly>
+
+```html
+<KMultiselect label="My Tooltip" :items="items">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KMultiselect>
+```
+
+:::tip Note:
+When utilizing the `label-tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
+:::
+
+<ClientOnly>
+  <KMultiselect label="My Tooltip" :label-attributes="{ help: 'true' }" :items="deepClone(defaultItems)">
+    <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+  </KMultiselect>
+</ClientOnly>
+
+```html
+<KMultiselect
+  label="My Tooltip"
+  :label-attributes="{ help: 'true' }"
+  :items="items"
+>
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KMultiselect>
+```
+
+### `item-template`
 
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
@@ -658,11 +695,11 @@ export default defineComponent({
 </script>
 ```
 
-### Empty State
+### `empty`
 
 You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
 
-### Dropdown Footer Text
+### `dropdown-footer-text`
 
 Slot the content of the dropdown footer text. This slot will override the `dropdownFooterText` prop if provided.
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -87,7 +87,7 @@ Enable this prop to overlay the label on the input element's border for `select`
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop.
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
 <ClientOnly>
   <KSelect label="Name" :label-attributes="{
@@ -588,13 +588,50 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 
 ## Slots
 
+- `label-tooltip` - slot for tooltip content if select has a label and label has tooltip (note: this slot overrides `help`/`info` content specified in `label-attributes`)
 - `item-template` - The template for each item in the dropdown list
 - `selected-item-template` - Slot for customizing selected item appearance
 - `loading` - Slot for the loading indicator
 - `empty` - Slot for the empty state in the dropdown list
 - `dropdown-footer-text` - Slot for footer text in the bottom of the dropdown
 
-### Item Template
+### `label-tooltip`
+
+If you want to utilize HTML in the select label's tooltip, use the slot.
+
+<ClientOnly>
+  <KSelect label="My Tooltip" :items="deepClone(defaultItems)">
+    <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect label="My Tooltip" :items="items">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KSelect>
+```
+
+:::tip Note:
+When utilizing the `label-tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
+:::
+
+<ClientOnly>
+  <KSelect label="My Tooltip" :label-attributes="{ help: 'true' }" :items="deepClone(defaultItems)">
+    <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect
+  label="My Tooltip"
+  :label-attributes="{ help: 'true' }"
+  :items="items"
+>
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KSelect>
+```
+
+### `item-template`
 You can use the `item-template` slot to customize the look and feel of your items. Use slots to gain access to the `item` data.
 
 ::: tip TIP
@@ -652,7 +689,7 @@ export default defineComponent({
 </script>
 ```
 
-### Selected Item Template
+### `selected-item-template`
 
 Use this slot to customize appearance of the selected item that appears when the `KSelect` dropdown is not activated. If present, the slot content takes precedence over the [reuseItemTemplate](#reuseitemtemplate) prop.
 
@@ -698,15 +735,15 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
 </KSelect>
 ```
 
-### Loading
+### `loading`
 
 You can use the `loading` slot to customize the loading indicator. Note that this only applies when `autoggest` is `true`. See [autosuggest](#autosuggest) for an example of this slot.
 
-### Empty State
+### `empty`
 
 You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
 
-### Dropdown Footer Text
+### `dropdown-footer-text`
 
 Slot the content of the dropdown footer text. This slot will override the `dropdownFooterText` prop if provided.
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -32,7 +32,7 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop.
+Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
 <KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
 
@@ -154,6 +154,39 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 </KComponent>
 ```
 
+## Slots
+
+- `label-tooltip` - slot for tooltip content if textarea has a label and label has tooltip (note: this slot overrides `help`/`info` content specified in `label-attributes`)
+
+If you want to utilize HTML in the textarea label's tooltip, use the slot.
+
+<KTextArea label="My Tooltip">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KTextArea>
+
+```html
+<KTextArea label="My Tooltip">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KTextArea>
+```
+
+:::tip Note:
+When utilizing the `label-tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
+:::
+
+<KTextArea label="My Tooltip" :label-attributes="{ help: 'true' }">
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KTextArea>
+
+```html
+<KTextArea
+  label="My Tooltip"
+  :label-attributes="{ help: 'true' }"
+>
+  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+</KTextArea>
+```
+
 ## Events
 
 `KTextArea` has a couple of natural event bindings.
@@ -196,16 +229,16 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KInputColor` | Input text color
-| `--KInputBorder` | Input border / label color
-| `--KInputBackground` | Input and label background color
-| `--KInputHover` | Input border / label hover color
-| `--KInputFocus` | Input border / label focus color
-| `--KInputDisabledBackground` | Input disabled background color
-| `--KInputError` | Input error border color
-| `--KInputPlaceholderColor`| Placeholder text color
+| Variable                     | Purpose                          |
+| :--------------------------- | :------------------------------- |
+| `--KInputColor`              | Input text color                 |
+| `--KInputBorder`             | Input border / label color       |
+| `--KInputBackground`         | Input and label background color |
+| `--KInputHover`              | Input border / label hover color |
+| `--KInputFocus`              | Input border / label focus color |
+| `--KInputDisabledBackground` | Input disabled background color  |
+| `--KInputError`              | Input error border color         |
+| `--KInputPlaceholderColor`   | Placeholder text color           |
 
 An Example of changing the error border color of KInput to pink might look like:
 

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -120,7 +120,7 @@
 <script lang="ts">
 import { defineComponent, computed, ref, watch, onMounted, PropType, useSlots } from 'vue'
 import type { IconPosition, Size, LabelAttributes, SizeRecord, IconPositionRecord } from '@/types'
-import { v1 as uuidv1 } from 'uuid'
+import { v4 as uuidv4 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
 import KLabel from '@/components/KLabel/KLabel.vue'
 
@@ -210,7 +210,7 @@ export default defineComponent({
     const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
     const isReadonly = computed((): boolean => attrs?.readonly !== undefined && String(attrs?.readonly) !== 'false')
     const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
-    const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-input-id-1234' : uuidv1())
+    const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-input-id-1234' : uuidv4())
     const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
     const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.help || props.labelAttributes?.info || slots['label-tooltip']))
     // we need this so we can create a watcher for programmatic changes to the modelValue

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -12,6 +12,13 @@
       :required="isRequired"
     >
       {{ strippedLabel }}
+
+      <template
+        v-if="hasLabelTooltip"
+        #tooltip
+      >
+        <slot name="label-tooltip" />
+      </template>
     </KLabel>
     <div
       :id="multiselectId"
@@ -242,8 +249,8 @@
 </template>
 
 <script lang="ts">
-import { ref, Ref, computed, watch, PropType, nextTick, onMounted, useAttrs } from 'vue'
-import { v1 as uuidv1 } from 'uuid'
+import { ref, Ref, computed, watch, PropType, nextTick, onMounted, useAttrs, useSlots } from 'vue'
+import { v4 as uuidv4 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
 import KBadge from '@/components/KBadge/KBadge.vue'
 import KButton from '@/components/KButton/KButton.vue'
@@ -278,6 +285,8 @@ export default {
 
 <script setup lang="ts">
 const attrs = useAttrs()
+const slots = useSlots()
+
 const { getSizeFromString, cloneDeep, stripRequiredLabel } = useUtilities()
 const SELECTED_ITEMS_SINGLE_LINE_HEIGHT = 34
 
@@ -415,6 +424,7 @@ const emit = defineEmits(['selected', 'item:added', 'item:removed', 'input', 'ch
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
+const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.help || props.labelAttributes?.info || slots['label-tooltip']))
 const defaultKPopAttributes = {
   hideCaret: true,
   placement: 'bottomStart' as PopPlacements,
@@ -425,11 +435,11 @@ const defaultKPopAttributes = {
 // keys and ids
 const key = ref(0)
 const stagingKey = ref(0)
-const multiselectId = computed((): string => props.testMode ? 'test-multiselect-id-1234' : uuidv1())
-const multiselectInputId = computed((): string => props.testMode ? 'test-multiselect-input-id-1234' : uuidv1())
-const multiselectTextId = computed((): string => props.testMode ? 'test-multiselect-text-id-1234' : uuidv1())
-const multiselectSelectedItemsId = computed((): string => props.testMode ? 'test-multiselect-selected-id-1234' : uuidv1())
-const multiselectSelectedItemsStagingId = computed((): string => props.testMode ? 'test-multiselect-selected-staging-id-1234' : uuidv1())
+const multiselectId = computed((): string => props.testMode ? 'test-multiselect-id-1234' : uuidv4())
+const multiselectInputId = computed((): string => props.testMode ? 'test-multiselect-input-id-1234' : uuidv4())
+const multiselectTextId = computed((): string => props.testMode ? 'test-multiselect-text-id-1234' : uuidv4())
+const multiselectSelectedItemsId = computed((): string => props.testMode ? 'test-multiselect-selected-id-1234' : uuidv4())
+const multiselectSelectedItemsStagingId = computed((): string => props.testMode ? 'test-multiselect-selected-staging-id-1234' : uuidv4())
 const multiselectRef = ref(null)
 const selectionBottomRef = ref(null)
 // filter and selection
@@ -702,7 +712,7 @@ const handleAddItem = (): void => {
   const pos = unfilteredItems.value.length + 1
   const item:MultiselectItem = {
     label: filterStr.value + '',
-    value: props.testMode ? `test-multiselect-added-item-${pos}` : uuidv1(),
+    value: props.testMode ? `test-multiselect-added-item-${pos}` : uuidv4(),
     key: `${filterStr.value.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${pos}`,
   }
   emit('item:added', item)

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -12,6 +12,13 @@
       :required="isRequired"
     >
       {{ strippedLabel }}
+
+      <template
+        v-if="hasLabelTooltip"
+        #tooltip
+      >
+        <slot name="label-tooltip" />
+      </template>
     </KLabel>
     <div
       :id="selectId"
@@ -230,7 +237,7 @@
 
 <script lang="ts">
 import { ref, Ref, computed, watch, PropType, nextTick, useAttrs, useSlots } from 'vue'
-import { v1 as uuidv1 } from 'uuid'
+import { v4 as uuidv4 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
@@ -419,11 +426,12 @@ const slots = useSlots()
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
+const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.help || props.labelAttributes?.info || slots['label-tooltip']))
 const filterStr = ref('')
 const selectedItem = ref<SelectItem|null>(null)
-const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv1())
-const selectInputId = computed((): string => props.testMode ? 'test-select-input-id-1234' : uuidv1())
-const selectTextId = computed((): string => props.testMode ? 'test-select-text-id-1234' : uuidv1())
+const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv4())
+const selectInputId = computed((): string => props.testMode ? 'test-select-input-id-1234' : uuidv4())
+const selectTextId = computed((): string => props.testMode ? 'test-select-text-id-1234' : uuidv4())
 const selectItems: Ref<SelectItem[]> = ref([])
 const initialFocusTriggered: Ref<boolean> = ref(false)
 const inputFocused: Ref<boolean> = ref(false)

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -58,6 +58,13 @@
         :required="isRequired"
       >
         {{ strippedLabel }}
+
+        <template
+          v-if="hasLabelTooltip"
+          #tooltip
+        >
+          <slot name="label-tooltip" />
+        </template>
       </KLabel>
       <textarea
         v-bind="modifiedAttrs"
@@ -87,8 +94,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch, useAttrs } from 'vue'
-import { v1 as uuidv1 } from 'uuid'
+import { ref, computed, watch, useAttrs, useSlots } from 'vue'
+import { v4 as uuidv4 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
 import KLabel from '@/components/KLabel/KLabel.vue'
 
@@ -155,6 +162,7 @@ const emit = defineEmits<{
 }>()
 
 const attrs = useAttrs()
+const slots = useSlots()
 
 const { stripRequiredLabel } = useUtilities()
 
@@ -163,6 +171,7 @@ const currValue = ref('') // We need this so that we don't lose the updated valu
 const isFocused = ref(false)
 const isHovered = ref(false)
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
+const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.help || props.labelAttributes?.info || slots['label-tooltip']))
 // we need this so we can create a watcher for programmatic changes to the modelValue
 const value = computed({
   get(): string | number {
@@ -173,7 +182,7 @@ const value = computed({
   },
 })
 
-const textAreaId = computed((): string => (attrs.id ? String(attrs.id) : props.testMode ? 'test-textArea-id-1234' : uuidv1()))
+const textAreaId = computed((): string => (attrs.id ? String(attrs.id) : props.testMode ? 'test-textArea-id-1234' : uuidv4()))
 
 const modifiedAttrs = computed(() => {
   const $attrs = { ...attrs }


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add tooltip slot support to `KTextArea`, `KSelect`, and `KMultiselect`.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
