### PR TITLE
fix(kselect): value when `enableItemCreation` is true

### DIFF
--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -505,4 +505,35 @@ describe('KSelect', () => {
     cy.get('input').type(newItem)
     cy.getTestId('k-select-add-item').should('be.visible').should('contain.text', newItem)
   })
+
+  it('accepts created item with enableItemCreation', () => {
+    const labels = ['Label 1', 'Label 2']
+    const vals = ['label1', 'label2']
+    const newItem = 'Rock me'
+
+    mount(KSelect, {
+      props: {
+        testMode: true,
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }],
+        modelValue: newItem,
+        enableItemCreation: true,
+      },
+    })
+
+    // accepts already created item as value
+    cy.get('.k-select-item-selection').should('contain.text', newItem)
+    cy.get('.k-select-input').click()
+    cy.getTestId(`k-select-item-${vals[0]}`).should('contain.text', labels[0])
+    cy.getTestId(`k-select-item-${vals[1]}`).should('contain.text', labels[1])
+    cy.get('.k-select-item').last().should('contain.text', newItem)
+    // item gone when deselected
+    cy.get('.k-select-item-selection').get('.clear-selection-icon').click()
+    cy.get('.k-select-item-selection').should('not.to.exist')
+  })
 })

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -697,9 +697,14 @@ watch(value, (newVal, oldVal) => {
       handleItemSelect(item[0])
     } else if (!newVal) {
       clearSelection()
+    } else if (props.enableItemCreation) {
+      nextTick(() => {
+        filterStr.value = `${newVal}`
+        handleAddItem()
+      })
     }
   }
-})
+}, { immediate: true })
 
 watch(() => props.items, (newValue, oldValue) => {
   // Only trigger the watcher if items actually change


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

`<KSelect>` with `enableItemCreation` should accept a previously created item as its value, otherwise there'll be a problem when editing an entity. Context: https://kongstrong.slack.com/archives/C04FLSMJ2ET/p1686726647993929.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
