### PR TITLE
feat(kbadge): introduce kui tokens [KHCP-7694]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 # Design Tokens Implemented Kongponents
 # This is temporary codeowners until we introduce design tokens practices to the whole team
 /src/components/KAlert @adamdehaven @jillztom @portikM
+/src/components/KBadge @adamdehaven @jillztom @portikM
 /src/components/KButton @adamdehaven @jillztom @portikM
 
 # Dependabot approvals

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -22,12 +22,14 @@ The Badge component can take the following appearance values:
 - `neutral`
 - `custom`
 
-<KBadge appearance="success" class="mr-2">SUCCESS</KBadge>
-<KBadge appearance="warning" class="mr-2">WARNING</KBadge>
-<KBadge appearance="danger" class="mr-2">DANGER</KBadge>
-<KBadge appearance="info" class="mr-2">INFO</KBadge>
-<KBadge appearance="neutral" class="mr-2">NEUTRAL</KBadge>
-<KBadge>DEFAULT</KBadge>
+<div class="vertical-spacing">
+  <KBadge appearance="success">SUCCESS</KBadge>
+  <KBadge appearance="warning">WARNING</KBadge>
+  <KBadge appearance="danger">DANGER</KBadge>
+  <KBadge appearance="info">INFO</KBadge>
+  <KBadge appearance="neutral">NEUTRAL</KBadge>
+  <KBadge>DEFAULT</KBadge>
+</div>
 
 ```html
 <KBadge appearance="success">SUCCESS</KBadge>
@@ -42,12 +44,14 @@ The Badge component can take the following appearance values:
 
 Use the `isBordered` prop for bordered badges. The border color matches the text color by default.
 
-<KBadge appearance="success" is-bordered class="mr-2">SUCCESS</KBadge>
-<KBadge appearance="warning" is-bordered class="mr-2">WARNING</KBadge>
-<KBadge appearance="danger" is-bordered class="mr-2">DANGER</KBadge>
-<KBadge appearance="info" is-bordered class="mr-2">INFO</KBadge>
-<KBadge appearance="neutral" is-bordered class="mr-2">NEUTRAL</KBadge>
-<KBadge is-bordered class="mr-2">DEFAULT</KBadge>
+<div class="vertical-spacing">
+  <KBadge appearance="success" is-bordered>SUCCESS</KBadge>
+  <KBadge appearance="warning" is-bordered>WARNING</KBadge>
+  <KBadge appearance="danger" is-bordered>DANGER</KBadge>
+  <KBadge appearance="info" is-bordered>INFO</KBadge>
+  <KBadge appearance="neutral" is-bordered>NEUTRAL</KBadge>
+  <KBadge is-bordered>DEFAULT</KBadge>
+</div>
 
 ```html
 <KBadge appearance="success" is-bordered>SUCCESS</KBadge>
@@ -65,8 +69,10 @@ The Badge has two shapes that can be changed with a `shape` property.
 - `rounded` - Default
 - `rectangular`
 
-<KBadge appearance="warning" class="mr-2">Round</KBadge>
-<KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
+<div class="vertical-spacing">
+  <KBadge appearance="warning">Round</KBadge>
+  <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
+</div>
 
 ```html
 <KBadge appearance="warning">Round</KBadge>
@@ -81,11 +87,13 @@ Use this prop to modify the badge text color
 
 Use this prop to modify the background color of the badge
 
-<KBadge color="brown" background-color="yellow" class="mr-2">Custom</KBadge>
-<KBadge color="red" background-color="pink" class="mr-2">Badge</KBadge>
-<KBadge color="blue" background-color="lightblue" class="mr-2">Hello</KBadge>
-<KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
-<KBadge color="pink" background-color="salmon">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<div class="vertical-spacing">
+  <KBadge color="brown" background-color="yellow">Custom</KBadge>
+  <KBadge color="red" background-color="pink">Badge</KBadge>
+  <KBadge color="blue" background-color="lightblue">Hello</KBadge>
+  <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
+  <KBadge color="pink" background-color="salmon">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+</div>
 
 ```html
 <KBadge color="brown" background-color="yellow">Custom</KBadge>
@@ -100,9 +108,9 @@ Use this prop in conjunction with the `is-bordered` prop to customize the color 
 
 <KBadge
   appearance="custom"
-  background-color="var(--purple-100)"
-  border-color="var(--purple-400)"
-  color="var(--purple-400)"
+  background-color="plum"
+  border-color="purple"
+  color="purple"
   is-bordered
 >
   Organization Admin
@@ -111,9 +119,9 @@ Use this prop in conjunction with the `is-bordered` prop to customize the color 
 ```html
 <KBadge
   appearance="custom"
-  background-color="var(--purple-100)"
-  border-color="var(--purple-400)"
-  color="var(--purple-400)"
+  background-color="plum"
+  border-color="purple"
+  color="purple"
   is-bordered
 >
   Organization Admin
@@ -126,11 +134,11 @@ Use this prop in conjunction with the `dismissable` prop to customize the color 
 
 <KBadge
   appearance="custom"
-  background-color="var(--teal-100)"
-  border-color="var(--teal-400)"
-  color="var(--teal-400)"
+  background-color="aquamarine"
+  border-color="teal"
+  color="teal"
   dismissable
-  hover-color="var(--teal-200)"
+  hover-color="mediumturquoise"
   is-bordered
 >
   Production
@@ -139,11 +147,11 @@ Use this prop in conjunction with the `dismissable` prop to customize the color 
 ```html
 <KBadge
   appearance="custom"
-  background-color="var(--teal-100)"
-  border-color="var(--teal-400)"
-  color="var(--teal-400)"
+  background-color="aquamarine"
+  border-color="teal"
+  color="teal"
   dismissable
-  hover-color="var(--teal-200)"
+  hover-color="mediumturquoise"
   is-bordered
 >
   Production
@@ -173,8 +181,10 @@ The `hoverColor` is also utilized if you wrap the `KBadge` with an anchor tag, o
 Use this prop if you want the badge to be dismissable. If the badge text is long enough to need truncation, the label will truncate; the dismiss button is always visible.
 The color of the dismiss button is determined by the badge type and uses the same theming variables as the badge text. Clicking the dismiss button will trigger a `dismissed` event.
 
-<KBadge dismissable class="mr-2">Close me</KBadge>
-<KBadge dismissable shape="rectangular">No, close me!</KBadge>
+<div class="vertical-spacing">
+  <KBadge dismissable>Close me</KBadge>
+  <KBadge dismissable shape="rectangular">No, close me!</KBadge>
+</div>
 
 ```html
 <KBadge dismissable>Close me</KBadge>
@@ -185,8 +195,10 @@ The color of the dismiss button is determined by the badge type and uses the sam
 
 Use this prop if you would like to conditionally display a tooltip when the badge text is truncated.
 
-<KBadge class="mr-2" truncation-tooltip="Truncation unnecessary">Truncation unnecessary</KBadge>
-<KBadge truncation-tooltip="Hey! Let me see that awesome truncation">Hey! Let me see that awesome truncation</KBadge>
+<div class="vertical-spacing">
+  <KBadge truncation-tooltip="Truncation unnecessary">Truncation unnecessary</KBadge>
+  <KBadge truncation-tooltip="Hey! Let me see that awesome truncation">Hey! Let me see that awesome truncation</KBadge>
+</div>
 
 ```html
 <KBadge truncation-tooltip="Truncation unnecessary">Truncation unnecessary</KBadge>
@@ -269,18 +281,17 @@ An example of theming a custom badge:
 <div class="KBadge-wrapper">
   <KBadge
     appearance="custom"
-    background-color="var(--grey-200)"
-    border-color="var(--grey-500)"
-    color="var(--grey-500)"
+    background-color="lightgrey"
+    border-color="grey"
+    color="grey"
     is-bordered
   >
-    <div class="d-flex aling-items-center">
+    <div>
       <KIcon
-        class="mr-2"
         icon="bot"
         height="10"
       />
-      <p class="ma-0">
+      <p>
         ARTIFICIAL INTELLIGENCE
       </p>
     </div>
@@ -292,18 +303,17 @@ An example of theming a custom badge:
 <div class="KBadge-wrapper">
   <KBadge
     appearance="custom"
-    background-color="var(--grey-200)"
-    border-color="var(--grey-500)"
-    color="var(--grey-500)"
+    background-color="lightgrey"
+    border-color="grey"
+    color="grey"
     is-bordered
   >
-    <div class="d-flex aling-items-center">
+    <div>
       <KIcon
-        class="mr-2"
         icon="bot"
         height="10"
       />
-      <p class="ma-0">
+      <p>
         ARTIFICIAL INTELLIGENCE
       </p>
     </div>
@@ -313,18 +323,25 @@ An example of theming a custom badge:
 
 <style>
 .KBadge-wrapper {
-  --KBadgeBorderRadius: 22px;
+  --KBadgeBorderRadius: 100px;
   --KBadgeFontSize: var(--type-sm);
   --KBadgePaddingX: var(--spacing-sm);
   --KBadgePaddingY: var(--spacing-xs);
   --KBadgeMaxWidth: auto;
 
+  div {
+    display: flex;
+    align-items: center;
+  }
+
   p {
-    line-height: 24px;
+    font-size: 12px;
+    margin: 0;
   }
 
   .kong-icon-bot {
     height: 24px;
+    margin-right: 4px;
   }
 }
 </style>
@@ -342,18 +359,30 @@ const testClick = () => {
 
 <style lang="scss">
 .KBadge-wrapper {
-  --KBadgeBorderRadius: 22px;
+  --KBadgeBorderRadius: 100px;
   --KBadgeFontSize: var(--type-sm);
   --KBadgePaddingX: var(--spacing-sm);
   --KBadgePaddingY: var(--spacing-xs);
   --KBadgeMaxWidth: auto;
 
+  div {
+    display: flex;
+    align-items: center;
+  }
+
   p {
-    line-height: 24px;
+    font-size: 12px;
+    margin: 0;
   }
 
   .kong-icon-bot {
     height: 24px;
+    margin-right: 4px;
   }
+}
+
+.vertical-spacing {
+  display: flex;
+  column-gap: 4px;
 }
 </style>

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -81,18 +81,18 @@ Use this prop to modify the badge text color
 
 Use this prop to modify the background color of the badge
 
-<KBadge color="var(--yellow-500)" background-color="var(--yellow-200)" class="mr-2">Custom</KBadge>
-<KBadge color="var(--red-100)" background-color="var(--red-400)" class="mr-2">Badge</KBadge>
-<KBadge color="var(--blue-200)" background-color="var(--blue-500)" class="mr-2">Hello</KBadge>
+<KBadge color="brown" background-color="yellow" class="mr-2">Custom</KBadge>
+<KBadge color="red" background-color="pink" class="mr-2">Badge</KBadge>
+<KBadge color="blue" background-color="lightblue" class="mr-2">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72" class="mr-2">Something</KBadge>
-<KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<KBadge color="pink" background-color="salmon">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 
 ```html
-<KBadge color="var(--yellow-400)" background-color="var(--yellow-300)">Custom</KBadge>
-<KBadge color="var(--red-100)" background-color="var(--red-400)">Badge</KBadge>
-<KBadge color="var(--blue-200)" background-color="var(--blue-500)">Hello</KBadge>
+<KBadge color="brown" background-color="yellow">Custom</KBadge>
+<KBadge color="red" background-color="pink">Badge</KBadge>
+<KBadge color="blue" background-color="lightblue">Hello</KBadge>
 <KBadge color="#dfe6e9" background-color="#636e72">Something</KBadge>
-<KBadge color="var(--red-500)" background-color="var(--red-300)">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
+<KBadge color="pink" background-color="salmon">Long Badge 236bfb09-fe79-4cc9-99be-9361d6b1db64 aa07575b-bcd3-4bb2-bfd7-998224e3d31e 364b78fc-dba3-4b94-9134-388515496de5</KBadge>
 ```
 ### borderColor
 

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -22,7 +22,7 @@ The Badge component can take the following appearance values:
 - `neutral`
 - `custom`
 
-<div class="vertical-spacing">
+<div class="horizontal-spacing">
   <KBadge appearance="success">SUCCESS</KBadge>
   <KBadge appearance="warning">WARNING</KBadge>
   <KBadge appearance="danger">DANGER</KBadge>
@@ -44,7 +44,7 @@ The Badge component can take the following appearance values:
 
 Use the `isBordered` prop for bordered badges. The border color matches the text color by default.
 
-<div class="vertical-spacing">
+<div class="horizontal-spacing">
   <KBadge appearance="success" is-bordered>SUCCESS</KBadge>
   <KBadge appearance="warning" is-bordered>WARNING</KBadge>
   <KBadge appearance="danger" is-bordered>DANGER</KBadge>
@@ -69,7 +69,7 @@ The Badge has two shapes that can be changed with a `shape` property.
 - `rounded` - Default
 - `rectangular`
 
-<div class="vertical-spacing">
+<div class="horizontal-spacing">
   <KBadge appearance="warning">Round</KBadge>
   <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 </div>
@@ -87,7 +87,7 @@ Use this prop to modify the badge text color
 
 Use this prop to modify the background color of the badge
 
-<div class="vertical-spacing">
+<div class="horizontal-spacing">
   <KBadge color="brown" background-color="yellow">Custom</KBadge>
   <KBadge color="red" background-color="pink">Badge</KBadge>
   <KBadge color="blue" background-color="lightblue">Hello</KBadge>
@@ -181,7 +181,7 @@ The `hoverColor` is also utilized if you wrap the `KBadge` with an anchor tag, o
 Use this prop if you want the badge to be dismissable. If the badge text is long enough to need truncation, the label will truncate; the dismiss button is always visible.
 The color of the dismiss button is determined by the badge type and uses the same theming variables as the badge text. Clicking the dismiss button will trigger a `dismissed` event.
 
-<div class="vertical-spacing">
+<div class="horizontal-spacing">
   <KBadge dismissable>Close me</KBadge>
   <KBadge dismissable shape="rectangular">No, close me!</KBadge>
 </div>
@@ -195,7 +195,7 @@ The color of the dismiss button is determined by the badge type and uses the sam
 
 Use this prop if you would like to conditionally display a tooltip when the badge text is truncated.
 
-<div class="vertical-spacing">
+<div class="horizontal-spacing">
   <KBadge truncation-tooltip="Truncation unnecessary">Truncation unnecessary</KBadge>
   <KBadge truncation-tooltip="Hey! Let me see that awesome truncation">Hey! Let me see that awesome truncation</KBadge>
 </div>
@@ -381,7 +381,7 @@ const testClick = () => {
   }
 }
 
-.vertical-spacing {
+.horizontal-spacing {
   display: flex;
   column-gap: 4px;
 }

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -240,99 +240,100 @@ watch(badgeText, () => {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-badge {
   display: inline-block;
-  font-family: var(--font-family-sans, font(sans));
-  font-size: var(--KBadgeFontSize, 12px);
-  font-weight: 400;
+  font-family: var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text));
+  font-size: var(--KBadgeFontSize, var(--kui-font-size-20, $kui-font-size-20));
+  font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
   height: auto;
-  line-height: var(--KBadgeLineHeight, var(--type-md, type(md)));
-  padding: var(--KBadgePaddingY, 2px) var(--KBadgePaddingX, 6px);
+  line-height: var(--KBadgeLineHeight, var(--type-md, var(--kui-line-height-20, $kui-line-height-20)));
+  padding: var(--KBadgePaddingY, var(--kui-space-10, $kui-space-10)) var(--KBadgePaddingX, var(--kui-space-30, $kui-space-30));
   text-align: center;
-  transition: all .2s ease-in-out;
+  transition: all $tmp-animation-timing-2 ease-in-out;
   width: fit-content;
 
   // Appearances
   &.k-badge-default {
-    background-color: var(--KBadgeDefaultBackground, var(--blue-100, color(blue-100)));
-    border-color: var(--KBadgeDefaultBorder, var(--blue-500, color(blue-500)));
-    color: var(--KBadgeDefaultColor, var(--blue-500, color(blue-500)));
+    background-color: var(--KBadgeDefaultBackground, var(--blue-100, var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest)));
+    border-color: var(--KBadgeDefaultBorder, var(--blue-500, var(--kui-color-border-primary, $kui-color-border-primary)));
+    color: var(--KBadgeDefaultColor, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
   }
   &.k-badge-success {
-    background-color: var(--KBadgeSuccessBackground, var(--green-100, color(green-100)));
-    border-color: var(--KBadgeSuccessBorder, var(--green-700, color(green-700)));
-    color: var(--KBadgeSuccessColor, var(--green-700, color(green-700)));
+    background-color: var(--KBadgeSuccessBackground, var(--green-100, $tmp-color-green-100)); // token needed
+    border-color: var(--KBadgeSuccessBorder, var(--green-700, $tmp-color-green-700)); // token needed
+    color: var(--KBadgeSuccessColor, var(--green-700, $tmp-color-green-700)); // token needed
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
   }
   &.k-badge-danger {
-    background-color: var(--KBadgeDangerBackground, var(--red-100, color(red-100)));
-    border-color: var(--KBadgeDangerBorder, var(--red-700, color(red-700)));
-    color: var(--KBadgeDangerColor, var(--red-700, color(red-700)));
+    background-color: var(--KBadgeDangerBackground, var(--red-100, var(--kui-color-background-danger-weakest, $kui-color-background-danger-weakest)));
+    border-color: var(--KBadgeDangerBorder, var(--red-700, var(--kui-color-border-danger, $kui-color-border-danger)));
+    color: var(--KBadgeDangerColor, var(--red-700, var(--kui-color-text-danger, $kui-color-text-danger)));
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
   }
   &.k-badge-info {
-    background-color: var(--KBadgeInfoBackground, var(--blue-200, color(blue-200)));
-    border-color: var(--KBadgeInfoBorder, var(--blue-500, color(blue-500)));
-    color: var(--KBadgeInfoColor, var(--blue-500, color(blue-500)));
+    background-color: var(--KBadgeInfoBackground, var(--blue-200, var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker)));
+    border-color: var(--KBadgeInfoBorder, var(--blue-500, var(--kui-color-border-primary, $kui-color-border-primary)));
+    color: var(--KBadgeInfoColor, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
   }
   &.k-badge-warning {
-    background-color: var(--KBadgeWarningBackground, var(--yellow-100, color(yellow-100)));
-    border-color: var(--KBadgeWarningBorder, var(--yellow-600, color(yellow-600)));
-    color: var(--KBadgeWarningColor, var(--yellow-600, color(yellow-600)));
+    background-color: var(--KBadgeWarningBackground, var(--yellow-100, $tmp-color-yellow-100)); // token needed
+    border-color: var(--KBadgeWarningBorder, var(--yellow-600, $tmp-color-yellow-600)); // token needed
+    color: var(--KBadgeWarningColor, var(--yellow-600, $tmp-color-yellow-600)); // token needed
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
   }
   &.k-badge-neutral {
-    background-color: var(--grey-200, color(grey-200));
-    border-color: var(--grey-500, color(grey-500));
-    color: var(--grey-500, color(grey-500));
+    background-color: var(--grey-200, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
+    border-color: var(--grey-500, var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak));
+    color: var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral));
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
   }
 
   &.k-badge-rectangular {
-    border-radius: var(--KBadgeBorderRadius, 4px);
+    border-radius: var(--KBadgeBorderRadius, var(--kui-border-radius-20, $kui-border-radius-20));
 
     .k-badge-dismiss-button {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: var(--KBadgeBorderRadius, 4px);
-      border-top-left-radius: 0;
-      border-top-right-radius: var(--KBadgeBorderRadius, 4px);
+      border-bottom-left-radius: var(--kui-border-radius-0, $kui-border-radius-0);
+      border-bottom-right-radius: var(--KBadgeBorderRadius, var(--kui-border-radius-20, $kui-border-radius-20));
+      border-top-left-radius: var(--kui-border-radius-0, $kui-border-radius-0);
+      border-top-right-radius: var(--KBadgeBorderRadius, var(--kui-border-radius-20, $kui-border-radius-20));
     }
   }
 
   &.k-badge-rounded {
-    border-radius: var(--KBadgeBorderRadius, 25px);
+    border-radius: var(--KBadgeBorderRadius, var(--kui-border-radius-round, $kui-border-radius-round)); // token value change
 
     .k-badge-dismiss-button {
-      border-bottom-left-radius: 0;
-      border-top-left-radius: 0;
+      border-bottom-left-radius: var(--kui-border-radius-0, $kui-border-radius-0);
+      border-top-left-radius: var(--kui-border-radius-0, $kui-border-radius-0);
     }
   }
 
@@ -355,44 +356,45 @@ watch(badgeText, () => {
   .k-badge-dismiss-button {
     border: none;
     cursor: pointer;
-    font-weight: 400;
+    font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
     // ignore badge padding
-    margin: calc(-1 * var(--KBadgePaddingY, 2px)) calc(-1 * var(--KBadgePaddingX, 6px));
+    margin: calc(-1 * var(--KBadgePaddingY, var(--kui-space-10, $kui-space-10))) calc(-1 * var(--KBadgePaddingX, var(--kui-space-30, $kui-space-30)));
     margin-left: auto;
-    padding: var(--spacing-xs);
+    padding: var(--spacing-xs, var(--kui-space-20, $kui-space-20));
   }
 }
 </style>
 
 <style lang="scss">
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-badge {
   // default appearance colors local variables
-  $KBadgeDefaultBackground: var(--KBadgeDefaultBackground, var(--blue-100, color(blue-100)));
-  $KBadgeDefaultColor :var(--KBadgeDefaultColor, var(--blue-500, color(blue-500)));
-  $KBadgeDefaultButtonHoverColor : var(--KBadgeDefaultButtonHoverColor, var(--blue-200, color(blue-200)));
+  $KBadgeDefaultBackground: var(--KBadgeDefaultBackground, var(--blue-100, var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest)));
+  $KBadgeDefaultColor :var(--KBadgeDefaultColor, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
+  $KBadgeDefaultButtonHoverColor : var(--KBadgeDefaultButtonHoverColor, var(--blue-200, var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker)));
   // success appearance colors local variables
-  $KBadgeSuccessBackground: var(--KBadgeSuccessBackground, var(--green-100, color(green-100)));
-  $KBadgeSuccessColor: var(--KBadgeSuccessColor, var(--green-700, color(green-700)));
-  $KBadgeSuccessButtonHoverColor: var(--KBadgeSuccessButtonHoverColor, var(--green-200, color(green-200)));
+  $KBadgeSuccessBackground: var(--KBadgeSuccessBackground, var(--green-100, $tmp-color-green-100)); // token needed
+  $KBadgeSuccessColor: var(--KBadgeSuccessColor, var(--green-700, $tmp-color-green-700)); // token needed
+  $KBadgeSuccessButtonHoverColor: var(--KBadgeSuccessButtonHoverColor, var(--green-200, $tmp-color-green-200)); // token needed
   // danger appearance colors local variables
-  $KBadgeDangerBackground: var(--KBadgeDangerBackground, var(--red-100, color(red-100)));
-  $KBadgeDangerColor: var(--KBadgeDangerColor, var(--red-700, color(red-700)));
-  $KBadgeDangerButtonHoverColor: var(--KBadgeDangerButtonHoverColor, var(--red-200, color(red-200)));
+  $KBadgeDangerBackground: var(--KBadgeDangerBackground, var(--red-100, var(--kui-color-background-danger-weakest, $kui-color-background-danger-weakest)));
+  $KBadgeDangerColor: var(--KBadgeDangerColor, var(--red-700, var(--kui-color-text-danger, $kui-color-text-danger)));
+  $KBadgeDangerButtonHoverColor: var(--KBadgeDangerButtonHoverColor, var(--red-200, var(--kui-color-background-danger-weaker, $kui-color-background-danger-weaker)));
   // info appearance colors local variables
-  $KBadgeInfoBackground: var(--KBadgeInfoBackground, var(--blue-200, color(blue-200)));
-  $KBadgeInfoColor: var(--KBadgeInfoColor, var(--blue-500, color(blue-500)));
-  $KBadgeInfoButtonHoverColor: var(--KBadgeInfoButtonHoverColor, var(--blue-300, color(blue-300)));
+  $KBadgeInfoBackground: var(--KBadgeInfoBackground, var(--blue-200, var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker)));
+  $KBadgeInfoColor: var(--KBadgeInfoColor, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
+  $KBadgeInfoButtonHoverColor: var(--KBadgeInfoButtonHoverColor, var(--blue-300, var(--kui-color-background-primary-weak, $kui-color-background-primary-weak)));
   // warning appearance colors local variables
-  $KBadgeWarningBackground: var(--KBadgeWarningBackground, var(--yellow-100, color(yellow-100)));
-  $KBadgeWarningColor: var(--KBadgeWarningColor, var(--yellow-600, color(yellow-600)));
-  $KBadgeWarningButtonHoverColor: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, color(yellow-200)));
+  $KBadgeWarningBackground: var(--KBadgeWarningBackground, var(--yellow-100, $tmp-color-yellow-100)); // token needed
+  $KBadgeWarningColor: var(--KBadgeWarningColor, var(--yellow-600, $tmp-color-yellow-600)); // token needed
+  $KBadgeWarningButtonHoverColor: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, $tmp-color-yellow-200)); // token needed
   // neutral appearance colors local variables
-  $KBadgeNeutralBackground: var(--grey-200, color(grey-200));
-  $KBadgeNeutralColor: var(--grey-500, color(grey-500));
-  $KBadgeNeutralButtonHoverColor: var(--grey-300, color(grey-300));
+  $KBadgeNeutralBackground: var(--grey-200, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
+  $KBadgeNeutralColor: var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral));
+  $KBadgeNeutralButtonHoverColor: var(--grey-300, var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak));
 
    &.k-badge-custom {
     background-color: v-bind('$props.backgroundColor');
@@ -401,7 +403,7 @@ watch(badgeText, () => {
 
     &.is-bordered {
       border-style: solid;
-      border-width: 1px;
+      border-width: var(--kui-border-width-10, $kui-border-width-10);
     }
 
     .k-badge-dismiss-button {

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -2,7 +2,7 @@
   <div
     v-if="!isDismissed"
     :aria-hidden="hidden ? true : undefined"
-    class="k-badge d-inline-flex"
+    class="k-badge"
     :class="[ `k-badge-${appearance}`, `k-badge-${shape}`, {
       'is-bordered': isBordered,
       'clickable': isClickable
@@ -12,7 +12,7 @@
   >
     <component
       :is="truncationTooltip && (forceTooltip || isTruncated) ? 'KTooltip' : 'div'"
-      class="k-badge-text truncate"
+      class="k-badge-text"
       :position-fixed="truncationTooltip && (forceTooltip || isTruncated) ? true : undefined"
     >
       <template #content>
@@ -20,7 +20,7 @@
       </template>
       <div
         ref="badgeText"
-        class="k-badge-text truncate"
+        class="k-badge-text"
       >
         <slot />
       </div>
@@ -28,7 +28,7 @@
     <KButton
       v-if="dismissable"
       :aria-hidden="hidden ? true : undefined"
-      class="k-badge-dismiss-button ml-1"
+      class="k-badge-dismiss-button"
       data-testid="k-badge-dismiss-button"
       :is-rounded="shape === 'rounded'"
       :tabindex="hidden ? -1 : 0"
@@ -242,9 +242,10 @@ watch(badgeText, () => {
 @import '@/styles/variables';
 @import '@/styles/tmp-variables';
 @import '@/styles/functions';
+@import '@/styles/mixins';
 
 .k-badge {
-  display: inline-block;
+  display: inline-flex;
   font-family: var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text));
   font-size: var(--KBadgeFontSize, var(--kui-font-size-20, $kui-font-size-20));
   font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
@@ -347,6 +348,7 @@ watch(badgeText, () => {
   }
 
   .k-badge-text {
+    @include truncate;
     align-self: center;
     max-width: var(--KBadgeMaxWidth, v-bind(maxWidth));
     min-width: var(--KBadgeMinWidth, 8px);
@@ -359,7 +361,7 @@ watch(badgeText, () => {
     font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
     // ignore badge padding
     margin: calc(-1 * var(--KBadgePaddingY, var(--kui-space-10, $kui-space-10))) calc(-1 * var(--KBadgePaddingX, var(--kui-space-30, $kui-space-30)));
-    margin-left: auto;
+    margin-left: var(--kui-space-10, $kui-space-10);
     padding: var(--spacing-xs, var(--kui-space-20, $kui-space-20));
   }
 }

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -50,25 +50,10 @@ import { ref, computed, watch, useAttrs, PropType } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
-import type { BadgeAppearance, BadgeAppearanceRecord, BadgeShapeRecord, BadgeShape } from '@/types'
+import { BadgeAppearance, BadgeShape, appearances, shapes } from '@/types'
 import useUtilities from '@/composables/useUtilities'
 
 const { getSizeFromString } = useUtilities()
-
-export const appearances: BadgeAppearanceRecord = {
-  default: 'default',
-  success: 'success',
-  danger: 'danger',
-  info: 'info',
-  warning: 'warning',
-  custom: 'custom',
-  neutral: 'neutral',
-}
-
-export const shapes: BadgeShapeRecord = {
-  rounded: 'rounded',
-  rectangular: 'rectangular',
-}
 
 // Must explicitly define components so KTooltip works in tests
 export default {

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -50,7 +50,8 @@ import { ref, computed, watch, useAttrs, PropType } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
-import { BadgeAppearance, BadgeShape, appearances, shapes } from '@/types'
+import type { BadgeAppearance, BadgeShape } from '@/types'
+import { BadgeAppearances, BadgeShapes } from '@/types'
 import useUtilities from '@/composables/useUtilities'
 
 const { getSizeFromString } = useUtilities()
@@ -72,7 +73,7 @@ const props = defineProps({
     type: String as PropType<BadgeAppearance>,
     required: false,
     validator: (value: string): boolean => {
-      return Object.keys({ ...appearances }).includes(value)
+      return Object.keys({ ...BadgeAppearances }).includes(value)
     },
     default: 'default',
   },
@@ -115,7 +116,7 @@ const props = defineProps({
     type: String as PropType<BadgeShape>,
     required: false,
     validator: (value: string): boolean => {
-      return Object.keys({ ...shapes }).includes(value)
+      return Object.keys({ ...BadgeShapes }).includes(value)
     },
     default: 'rounded',
   },

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -253,9 +253,9 @@ watch(badgeText, () => {
     }
   }
   &.k-badge-success {
-    background-color: var(--KBadgeSuccessBackground, var(--green-100, $tmp-color-green-100)); // token needed
-    border-color: var(--KBadgeSuccessBorder, var(--green-700, $tmp-color-green-700)); // token needed
-    color: var(--KBadgeSuccessColor, var(--green-700, $tmp-color-green-700)); // token needed
+    background-color: var(--KBadgeSuccessBackground, var(--green-100, $tmp-color-green-100));
+    border-color: var(--KBadgeSuccessBorder, var(--green-700, $tmp-color-green-700));
+    color: var(--KBadgeSuccessColor, var(--green-700, $tmp-color-green-700));
 
     &.is-bordered {
       border-style: solid;
@@ -283,9 +283,9 @@ watch(badgeText, () => {
     }
   }
   &.k-badge-warning {
-    background-color: var(--KBadgeWarningBackground, var(--yellow-100, $tmp-color-yellow-100)); // token needed
-    border-color: var(--KBadgeWarningBorder, var(--yellow-600, $tmp-color-yellow-600)); // token needed
-    color: var(--KBadgeWarningColor, var(--yellow-600, $tmp-color-yellow-600)); // token needed
+    background-color: var(--KBadgeWarningBackground, var(--yellow-100, $tmp-color-yellow-100));
+    border-color: var(--KBadgeWarningBorder, var(--yellow-600, $tmp-color-yellow-600));
+    color: var(--KBadgeWarningColor, var(--yellow-600, $tmp-color-yellow-600));
 
     &.is-bordered {
       border-style: solid;
@@ -315,7 +315,7 @@ watch(badgeText, () => {
   }
 
   &.k-badge-rounded {
-    border-radius: var(--KBadgeBorderRadius, var(--kui-border-radius-round, $kui-border-radius-round)); // token value change
+    border-radius: var(--KBadgeBorderRadius, var(--kui-border-radius-round, $kui-border-radius-round));
 
     .k-badge-dismiss-button {
       border-bottom-left-radius: var(--kui-border-radius-0, $kui-border-radius-0);
@@ -363,9 +363,9 @@ watch(badgeText, () => {
   $KBadgeDefaultColor :var(--KBadgeDefaultColor, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
   $KBadgeDefaultButtonHoverColor : var(--KBadgeDefaultButtonHoverColor, var(--blue-200, var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker)));
   // success appearance colors local variables
-  $KBadgeSuccessBackground: var(--KBadgeSuccessBackground, var(--green-100, $tmp-color-green-100)); // token needed
-  $KBadgeSuccessColor: var(--KBadgeSuccessColor, var(--green-700, $tmp-color-green-700)); // token needed
-  $KBadgeSuccessButtonHoverColor: var(--KBadgeSuccessButtonHoverColor, var(--green-200, $tmp-color-green-200)); // token needed
+  $KBadgeSuccessBackground: var(--KBadgeSuccessBackground, var(--green-100, $tmp-color-green-100));
+  $KBadgeSuccessColor: var(--KBadgeSuccessColor, var(--green-700, $tmp-color-green-700));
+  $KBadgeSuccessButtonHoverColor: var(--KBadgeSuccessButtonHoverColor, var(--green-200, $tmp-color-green-200));
   // danger appearance colors local variables
   $KBadgeDangerBackground: var(--KBadgeDangerBackground, var(--red-100, var(--kui-color-background-danger-weakest, $kui-color-background-danger-weakest)));
   $KBadgeDangerColor: var(--KBadgeDangerColor, var(--red-700, var(--kui-color-text-danger, $kui-color-text-danger)));
@@ -375,9 +375,9 @@ watch(badgeText, () => {
   $KBadgeInfoColor: var(--KBadgeInfoColor, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
   $KBadgeInfoButtonHoverColor: var(--KBadgeInfoButtonHoverColor, var(--blue-300, var(--kui-color-background-primary-weak, $kui-color-background-primary-weak)));
   // warning appearance colors local variables
-  $KBadgeWarningBackground: var(--KBadgeWarningBackground, var(--yellow-100, $tmp-color-yellow-100)); // token needed
-  $KBadgeWarningColor: var(--KBadgeWarningColor, var(--yellow-600, $tmp-color-yellow-600)); // token needed
-  $KBadgeWarningButtonHoverColor: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, $tmp-color-yellow-200)); // token needed
+  $KBadgeWarningBackground: var(--KBadgeWarningBackground, var(--yellow-100, $tmp-color-yellow-100));
+  $KBadgeWarningColor: var(--KBadgeWarningColor, var(--yellow-600, $tmp-color-yellow-600));
+  $KBadgeWarningButtonHoverColor: var(--KBadgeWarningButtonHoverColor, var(--yellow-200, $tmp-color-yellow-200));
   // neutral appearance colors local variables
   $KBadgeNeutralBackground: var(--grey-200, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
   $KBadgeNeutralColor: var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral));

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -85,3 +85,9 @@
   top: 0;
   z-index: 10500;
 }
+
+@mixin truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -4,7 +4,7 @@ export type BadgeAppearanceRecord = Record<BadgeAppearance, BadgeAppearance>
 export type BadgeShape = 'rounded' | 'rectangular'
 export type BadgeShapeRecord = Record<BadgeShape, BadgeShape>
 
-export const appearances: BadgeAppearanceRecord = {
+export const BadgeAppearances: BadgeAppearanceRecord = {
   default: 'default',
   success: 'success',
   danger: 'danger',
@@ -14,7 +14,7 @@ export const appearances: BadgeAppearanceRecord = {
   neutral: 'neutral',
 }
 
-export const shapes: BadgeShapeRecord = {
+export const BadgeShapes: BadgeShapeRecord = {
   rounded: 'rounded',
   rectangular: 'rectangular',
 }

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -12,9 +12,9 @@ export const BadgeAppearances: BadgeAppearanceRecord = {
   warning: 'warning',
   custom: 'custom',
   neutral: 'neutral',
-}
+} as const
 
 export const BadgeShapes: BadgeShapeRecord = {
   rounded: 'rounded',
   rectangular: 'rectangular',
-}
+} as const

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -3,3 +3,18 @@ export type BadgeAppearanceRecord = Record<BadgeAppearance, BadgeAppearance>
 
 export type BadgeShape = 'rounded' | 'rectangular'
 export type BadgeShapeRecord = Record<BadgeShape, BadgeShape>
+
+export const appearances: BadgeAppearanceRecord = {
+  default: 'default',
+  success: 'success',
+  danger: 'danger',
+  info: 'info',
+  warning: 'warning',
+  custom: 'custom',
+  neutral: 'neutral',
+}
+
+export const shapes: BadgeShapeRecord = {
+  rounded: 'rounded',
+  rectangular: 'rectangular',
+}


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7694

Changes:
- introduce `kui-` design tokens in `KBadge` component
- break down usage of Kongponents utility classes in `KBadge` component template AND in documentation markdown file

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
