### PR TITLE
fix(deps): move @kong/design-tokens from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
+    "@kong/design-tokens": "^1.2.0",
     "axios": "^0.27.2",
     "date-fns": "^2.29.3",
     "date-fns-tz": "^1.3.7",
@@ -74,7 +75,6 @@
     "@cypress/vite-dev-server": "^5.0.2",
     "@digitalroute/cz-conventional-changelog-for-jira": "^7.3.1",
     "@evilmartians/lefthook": "^1.4.1",
-    "@kong/design-tokens": "^1.2.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/inquirer": "^8.2.3",


### PR DESCRIPTION
# Summary

Moves `@kong/design-tokens` from devDeps to deps.

Files from `@kong/design-tokens` are required in production. Therefore if/when `@kong/kongponents` is installed as an indirect dependency, the current configuration (using `devDependencies`) means `@kong/design-tokens` is not available, therefore breaking the application.

## PR Checklist

* [ ] Does not introduce dependencies **_(It doesn't 'introduce' as such but makes dependencies available that unintentionally weren't previously available)_**
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test. **_Tests don't run in CI due to what seems like a lack of token, locally theres failures but `main` also fails. Let me know if you need me to do anything._**
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
