### PR TITLE
fix(kicon): restore inheritAttrs setting

### DIFF
--- a/src/components/KIcon/KIcon.vue
+++ b/src/components/KIcon/KIcon.vue
@@ -246,6 +246,12 @@ onMounted(async () => {
 })
 </script>
 
+<script lang="ts">
+export default {
+  inheritAttrs: false,
+}
+</script>
+
 <style lang="scss" scoped>
 .kong-icon {
   display: inline-block;


### PR DESCRIPTION
# Summary

Restore the `inheritAttrs` setting in `KIcon`

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
