### PR TITLE
feat: cron job to cleanup PR preview versions published [KHCP-7461]

### DIFF
--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
   cleanup:
     name: Cleanup PR Previews
-    needs: prepare
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_PUBLISH }}

--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -1,0 +1,41 @@
+name: Cleanup PR preview packages
+on:
+  push:
+    branches:
+      - fix/KHCP-7461_unpublish-pr-pkgs
+
+  workflow_dispatch:
+
+  schedule:
+    - cron: '30 * * * 6,0'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Cleanup PR Previews
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_PUBLISH }}
+      GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v3
+
+      - name: Setup PNPM with Dependencies
+        uses: ./.github/actions/setup-pnpm-with-dependencies/
+
+      - name: Prepare package matrix
+        id: prepare
+        run: |
+          echo "openPRs=$(gh pr list --state open --json number|jq  -cM 'map(.number|tostring)')" >> $GITHUB_OUTPUT
+
+      - name: Cleanup PR preview
+        uses: Kong/public-shared-actions/pr-previews/cleanup@main
+        with:
+          package: "@kong/kongponents"
+          openPRs: ${{ steps.prepare.outputs.openPRs }}

--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -29,6 +29,7 @@ jobs:
         id: prepare
         run: |
           echo "openPRs=$(gh pr list --state open --json number|jq  -cM 'map(.number|tostring)')" >> $GITHUB_OUTPUT
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}" > .npmrc
 
       - name: Cleanup PR preview
         uses: Kong/public-shared-actions/pr-previews/cleanup@main

--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -1,9 +1,5 @@
 name: Cleanup PR preview packages
 on:
-  push:
-    branches:
-      - fix/KHCP-7461_unpublish-pr-pkgs
-
   workflow_dispatch:
 
   schedule:

--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -25,10 +25,7 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v3
 
-      - name: Setup PNPM with Dependencies
-        uses: ./.github/actions/setup-pnpm-with-dependencies/
-
-      - name: Prepare package matrix
+      - name: Prepare cleanup
         id: prepare
         run: |
           echo "openPRs=$(gh pr list --state open --json number|jq  -cM 'map(.number|tostring)')" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -5,8 +5,8 @@ on:
       - closed
 
 jobs:
-  unpublish:
-    name: Unpublish or Deprecate NPM previews for PR
+  remove-pr-preview-comment:
+    name: Remove PR preview comment from PR
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -20,39 +20,3 @@ jobs:
           header: pr_preview_consumption
           delete: true
           GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
-
-      - name: Create .npmrc
-        # Reference the env variable NPM_TOKEN here, not the secret
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-
-      - name: Unpublish
-        run: |
-          toUnpublish=()
-
-          prNumber="${{github.event.number}}"
-
-          pkgName="@kong/kongponents"
-
-          npm dist-tag rm "${pkgName}" "pr-${prNumber}" || true
-
-          for pkgVersion in $(npm view ${pkgName} --json|jq -r .versions|grep "\-pr.${prNumber}."|sed 's/,//'| sed 's/\"//g')
-          do
-            toUnpublish+=("${pkgName}@${pkgVersion}")
-          done
-
-          echo  "List: ${toUnpublish[*]}"|sed 's/ /\n/g'
-
-          for (( i=${#toUnpublish[@]}-1; i>=0; i-- ))
-          do
-            echo ""
-            echo "*** deprecating: ${toUnpublish[i]}"
-            npm deprecate --force "${toUnpublish[i]}" "Deprecated PR preview" || true
-          done
-
-
-          for (( i=${#toUnpublish[@]}-1; i>=0; i-- ))
-          do
-            echo ""
-            echo "unpublishing: ${toUnpublish[i]}"
-            npm unpublish --force "${toUnpublish[i]}" || true
-          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         run: yarn build:ci
 
       - name: Publish Previews
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         run: |
           git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
           git config user.name "Kong UI Bot"


### PR DESCRIPTION
# Summary

- add job to cleanup PR preview version published 
- do not publish PR previews for dependabot originated PRs
