### PR TITLE
fix(kcodeblock): not showing correct number of matching lines

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -18,20 +18,20 @@
           'k-code-block-search-results-has-query': query !== '',
         }"
       >
-        <template v-if="query === '' && numberOfMatches === 0">
+        <template v-if="query === '' && matchingLineNumbers.length === 0">
           &nbsp;
         </template>
 
-        <template v-else-if="numberOfMatches === 0">
+        <template v-else-if="matchingLineNumbers.length === 0">
           No results
         </template>
 
         <template v-else-if="typeof currentLineIndex === 'number' && !isShowingFilteredCode">
-          {{ currentLineIndex + 1 }} of {{ numberOfMatches }}
+          {{ currentLineIndex + 1 }} of {{ matchingLineNumbers.length }}
         </template>
 
         <template v-else>
-          {{ numberOfMatches }} {{ numberOfMatches === 1 ? 'result' : 'results' }}
+          {{ matchingLineNumbers.length }} {{ matchingLineNumbers.length === 1 ? 'result' : 'results' }}
         </template>
       </p>
 


### PR DESCRIPTION
# Summary

Fixes not showing the correct number of matching lines. Since cycling through matches happens on a line by line basis (i.e. we don’t jump to one line containing multiple matches once per match but only once per matching line), we should also show the number of results in relation to matched lines.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
