### PR TITLE
fix(KTruncate, KMultiselect): add fix for ResizeObserver [KHCP-7734]

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -911,7 +911,15 @@ const setNumericWidth = (): void => {
 
 const resizeObserver = ref()
 onMounted(() => {
-  resizeObserver.value = new ResizeObserver(setNumericWidth).observe(multiselectRef.value as HTMLDivElement)
+  resizeObserver.value = new ResizeObserver(entries => {
+    window.requestAnimationFrame(() => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return
+      }
+      setNumericWidth()
+    })
+  })
+  resizeObserver.value.observe(multiselectRef.value as HTMLDivElement)
 })
 
 onBeforeUnmount(() => {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -912,10 +912,12 @@ const setNumericWidth = (): void => {
 const resizeObserver = ref()
 onMounted(() => {
   resizeObserver.value = new ResizeObserver(entries => {
+    // Wrapper 'window.requestAnimationFrame' is needed for disabling "ResizeObserver loop limit exceeded" error in DD
     window.requestAnimationFrame(() => {
       if (!Array.isArray(entries) || !entries.length) {
         return
       }
+      // Actual code
       setNumericWidth()
     })
   })

--- a/src/components/KTruncate/KTruncate.vue
+++ b/src/components/KTruncate/KTruncate.vue
@@ -227,7 +227,15 @@ const widthStyle = computed((): Record<string, string> => {
 })
 
 onMounted(() => {
-  resizeObserver.value = new ResizeObserver(setWrapperHeight).observe(kTruncateContainer.value as HTMLDivElement)
+  resizeObserver.value = new ResizeObserver(entries => {
+    window.requestAnimationFrame(() => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return
+      }
+      setWrapperHeight()
+    })
+  })
+  resizeObserver.value.observe(kTruncateContainer.value as HTMLDivElement)
   updateToggleVisibility()
 })
 

--- a/src/components/KTruncate/KTruncate.vue
+++ b/src/components/KTruncate/KTruncate.vue
@@ -228,10 +228,12 @@ const widthStyle = computed((): Record<string, string> => {
 
 onMounted(() => {
   resizeObserver.value = new ResizeObserver(entries => {
+    // Wrapper 'window.requestAnimationFrame' is needed for disabling "ResizeObserver loop limit exceeded" error in DD
     window.requestAnimationFrame(() => {
       if (!Array.isArray(entries) || !entries.length) {
         return
       }
+      // Actual code
       setWrapperHeight()
     })
   })


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

https://konghq.atlassian.net/browse/KHCP-7734

Disable Uncaught "ResizeObserver loop limit exceeded" error

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
