### PR TITLE
feat(kselect): add enable-item-creation prop [KHCP-7555]

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -555,6 +555,56 @@ Use this prop to customize selected item element appearance by reusing content p
 </KSelect>
 ```
 
+### enableItemCreation
+
+`KSelect` offers users the ability to add custom item to the list by typing the item they want to and then clicking the `... (Add new value)` item at the bottom of the list, which will also automatically select it.
+
+Newly created item will have a `label` consisting of the user input and a randomly generated id for the `value` to ensure uniqueness. It will also have an attribute `custom` set to `true`. This action triggers an `item:added` event containing the added item data.
+
+Deselecting the item will completely remove it from the list and underlying data, and trigger a `item:removed` event containing the removed item's data.
+
+:::tip NOTE
+You cannot add an item if the `label` matches the `label` of a pre-existing item. In that scenario the `... (Add new value)` item will not be displayed.
+:::
+
+<ClientOnly>
+  <KLabel>Added Item:</KLabel> <pre class="json ma-0">{{ JSON.stringify(addedItems) }}</pre>
+  <KSelect
+    v-model="myVal"
+    :items="deepClone(defaultItems)"
+    enable-item-creation
+    class="mt-2"
+    @item:added="(item) => trackNewItems(item, true)"
+    @item:removed="(item) => trackNewItems(item, false)"
+  />
+</ClientOnly>
+
+```html
+<template>
+  <KLabel>Added Item:</KLabel> {{ addedItems }}
+  <KSelect
+    v-model="myVal"
+    :items="items"
+    enable-item-creation
+    @item:added="(item) => trackNewItems(item, true)"
+    @item:removed="(item) => trackNewItems(item, false)"
+  />
+</template>
+
+<script setup lang="ts">
+  const myVal = 'cats'
+  const addedItems = ref([])
+
+  const trackNewItems = (item, added) => {
+    if (added) {
+      addedItems.value.push(item)
+    } else {
+      addedItems.value = addedItems.value.filter(anItem => anItem.value !== item.value)
+    }
+  }
+</script>
+```
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.
@@ -810,6 +860,7 @@ export default defineComponent({
       myItems: getItems(5),
       mySelect: '',
       myVal: 'cats',
+      addedItems: [],
       defaultItems: [{
         label: 'Cats',
         value: 'cats',
@@ -875,6 +926,13 @@ export default defineComponent({
     }
   },
   methods: {
+    trackNewItems (item, added) {
+      if (added) {
+        this.addedItems.push(item)
+      } else {
+        this.addedItems = this.addedItems.filter(anItem => anItem.value !== item.value)
+      }
+    },
     handleItemSelect (item) {
       this.mySelect = item.label
     },

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -458,4 +458,51 @@ describe('KSelect', () => {
     cy.get('.custom-selected-item').should('not.exist')
     cy.get('input').invoke('attr', 'placeholder').should('contain', placeholderText)
   })
+
+  it.only('allows adding an item with enableItemCreation', () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+    const newItem = 'Rock me'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }],
+        enableItemCreation: true,
+      },
+    })
+
+    cy.get('.k-select-input').click()
+    cy.getTestId(`k-select-item-${vals[0]}`).should('contain.text', labels[0])
+    cy.getTestId(`k-select-item-${vals[1]}`).should('contain.text', labels[1])
+    // no adding a label that already exists
+    cy.get('input').type(labels[0])
+    cy.getTestId('k-select-add-item').should('not.exist')
+    cy.get('input').clear()
+    // add new item
+    cy.get('input').type(newItem)
+    cy.getTestId('k-select-add-item').should('contain.text', newItem).click()
+    // search is cleared
+    cy.get('input').should('not.contain.text', newItem)
+    // displays selected item correctly
+    cy.get('.k-select-item-selection').should('contain.text', newItem)
+    // item displays when searching
+    cy.get('input').type(newItem)
+    cy.get('.k-select-item .k-select-item-label').should('contain.text', newItem)
+    // no adding a label that already exists
+    cy.getTestId('k-select-add-item').should('not.exist')
+    // item gone when deselected
+    cy.get('.k-select-item-selection').get('.clear-selection-icon').click()
+    cy.get('.k-select-item-selection').should('not.to.exist')
+    // gone when searching
+    cy.get('input').clear()
+    cy.get('input').type(newItem)
+    cy.getTestId('k-select-add-item').should('be.visible').should('contain.text', newItem)
+  })
 })

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -459,7 +459,7 @@ describe('KSelect', () => {
     cy.get('input').invoke('attr', 'placeholder').should('contain', placeholderText)
   })
 
-  it.only('allows adding an item with enableItemCreation', () => {
+  it('allows adding an item with enableItemCreation', () => {
     const labels = ['Label 1', 'Label 2']
     const vals = ['label1', 'label2']
     const newItem = 'Rock me'

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -209,11 +209,26 @@
                 </template>
               </KSelectItems>
               <KSelectItem
-                v-if="!filteredItems.length && !$slots.empty"
+                v-if="!filteredItems.length && !$slots.empty && !enableItemCreation"
                 key="k-select-empty-state"
                 class="k-select-empty-item"
                 :item="{ label: 'No results', value: 'no_results' }"
               />
+              <KSelectItem
+                v-if="!filteredItems.length && uniqueFilterStr && !$slots.empty && enableItemCreation"
+                key="k-select-new-item"
+                class="k-select-new-item"
+                data-testid="k-select-add-item"
+                :item="{ label: `${filterStr} (Add new value)`, value: 'add_item' }"
+                @selected="handleAddItem"
+              >
+                <template #content>
+                  <div class="select-item-description">
+                    {{ filterStr }}
+                    <span class="select-item-new-indicator">(Add new value)</span>
+                  </div>
+                </template>
+              </KSelectItem>
             </div>
             <slot
               v-if="!loading && !filteredItems.length"
@@ -411,6 +426,13 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  /**
+   * Allow creating new items
+   */
+  enableItemCreation: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emit = defineEmits<{
@@ -419,6 +441,8 @@ const emit = defineEmits<{
   (e: 'change', item: SelectItem | null): void
   (e: 'update:modelValue', value: string | number | null): void
   (e: 'query-change', value: string): void
+  (e: 'item:added', value: SelectItem): void
+  (e: 'item:removed', value: SelectItem): void
 }>()
 
 const attrs = useAttrs()
@@ -428,6 +452,18 @@ const isRequired = computed((): boolean => attrs.required !== undefined && Strin
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.help || props.labelAttributes?.info || slots['label-tooltip']))
 const filterStr = ref('')
+// whether or not filter string matches an existing item's label
+const uniqueFilterStr = computed((): boolean => {
+  if (!filterStr.value) {
+    return false
+  }
+
+  if (selectItems.value.filter((item: SelectItem) => item.label === filterStr.value).length) {
+    return false
+  }
+
+  return true
+})
 const selectedItem = ref<SelectItem|null>(null)
 const selectId = computed((): string => props.testMode ? 'test-select-id-1234' : uuidv4())
 const selectInputId = computed((): string => props.testMode ? 'test-select-input-id-1234' : uuidv4())
@@ -555,16 +591,45 @@ const onInputKeypress = (event: Event) => {
   }
 }
 
-const handleItemSelect = (item: SelectItem) => {
-  selectItems.value.forEach(anItem => {
+// add an item with `enter`
+const handleAddItem = (): void => {
+  if (!props.enableItemCreation || !filterStr.value || !uniqueFilterStr.value) {
+    // do nothing if not enabled or no label or label already exists
+    return
+  }
+
+  const pos = selectItems.value.length + 1
+  const item: SelectItem = {
+    label: filterStr.value + '',
+    value: props.testMode ? `test-multiselect-added-item-${pos}` : uuidv4(),
+    key: `${filterStr.value.replace(/ /gi, '-')?.replace(/[^a-z0-9-_]/gi, '')}-${pos}`,
+    custom: true,
+  }
+
+  emit('item:added', item)
+
+  handleItemSelect(item, true)
+  filterStr.value = ''
+}
+
+const handleItemSelect = (item: SelectItem, isNew?: boolean) => {
+  if (isNew) {
+    // if it's a new item, we need to add it to the list
+    selectItems.value.push(item)
+  }
+
+  selectItems.value.forEach((anItem, i) => {
     if (anItem.key === item.key) {
       anItem.selected = true
       anItem.key = anItem?.key?.includes('-selected') ? anItem.key : `${anItem.key}-selected`
-      anItem.key += '-selected'
       selectedItem.value = anItem
     } else if (anItem.selected) {
       anItem.selected = false
       anItem.key = anItem?.key?.replace(/-selected/gi, '')
+      if (anItem.custom) {
+        selectItems.value.splice(i, 1)
+        emit('item:removed', anItem)
+      }
     } else {
       anItem.selected = false
     }
@@ -578,9 +643,13 @@ const handleItemSelect = (item: SelectItem) => {
 }
 
 const clearSelection = (): void => {
-  selectItems.value.forEach(anItem => {
+  selectItems.value.forEach((anItem, i) => {
     anItem.selected = false
     anItem.key = anItem?.key?.replace(/-selected/gi, '')
+    if (anItem.custom) {
+      selectItems.value.splice(i, 1)
+      emit('item:removed', anItem)
+    }
   })
   selectedItem.value = null
   if (props.appearance === 'select') {
@@ -960,6 +1029,15 @@ $chevronDownIconMargin: 10px;
     .k-select-empty-item button:hover {
       color: var(--grey-500);
       font-style: italic;
+    }
+
+    .k-select-new-item {
+      word-break: break-word;
+
+      .select-item-new-indicator {
+        font-style: italic;
+        font-weight: 600;
+      }
     }
 
     ul {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -591,7 +591,6 @@ const onInputKeypress = (event: Event) => {
   }
 }
 
-// add an item with `enter`
 const handleAddItem = (): void => {
   if (!props.enableItemCreation || !filterStr.value || !uniqueFilterStr.value) {
     // do nothing if not enabled or no label or label already exists


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7555

Adds `enableItemCreation` prop to allow custom select item creation

<img width="731" alt="Screen Shot 2023-06-09 at 5 33 54 PM" src="https://github.com/Kong/kongponents/assets/36751160/b6c77641-2126-4271-8480-2c6bb81aa679">
<img width="748" alt="Screen Shot 2023-06-09 at 5 34 11 PM" src="https://github.com/Kong/kongponents/assets/36751160/0e717d3c-0f46-4014-80b8-d062b5ed2b55">

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
