### PR TITLE
feat(ktable): provide swrv state in toolbar slot

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -323,7 +323,7 @@ Remember that the `fetcher` function is responsible for managing pagination/sort
 ```
 ### cacheIdentifier
 
-The fetcher functionality makes use of [SWRV](https://docs-swrv.netlify.app/) to handle caching of response data. In order to take advantage of this caching, SWRV needs a way to identify which cache entry is associated with the table. 
+The fetcher functionality makes use of [SWRV](https://docs-swrv.netlify.app/) to handle caching of response data. In order to take advantage of this caching, SWRV needs a way to identify which cache entry is associated with the table.
 
 The identifier should be a string and will default to `''` if not provided. In that scenario, we will generate a random ID for the identifier every time the table is mounted.
 
@@ -907,14 +907,23 @@ interface TablePreferences {
 
 ### Toolbar
 
-The `toolbar` slot allows you to slot table controls rendered right above the `<table>` element such as a search input or other UI elements.
+The `toolbar` slot allows you to slot table controls rendered right above the `<table>` element such as a search input or other UI elements. It provides the [SWRV](https://docs-swrv.netlify.app/) `state` and `hasData` in the slot param.
+
+```ts
+{
+  state: {
+    hasData: boolean
+    state: string
+  }
+}
+```
 
 If utilizing multiple elements, we recommend adding `display: flex; width: 100%;` to the root slot tag.
 
 <KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" :hasHover="false">
-  <template #toolbar>
+  <template #toolbar="{ state }">
     <div class="d-flex w-100 justify-content-between">
-      <KInput placeholder="Search" />
+      <KInput v-if="state.hasData" placeholder="Search" />
       <KSelect appearance="select" :items="[{ label: 'First option', value: '1', selected: true }, { label: 'Another option', value: '2'}]" />
     </div>
   </template>
@@ -922,9 +931,9 @@ If utilizing multiple elements, we recommend adding `display: flex; width: 100%;
 
 ```html
 <KTable :fetcher="fetcher" :headers="headers">
-  <template #toolbar>
+  <template #toolbar="{ state }">
     <div class="d-flex w-100 justify-content-between">
-      <KInput placeholder="Search" />
+      <KInput v-if="state.hasData" placeholder="Search" />
       <KSelect appearance="select" :items="[{ label: 'Ascending', value: 'asc', selected: true }, { label: 'Descending', value: 'desc'}]" />
     </div>
   </template>

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -57,7 +57,7 @@
     </div>
 
     <div
-      v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length)"
+      v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length || hasData)"
       class="k-table-empty-state"
       data-testid="k-table-empty-state"
     >

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -57,7 +57,7 @@
     </div>
 
     <div
-      v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length && !hasData)"
+      v-else-if="!hasError && (!isTableLoading && !isLoading && !isRevalidating) && (data && !data.length && !hasData)"
       class="k-table-empty-state"
       data-testid="k-table-empty-state"
     >

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -15,7 +15,7 @@
     </div>
 
     <KSkeleton
-      v-if="(!testMode || testMode === 'loading') && (isTableLoading || isLoading) && !hasError"
+      v-if="(!testMode || testMode === 'loading') && (isTableLoading || isLoading || isRevalidating) && !hasError"
       data-testid="k-table-skeleton"
       type="table"
     />
@@ -57,7 +57,7 @@
     </div>
 
     <div
-      v-else-if="!hasError && (!isTableLoading && !isLoading && !isRevalidating) && (data && !data.length && !hasData)"
+      v-else-if="!hasError && (!isTableLoading && !isLoading && !isRevalidating) && (data && !data.length)"
       class="k-table-empty-state"
       data-testid="k-table-empty-state"
     >

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -5,7 +5,13 @@
       class="k-table-toolbar mb-5"
       data-testid="k-table-toolbar"
     >
-      <slot name="toolbar" />
+      <slot
+        name="toolbar"
+        :state="{
+          hasData,
+          state
+        }"
+      />
     </div>
 
     <KSkeleton
@@ -746,7 +752,7 @@ const { data: fetcherData, error: fetcherError, revalidate: _revalidate, isValid
   { revalidateOnFocus: false, revalidateDebounce: 0 },
 )
 
-const { state, swrvState } = useSwrvState(fetcherData, fetcherError, fetcherIsValidating)
+const { state, hasData, swrvState } = useSwrvState(fetcherData, fetcherError, fetcherIsValidating)
 const isTableLoading = ref<boolean>(true)
 
 const { debouncedFn: debouncedRevalidate, generateDebouncedFn: generateDebouncedRevalidate } = useDebounce(_revalidate, 500)

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -57,7 +57,7 @@
     </div>
 
     <div
-      v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length || hasData)"
+      v-else-if="!hasError && (!isTableLoading && !isLoading) && (data && !data.length && !hasData)"
       class="k-table-empty-state"
       data-testid="k-table-empty-state"
     >

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -7,10 +7,7 @@
     >
       <slot
         name="toolbar"
-        :state="{
-          hasData,
-          state
-        }"
+        :state="stateData"
       />
     </div>
 
@@ -208,7 +205,7 @@ import KSkeleton from '@/components/KSkeleton/KSkeleton.vue'
 import KPagination from '@/components/KPagination/KPagination.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import useUtilities from '@/composables/useUtilities'
-import type { TablePreferences, TablePaginationType, TableHeader, TableColumnSlotName } from '@/types'
+import type { TablePreferences, TablePaginationType, TableHeader, TableColumnSlotName, SwrvState, SwrvStateData } from '@/types'
 
 const { useDebounce, useRequest, useSwrvState } = useUtilities()
 
@@ -754,6 +751,10 @@ const { data: fetcherData, error: fetcherError, revalidate: _revalidate, isValid
 
 const { state, hasData, swrvState } = useSwrvState(fetcherData, fetcherError, fetcherIsValidating)
 const isTableLoading = ref<boolean>(true)
+const stateData = computed((): SwrvStateData => ({
+  hasData: hasData.value,
+  state: state.value as SwrvState,
+}))
 
 const { debouncedFn: debouncedRevalidate, generateDebouncedFn: generateDebouncedRevalidate } = useDebounce(_revalidate, 500)
 const revalidate = generateDebouncedRevalidate(0) // generate a debounced function with zero delay (immediate)

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -163,9 +163,10 @@ export default function useUtilities() {
 
   const useSwrvState = (response: Ref<any>, error: Ref<any>, isValidating: Ref<boolean>) => {
     const state = ref(swrvState.PENDING)
+    const hasData = ref(false)
 
     watchEffect(() => {
-      const hasData = response.value && !!(
+      hasData.value = response.value && !!(
         Object.keys(response.value)?.length ||
         response.value.data?.length ||
         response.value.data?.data?.length ||
@@ -174,7 +175,7 @@ export default function useUtilities() {
           Object.keys(response.value?.data).length)
       )
 
-      if (response.value && hasData && isValidating.value) {
+      if (response.value && hasData.value && isValidating.value) {
         state.value = swrvState.VALIDATING_HAS_DATA
 
         return
@@ -198,7 +199,7 @@ export default function useUtilities() {
         return
       }
 
-      if (response.value && !error.value && hasData) {
+      if (response.value && !error.value && hasData.value) {
         state.value = swrvState.SUCCESS_HAS_DATA
 
         return
@@ -216,6 +217,7 @@ export default function useUtilities() {
     })
 
     return {
+      hasData,
       state,
       swrvState,
     }

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -24,3 +24,10 @@ export interface TableHeader {
  * the slot props can be resolved.
  */
 export type TableColumnSlotName = `column-${string}`
+
+export type SwrvState = 'VALIDATING' | 'VALIDATING_HAS_DATA' | 'PENDING' | 'SUCCESS' | 'SUCCESS_HAS_DATA' | 'ERROR' | 'STALE_IF_ERROR'
+
+export interface SwrvStateData {
+  hasData: boolean
+  state: SwrvState
+}


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Provide the SWRV state information as a slot param for the `toolbar` slot to allow proper show/hide of that content.
- make `hasData` reactive so that we can correctly use it
- fix an issue where the empty state would flash after clearing search input

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
