### PR TITLE
fix(kdropdownitem): increase line-height to prevent cutoff in kdropdownitem [KHCP-7907]

### DIFF
--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -196,6 +196,7 @@ li.k-dropdown-item {
   // Override .btn-link styles
   .k-dropdown-item-trigger.btn-link {
     color: var(--black-70, rgba(0, 0, 0, 0.7));
+    line-height: var(--type-lg, type(lg));
     padding: var(--spacing-md, spacing(md)) var(--spacing-lg, spacing(lg));
     text-align: left;
     text-decoration: none;
@@ -216,6 +217,7 @@ li.k-dropdown-item {
 .k-dropdown-item {
   a, button {
     &.k-dropdown-item-trigger {
+      line-height: var(--type-lg, type(lg));
       text-decoration: none !important;
     }
   }


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->


https://konghq.atlassian.net/browse/KHCP-7907
increased line-height to prevent cutoff in KDropdownItem

### Before:
<img width="1721" alt="Screenshot 2023-06-28 at 2 42 02 PM" src="https://github.com/Kong/kongponents/assets/2568272/17f03466-8036-4bae-a9e6-3c7e183cbfd1">

### After:
<img width="1728" alt="Screenshot 2023-06-28 at 3 00 14 PM" src="https://github.com/Kong/kongponents/assets/2568272/a776afd6-8b43-44a4-9361-e1cd99065117">

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
