### PR TITLE
fix(kmultiselect): width calc

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -440,7 +440,7 @@ const multiselectInputId = computed((): string => props.testMode ? 'test-multise
 const multiselectTextId = computed((): string => props.testMode ? 'test-multiselect-text-id-1234' : uuidv4())
 const multiselectSelectedItemsId = computed((): string => props.testMode ? 'test-multiselect-selected-id-1234' : uuidv4())
 const multiselectSelectedItemsStagingId = computed((): string => props.testMode ? 'test-multiselect-selected-staging-id-1234' : uuidv4())
-const multiselectRef = ref(null)
+const multiselectRef = ref<HTMLDivElement | null>(null)
 const selectionBottomRef = ref(null)
 // filter and selection
 const selectionsMaxHeight = computed((): number => {
@@ -905,9 +905,13 @@ watch(() => props.items, (newValue, oldValue) => {
 }, { deep: true, immediate: true })
 
 const numericWidth = ref<number>(300)
-onMounted(() => {
-  // @ts-ignore
+const setNumericWidth = (): void => {
   numericWidth.value = multiselectRef.value?.clientWidth || 300
+}
+
+const resizeObserver = ref()
+onMounted(() => {
+  resizeObserver.value = new ResizeObserver(setNumericWidth).observe(multiselectRef.value as HTMLDivElement)
 })
 </script>
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Make it reactive, so it sizes correctly if the multiselect starts off hidden with no width (ex. if it is inside a `KCollapse`).

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
