### PR TITLE
feat(kbreadcrumb): custom divider [khcp-8029]

### DIFF
--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -2,8 +2,14 @@
 
 **KBreadcrumbs** is a breadcrumbs component that takes an array of route objects and generates a list of links. You can pass both [vue router](https://router.vuejs.org/) route objects or pass your own url.
 
+## Props
+
+### items
+
+An array of Breadcrumb items.
+
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KBreadcrumbs :items="internalBreadcrumbItems" />
   </template>
 </KCard>
@@ -13,51 +19,31 @@
   <KBreadcrumbs :items="breadcrumbItems" />
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  setup() {
-    const breadcrumbItems = [
-      {
-        key: 'home',
-        to: { path: '/' },
-        title: 'Go Home',
-        text: 'Home',
-        icon: 'kong'
-      },
-      {
-        key: 'button',
-        to: { path: '/components/breadcrumbs.html' },
-        title: 'Go to Button',
-        text: 'Breadcrumbs'
-      }
-    ]
-
-    return { breadcrumbItems }
-  }
-})
+<script lang="ts" setup>
+  /**
+   * @typedef {Object} Item - breadcrumb item holding router-link properties
+   * @property {RawLocation} to - router-link 'to' object or href string
+   * @property {string} text - The anchor text displayed (optional, can be used with or without 'icon')
+   * @property {string} title - The anchor title shown when hovering the link
+   * @property {string} icon - Display a KIcon before the anchor title (optional, can be used with or without 'text')
+   * @property {string} [key] - An ID when the list is generated. Defaults to text if not set.
+   * @property {string} [maxWidth] - maxWidth of item, overrides itemMaxWidth
+   */
+  const breadcrumbItems = [{
+    key: 'home',
+    to: { path: '/' },
+    title: 'Go Home',
+    text: 'Home',
+    icon: 'kong'
+  },
+  {
+    key: 'button',
+    to: { path: '/components/breadcrumbs.html' },
+    title: 'Go to Button',
+    text: 'Breadcrumbs'
+  }]
 </script>
 ```
-
-## Props
-
-### items
-
-An array of Breadcrumb items
-
-```html
-<!--
- * @typedef {Object} Item - breadcrumb item holding router-link properties
- * @property {RawLocation} to - router-link 'to' object or href string
- * @property {string} text - The anchor text displayed (optional, can be used with or without 'icon')
- * @property {string} title - The anchor title shown when hovering the link
- * @property {string} icon - Display a KIcon before the anchor title (optional, can be used with or without 'text')
- * @property {string} [key] - An ID when the list is generated. Defaults to text if not set.
- * @property {string} [maxWidth] - maxWidth of item, overrides itemMaxWidth
- -->
-<KBreadcrumbs :items="[{ key: 'home', to: { path: '/' }, title: 'Home', icon: 'kong', text: 'Home' }]" />
- ```
 
 #### Breadcrumb content
 
@@ -68,7 +54,7 @@ Each breadcrumb item can display `text`, an `icon`, or both.
 The `to` property can be a Vue route or traditional URL. When using a URL though the target will be blank and a new window will open. In most scenarios you will build your breadcrumb items using your Vue application routes.
 
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KBreadcrumbs :items="externalBreadcrumbItems" />
   </template>
 </KCard>
@@ -78,29 +64,19 @@ The `to` property can be a Vue route or traditional URL. When using a URL though
   <KBreadcrumbs :items="breadcrumbItems" />
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  setup() {
-    const breadcrumbItems = [
-      {
-        key: 'home',
-        to: { path: '/' },
-        title: 'Home',
-        text: 'Home'
-      },
-      {
-        key: 'google',
-        to: 'https://google.com',
-        title: 'Search at Google',
-        text: 'Google'
-      }
-    ]
-
-    return { breadcrumbItems }
-  }
-})
+<script lang="ts" setup>
+  const breadcrumbItems = [{
+    key: 'home',
+    to: { path: '/' },
+    title: 'Home',
+    text: 'Home'
+  },
+  {
+    key: 'google',
+    to: 'https://google.com',
+    title: 'Search at Google',
+    text: 'Google'
+  }]
 </script>
 ```
 
@@ -109,13 +85,40 @@ export default defineComponent({
 Maximum width of each breadcrumb item for truncating to ellipsis.
 
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KBreadcrumbs :items="longBreadcrumbs" item-max-width="16ch" />
   </template>
 </KCard>
 
 ```html
-<KBreadcrumbs :items="longBreadcrumbs" item-max-width="16ch" />
+<KBreadcrumbs
+  :items="breadcrumbItems"
+  item-max-width="16ch"
+/>
+```
+
+## Slots
+
+### divider
+
+Content to be displayed between breadcrumb items, defaults to a chevron.
+
+<KCard>
+  <template #body>
+    <KBreadcrumbs :items="internalBreadcrumbItems">
+      <template #divider>
+        <span class="custom-divider">/</span>
+      </template>
+    </KBreadcrumbs>
+  </template>
+</KCard>
+
+```html
+<KBreadcrumbs :items="breadcrumbItems">
+  <template #divider>
+    <span class="custom-divider">/</span>
+  </template>
+</KBreadcrumbs>
 ```
 
 <script lang="ts">
@@ -166,7 +169,7 @@ export default defineComponent({
         },
         {
           to: { path: '/' },
-          title: 'Go Home',
+          title: 'f67a3ead-dfb9-4ef9-8cda-6646bc4db950',
           text: 'f67a3ead-dfb9-4ef9-8cda-6646bc4db950'
         }
       ]
@@ -174,3 +177,12 @@ export default defineComponent({
   }
 })
 </script>
+
+<style lang="scss">
+  .custom-divider {
+    font-size: 13px;
+    font-weight: 300;
+    line-height: 14px;
+    color: var(--grey-400);
+  }
+</style>

--- a/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
@@ -20,6 +20,29 @@ describe('KBreadcrumbs', () => {
     cy.get('.k-breadcrumbs').find('li .k-breadcrumb-icon').its('length').should('eq', 1)
   })
 
+  it('renders custom divider when using slot', () => {
+    const customDivider = 'custom_divider'
+
+    mount(KBreadcrumbs, {
+      props: {
+        items: [
+          {
+            key: 'docs',
+            to: 'https://docs.konghq.com',
+            title: 'Go to Kong Docs',
+            icon: 'kong',
+          },
+        ],
+      },
+      slots: {
+        divider: customDivider,
+      },
+    })
+
+    cy.get('.k-breadcrumbs').find('li').its('length').should('eq', 1)
+    cy.get('.k-breadcrumbs .k-breadcrumb-divider').should('contain.text', customDivider)
+  })
+
   it('renders breadcrumb links without needing a router', () => {
     mount(KBreadcrumbs, {
       props: {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -113,22 +113,22 @@ export default {
     .k-breadcrumb-divider,
     .k-breadcrumb-icon {
       align-self: center;
-      color: var(--grey-500);
+      color: var(--grey-500, color(grey-500));
       display: inline-flex;
     }
 
     .k-breadcrumb-divider {
-      padding: 0 12px 0 var(--spacing-xs);
+      padding: 0 var(--spacing-sm, spacing(sm)) 0 var(--spacing-xs, spacing(xs));
     }
 
     .k-breadcrumb-icon {
-      padding: 0 12px 0 0;
+      padding: 0 var(--spacing-sm, spacing(sm)) 0 0;
 
       &:deep(.kong-icon) {
         align-items: center;
         align-self: baseline;
         justify-content: center;
-        padding: 0 var(--spacing-xs) 0 0;
+        padding: 0 var(--spacing-xs, spacing(xs)) 0 0;
 
         &.has-no-text {
           padding-right: 0;
@@ -141,7 +141,7 @@ export default {
     display: inline-flex;
 
     a {
-      color: var(--grey-500);
+      color: var(--grey-500, color(grey-500));
       display: inline-flex;
       font-size: 15px;
       letter-spacing: 1px;

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -10,13 +10,13 @@
     >
       <router-link
         v-if="typeof item.to === 'object'"
-        :class="{'no-underline': !item.text}"
+        :class="{ 'no-underline': !item.text }"
         :title="item.title"
         :to="item.to"
       >
         <KIcon
           v-if="item.icon"
-          :class="[ 'k-breadcrumb-icon', {'has-no-text': !item.text} ]"
+          :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
           color="var(--grey-500)"
           hide-title
           :icon="item.icon"
@@ -25,20 +25,20 @@
         <span
           v-if="item.text"
           class="k-breadcrumb-text truncate"
-          :style="{maxWidth: item.maxWidth || itemMaxWidth}"
+          :style="{ maxWidth: item.maxWidth || itemMaxWidth }"
         >{{ item.text }}</span>
       </router-link>
 
       <a
         v-else
-        :class="{'no-underline': !item.text}"
+        :class="{ 'no-underline': !item.text }"
         :href="item.to"
         target="_blank"
         :title="item.title"
       >
         <KIcon
           v-if="item.icon"
-          :class="[ 'k-breadcrumb-icon', {'has-no-text': !item.text} ]"
+          :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
           color="var(--grey-500)"
           hide-title
           :icon="item.icon"
@@ -47,16 +47,20 @@
         <span
           v-if="item.text"
           class="k-breadcrumb-text truncate"
-          :style="{maxWidth: item.maxWidth || itemMaxWidth}"
+          :style="{ maxWidth: item.maxWidth || itemMaxWidth }"
         >{{ item.text }}</span>
       </a>
 
-      <KIcon
-        color="var(--grey-500)"
-        hide-title
-        icon="chevronRight"
-        size="15"
-      />
+      <span class="k-breadcrumb-divider">
+        <slot name="divider">
+          <KIcon
+            color="var(--grey-500)"
+            hide-title
+            icon="chevronRight"
+            size="15"
+          />
+        </slot>
+      </span>
     </li>
   </ul>
 </template>
@@ -104,52 +108,57 @@ export default {
   list-style: none;
   margin-bottom: 16px;
   padding: 0;
-}
 
-.k-breadcrumbs .k-breadcrumbs-item :deep(.kong-icon) {
-  color: var(--grey-500);
-  display: inline-flex;
-  padding: 0 12px 0 var(--spacing-xs);
-  vertical-align: middle;
-
-  &.k-breadcrumb-icon {
-    align-items: center;
-    justify-content: center;
-    padding: 0 var(--spacing-xs) 0 0;
-
-    &.has-no-text {
-      padding-right: 0;
-    }
-  }
-}
-
-.k-breadcrumbs li {
-  display: inline-flex;
-
-  a {
-    color: var(--grey-500);
-    display: inline-flex;
-    font-size: 15px;
-    letter-spacing: 1px;
-
-    &:hover,
-    &.no-underline {
-      text-decoration: none !important;
+  .k-breadcrumbs-item {
+    .k-breadcrumb-divider,
+    .k-breadcrumb-icon {
+      align-self: center;
+      color: var(--grey-500);
+      display: inline-flex;
     }
 
-    > .k-breadcrumb-text {
-      transition: all 0.2s ease-in-out;
+    .k-breadcrumb-divider {
+      padding: 0 12px 0 var(--spacing-xs);
+    }
 
-      &:hover {
-        text-decoration: underline;
+    .k-breadcrumb-icon {
+      padding: 0 12px 0 0;
+
+      &:deep(.kong-icon) {
+        align-items: center;
+        align-self: baseline;
+        justify-content: center;
+        padding: 0 var(--spacing-xs) 0 0;
+
+        &.has-no-text {
+          padding-right: 0;
+        }
       }
     }
   }
-}
 
-.truncate {
-  align-items: center;
-  display: inline-block;
-  justify-content: center;
+  li {
+    display: inline-flex;
+
+    a {
+      color: var(--grey-500);
+      display: inline-flex;
+      font-size: 15px;
+      letter-spacing: 1px;
+
+      &:hover,
+      &.no-underline {
+        text-decoration: none !important;
+      }
+
+      > .k-breadcrumb-text {
+        transition: all 0.2s ease-in-out;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
 }
 </style>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add new `divider` slot for KBreadcrumb for page header update.
Part of [KHCP-8092](https://konghq.atlassian.net/browse/KHCP-8029).

![image](https://github.com/Kong/kongponents/assets/67973710/9c855a8e-27fa-46be-a723-1b91e25bd99b)

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
