### PR TITLE
fix(ktooltip): remove kpop default timeout

### DIFF
--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -5,6 +5,7 @@
     :max-width="maxWidth"
     :placement="placement"
     :popover-classes="`k-tooltip ${computedClass} ${className}`"
+    :popover-timeout="0"
     :position-fixed="positionFixed"
     :test-mode="!!testMode || undefined"
     trigger="hover"


### PR DESCRIPTION
# Summary

Remove default `KPop` timeout from `KTooltip`

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
