### PR TITLE
feat(ktabs): hide panels [KHCP-7542]

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -132,6 +132,67 @@ If you want to keep your `v-model` in sync so that you can programatically chang
 <KButton @click="defaultTab = '#tab2'">Activate Tab 2</KButton>
 ```
 
+### hasPanels
+
+A `boolean` that determines whether all tabs should have corresponding "panel" (the tab content) containers. Defaults to `true`.
+
+A use-case for setting the `hasPanels` prop to `false` would be if you want the KTabs UI without the default behavior of hiding/showing tab content below. Instead, your host app could provide custom functionality such as navigating to a different page on click.
+
+Here's an example of utilizing the `hasPanels` prop with a nested `<router-view>` component:
+
+<KTabs :has-panels="false" :tabs="tabs">
+  <template
+    v-for="tab in tabs"
+    :key="`${tab.hash}-anchor`"
+    #[`${item.hash}-anchor`]
+  >
+    <router-link :to="{ name: tab.hash }">
+      {{ tab.title }}
+    </router-link>
+  </template>
+</KTabs>
+
+```html
+<KTabs
+  :has-panels="false"
+  :tabs="tabs"
+  :model-value="(tabs.find(item => (router.currentRoute?.value.name ?? '').toString().startsWith(item.hash)) ?? tabs[0]).hash"
+>
+  <template
+    v-for="tab in tabs"
+    :key="`${tab.hash}-anchor`"
+    #[`${item.hash}-anchor`]
+  >
+    <router-link :to="{ name: tab.hash }">
+      {{ tab.title }}
+    </router-link>
+  </template>
+</KTabs>
+
+<router-view v-slot="{ Component, route }">
+  <component
+    :is="Component"
+    :key="route.path"
+  />
+</router-view>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const tabs = [
+  {
+    hash: 'list',
+    title: 'List',
+  },
+  {
+    hash: 'details',
+    title: 'Details',
+  },
+]
+</script>
+```
+
 ## Slots
 
 In order to actually see your tabbed content you must slot it using the tab hash property without the hash mark.

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -8,11 +8,11 @@
         v-for="(tab, i) in tabs"
         :id="`${tab.hash.replace('#','')}-tab`"
         :key="tab.hash"
-        :aria-controls="`panel-${i}`"
-        :aria-selected="activeTab === tab.hash ? 'true' : 'false'"
+        :aria-controls="hasPanels ? `panel-${i}` : undefined"
+        :aria-selected="hasPanels ? (activeTab === tab.hash ? 'true' : 'false') : undefined"
         class="tab-item"
         :class="{ active: activeTab === tab.hash }"
-        role="tab"
+        :role="hasPanels ? 'tab' : undefined"
         tabindex="0"
         @click="handleTabChange(tab.hash)"
         @keydown.enter.prevent="handleTabChange(tab.hash)"
@@ -26,20 +26,26 @@
       </li>
     </ul>
 
-    <div
-      v-for="(tab, i) in tabs"
-      :id="`panel-${i}`"
-      :key="tab.hash"
-      :aria-labelledby="`${tab.hash.replace('#','')}-tab`"
-      class="tab-container"
-      role="tabpanel"
-      tabindex="0"
-    >
-      <slot
-        v-if="activeTab === tab.hash"
-        :name="tab.hash.replace('#','')"
-      />
-    </div>
+    <template v-if="hasPanels">
+      <div
+        v-for="(tab, i) in tabs"
+        :id="`panel-${i}`"
+        :key="tab.hash"
+        :aria-labelledby="`${tab.hash.replace('#','')}-tab`"
+        class="tab-container"
+        role="tabpanel"
+        tabindex="0"
+      >
+        <slot
+          v-if="activeTab === tab.hash"
+          :name="tab.hash.replace('#','')"
+        />
+      </div>
+    </template>
+    <slot
+      v-else
+      name="default"
+    />
   </div>
 </template>
 
@@ -49,19 +55,26 @@ import type { Tab } from '@/types'
 
 const props = defineProps({
   /**
-     * Array of Tab objects [{hash: '#tab1', title: 'tab1'}, {hash: '#tab2', title: 'tab2'}]
-     */
+   * Array of Tab objects [{hash: '#tab1', title: 'tab1'}, {hash: '#tab2', title: 'tab2'}]
+   */
   tabs: {
     type: Array as PropType<Tab[]>,
     required: true,
   },
   /**
-     * A set tab hash to use as default
-     */
+   * A set tab hash to use as default
+   */
   modelValue: {
     type: String,
     default: '',
     validator: (val: string): boolean => val === '' || (val.includes('#') && !val.includes(' ')),
+  },
+  /**
+   * Render the tab's corresponding panel container
+   */
+  hasPanels: {
+    type: Boolean,
+    default: true,
   },
 })
 
@@ -121,12 +134,18 @@ watch(() => props.modelValue, (newTabHash) => {
       &.active,
       &:hover {
         border-bottom: 4px solid var(--KTabBottomBorderColor, var(--teal-300, color(teal-300)));
-        .tab-link { color: var(--KTabsActiveColor, var(--black-500, color(black-500))); }
+
+        .tab-link,
+        .tab-link a {
+          color: var(--KTabsActiveColor, var(--black-500, color(black-500)));
+        }
       }
     }
 
-    .tab-link {
+    .tab-link,
+    .tab-link a {
       color: var(--KTabsColor, var(--black-45, color(black-45)));
+
       &:hover {
         border: none;
         text-decoration: none;


### PR DESCRIPTION
# Summary

Add a new `hasPanels` prop to `KTabs` in order to only render the tab controls, without the corresponding panels.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
