### PR TITLE
docs(KInput): add tooltipAttributes description and example [KHCP-7360]

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -46,7 +46,11 @@ If the label is omitted it can be handled with another component, like **KLabel*
 
 Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
-<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test' } "/>
+You can add `tooltipAttributes` to configure the **KTooltip's** [props](/components/tooltip.md)
+
+<KInput label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop', 'data-testid': 'test', tooltipAttributes: {
+maxWidth: '150px'
+} } "/>
 
 ```html
 <KInput
@@ -54,6 +58,9 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
   :label-attributes="{
     help: 'I use the KLabel `help` prop',
     'data-testid': 'test'
+    tooltipAttributes: {
+        maxWidth: '150px'
+    }
   }"
 />
 ```


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

https://konghq.atlassian.net/browse/KHCP-7360

Add nested label attributes examples to KInput documentation

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
