### PR TITLE
fix(kemptystate): `cta` slot

### DIFF
--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -30,12 +30,10 @@
       >
         <slot name="message" />
       </div>
-      <div
-        v-if="!ctaIsHidden && ctaText"
-        class="k-empty-state-cta"
-      >
+      <div class="k-empty-state-cta">
         <slot name="cta">
           <KButton
+            v-if="!ctaIsHidden && ctaText"
             appearance="primary"
             size="small"
             @click.prevent="() => handleClick && handleClick()"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Fixing a bug where the `cta` named slot renders nothing. This is caught in the `shared-ui-components` CI: https://github.com/Kong/shared-ui-components/actions/runs/5396449758/jobs/9800184704

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
