### PR TITLE
fix(scss): autocompletion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,11 +35,10 @@
   "cssVariables.lookupFiles": [
     "**/*.css",
     "**/*.scss",
-    "node_modules/@kong/design-tokens/dist/tokens/css/variables.css",
+    "node_modules/@kong/design-tokens/dist/tokens/css/variables.css"
   ],
   "scss.scannerExclude": [
     "**/.git",
-    "**/bower_components",
-    "**/node_modules/!(@kong/design-tokens)",
+    "**/bower_components"
   ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,5 +40,5 @@
   "scss.scannerExclude": [
     "**/.git",
     "**/bower_components"
-  ],
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@cypress/vite-dev-server": "^5.0.2",
     "@digitalroute/cz-conventional-changelog-for-jira": "^7.3.1",
     "@evilmartians/lefthook": "^1.4.1",
-    "@kong/design-tokens": "^1.2.0",
+    "@kong/design-tokens": "^1.3.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/inquirer": "^8.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,10 +795,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kong/design-tokens@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.2.0.tgz#1ec12665ec3519f700ce0e31fab0165d08ffebc3"
-  integrity sha512-eTKLwr5Gz82bTHYMwiPhixs+8uPQUzioapXJQi5lA94aUYiO8lcFtlR2YYmiE7QZhNn4KawxPQ8T6Fk9daD5jA==
+"@kong/design-tokens@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.3.0.tgz#ce59d9f699d95300776582d20325bad20b26f01b"
+  integrity sha512-FMFL/+njsePKLxu42mhodbTj24Grxp/rfTRN2y2PmIc/+eRuglQYWTr0zdtmUzvb3dY5jzTmPYLvsh0uJhOdwA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
# Summary

Update the `@kong/design-tokens` package and adjust the SCSS intellisense plugin settings to not exclude `node_modules`

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
