### PR TITLE
feat(kbadge): add appearance neutral variant [KHCP-7612]

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -19,12 +19,14 @@ The Badge component can take the following appearance values:
 - `danger`
 - `info`
 - `default`
+- `neutral`
 - `custom`
 
 <KBadge appearance="success" class="mr-2">SUCCESS</KBadge>
 <KBadge appearance="warning" class="mr-2">WARNING</KBadge>
 <KBadge appearance="danger" class="mr-2">DANGER</KBadge>
 <KBadge appearance="info" class="mr-2">INFO</KBadge>
+<KBadge appearance="neutral" class="mr-2">NEUTRAL</KBadge>
 <KBadge>DEFAULT</KBadge>
 
 ```html
@@ -32,6 +34,7 @@ The Badge component can take the following appearance values:
 <KBadge appearance="warning">WARNING</KBadge>
 <KBadge appearance="danger">DANGER</KBadge>
 <KBadge appearance="info">INFO</KBadge>
+<KBadge appearance="neutral">NEUTRAL</KBadge>
 <KBadge>DEFAULT</KBadge>
 ```
 
@@ -43,6 +46,7 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="warning" is-bordered class="mr-2">WARNING</KBadge>
 <KBadge appearance="danger" is-bordered class="mr-2">DANGER</KBadge>
 <KBadge appearance="info" is-bordered class="mr-2">INFO</KBadge>
+<KBadge appearance="neutral" is-bordered class="mr-2">NEUTRAL</KBadge>
 <KBadge is-bordered class="mr-2">DEFAULT</KBadge>
 
 ```html
@@ -50,6 +54,7 @@ Use the `isBordered` prop for bordered badges. The border color matches the text
 <KBadge appearance="warning" is-bordered>WARNING</KBadge>
 <KBadge appearance="danger" is-bordered>DANGER</KBadge>
 <KBadge appearance="info" is-bordered>INFO</KBadge>
+<KBadge appearance="neutral" is-bordered>NEUTRAL</KBadge>
 <KBadge is-bordered>DEFAULT</KBadge>
 ```
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -62,6 +62,7 @@ export const appearances: BadgeAppearanceRecord = {
   info: 'info',
   warning: 'warning',
   custom: 'custom',
+  neutral: 'neutral',
 }
 
 export const shapes: BadgeShapeRecord = {
@@ -304,6 +305,16 @@ watch(badgeText, () => {
       border-width: 1px;
     }
   }
+  &.k-badge-neutral {
+    background-color: var(--KBadgeNeutralBackground, var(--grey-200, color(grey-200)));
+    border-color: var(--KBadgeNeutralBorder, var(--grey-500, color(grey-500)));
+    color: var(--KBadgeNeutralColor, var(--grey-500, color(grey-500)));
+
+    &.is-bordered {
+      border-style: solid;
+      border-width: 1px;
+    }
+  }
 
   &.k-badge-rectangular {
     border-radius: var(--KBadgeBorderRadius, 4px);
@@ -378,6 +389,10 @@ watch(badgeText, () => {
   $KBadgeWarningBackground: var(--KBadgeWarningBackground, var(--yellow-100, color(yellow-100)));
   $KBadgeWarningColor: var(--KBadgeWarningColor, var(--yellow-600, color(yellow-600)));
   $KBadgeWarningButtonHoverColor: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, color(yellow-200)));
+  // neutral appearance colors local variables
+  $KBadgeNeutralBackground: var(--KBadgeNeutralBackground, var(--grey-200, color(grey-200)));
+  $KBadgeNeutralColor: var(--KBadgeNeutralColor, var(--grey-500, color(grey-500)));
+  $KBadgeNeutralButtonHoverColor: var(--KBadgeNeutralButtonHoverColor, var(--grey-300, color(grey-300)));
 
    &.k-badge-custom {
     background-color: v-bind('$props.backgroundColor');
@@ -530,6 +545,30 @@ watch(badgeText, () => {
 
     &:has(.k-badge-dismiss-button:hover) {
       background-color: $KBadgeWarningBackground;
+    }
+  }
+
+  &.k-badge-neutral {
+    .k-badge-dismiss-button {
+      background-color: $KBadgeNeutralBackground;
+      .kong-icon.kong-icon-close path {
+        stroke: $KBadgeNeutralColor;
+      }
+
+      &:hover {
+        background-color: $KBadgeNeutralButtonHoverColor;
+      }
+    }
+
+    a &:hover,
+    a:focus &,
+    &.clickable:hover,
+    &:focus {
+      background-color: $KBadgeNeutralButtonHoverColor;
+    }
+
+    &:has(.k-badge-dismiss-button:hover) {
+      background-color: $KBadgeNeutralBackground;
     }
   }
 }

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,4 +1,4 @@
-export type BadgeAppearance = 'default' | 'success' | 'danger' | 'warning' | 'info' | 'custom'
+export type BadgeAppearance = 'default' | 'success' | 'danger' | 'warning' | 'info' | 'custom' | 'neutral'
 export type BadgeAppearanceRecord = Record<BadgeAppearance, BadgeAppearance>
 
 export type BadgeShape = 'rounded' | 'rectangular'


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7612

Adds `appearance="neutral"` variant to KBadge (screenshot)

![Screen Shot 2023-06-05 at 6 08 56 PM](https://github.com/Kong/kongponents/assets/36751160/5528b1e5-65a8-45f2-bee4-c1178666bb0c)

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
