### PR TITLE
feat(kbreadcrumb): style updates [khcp-8029]

### DIFF
--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -6,7 +6,7 @@
 
 ### items
 
-An array of Breadcrumb items.
+An array of Breadcrumb items. Items that are not links, displayed at the end will not be followed by a divider.
 
 <KCard>
   <template #body>
@@ -41,6 +41,16 @@ An array of Breadcrumb items.
     to: { path: '/components/breadcrumbs.html' },
     title: 'Go to Button',
     text: 'Breadcrumbs'
+  },
+  {
+    key: 'not-here',
+    title: 'You are not Here',
+    text: 'You are not Here'
+  },
+  {
+    key: 'here',
+    title: 'You are Here',
+    text: 'You are Here'
   }]
 </script>
 ```
@@ -97,6 +107,23 @@ Maximum width of each breadcrumb item for truncating to ellipsis.
 />
 ```
 
+### emphasis
+
+Emphasize the breadcrumbs by making them bolder.
+
+<KCard>
+  <template #body>
+    <KBreadcrumbs :items="contextualBreadcrumbs" emphasis />
+  </template>
+</KCard>
+
+```html
+<KBreadcrumbs
+  :items="breadcrumbItems"
+  emphasis
+/>
+```
+
 ## Slots
 
 ### divider
@@ -140,6 +167,16 @@ export default defineComponent({
           to: { path: '/components/breadcrumbs.html' },
           title: 'Go to Button',
           text: 'Breadcrumbs'
+        },
+        {
+          key: 'not-here',
+          title: 'You are not Here',
+          text: 'You are not Here'
+        },
+        {
+          key: 'here',
+          title: 'You are Here',
+          text: 'You are Here'
         }
       ],
       externalBreadcrumbItems: [
@@ -172,6 +209,17 @@ export default defineComponent({
           title: 'f67a3ead-dfb9-4ef9-8cda-6646bc4db950',
           text: 'f67a3ead-dfb9-4ef9-8cda-6646bc4db950'
         }
+      ],
+      contextualBreadcrumbs: [
+        {
+          to: { path: '/' },
+          title: 'Services',
+          text: 'Services'
+        },
+        {
+          title: 'My Service',
+          text: 'My Service'
+        },
       ]
     }
   }

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -231,6 +231,6 @@ export default defineComponent({
     font-size: 13px;
     font-weight: 300;
     line-height: 14px;
-    color: var(--grey-400, var(--kui-color-text-neutral-weak, $kui-color-text-neutral-weak));
+    color: var(--kui-color-text-neutral-weak, $kui-color-text-neutral-weak);
   }
 </style>

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -231,6 +231,6 @@ export default defineComponent({
     font-size: 13px;
     font-weight: 300;
     line-height: 14px;
-    color: var(--grey-400);
+    color: var(--grey-400, var(--kui-color-text-neutral-weak, $kui-color-text-neutral-weak));
   }
 </style>

--- a/src/components/KBadge/KBadge.cy.ts
+++ b/src/components/KBadge/KBadge.cy.ts
@@ -1,8 +1,8 @@
 import { mount } from 'cypress/vue'
 import KBadge from '@/components/KBadge/KBadge.vue'
-import { BadgeAppearances } from '@/types'
+import { BadgeAppearance, BadgeAppearances } from '@/types'
 
-const rendersCorrectAppearance = (variant: string) => {
+const rendersCorrectAppearance = (variant: BadgeAppearance) => {
   it(`renders KBadge with the ${variant} appearance`, () => {
     mount(KBadge, {
       props: {
@@ -22,7 +22,7 @@ const rendersCorrectAppearance = (variant: string) => {
 
 describe('KBadge', () => {
   // Loop through BadgeAppearances
-  Object.keys(BadgeAppearances).map(a => rendersCorrectAppearance(a))
+  Object.keys(BadgeAppearances).map(a => rendersCorrectAppearance(a as BadgeAppearance))
 
   it('renders with borders', () => {
     mount(KBadge, {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
@@ -20,6 +20,47 @@ describe('KBreadcrumbs', () => {
     cy.get('.k-breadcrumbs').find('li .k-breadcrumb-icon').its('length').should('eq', 1)
   })
 
+  it('renders with emphasis', () => {
+    mount(KBreadcrumbs, {
+      props: {
+        items: [
+          {
+            key: 'docs',
+            to: 'https://docs.konghq.com',
+            title: 'Go to Kong Docs',
+            icon: 'kong',
+          },
+        ],
+        emphasis: true,
+      },
+    })
+
+    cy.get('.k-breadcrumbs').find('li').its('length').should('eq', 1)
+    cy.get('.k-breadcrumbs').find('.k-breadcrumb-text.emphasis').its('length').should('eq', 1)
+  })
+
+  it('correctly renders an non-link breadcrumbs', () => {
+    mount(KBreadcrumbs, {
+      props: {
+        items: [
+          {
+            key: 'docs',
+            title: 'Go to Kong Docs',
+            icon: 'kong',
+          },
+          {
+            key: 'specific-doc',
+            title: 'My Doc',
+          },
+        ],
+      },
+    })
+
+    cy.get('.k-breadcrumbs').find('li').its('length').should('eq', 2)
+    cy.get('.k-breadcrumbs').find('.k-breadcrumb-text.non-link').its('length').should('eq', 2)
+    cy.get('.k-breadcrumbs').find('.k-breadcrumb-divider').its('length').should('eq', 1)
+  })
+
   it('renders custom divider when using slot', () => {
     const customDivider = 'custom_divider'
 

--- a/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
@@ -1,18 +1,19 @@
 import { mount } from 'cypress/vue'
 import KBreadcrumbs from '@/components/KBreadcrumbs/KBreadcrumbs.vue'
+import type { BreadcrumbItem } from '@/types'
 
 describe('KBreadcrumbs', () => {
   it('renders an icon breadcrumb', () => {
+    const items = [{
+      key: 'docs',
+      to: 'https://docs.konghq.com',
+      text: 'Go to Kong Docs',
+      icon: 'kong',
+    }] as BreadcrumbItem[]
+
     mount(KBreadcrumbs, {
       props: {
-        items: [
-          {
-            key: 'docs',
-            to: 'https://docs.konghq.com',
-            title: 'Go to Kong Docs',
-            icon: 'kong',
-          },
-        ],
+        items,
       },
     })
 
@@ -27,7 +28,7 @@ describe('KBreadcrumbs', () => {
           {
             key: 'docs',
             to: 'https://docs.konghq.com',
-            title: 'Go to Kong Docs',
+            text: 'Go to Kong Docs',
             icon: 'kong',
           },
         ],
@@ -45,12 +46,12 @@ describe('KBreadcrumbs', () => {
         items: [
           {
             key: 'docs',
-            title: 'Go to Kong Docs',
+            text: 'Go to Kong Docs',
             icon: 'kong',
           },
           {
             key: 'specific-doc',
-            title: 'My Doc',
+            text: 'My Doc',
           },
         ],
       },
@@ -70,7 +71,7 @@ describe('KBreadcrumbs', () => {
           {
             key: 'docs',
             to: 'https://docs.konghq.com',
-            title: 'Go to Kong Docs',
+            text: 'Go to Kong Docs',
             icon: 'kong',
           },
         ],

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -152,7 +152,7 @@ export default {
 
     .k-breadcrumb-text {
       &:hover {
-        color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger); /** TODO: $kui-color-text-selected */
+        color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger); /** TODO: use $kui-color-text-selected token, once it is added */
       }
 
       &.non-link {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -114,9 +114,9 @@ export default {
   display: flex;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  font-size: $kui-font-size-30;
-  font-weight: $kui-font-weight-medium;
-  line-height: $kui-line-height-40;
+  font-size: var(--kui-font-size-30, $kui-font-size-30);
+  font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
+  line-height: var(--kui-line-height-40, $kui-line-height-40);
   list-style: none;
   margin-bottom: 16px;
   padding: 0;
@@ -131,7 +131,7 @@ export default {
     }
 
     .k-breadcrumb-divider {
-      padding: 0 $kui-space-20;
+      padding: var(--kui-space-0, $kui-space-0) var(--kui-space-20, $kui-space-20);
     }
 
     .k-breadcrumb-icon {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -13,14 +13,16 @@
         v-bind="getComponentAttrs(item).attrs"
         class="no-underline"
       >
-        <KIcon
-          v-if="item.icon"
-          :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
-          :color="KUI_COLOR_TEXT_DECORATIVE"
-          hide-title
-          :icon="item.icon"
-          size="16"
-        />
+        <slot name="icon">
+          <KIcon
+            v-if="item.icon"
+            :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
+            :color="KUI_COLOR_TEXT_DECORATIVE"
+            hide-title
+            :icon="item.icon"
+            :size="KUI_ICON_SIZE_30"
+          />
+        </slot>
         <span
           v-if="item.text"
           class="k-breadcrumb-text truncate"
@@ -49,7 +51,7 @@
 <script setup lang="ts">
 import { PropType } from 'vue'
 import type { BreadcrumbItem } from '@/types'
-import { KUI_COLOR_TEXT_DECORATIVE } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_DECORATIVE, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import KIcon from '@/components/KIcon/KIcon.vue'
 
 defineProps({
@@ -110,7 +112,7 @@ export default {
 @import '@/styles/functions';
 
 .k-breadcrumbs {
-  border-radius: 4px;
+  border-radius: var(--kui-border-radius-4, $kui-border-radius-4);
   display: flex;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -118,14 +120,14 @@ export default {
   font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   line-height: var(--kui-line-height-40, $kui-line-height-40);
   list-style: none;
-  margin-bottom: 16px;
-  padding: 0;
+  margin-bottom: var(--kui-space-60, $kui-space-60);
+  padding: var(--kui-space-0, $kui-space-0);
 
   .k-breadcrumbs-item {
     .k-breadcrumb-divider,
     .k-breadcrumb-icon {
       align-self: center;
-      color: $kui-color-text-decorative;
+      color: var(--kui-color-text-decorative, $kui-color-text-decorative);
       display: inline-flex;
       line-height: 1;
     }
@@ -135,7 +137,7 @@ export default {
     }
 
     .k-breadcrumb-icon {
-      padding: 0 $kui-space-30 0 0;
+      padding: var(--kui-space-0, $kui-space-0) var(--kui-space-30, $kui-space-30) var(--kui-space-0, $kui-space-0) var(--kui-space-0, $kui-space-0);
 
       &:deep(.kong-icon) {
         align-items: center;
@@ -143,22 +145,22 @@ export default {
         justify-content: center;
 
         &.has-no-text {
-          padding-right: 0;
+          padding-right: var(--kui-space-0, $kui-space-0);
         }
       }
     }
 
     .k-breadcrumb-text {
       &:hover {
-        color: $kui-color-text-neutral-stronger; /** $kui-color-text-selected */
+        color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger); /** TODO: $kui-color-text-selected */
       }
 
       &.non-link {
-        color: $kui-color-text;
+        color: var(--kui-color-text, $kui-color-text);
       }
 
       &.emphasis {
-        font-weight: $kui-font-weight-bold;
+        font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
         letter-spacing: -0.14px;
       }
     }
@@ -168,9 +170,9 @@ export default {
     display: inline-flex;
 
     a {
-      color: $kui-color-text-neutral;
+      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
       display: inline-flex;
-      font-size: $kui-font-size-30;
+      font-size: var(--kui-font-size-30, $kui-font-size-30);
 
       &:hover,
       &.no-underline {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -4,54 +4,35 @@
     v-bind="$attrs"
   >
     <li
-      v-for="item in items"
+      v-for="(item, idx) in items"
       :key="item.key || item.text"
       class="k-breadcrumbs-item truncate"
     >
-      <router-link
-        v-if="typeof item.to === 'object'"
-        :class="{ 'no-underline': !item.text }"
-        :title="item.title"
-        :to="item.to"
+      <component
+        :is="getComponentAttrs(item).type"
+        v-bind="getComponentAttrs(item).attrs"
+        class="no-underline"
       >
         <KIcon
           v-if="item.icon"
           :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
-          color="var(--grey-500)"
+          :color="KUI_COLOR_TEXT_DECORATIVE"
           hide-title
           :icon="item.icon"
-          size="20"
+          size="16"
         />
         <span
           v-if="item.text"
           class="k-breadcrumb-text truncate"
+          :class="{ 'non-link': !item.to, 'emphasis': emphasis }"
           :style="{ maxWidth: item.maxWidth || itemMaxWidth }"
         >{{ item.text }}</span>
-      </router-link>
+      </component>
 
-      <a
-        v-else
-        :class="{ 'no-underline': !item.text }"
-        :href="item.to"
-        target="_blank"
-        :title="item.title"
+      <span
+        v-if="item.to || idx < items.length - 1"
+        class="k-breadcrumb-divider"
       >
-        <KIcon
-          v-if="item.icon"
-          :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
-          color="var(--grey-500)"
-          hide-title
-          :icon="item.icon"
-          size="20"
-        />
-        <span
-          v-if="item.text"
-          class="k-breadcrumb-text truncate"
-          :style="{ maxWidth: item.maxWidth || itemMaxWidth }"
-        >{{ item.text }}</span>
-      </a>
-
-      <span class="k-breadcrumb-divider">
         <slot name="divider">
           <KIcon
             color="var(--grey-500)"
@@ -67,8 +48,9 @@
 
 <script setup lang="ts">
 import { PropType } from 'vue'
-import KIcon from '@/components/KIcon/KIcon.vue'
 import type { BreadcrumbItem } from '@/types'
+import { KUI_COLOR_TEXT_DECORATIVE } from '@kong/design-tokens'
+import KIcon from '@/components/KIcon/KIcon.vue'
 
 defineProps({
   items: {
@@ -84,7 +66,37 @@ defineProps({
     required: false,
     default: '38ch', // can handle a monospaced uuid
   },
+  emphasis: {
+    type: Boolean,
+    default: false,
+  },
 })
+
+const getComponentAttrs = (item: BreadcrumbItem) => {
+  if (!item.to) {
+    return {
+      type: 'div',
+      attrs: {},
+    }
+  } else if (typeof item.to === 'object') {
+    return {
+      type: 'router-link',
+      attrs: {
+        title: item.title,
+        to: item.to,
+      },
+    }
+  } else {
+    return {
+      type: 'a',
+      attrs: {
+        href: item.to,
+        target: '_blank',
+        title: item.title,
+      },
+    }
+  }
+}
 </script>
 
 <script lang="ts">
@@ -102,9 +114,9 @@ export default {
   display: flex;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  font-size: 15px;
-  font-weight: 600 !important;
-  line-height: 24px !important;
+  font-size: $kui-font-size-30;
+  font-weight: $kui-font-weight-medium;
+  line-height: $kui-line-height-40;
   list-style: none;
   margin-bottom: 16px;
   padding: 0;
@@ -113,27 +125,41 @@ export default {
     .k-breadcrumb-divider,
     .k-breadcrumb-icon {
       align-self: center;
-      color: var(--grey-500, color(grey-500));
+      color: $kui-color-text-decorative;
       display: inline-flex;
       line-height: 1;
     }
 
     .k-breadcrumb-divider {
-      padding: 0 var(--spacing-sm, spacing(sm)) 0 var(--spacing-xs, spacing(xs));
+      padding: 0 $kui-space-20;
     }
 
     .k-breadcrumb-icon {
-      padding: 0 var(--spacing-sm, spacing(sm)) 0 0;
+      padding: 0 $kui-space-30 0 0;
 
       &:deep(.kong-icon) {
         align-items: center;
         align-self: baseline;
         justify-content: center;
-        padding: 0 var(--spacing-xs, spacing(xs)) 0 0;
 
         &.has-no-text {
           padding-right: 0;
         }
+      }
+    }
+
+    .k-breadcrumb-text {
+      &:hover {
+        color: $kui-color-text-neutral-stronger; /** $kui-color-text-selected */
+      }
+
+      &.non-link {
+        color: $kui-color-text;
+      }
+
+      &.emphasis {
+        font-weight: $kui-font-weight-bold;
+        letter-spacing: -0.14px;
       }
     }
   }
@@ -142,22 +168,13 @@ export default {
     display: inline-flex;
 
     a {
-      color: var(--grey-500, color(grey-500));
+      color: $kui-color-text-neutral;
       display: inline-flex;
-      font-size: 15px;
-      letter-spacing: 1px;
+      font-size: $kui-font-size-30;
 
       &:hover,
       &.no-underline {
         text-decoration: none !important;
-      }
-
-      > .k-breadcrumb-text {
-        transition: all 0.2s ease-in-out;
-
-        &:hover {
-          text-decoration: underline;
-        }
       }
     }
   }

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -6,7 +6,7 @@
     <li
       v-for="(item, idx) in items"
       :key="item.key || item.text"
-      class="k-breadcrumbs-item truncate"
+      class="k-breadcrumbs-item"
     >
       <component
         :is="getComponentAttrs(item).type"
@@ -25,7 +25,7 @@
         </slot>
         <span
           v-if="item.text"
-          class="k-breadcrumb-text truncate"
+          class="k-breadcrumb-text"
           :class="{ 'non-link': !item.to, 'emphasis': emphasis }"
           :style="{ maxWidth: item.maxWidth || itemMaxWidth }"
         >{{ item.text }}</span>
@@ -37,7 +37,7 @@
       >
         <slot name="divider">
           <KIcon
-            color="var(--grey-500)"
+            :color="`var(--grey-500, var(--kui-color-text-neutral-weak, ${KUI_COLOR_TEXT_NEUTRAL_WEAK}))`"
             hide-title
             icon="chevronRight"
             size="15"
@@ -51,7 +51,7 @@
 <script setup lang="ts">
 import { PropType } from 'vue'
 import type { BreadcrumbItem } from '@/types'
-import { KUI_COLOR_TEXT_DECORATIVE, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_DECORATIVE, KUI_ICON_SIZE_30, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
 import KIcon from '@/components/KIcon/KIcon.vue'
 
 defineProps({
@@ -110,6 +110,7 @@ export default {
 <style lang="scss" scoped>
 @import '@/styles/variables';
 @import '@/styles/functions';
+@import '@/styles/mixins';
 
 .k-breadcrumbs {
   border-radius: var(--kui-border-radius-40, $kui-border-radius-40);
@@ -124,6 +125,8 @@ export default {
   padding: var(--kui-space-0, $kui-space-0);
 
   .k-breadcrumbs-item {
+    @include truncate;
+
     .k-breadcrumb-divider,
     .k-breadcrumb-icon {
       align-self: center;
@@ -151,6 +154,8 @@ export default {
     }
 
     .k-breadcrumb-text {
+      @include truncate;
+
       &:hover {
         color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger); /** TODO: use $kui-color-text-selected token, once it is added */
       }

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -40,7 +40,7 @@
             :color="`var(--grey-500, var(--kui-color-text-neutral-weak, ${KUI_COLOR_TEXT_NEUTRAL_WEAK}))`"
             hide-title
             icon="chevronRight"
-            size="15"
+            :size="KUI_ICON_SIZE_30"
           />
         </slot>
       </span>

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -17,7 +17,7 @@
           <KIcon
             v-if="item.icon"
             :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
-            :color="KUI_COLOR_TEXT_DECORATIVE"
+            :color="`var(--kui-color-text-decorative, ${KUI_COLOR_TEXT_DECORATIVE})`"
             hide-title
             :icon="item.icon"
             :size="KUI_ICON_SIZE_30"
@@ -112,7 +112,7 @@ export default {
 @import '@/styles/functions';
 
 .k-breadcrumbs {
-  border-radius: var(--kui-border-radius-4, $kui-border-radius-4);
+  border-radius: var(--kui-border-radius-40, $kui-border-radius-40);
   display: flex;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -1,5 +1,5 @@
 export interface BreadcrumbItem {
-  to: object | string // router-link "to" object or href string
+  to?: object | string // router-link "to" object or href string
   text?: string
   title?: string
   icon?: string


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
KBreadcrumb style updates for [KHCP-8029](https://konghq.atlassian.net/browse/KHCP-8029).
Adds `emphasis` prop, divider slot, and support for breadcrumb item's that are not a link.

Figma: https://www.figma.com/file/8k70HMMdPj98APLaexYJyR/Header?type=design&node-id=11%3A7494&mode=dev

## PR Checklist

* [x] Does not introduce dependencies
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate


[KHCP-8029]: https://konghq.atlassian.net/browse/KHCP-8029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ