### PR TITLE
fix(ktable): pagination event handlers

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -189,8 +189,8 @@
         :total-count="total"
         @get-next-offset="getNextOffsetHandler"
         @get-prev-offset="getPrevOffsetHandler"
-        @page-changed="() => pageChangeHandler"
-        @page-size-changed="() => pageSizeChangeHandler"
+        @page-changed="pageChangeHandler"
+        @page-size-changed="pageSizeChangeHandler"
       />
     </section>
   </div>
@@ -205,7 +205,17 @@ import KSkeleton from '@/components/KSkeleton/KSkeleton.vue'
 import KPagination from '@/components/KPagination/KPagination.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import useUtilities from '@/composables/useUtilities'
-import type { TablePreferences, TablePaginationType, TableHeader, TableColumnSlotName, SwrvState, SwrvStateData, TableState } from '@/types'
+import type {
+  TablePreferences,
+  TablePaginationType,
+  TableHeader,
+  TableColumnSlotName,
+  SwrvState,
+  SwrvStateData,
+  TableState,
+  PageChangedData,
+  PageSizeChangedData,
+} from '@/types'
 
 const { useDebounce, useRequest, useSwrvState } = useUtilities()
 
@@ -810,11 +820,11 @@ const sortClickHandler = (header: TableHeader) => {
   emitTablePreferences()
 }
 
-const pageChangeHandler = ({ page: newPage }: Record<string, number>) => {
+const pageChangeHandler = ({ page: newPage }: PageChangedData) => {
   page.value = newPage
 }
 
-const pageSizeChangeHandler = ({ pageSize: newPageSize }: Record<string, number>) => {
+const pageSizeChangeHandler = ({ pageSize: newPageSize }: PageSizeChangedData) => {
   offsets.value = [null]
   offset.value = null
   pageSize.value = newPageSize


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a bug that changing page sizes has no effect: 

![Kapture 2023-05-31 at 14 58 27](https://github.com/Kong/kongponents/assets/10095631/a4a1cd62-f9eb-4dd7-b071-821830bb11ef)

`@event="() => handler"` will not actually call `handler` but just returns it.

## PR Checklist


* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
