### PR TITLE
feat(kradio,kcheckbox): cleanup / support tooltip

### DIFF
--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -12,7 +12,8 @@
 <template>
   <KCheckbox
     v-model="checked"
-    @change="handleToggle" />
+    @change="handleToggle"
+  />
 </template>
 
 <script lang="ts">
@@ -43,8 +44,8 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 
 <KCard>
   <template v-slot:body>
-    <KCheckbox v-model="defaultChecked">
-      {{ defaultChecked ? 'Checked!' : 'Unchecked' }}
+    <KCheckbox v-model="modelChecked">
+      {{ modelChecked ? 'Checked!' : 'Unchecked' }}
     </KCheckbox>
   </template>
 </KCard>
@@ -59,50 +60,67 @@ Use `v-model` to bind the `checked` state of the underlying `<input />`. The `v-
 
 Will place label text to the right of the checkbox. Can also be [slotted](#slots).
 
+<KCheckbox v-model="labelChecked" label="Label Example" />
+
 ```html
-<KCheckbox v-model="checked" label="Label Example" />
+<KCheckbox
+  v-model="checked"
+  label="Label Example"
+/>
 ```
 
-<KCheckbox v-model="checked" label="Label Example" />
+### labelAttributes
+
+ `KCheckbox` has an instance of `KLabel` for supporting tooltip text. Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label). This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
+
+<KCheckbox v-model="labelAChecked" label="Tooltips?" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
+
+```html
+<KCheckbox
+  v-model="checked"
+  label="Tooltips?"
+  :label-attributes="{ help: 'I use the KLabel `help` prop' }"
+/>
+```
 
 ### description
 
 Will place description text under the checkbox label (required). Can also be [slotted](#slots).
 
-```html
-<KCheckbox v-model="checked" label="Label Example" description="Some subheader text" />
-```
+<KCheckbox v-model="descriptionChecked" label="Label Example" description="Some subheader text" />
 
-<KCheckbox v-model="checked" label="Label Example" description="Some subheader text" />
+```html
+<KCheckbox
+  v-model="checked"
+  label="Label Example"
+  description="Some subheader text"
+/>
+```
 
 ### HTML attributes
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/api/composition-api-setup.html#setup-context).
 
+<KCard>
+  <template v-slot:body>
+    <div class="mb-2">
+      <KCheckbox v-model="disabled" label="Can't check this" disabled />
+    </div>
+    <div>
+      <KCheckbox v-model="disabledChecked" disabled />
+    </div>
+  </template>
+</KCard>
+
 ```html
 <KCheckbox v-model="checked" disabled />
 ```
 
-<KCard>
-  <template v-slot:body>
-    <KCheckbox v-model="checked" disabled />
-    <KCheckbox v-model="disabledChecked" disabled />
-  </template>
-</KCard>
-
 ## Slots
 
-- `default` - Anything passed in to the default slot will replace the label prop text
+### `default`
 
-```html
-<KCheckbox v-model="checkbox1">
-  Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}
-</KCheckbox>
-
-<KCheckbox v-model="checkbox2">
-  I agree to the <a :href="privacyPolicyURL">privacy policy</a>.
-</KCheckbox>
-```
+Anything passed in to the default slot will replace the label prop text
 
 <KCard>
   <template v-slot:body>
@@ -119,6 +137,79 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
   </template>
 </KCard>
 
+```html
+<KCheckbox v-model="checkbox1">
+  Label goes here. The checkbox is {{ checkbox1 ? 'checked' : 'not checked' }}
+</KCheckbox>
+
+<KCheckbox v-model="checkbox2">
+  I agree to the <a :href="privacyPolicyURL">privacy policy</a>.
+</KCheckbox>
+```
+
+### `description`
+
+Anything passed in to this slot will replace the `description` prop text
+
+<KCard>
+  <template #body>
+    <KCheckbox label="Some label" description="This will be replaced with a slot" v-model="slotsd" :selected-value="true">
+      <template #description>
+        Anything goes here
+      </template>
+    </KCheckbox>
+  </template>
+</KCard>
+
+```html
+<KCheckbox
+  v-model="checked"
+  :selected-value="true"
+  description="This will be replaced with a slot"
+  label="Some label"
+>
+  <template #description>
+    Anything goes here
+  </template>
+</KCheckbox>
+```
+
+### `tooltip`
+
+Provides a slot for tooltip content displayed after the checkbox label
+
+<KCheckbox v-model="slots3" :selected-value="true">
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KCheckbox>
+
+```html
+<KCheckbox v-model="checked" :selected-value="true">
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KCheckbox>
+```
+
+:::tip Note:
+When utilizing the `tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
+:::
+
+<KCheckbox v-model="slots4" :selected-value="true" :label-attributes="{ help: 'true' }">
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KCheckbox>
+
+```html
+<KCheckbox
+  v-model="checked"
+  :selected-value="true"
+  :label-attributes="{ help: 'true' }"
+>
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KCheckbox>
+```
+
 ## Events
 
 `KCheckbox` has a couple of natural event bindings that all emit the same data.
@@ -129,11 +220,11 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KCheckboxPrimary`| KCheckbox checked background color
-| `--KCheckboxDisabled`| KCheckbox disabled background color
-| `--KCheckboxDisabledChecked`| KCheckbox disabled checked background color
+| Variable                     | Purpose                                     |
+| :--------------------------- | :------------------------------------------ |
+| `--KCheckboxPrimary`         | KCheckbox checked background color          |
+| `--KCheckboxDisabled`        | KCheckbox disabled background color         |
+| `--KCheckboxDisabledChecked` | KCheckbox disabled checked background color |
 
 An Example of changing the background color of KCheckbox to `blueviolet` might look like:
 
@@ -169,14 +260,19 @@ import { defineComponent, ref } from 'vue'
 export default defineComponent ({
   data () {
     return {
-      labelPropChecked1: false,
-      labelPropChecked2: false,
-      labelPropChecked3: false,
       defaultChecked: false,
+      modelChecked: false,
+      descriptionChecked: false,
+      labelChecked: false,
+      labelAChecked: false,
+      disabled: false,
       disabledChecked: true,
       themeChecked: true,
       slots1: true,
-      slots2: false
+      slots2: false,
+      slotsd: false,
+      slots3: false,
+      slots4: false
     }
   }
 })

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -46,10 +46,16 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
-<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' }"/>
+<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' } "/>
 
 ```html
-<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
+<KInput
+  label="Name"
+  :label-attributes="{
+    help: 'I use the KLabel `help` prop',
+    'data-testid': 'test'
+  }"
+/>
 ```
 
 ### overlayLabel

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -4,23 +4,23 @@
 
 <KCard>
   <template #body>
+    <div class="mb-3">Selected: {{ radioGroup }}</div>
     <div>
-      <KRadio name="test" :selected-value="true" v-model="radio">Boolean</KRadio>
-      <KRadio name="test" selected-value="string" v-model="radio">String</KRadio>
-      <KRadio name="test" :selected-value="objA" v-model="radio">Object A</KRadio>
-      <KRadio name="test" :selected-value="objB" v-model="radio">Object B</KRadio>
+      <KRadio name="test" :selected-value="true" v-model="radioGroup">Boolean</KRadio>
+      <KRadio name="test" selected-value="string" v-model="radioGroup">String</KRadio>
+      <KRadio name="test" :selected-value="objA" v-model="radioGroup">Object A</KRadio>
+      <KRadio name="test" :selected-value="objB" v-model="radioGroup">Object B</KRadio>
     </div>
-    <div class="mt-3">Selected: {{ radio }}</div>
   </template>
 </KCard>
 
 ```html
 <template>
-  <KRadio name="test" :selected-value="true" v-model="radio">Boolean</KRadio>
-  <KRadio name="test" selected-value="string" v-model="radio">String</KRadio>
-  <KRadio name="test" :selected-value="objA" v-model="radio">Object A</KRadio>
-  <KRadio name="test" :selected-value="objB" v-model="radio">Object B</KRadio>
-  <div class="mt-3">Selected: {{ radio }}</div>
+  <div class="mb-3">Selected: {{ radioGroup }}</div>
+  <KRadio name="test" :selected-value="true" v-model="radioGroup">Boolean</KRadio>
+  <KRadio name="test" selected-value="string" v-model="radioGroup">String</KRadio>
+  <KRadio name="test" :selected-value="objA" v-model="radioGroup">Object A</KRadio>
+  <KRadio name="test" :selected-value="objB" v-model="radioGroup">Object B</KRadio>
 </template>
 
 <script lang="ts">
@@ -31,7 +31,7 @@ export default defineComponent({
     const data = reactive({
       objA: { name: 'a' },
       objB: { name: 'b' },
-      radio: true,
+      radioGroup: 'string',
     })
 
     return {
@@ -56,26 +56,26 @@ The value of the `KRadio` option that will be emitted by the `change` and `updat
 
 Will place label text to the right of the radio. Can also be [slotted](#slots).
 
-```html
-<KRadio :selected-value="true" v-model="radio" label="Label Example" />
-```
+<KRadio v-model="checked" label="Label Example" :selected-value="true" />
 
-<KRadio :selected-value="true" v-model="radio" label="Label Example" />
+```html
+<KRadio v-model="checked" label="Label Example" :selected-value="true" />
+```
 
 ### description
 
 Will place description text under the radio label. Can also be [slotted](#slots).
 
+<KRadio v-model="radio" label="Label Example" description="Some subheader text" :selected-value="true" />
+
 ```html
 <KRadio
-  :selected-value="true"
   v-model="radio"
   label="Label Example"
   description="Some subheader text"
+  :selected-value="true"
 />
 ```
-
-<KRadio :selected-value="true" v-model="radio" label="Label Example" description="Some subheader text" />
 
 ### type
 
@@ -85,7 +85,7 @@ Controls appearance of radio input element. Accepted values:
 - `card`
 
 ::: warning NOTE
-The `label` and `description` props, as well as the `description` slot, are ignored when `type` prop is `card`. 
+The `label` and `description` props, as well as the `description` slot, are ignored when `type` prop is `card`.
 
 You can only define content of a card via the `default` slot.
 :::
@@ -144,21 +144,40 @@ export default defineComponent({
 </script>
 ```
 
+### labelAttributes
+
+ `KRadio` has an instance of `KLabel` for supporting tooltip text. Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label). This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
+
+<KRadio v-model="labelAChecked" label="Tooltips?" :label-attributes="{ help: 'I use the KLabel `help` prop' }" :selected-value="true" />
+
+```html
+<KRadio
+  v-model="checked"
+  label="Tooltips?"
+  :label-attributes="{ help: 'I use the KLabel `help` prop' }"
+  :selected-value="true"
+/>
+```
+
 ### HTML attributes
 
 Any valid attribute will be added to the input. You can read more about `$attrs` [here](https://vuejs.org/api/composition-api-setup.html#setup-context).
 
+<KCard>
+  <template #body>
+    <KRadio v-model="disabledChecked" :selected-value="true" disabled>Disabled radio</KRadio>
+  </template>
+</KCard>
+
 ```html
-<KRadio v-model="checked" :selected-value="true" disabled>
+<KRadio
+  v-model="checked"
+  :selected-value="true"
+  disabled
+>
   Disabled radio
 </KRadio>
 ```
-
-<KCard>
-  <template #body>
-    <KRadio v-model="radioState" :selected-value="true" disabled>Disabled radio</KRadio>
-  </template>
-</KCard>
 
 ## Slots
 
@@ -174,11 +193,11 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ```html
 <KRadio
+  v-model="checked"
   label="This will be replaced with a slot"
-  v-model="isStateOn"
   :selected-value="true"
 >
-  Label goes here. The radio is {{ isStateOn ? "selected" : "not selected" }}
+  Label goes here. The radio is {{ checked ? "selected" : "not selected" }}
 </KRadio>
 ```
 
@@ -186,7 +205,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 <KCard>
   <template #body>
-    <KRadio label="Some label" description="This will be replaced with a slot" v-model="isStateOn" :selected-value="true">
+    <KRadio label="Some label" description="This will be replaced with a slot" v-model="slotChecked" :selected-value="true">
       <template #description>
         Description goes here
       </template>
@@ -196,12 +215,46 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 ```html
 <KRadio
-  v-model="isStateOn"
-  description="This will be replaced with a slot"
+  v-model="checked"
   label="Some label"
+  description="This will be replaced with a slot"
   :selected-value="true"
 >
   <template #description>Description goes here</template>
+</KRadio>
+```
+
+- `tooltip` - Provides a slot for tooltip content displayed after the radio label
+
+<KRadio v-model="tooltipChecked" :selected-value="true">
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KRadio>
+
+```html
+<KRadio v-model="checked" :selected-value="true">
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KRadio>
+```
+
+:::tip Note:
+When utilizing the `tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
+:::
+
+<KRadio v-model="tooltipChecked2" :selected-value="true" :label-attributes="{ help: 'true' }">
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
+</KRadio>
+
+```html
+<KRadio
+  v-model="checked"
+  :label-attributes="{ help: 'true' }"
+  :selected-value="true"
+>
+  My tooltip
+  <template #tooltip>Brings all the <code>devs</code> to the yard</template>
 </KRadio>
 ```
 
@@ -224,13 +277,13 @@ An Example of changing the background color of KRadio to lime might look like:
 > Note: We are scoping the overrides to a wrapper in this example
 
 <div class="KRadio-wrapper">
-  <KRadio v-model="radioState" :selected-value="true" />
+  <KRadio v-model="themeChecked" :selected-value="true" />
 </div>
 
 ```html
 <template>
   <div class="KRadio-wrapper">
-    <KRadio v-model="isStateOn" :selected-value="true" />
+    <KRadio v-model="checked" :selected-value="true" />
   </div>
 </template>
 
@@ -249,10 +302,17 @@ export default defineComponent({
     const data = reactive({
       objA: { name: 'a' },
       objB: { name: 'b' },
-      radio: true,
-      radioState: true,
+      radioGroup: 'string',
       isStateOn: false,
-      cardRadio: ''
+      cardRadio: '',
+      checked: false,
+      disabledChecked: true,
+      descriptionChecked: false,
+      labelAChecked: false,
+      slotChecked: false,
+      tooltipChecked: false,
+      tooltipChecked2: false,
+      themeChecked: true
     })
 
     return {

--- a/src/components/KCheckbox/KCheckbox.cy.ts
+++ b/src/components/KCheckbox/KCheckbox.cy.ts
@@ -1,11 +1,21 @@
 import { mount } from 'cypress/vue'
 import KCheckbox from '@/components/KCheckbox/KCheckbox.vue'
 
+/**
+ * ALL TESTS MUST USE testMode
+ * We generate unique IDs for reference by aria properties. Test mode strips these out
+ * allowing for successful snapshot verification.
+ * props: {
+ *   testMode: true
+ * }
+ */
 describe('KCheckbox', () => {
   it('shows as checked when prop passed', () => {
+    const model = true
     mount(KCheckbox, {
       props: {
-        modelValue: true,
+        modelValue: model,
+        testMode: true,
       },
     })
 
@@ -13,9 +23,11 @@ describe('KCheckbox', () => {
   })
 
   it('emits checked value on click', () => {
+    const model = false
     mount(KCheckbox, {
       props: {
-        modelValue: false,
+        modelValue: model,
+        testMode: true,
       },
     })
 
@@ -24,9 +36,9 @@ describe('KCheckbox', () => {
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'change')
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue')
 
-      cy.wrap(Cypress.vueWrapper.emitted('input')[0][0]).should('eq', true)
-      cy.wrap(Cypress.vueWrapper.emitted('change')[0][0]).should('eq', true)
-      cy.wrap(Cypress.vueWrapper.emitted('update:modelValue')[0][0]).should('eq', true)
+      cy.wrap(Cypress.vueWrapper.emitted('input')?.[0][0]).should('eq', true)
+      cy.wrap(Cypress.vueWrapper.emitted('change')?.[0][0]).should('eq', true)
+      cy.wrap(Cypress.vueWrapper.emitted('update:modelValue')?.[0][0]).should('eq', true)
     })
   })
 })

--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -74,8 +74,8 @@ const props = defineProps({
     default: '',
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+   * Test mode - for testing only, strips out generated ids
+   */
   testMode: {
     type: Boolean,
     default: false,

--- a/src/components/KRadio/KRadio.cy.ts
+++ b/src/components/KRadio/KRadio.cy.ts
@@ -1,12 +1,21 @@
 import { mount } from 'cypress/vue'
 import KRadio from '@/components/KRadio/KRadio.vue'
 
+/**
+ * ALL TESTS MUST USE testMode
+ * We generate unique IDs for reference by aria properties. Test mode strips these out
+ * allowing for successful snapshot verification.
+ * props: {
+ *   testMode: true
+ * }
+ */
 describe('KRadio', () => {
   it('shows as not selected when modelValue is true', () => {
     mount(KRadio, {
       props: {
         modelValue: false,
         selectedValue: true,
+        testMode: true,
       },
     })
 
@@ -18,6 +27,7 @@ describe('KRadio', () => {
       props: {
         modelValue: true,
         selectedValue: true,
+        testMode: true,
       },
     })
 
@@ -29,12 +39,16 @@ describe('KRadio', () => {
       props: {
         modelValue: false,
         selectedValue: true,
+        testMode: true,
       },
     })
 
     cy.get('input').check().then(() => {
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'change')
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue')
+
+      cy.wrap(Cypress.vueWrapper.emitted('input')?.[0][0]).should('eq', true)
+      cy.wrap(Cypress.vueWrapper.emitted('update:modelValue')?.[0][0]).should('eq', true)
     })
   })
 
@@ -46,6 +60,7 @@ describe('KRadio', () => {
         selectedValue: true,
         type: 'card',
         label: 'Some label',
+        testMode: true,
       },
       slots: {
         default: () => slotText,
@@ -61,6 +76,8 @@ describe('KRadio', () => {
         modelValue: false,
         selectedValue: true,
         type: 'card',
+        label: 'Some label',
+        testMode: true,
       },
     })
 
@@ -73,6 +90,8 @@ describe('KRadio', () => {
         modelValue: false,
         selectedValue: true,
         type: 'card',
+        label: 'Some label',
+        testMode: true,
       },
     })
 
@@ -81,10 +100,7 @@ describe('KRadio', () => {
       .then(() => {
         cy.get('input').should('be.checked')
         cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'change')
-        cy.wrap(Cypress.vueWrapper.emitted()).should(
-          'have.property',
-          'update:modelValue',
-        )
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue')
       })
   })
 
@@ -94,6 +110,8 @@ describe('KRadio', () => {
         modelValue: false,
         selectedValue: true,
         type: 'card',
+        label: 'Some label',
+        testMode: true,
       },
       attrs: {
         disabled: true,

--- a/src/components/KRadio/KRadio.cy.ts
+++ b/src/components/KRadio/KRadio.cy.ts
@@ -47,7 +47,7 @@ describe('KRadio', () => {
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'change')
       cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:modelValue')
 
-      cy.wrap(Cypress.vueWrapper.emitted('input')?.[0][0]).should('eq', true)
+      cy.wrap(Cypress.vueWrapper.emitted('change')?.[0][0]).should('eq', true)
       cy.wrap(Cypress.vueWrapper.emitted('update:modelValue')?.[0][0]).should('eq', true)
     })
   })
@@ -90,8 +90,10 @@ describe('KRadio', () => {
         modelValue: false,
         selectedValue: true,
         type: 'card',
-        label: 'Some label',
         testMode: true,
+      },
+      slots: {
+        default: () => 'Hello',
       },
     })
 
@@ -110,11 +112,13 @@ describe('KRadio', () => {
         modelValue: false,
         selectedValue: true,
         type: 'card',
-        label: 'Some label',
         testMode: true,
       },
       attrs: {
         disabled: true,
+      },
+      slots: {
+        default: () => 'Hello',
       },
     })
 

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -1,37 +1,62 @@
 <template>
-  <label
+  <div
     :checked="isSelected"
-    class="k-radio"
-    :class="[isTypeDefault ? 'k-radio-default' : `k-radio-${type}`, $attrs.class ? $attrs.class : '']"
+    class="k-radio d-inline-block"
+    :class="[
+      isTypeDefault ? 'k-radio-default' : `k-radio-${type}`,
+      $attrs.class ? $attrs.class : '',
+      { 'disabled': isDisabled }
+    ]"
   >
     <input
+      :id="inputId"
       :checked="isSelected"
       v-bind="modifiedAttrs"
       class="k-input"
       type="radio"
       @click="handleClick"
     >
-    <span
+
+    <KLabel
       v-if="isTypeDefault && hasLabel"
+      v-bind="labelAttributes"
       class="k-radio-label"
+      :class="{ 'd-inline': hasDescription }"
+      :for="inputId"
     >
-      <slot name="default">{{ label }}</slot>
-    </span>
-    <div
-      v-if="isTypeDefault && hasLabel && hasDescription"
-      class="k-radio-description"
+      <slot>{{ label }}</slot>
+
+      <div
+        v-if="hasDescription"
+        class="k-radio-description"
+      >
+        <slot name="description">
+          {{ description }}
+        </slot>
+      </div>
+
+      <template
+        v-if="hasTooltip"
+        #tooltip
+      >
+        <slot name="tooltip" />
+      </template>
+    </KLabel>
+
+    <label
+      v-else-if="hasLabel"
+      :for="inputId"
     >
-      <slot name="description">{{ description }}</slot>
-    </div>
-    <div v-if="!isTypeDefault && hasLabel">
       <slot name="default" />
-    </div>
-  </label>
+    </label>
+  </div>
 </template>
 
 <script lang="ts">
 import { computed, useAttrs, useSlots, PropType } from 'vue'
-import { RadioTypes, RadioTypesArray } from '@/types'
+import { v4 as uuidv4 } from 'uuid'
+import { RadioTypes, RadioTypesArray, LabelAttributes } from '@/types'
+import KLabel from '@/components/KLabel/KLabel.vue'
 
 export default {
   inheritAttrs: false,
@@ -55,6 +80,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  labelAttributes: {
+    type: Object as PropType<LabelAttributes>,
+    default: () => ({}),
+  },
   /**
    * Overrides default description text
    */
@@ -77,12 +106,22 @@ const props = defineProps({
     default: 'radio',
     validator: (value: RadioTypes): boolean => RadioTypesArray.includes(value),
   },
+  /**
+     * Test mode - for testing only, strips out generated ids
+     */
+  testMode: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const slots = useSlots()
 
+const inputId = computed((): string => attrs.id ? String(attrs.id) : props.testMode ? 'test-radio-input-id-1234' : uuidv4())
+const isDisabled = computed((): boolean => attrs?.disabled !== undefined && String(attrs?.disabled) !== 'false')
 const hasLabel = computed((): boolean => !!(props.label || slots.default))
 const hasDescription = computed((): boolean => !!(props.description || slots.description))
+const hasTooltip = computed((): boolean => !!slots.tooltip)
 
 const isSelected = computed((): boolean => props.selectedValue === props.modelValue)
 
@@ -148,7 +187,19 @@ $background-color-card-disabled: color(grey-200);
 
 .k-radio {
   .k-radio-label {
-    font-size: var(--type-sm, type(sm));
+    --KInputLabelWeight: 400;
+    --KInputLabelLineHeight: 20px;
+    --KInputLabelFont: Inter,Helvetica,Arial,sans-serif;
+    --KInputLabelMargin: 0;
+    --KInputLabelSize: var(--type-sm, type(sm));
+
+    vertical-align: middle;
+  }
+
+  &.disabled {
+    .k-radio-label {
+      color: var(--KInputRadioDisabled, var(--grey-400, color(grey-400)));
+    }
   }
 
   .k-radio-description {
@@ -160,13 +211,15 @@ $background-color-card-disabled: color(grey-200);
 
   // default radio input styling
   &.k-radio-default {
+    .k-radio-label:has(> .k-radio-description) {
+      --KInputLabelWeight: 600;
+    }
+
     .k-radio-description {
+      font-weight: 400;
       padding-left: var(--spacing-lg);
     }
 
-    .k-radio-label:has(+ .k-radio-description) {
-      font-weight: 600;
-    }
   }
 
   // card radio input styling

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -107,8 +107,8 @@ const props = defineProps({
     validator: (value: RadioTypes): boolean => RadioTypesArray.includes(value),
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+   * Test mode - for testing only, strips out generated ids
+   */
   testMode: {
     type: Boolean,
     default: false,

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -44,7 +44,7 @@
     </KLabel>
 
     <label
-      v-else-if="hasLabel"
+      v-else-if="$slots.default"
       :for="inputId"
     >
       <slot name="default" />

--- a/src/styles/forms/_checkbox-radio.scss
+++ b/src/styles/forms/_checkbox-radio.scss
@@ -97,6 +97,7 @@ input.form-control {
       background-repeat: no-repeat;
       background-size: 100% 100%;
       border-color: currentColor;
+
       &:after {
         background-color: currentColor;
         border-radius: 100%;
@@ -104,6 +105,14 @@ input.form-control {
         display: flex;
         height: 10px;
         width: 10px;
+      }
+
+      &:disabled {
+        border-color: var(--KInputRadioDisabled, var(--grey-400, color(grey-400)));
+
+        &:after {
+          background-color: var(--KInputRadioDisabled, var(--grey-400, color(grey-400)));
+        }
       }
     }
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
General cleanup / switch to `KLabel` for tooltip support for `KRadio` / `KCheckbox`.
Fixes:
- Cleanup reuse of v-model vars in docs
- Update docs - format is example followed by code snippet (not the reverse)
- Add `labelAttributes` prop for both components
- Add `tooltip` slot
- Add example usage of `description` slot
- Fix bug causing KRadio disabled styles not to be applied correctly
- Bind the label to the input using generated id's (and requiring `testMode` prop)

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
