### PR TITLE
fix(kdropdownmenu): item truncation [khcp-7688]

### DIFF
--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -299,7 +299,7 @@ Text to display on hover if dropdown is disabled.
 
 There are 2 supported slots:
 
-#### default
+### default
 
 The trigger element for opening/closing the menu.
 
@@ -329,7 +329,7 @@ The trigger element for opening/closing the menu.
 </KDropdownMenu>
 ```
 
-#### items
+### items
 
 You can customize the appearance of dropdown items using this slot.
 
@@ -365,12 +365,14 @@ There are 3 primary item types:
 - `custom` - no special handling, you completely control the content
 
 <ClientOnly>
-  <KDropdownMenu label="Variety">
+  <KDropdownMenu label="Variety" width="250">
     <template #items="{ closeDropdown }">
       <KDropdownItem :item="youAreHere" />
-      <KDropdownItem has-divider @click="clickHandler('Button clicked!')">
-        A button
-      </KDropdownItem>
+      <KDropdownItem
+        :item="{ label: 'A button with a a long long long long long long looooooooooooooooooooooooooooooooooooooooooooooong name' }"
+        has-divider
+        @click="clickHandler('Button clicked!')"
+      />
       <KDropdownItem
         disabled
         @click="clickHandler"
@@ -417,12 +419,14 @@ There are 3 primary item types:
 </ClientOnly>
 
 ```html
-<KDropdownMenu label="Variety">
+<KDropdownMenu label="Variety" width="250">
   <template #items="{ closeDropdown }">
-    <KDropdownItem :item="{ label: 'You are here', to: { path: '/components/dropdown-menu.html' } }" />
-    <KDropdownItem has-divider @click="clickHandler">
-      A button
-    </KDropdownItem>
+    <KDropdownItem :item="youAreHere" />
+    <KDropdownItem
+      :item="{ label: 'A button with a a long long long long long long looooooooooooooooooooooooooooooooooooooooooooooong name' }"
+      has-divider
+      @click="clickHandler('Button clicked!')"
+    />
     <KDropdownItem
       disabled
       @click="clickHandler"

--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -15,7 +15,13 @@
       v-bind="availableComponents[componentType].attrs"
       @click="availableComponents[componentType].onClick"
     >
-      <slot>{{ label }}</slot>
+      <span
+        class="truncate"
+        :title="label"
+      >
+
+        <slot>{{ label }}</slot>
+      </span>
     </component>
   </li>
 </template>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Fix `KDropdownMenu` to truncate button content when it extends beyond explicit set width.
Addresses [KHCP-7688](https://konghq.atlassian.net/browse/KHCP-7688).

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-7688]: https://konghq.atlassian.net/browse/KHCP-7688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ