### PR TITLE
fix(*): design token imports

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -23,4 +23,13 @@ export default defineConfig({
       'date-fns-tz': path.resolve(__dirname, '../node_modules/date-fns-tz/esm'),
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Inject the @kong/design-tokens SCSS variables since our docs site imports Kongponents locally (i.e. not compiled)
+        // This is not needed in host applications.
+        additionalData: '@import "@kong/design-tokens/tokens/scss/variables";',
+      },
+    },
+  },
 })

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,5 +1,3 @@
-@import "@kong/design-tokens/tokens/scss/variables";
-
 $colors: (
   blue-100: #f2f6fe,
   blue-200: #bdd3f9,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,13 @@ export default defineConfig({
   },
   css: {
     devSourcemap: true,
+    preprocessorOptions: {
+      scss: {
+        // Inject the @kong/design-tokens SCSS variables to make them available for all components.
+        // This is not needed in host applications.
+        additionalData: '@import "@kong/design-tokens/tokens/scss/variables";',
+      },
+    },
   },
   build: {
     lib: {


### PR DESCRIPTION
# Summary

Refactor the design token imports so they are not exposed in the existing `dist/_variables.scss` file, which allows the `@kong/design-tokens` package to remain a `devDependency`.

Having the import directly in the `src/styles/_variables.scss` requires the package to be linked as a `dependency` for host applications as well since this file is being directly exported. 👎🏼 

**Note**: in the future breaking release, we should remove the `dist/_variables.scss` export as it should not be exposed.

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
