### PR TITLE
fix(ktable): add missing test coverage for data changes as expected [KHCP-7560]

### DIFF
--- a/mocks/KTableMockData.ts
+++ b/mocks/KTableMockData.ts
@@ -1,0 +1,49 @@
+export const offsetPaginationHeaders = [
+  { label: 'Host', key: 'hostname', sortable: false },
+  { label: 'Version', key: 'version', sortable: false },
+  { label: 'Connected', key: 'connected', sortable: false },
+  { label: 'Last Seen', key: 'last_seen', sortable: false },
+]
+
+export const generateOffsetPaginationTableData = async (pgSize: number) => {
+  const pageSize = pgSize
+  const data = [] as any
+  const offsetObj = {} as any
+  const offsetVal = 'abc'
+
+  for (let i = 0; i < 50; i++) {
+    data.push({
+      id: `08cc7d81-a9d8-4ae1-a42f-8d4e5a919d0${i}`,
+      version: '2.8.0.0-enterprise-edition',
+      hostname: `99e591ae377${i}`,
+      last_ping: 1648855072,
+      connected: 'Connected',
+      last_seen: `${i} days ago`,
+    })
+  }
+
+  const totalPages = Math.ceil(data.length / pageSize)
+
+  for (let i = 0; i < totalPages; i++) {
+    const start = i * pageSize
+    const end = pageSize * (i + 1)
+    const index = `${offsetVal}_${i}`
+
+    offsetObj[index] = { data: [], pagination: { offset: 'abc' } }
+    offsetObj[index].data = data.slice(start, end)
+
+    if (i < totalPages - 1) {
+      offsetObj[index].pagination.offset = `${offsetVal}_${i + 1}`
+    }
+  }
+
+  return offsetObj
+}
+
+export const offsetPaginationFetcher = async ({ pageSize = 15, offset = 'abc' }) => {
+  const offsetPaginationData = await generateOffsetPaginationTableData(pageSize)
+
+  return offset
+    ? offsetPaginationData[offset]
+    : Object.values(offsetPaginationData)[0]
+}

--- a/src/components/KTable/KTable.cy.ts
+++ b/src/components/KTable/KTable.cy.ts
@@ -1,6 +1,7 @@
 import { mount } from 'cypress/vue'
 import { h } from 'vue'
 import KTable from '@/components/KTable/KTable.vue'
+import { offsetPaginationHeaders, offsetPaginationFetcher } from '../../../mocks/KTableMockData'
 
 const largeDataSet = [
   {
@@ -149,7 +150,7 @@ describe('KTable', () => {
     })
   })
 
-  describe('data changes as expected', () => {
+  describe('data revalidates and changes as expected', () => {
     it('when clicking a specific page number for non-offset pagination', () => {
       mount(KTable, {
         propsData: {
@@ -180,56 +181,6 @@ describe('KTable', () => {
     })
 
     it('when clicking arrows for offset based pagination', () => {
-      const offsetPaginationHeaders = [
-        { label: 'Host', key: 'hostname', sortable: false },
-        { label: 'Version', key: 'version', sortable: false },
-        { label: 'Connected', key: 'connected', sortable: false },
-        { label: 'Last Seen', key: 'last_seen', sortable: false },
-      ]
-
-      let offsetPaginationData = {} as any
-      const generateOffsetPaginationTableData = async (pgSize: number) => {
-        const pageSize = pgSize
-        const data = []
-        const offsetObj = {} as any
-        const offsetVal = 'abc'
-
-        for (let i = 0; i < 50; i++) {
-          data.push({
-            id: `08cc7d81-a9d8-4ae1-a42f-8d4e5a919d0${i}`,
-            version: '2.8.0.0-enterprise-edition',
-            hostname: `99e591ae377${i}`,
-            last_ping: 1648855072,
-            connected: 'Connected',
-            last_seen: `${i} days ago`,
-          })
-        }
-
-        const totalPages = Math.ceil(data.length / pageSize)
-
-        for (let i = 0; i < totalPages; i++) {
-          const start = i * pageSize
-          const end = pageSize * (i + 1)
-          const index = `${offsetVal}_${i}`
-
-          offsetObj[index] = { data: [], pagination: { offset: 'abc' } }
-          offsetObj[index].data = data.slice(start, end)
-
-          if (i < totalPages - 1) {
-            offsetObj[index].pagination.offset = `${offsetVal}_${i + 1}`
-          }
-        }
-
-        offsetPaginationData = offsetObj
-      }
-
-      const offsetPaginationFetcher = async ({ pageSize = 15, offset = 'abc' }) => {
-        generateOffsetPaginationTableData(pageSize)
-
-        return offset
-          ? offsetPaginationData[offset]
-          : Object.values(offsetPaginationData)[0]
-      }
       mount(KTable, {
         propsData: {
           testMode: 'true',


### PR DESCRIPTION
Addresses https://konghq.atlassian.net/browse/KHCP-7560

# Summary

Adds missing test for the following scenarios:

- Data changes as expected when clicking a specific page number for non-offset pagination
- Data changes as expected when clicking arrows for offset based pagination
- Data changes as expected when pageSize is changed
- Data changes as expected when sort key or sort direction is changed and NOT using clientSideSort

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
