### PR TITLE
fix(kradio): allow type=card entire element to be clickable

### DIFF
--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -13,6 +13,7 @@
       :checked="isSelected"
       v-bind="modifiedAttrs"
       class="k-input"
+      :disabled="isDisabled"
       type="radio"
       @click="handleClick"
     >
@@ -246,6 +247,12 @@ $background-color-card-disabled: color(grey-200);
       padding: var(--spacing-md);
     }
 
+    &[disabled], &.disabled {
+      > label {
+        cursor: not-allowed;
+      }
+    }
+
     .k-radio-label {
       color: $text-color-card;
       font-size: var(--type-sm, type(sm));
@@ -260,10 +267,6 @@ $background-color-card-disabled: color(grey-200);
     // Firefox disabled state handling
     &[disabled=""], &[disabled="true"] {
       @include kRadioDisabled;
-
-      > label {
-        cursor: not-allowed;
-      }
     }
 
     &:hover {

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -245,6 +245,7 @@ $background-color-card-disabled: color(grey-200);
       justify-content: center;
       // Apply padding to the label so the entire element is clickable
       padding: var(--spacing-md);
+      width: 100%;
     }
 
     &[disabled], &.disabled {

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -230,7 +230,6 @@ $background-color-card-disabled: color(grey-200);
     border: 1px solid $border-color-card;
     border-radius: var(--spacing-xxs);
     cursor: pointer;
-    padding: var(--spacing-md);
 
     .k-input {
       display: none;
@@ -242,6 +241,8 @@ $background-color-card-disabled: color(grey-200);
       flex-direction: column;
       height: 100%;
       justify-content: center;
+      // Apply padding to the label so the entire element is clickable
+      padding: var(--spacing-md);
     }
 
     .k-radio-label {

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -237,6 +237,7 @@ $background-color-card-disabled: color(grey-200);
 
     > label {
       align-items: center;
+      cursor: pointer;
       display: flex;
       flex-direction: column;
       height: 100%;
@@ -259,6 +260,10 @@ $background-color-card-disabled: color(grey-200);
     // Firefox disabled state handling
     &[disabled=""], &[disabled="true"] {
       @include kRadioDisabled;
+
+      > label {
+        cursor: not-allowed;
+      }
     }
 
     &:hover {


### PR DESCRIPTION
# Summary

- Prevent activating the radio if clicked when disabled
- Moves the padding from the `.k-radio-card` element to the interior label in order to allow a user to click anywhere on the card to activate the radio.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
