### PR TITLE
fix(KModal): fix focusTrap error [KHCP-7758]

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -7,12 +7,14 @@
     role="dialog"
   >
     <div
+      ref="modalOuter"
       class="k-modal-backdrop modal-backdrop"
       @click="(evt: any) => close(false, evt)"
     >
       <FocusTrap
         ref="focusTrap"
         :active="false"
+        :fallback-focus="modalOuter?.$el"
         :tabbable-options="tabbableOptions"
       >
         <div class="k-modal-dialog modal-dialog">
@@ -216,6 +218,7 @@ const emit = defineEmits<{
 
 const slots = useSlots()
 const focusTrap = ref<InstanceType<typeof FocusTrap> | null>(null)
+const modalOuter = ref<{ $el: HTMLElement} | null>(null)
 
 const hasHeaderImage = computed((): boolean => {
   return !!slots['header-image']


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
https://konghq.atlassian.net/browse/KHCP-7758

Fix `Your focus-trap must have at least one container with at least one tabbable node in it at all times` DD error

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
