### PR TITLE
ci: skips preview publishing if version already exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,11 +73,7 @@ jobs:
 
           yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version --yes --amend
 
-          package_version=$(cat package.json \
-            | grep version \
-            | head -1 \
-            | awk -F: '{ print $2 }' \
-            | sed 's/[", ]//g')
+          package_version=$(jq -r ".version" package.json)
           package=@kong/kongponents@"${package_version}"
 
           npm show "${package}" >/dev/null 2>&1 && npm_show_status=0 || npm_show_status=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,11 +71,24 @@ jobs:
 
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}" > .npmrc
 
-          yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version  --yes --amend
+          yarn version --prerelease --preid ${preid} --allow-branch ${{ github.head_ref }} --no-git-tag-version --yes --amend
+
+          package_version=$(cat package.json \
+            | grep version \
+            | head -1 \
+            | awk -F: '{ print $2 }' \
+            | sed 's/[", ]//g')
+          package=@kong/kongponents@"${package_version}"
+
+          npm show "${package}" >/dev/null 2>&1 && npm_show_status=0 || npm_show_status=1
+          if [ $npm_show_status -eq 0 ]; then
+            echo "Package ${package} is already published. Skipping publishing."
+            exit 0
+          fi
 
           npm_instructions=""
 
-          pkg=$(npm publish  --no-git-checks --access public --report-summary --tag "${tag}" | grep "+ "| sed 's/+ //')
+          pkg=$(npm publish --no-git-checks --access public --report-summary --tag "${tag}" | grep "+ "| sed 's/+ //')
 
           if [[ -z "${pkg}" ]]; then
             echo "Error publishing package"


### PR DESCRIPTION
# Summary

Skips trying to publish a preview package if a package with the same version already exists. This is necessary in order to be able to re-run flaky tests.

## Notes

Someone with better Shell foo should be looking over this

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
