### PR TITLE
fix(kemptystate): unnecessary spaces and gaps

### DIFF
--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -91,7 +91,7 @@ defineProps({
 .empty-state-wrapper {
   background-color: var(--KEmptyBackground, var(--white));
   border-radius: 4px;
-  padding: 48px 0;
+  padding: var(--spacing-xxl, spacing(xxl)) 0;
   text-align: center;
 
   > * + * {

--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -6,7 +6,7 @@
     <div class="empty-state-title">
       <div
         v-if="isError || icon"
-        class="k-empty-state-icon card-icon mb-3"
+        class="k-empty-state-icon card-icon"
         :class="{ 'warning-icon': isError }"
       >
         <KIcon
@@ -16,18 +16,26 @@
           :size="iconSize"
         />
       </div>
-      <div class="k-empty-state-title-header mt-4 mb-4">
+      <div
+        v-if="slots.title"
+        class="k-empty-state-title-header"
+      >
         <slot name="title" />
       </div>
     </div>
     <div class="empty-state-content">
-      <div class="k-empty-state-message mb-6">
+      <div
+        v-if="slots.message"
+        class="k-empty-state-message"
+      >
         <slot name="message" />
       </div>
-      <div class="k-empty-state-cta">
+      <div
+        v-if="!ctaIsHidden && ctaText"
+        class="k-empty-state-cta"
+      >
         <slot name="cta">
           <KButton
-            v-if="!ctaIsHidden && ctaText"
             appearance="primary"
             size="small"
             @click.prevent="() => handleClick && handleClick()"
@@ -43,6 +51,9 @@
 <script lang="ts" setup>
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
+import { useSlots } from 'vue'
+
+const slots = useSlots()
 
 defineProps({
   isError: {
@@ -86,24 +97,35 @@ defineProps({
   padding: 48px 0;
   text-align: center;
 
+  > * + * {
+    margin-top: var(--spacing-md, spacing(md));
+  }
+
   .k-empty-state-title-header {
     color: var(--KEmptyTitleColor, var(--black-500));
     font-size: 20px;
     font-weight: 600;
     line-height: 24px;
-    margin: 0 0 14px;
+  }
+
+  .empty-state-title > * + * {
+    margin-top: var(--spacing-xs, spacing(xs));
   }
 
   .k-empty-state-message {
     color: var(--KEmptyContentColor, var(--black-400));
     font-size: 13px;
     line-height: 20px;
-    margin: 0 auto 14px;
+    margin-left: auto;
+    margin-right: auto;
     max-width: 50%;
   }
 
+  .empty-state-content > * + * {
+    margin-top: var(--spacing-xl, spacing(xl));
+  }
+
   .k-empty-state-cta {
-    margin: 0;
     margin-left: auto;
     margin-right: auto;
   }

--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -17,7 +17,7 @@
         />
       </div>
       <div
-        v-if="slots.title"
+        v-if="$slots.title"
         class="k-empty-state-title-header"
       >
         <slot name="title" />
@@ -25,7 +25,7 @@
     </div>
     <div class="empty-state-content">
       <div
-        v-if="slots.message"
+        v-if="$slots.message"
         class="k-empty-state-message"
       >
         <slot name="message" />
@@ -51,9 +51,6 @@
 <script lang="ts" setup>
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
-import { useSlots } from 'vue'
-
-const slots = useSlots()
 
 defineProps({
   isError: {


### PR DESCRIPTION
# Summary

Changes the empty state component to only render container divs if the associated slots which don’t have fallback content are slotted in (e.g. if `title` is not slotted in, the component no longer renders an empty `.k-empty-state-title-header` div).

Changes the margins used to space out the individual parts of the empty state component to only apply if they make sense (e.g. the `message` slot will no longer have a large bottom margin if the CTA is hidden).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
