### PR TITLE
fix(kmultiselect): always show lock [khcp-7963]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -890,7 +890,9 @@ export default defineComponent({
       },
       {
         label: 'Lions',
-        value: 'lions'
+        value: 'lions',
+        disabled: true,
+        disabledTooltipText: 'This item is disabled and cannot be selected'
       }, {
         label: 'Tigers',
         value: 'tigers',
@@ -954,8 +956,6 @@ export default defineComponent({
         label: 'Dogs',
         value: 'dogs',
         selected: true,
-        disabled: true,
-        disabledTooltipText: 'This item is locked and cannot be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies',
@@ -982,10 +982,7 @@ export default defineComponent({
         value: 'cats'
       }, {
         label: 'Dogs',
-        value: 'dogs',
-        selected: true,
-        disabled: true,
-        disabledTooltipText: 'This item is locked and cannot be removed'
+        value: 'dogs'
       }, {
         label: 'Bunnies',
         value: 'bunnies'

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -46,7 +46,7 @@ You can specify `disabledTooltipText` property to customize the disabled tooltip
     value: 'dogs',
     selected: true,
     disabled: true,
-    disabledTooltipText: 'This item is locked and cannot be removed'
+    disabledTooltipText: 'This item is disabled and cannot be removed'
   }, {
     label: 'Bunnies',
     value: 'bunnies',
@@ -54,7 +54,9 @@ You can specify `disabledTooltipText` property to customize the disabled tooltip
   },
   {
     label: 'Lions',
-    value: 'lions'
+    value: 'lions',
+    disabled: true,
+    disabledTooltipText: 'This item is disabled and cannot be selected'
   }, {
     label: 'Tigers',
     value: 'tigers',
@@ -69,6 +71,10 @@ You can specify `disabledTooltipText` property to customize the disabled tooltip
     label: 'Duck',
     value: 'duck',
     group: 'Birds'
+  },{
+    label: 'Salmon',
+    value: 'salmon',
+    group: 'Fish'
   }, {
     label: 'Oriole',
     value: 'oriole',
@@ -76,10 +82,6 @@ You can specify `disabledTooltipText` property to customize the disabled tooltip
   }, {
     label: 'Trout',
     value: 'trout',
-    group: 'Fish'
-  }, {
-    label: 'Salmon',
-    value: 'salmon',
     group: 'Fish'
   }]"
 />
@@ -882,7 +884,7 @@ export default defineComponent({
         value: 'dogs',
         selected: true,
         disabled: true,
-        disabledTooltipText: 'This item is locked and cannot be removed'
+        disabledTooltipText: 'This item is disabled and cannot be removed'
       }, {
         label: 'Bunnies',
         value: 'bunnies',

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -21,9 +21,10 @@
           </slot>
         </span>
         <span class="k-multiselect-selected-icon-container">
-          <KTooltip
-            v-if="item.selected && item.disabled"
-            :label="item.disabledTooltipText"
+          <component
+            :is="item.disabledTooltipText ? 'KTooltip' : 'div'"
+            v-if="item.disabled"
+            :label="item.disabledTooltipText ? item.disabledTooltipText : undefined"
             placement="left"
           >
             <KIcon
@@ -33,7 +34,7 @@
               icon="lock"
               size="14"
             />
-          </KTooltip>
+          </component>
           <KIcon
             v-else-if="item.selected"
             class="selected-item-icon"

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -29,7 +29,7 @@
           >
             <KIcon
               class="selected-item-icon"
-              color="var(--blue-200)"
+              :color="item.selected ? 'var(--blue-200)' : 'var(--grey-400)'"
               hide-title
               icon="lock"
               size="14"

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -22,7 +22,7 @@
         </span>
         <span class="k-multiselect-selected-icon-container">
           <component
-            :is="item.disabledTooltipText ? 'KTooltip' : 'div'"
+            :is="item.disabledTooltipText ? 'KTooltip' : 'span'"
             v-if="item.disabled"
             :label="item.disabledTooltipText ? item.disabledTooltipText : undefined"
             placement="left"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Always display the lock icon if a `KMultiselect` item is `disabled` (even if it's not `selected`) for [KHCP-7963](https://konghq.atlassian.net/browse/KHCP-7963).
Fix logic to not render a `KTooltip` if no `disabledTooltipText`.

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-7963]: https://konghq.atlassian.net/browse/KHCP-7963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ