### PR TITLE
fix(kcatalog): fix loading skeleton cards width [KHCP-5907]

### DIFF
--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -635,11 +635,6 @@ onMounted(() => {
   $cardHeight: 181px;
 
   .k-skeleton-grid {
-    --KSkeletonCardWidth: 25%;
-
-    .skeleton-card-column {
-      padding-right: 32px;
-    }
     .skeleton-card {
       height: $cardHeight;
     }

--- a/src/components/KSkeleton/CardSkeleton.vue
+++ b/src/components/KSkeleton/CardSkeleton.vue
@@ -56,12 +56,13 @@ $borderColor: #e6e6e6;
 .skeleton-card-wrapper {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--spacing-md, spacing(md));
+  justify-content: space-between;
   width: 100%;
 }
 .skeleton-card-column {
-  margin-bottom: 16px;
-  width: var(--KSkeletonCardWidth, calc(33% - 16px));
+  margin-bottom: var(--spacing-md, spacing(md));
+  width: var(--KSkeletonCardWidth, calc(33% - var(--spacing-md, spacing(md))));
 }
 .skeleton-card {
   border: 1px solid $borderColor;
@@ -70,10 +71,10 @@ $borderColor: #e6e6e6;
   flex-direction: column;
   min-height: 324px;
   overflow: hidden;
-  padding: 16px;
+  padding: var(--spacing-md, spacing(md));
   .skeleton-card-header {
     display: flex;
-    margin-bottom: 16px;
+    margin-bottom: var(--spacing-md, spacing(md));
     width: 100%;
   }
   .skeleton-card-content {
@@ -85,7 +86,7 @@ $borderColor: #e6e6e6;
     display: flex;
     justify-content: space-between;
     margin-top: auto;
-    padding-top: 16px;
+    padding-top: var(--spacing-md, spacing(md));
     width: 100%;
   }
 }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-5907

Fix `KCatalog` loading `KSkeleton` cards width.

Before
<img width="1728" alt="Screen Shot 2023-06-20 at 4 33 04 PM" src="https://github.com/Kong/kongponents/assets/36751160/ec5e90fe-6bbf-4cd3-a59d-45880be7b73f">

After
<img width="1726" alt="Screen Shot 2023-06-20 at 4 32 30 PM" src="https://github.com/Kong/kongponents/assets/36751160/355bf266-55b7-4be8-961b-754460cf6ee5">


## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
