### PR TITLE
chore(kselect): fix passing size prop as number

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -436,7 +436,7 @@ const selectItems: Ref<SelectItem[]> = ref([])
 const initialFocusTriggered: Ref<boolean> = ref(false)
 const inputFocused: Ref<boolean> = ref(false)
 const popper = ref(null)
-const iconSize = 18
+const iconSize = '18'
 
 // we need this so we can create a watcher for programmatic changes to the modelValue
 const value = computed({


### PR DESCRIPTION
# Summary

Changes the local variable `iconSize` from `18` to `'18'` as it is used as the value for string prop which leads to the warning `Invalid prop: type check failed for prop "size". Expected String with value "18", got Number with value 18.`.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
