### PR TITLE
fix(kpagination): kpopAttrs not being defined but used

### DIFF
--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -207,9 +207,9 @@ const pageSizeOptions = props.pageSizes.map((size, i) => ({
 }))
 const pageSizeText = ref('')
 
-const getVisiblePages = (currPage: number, pageCount: number, firstDetached: boolean, lastDetached: boolean): number | number[] => {
+const getVisiblePages = (currPage: number, pageCount: number, firstDetached: boolean, lastDetached: boolean): number[] => {
   if (props.disablePageJump) {
-    return 0
+    return []
   }
   let pages = [...Array(pageCount).keys()].map((n) => n + 1)
   const visiblePages = 5 + 2 * props.neighbors

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -134,6 +134,10 @@ import PaginationOffset from './PaginationOffset.vue'
 import type { PaginationType } from '@/types'
 import { PageSizeChangedData, PageChangedData } from '@/types'
 
+const kpopAttrs = {
+  placement: 'top',
+}
+
 const props = defineProps({
   items: {
     type: Array,


### PR DESCRIPTION
# Summary

**chore: ensures pagesVisible is list of number**

Changes `getVisiblePages` to return `[]` when `props.disablePageJump` is true instead of `0` allowing the function’s return type to be `number[]` instead of `number | number[]` which is likely unintentional seeing as `pageVisible` is used in a `v-for` directive. This silences the TypeScript error shown in the template related to this.

**fix(kpagination): kpopAttrs not being defined but used**

Adds `kpopAttrs` again which was lost in a previous refactoring. This ensures `placement: top` is passed to `KSelect` and silences the Vue warning appearing during development.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
