### PR TITLE
feat(kinput): introduce kui tokens [KHCP-7709]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /src/components/KCard @adamdehaven @jillztom @portikM
 /src/components/KCatalog @adamdehaven @jillztom @portikM
 /src/components/KDateTimePicker @adamdehaven @jillztom @portikM
+/src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KPop @adamdehaven @jillztom @portikM
 /src/components/KTable @adamdehaven @jillztom @portikM
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -2,7 +2,7 @@
 
 **KInput** provides a wrapper around general `text` input's and provides specific Kong styling and state treatments (error, focus, etc).
 
-<KInput class="w-100" placeholder="Placeholder text" type="number" />
+<KInput class="w-100" placeholder="Placeholder text" />
 
 ```html
 <KInput class="w-100" placeholder="Placeholder text" />

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@cypress/vite-dev-server": "^5.0.2",
     "@digitalroute/cz-conventional-changelog-for-jira": "^7.3.1",
     "@evilmartians/lefthook": "^1.4.1",
-    "@kong/design-tokens": "^1.5.1",
+    "@kong/design-tokens": "^1.6.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/inquirer": "^8.2.3",

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -324,13 +324,16 @@ export default {
   box-shadow: none !important;
 
   &.has-icon {
+    $kInputLineHeight: var(--kui-line-height-40, $kui-line-height-40);
+    // TODO: this block is repetitive and can be refactored into a mixin
     // input size medium
-    $kInputMediumSizingX: 10px;
-    $kInputMediumSizingY: var(--spacing-md, spacing(md));
-    $kInputMediumIconSize: 24px;
+    $kInputMediumSizingY: var(--kui-space-40, $kui-space-40);
+    $kInputMediumSizingX: var(--spacing-md, var(--kui-space-60, $kui-space-60));
+    $kInputMediumIconSize: var(--kui-icon-size-50, $kui-icon-size-50);
 
     ~ .input-icon {
-      top: $kInputMediumSizingX;
+      // (height of entire element (paddings + line height) - icon size) / 2
+      top: calc((($kInputMediumSizingY + $kInputMediumSizingY + $kInputLineHeight) - $kInputMediumIconSize) / 2);
 
       :deep(svg) {
         height: $kInputMediumIconSize;
@@ -339,27 +342,28 @@ export default {
     }
 
     &.icon-start {
-      padding-left: calc($kInputMediumSizingY + var(--spacing-xs, spacing(xs)) + $kInputMediumIconSize) !important; // account for icon offset and width
+      padding-left: calc($kInputMediumSizingX + var(--spacing-xs, var(--kui-space-40, $kui-space-40)) + $kInputMediumIconSize) !important; // account for icon offset and width
       ~ .input-icon {
-        left: $kInputMediumSizingY;
+        left: $kInputMediumSizingX;
       }
     }
 
     &.icon-end {
-      padding-right: calc($kInputMediumSizingY + var(--spacing-xs, spacing(xs)) + $kInputMediumIconSize) !important; // account for icon offset and width
+      padding-right: calc($kInputMediumSizingX + var(--spacing-xs, var(--kui-space-40, $kui-space-40)) + $kInputMediumIconSize) !important; // account for icon offset and width
       ~ .input-icon {
-        right: $kInputMediumSizingY;
+        right: $kInputMediumSizingX;
       }
     }
 
     // input size small
-    $kInputSmallSizingX: var(--spacing-xs, spacing(xs));
-    $kInputSmallSizingY: var(--spacing-sm, spacing(sm));
-    $kInputSmallIconSize: 22px;
+    $kInputSmallSizingY: var(--spacing-xs, var(--kui-space-40, $kui-space-40));
+    $kInputSmallSizingX: var(--spacing-sm, var(--kui-space-50, $kui-space-50));
+    $kInputSmallIconSize: var(--kui-icon-size-40, $kui-icon-size-40);
 
     &.k-input-small {
       ~ .input-icon {
-        top: $kInputSmallSizingX;
+        // (height of entire element (paddings + line height) - icon size) / 2
+        top: calc((($kInputSmallSizingY + $kInputSmallSizingY + $kInputLineHeight) - $kInputSmallIconSize) / 2);
 
         :deep(svg) {
           height: $kInputSmallIconSize;
@@ -368,27 +372,28 @@ export default {
       }
 
       &.icon-start {
-        padding-left: calc($kInputSmallSizingY + var(--spacing-xs, spacing(xs)) + $kInputSmallIconSize) !important; // account for icon offset and width
+        padding-left: calc($kInputSmallSizingX + var(--spacing-xs, var(--kui-space-40, $kui-space-40)) + $kInputSmallIconSize) !important; // account for icon offset and width
         ~ .input-icon {
-          left: $kInputSmallSizingY;
+          left: $kInputSmallSizingX;
         }
       }
       &.icon-end {
-        padding-right: calc($kInputSmallSizingY + var(--spacing-xs, spacing(xs)) + $kInputSmallIconSize) !important; // account for icon offset and width
+        padding-right: calc($kInputSmallSizingX + var(--spacing-xs, var(--kui-space-40, $kui-space-40)) + $kInputSmallIconSize) !important; // account for icon offset and width
         ~ .input-icon {
-          right: $kInputSmallSizingY;
+          right: $kInputSmallSizingX;
         }
       }
     }
 
     // input size large
-    $kInputLargeSizingX: var(--spacing-md, spacing(md));
-    $kInputLargeSizingY: var(--spacing-lg, spacing(lg));
-    $kInputLargeIconSize: 26px;
+    $kInputLargeSizingY: var(--spacing-md, var(--kui-space-60, $kui-space-60));
+    $kInputLargeSizingX: var(--spacing-lg, var(--kui-space-80, $kui-space-80));
+    $kInputLargeIconSize: var(--kui-icon-size-60, $kui-icon-size-60);
 
     &.k-input-large {
       ~ .input-icon {
-        top: $kInputLargeSizingX;
+        // (height of entire element (paddings + line height) - icon size) / 2
+        top: calc((($kInputLargeSizingY + $kInputLargeSizingY + $kInputLineHeight) - $kInputLargeIconSize) / 2);
 
         :deep(svg) {
           height: $kInputLargeIconSize;
@@ -397,15 +402,15 @@ export default {
       }
 
       &.icon-start {
-        padding-left: calc($kInputLargeSizingY + var(--spacing-xs, spacing(xs)) + $kInputLargeIconSize) !important; // account for icon offset and width
+        padding-left: calc($kInputLargeSizingX + var(--spacing-xs, var(--kui-space-40, $kui-space-40)) + $kInputLargeIconSize) !important; // account for icon offset and width
         ~ .input-icon {
-          left: $kInputLargeSizingY;
+          left: $kInputLargeSizingX;
         }
       }
       &.icon-end {
-        padding-right: calc($kInputLargeSizingY + var(--spacing-xs, spacing(xs)) + $kInputLargeIconSize) !important; // account for icon offset and width
+        padding-right: calc($kInputLargeSizingX + var(--spacing-xs, var(--kui-space-40, $kui-space-40)) + $kInputLargeIconSize) !important; // account for icon offset and width
         ~ .input-icon {
-          right: $kInputLargeSizingY;
+          right: $kInputLargeSizingX;
         }
       }
     }
@@ -413,10 +418,10 @@ export default {
 }
 
 .help {
-  color: var(--black-45, color(black-45));
+  color: var(--black-45, var(--kui-color-text, $kui-color-text));
   display: block;
-  font-size: var(--type-sm, type(sm));
-  margin: var(--spacing-xs, spacing(xs)) 0 0;
+  font-size: var(--type-sm, var(--kui-font-size-30, $kui-font-size-30));
+  margin: var(--spacing-xs, var(--kui-space-40, $kui-space-40)) var(--kui-space-0, $kui-space-0) var(--kui-space-0, $kui-space-0);
 }
 
 .input-icon {
@@ -432,8 +437,8 @@ export default {
 }
 
 .has-error {
-  color: var(--red-500);
-  font-weight: 500;
+  color: var(--red-500, var(--kui-color-text-danger, $kui-color-text-danger));
+  font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
 }
 
 .k-input-wrapper {
@@ -445,28 +450,28 @@ export default {
 
   & .k-input-label-wrapper-large .has-error,
   & .k-input-large + .has-error {
-    font-size: 12px;
-    line-height: 15px;
-    margin-top: 4px;
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    line-height: var(--kui-line-height-20, $kui-line-height-20);
+    margin-top: var(--kui-space-20, $kui-space-20);
   }
 
   & .k-input-label-wrapper-medium .has-error,
   & .k-input-medium + .has-error {
-    font-size: 11px;
-    line-height: 13px;
-    margin-top: 3px;
+    font-size: var(--kui-font-size-10, $kui-font-size-10);
+    line-height: var(--kui-line-height-10, $kui-line-height-10);
+    margin-top: var(--kui-space-10, $kui-space-10);
   }
 
   & .k-input-label-wrapper-small .has-error,
   & .k-input-small + .has-error {
-    font-size: 11px;
-    line-height: 11px;
-    margin-top: 2px;
+    font-size: var(--kui-font-size-10, $kui-font-size-10);
+    line-height: var(--kui-line-height-10, $kui-line-height-10);
+    margin-top: var(--kui-space-10, $kui-space-10);
   }
 
   .text-on-input label:not(.disabled):not(.readonly).hovered,
   .text-on-input label:not(.disabled):not(.readonly):hover {
-    color: var(--KInputHover, var(--blue-500));
+    color: var(--KInputHover, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
   }
 
   &.input-error {
@@ -474,7 +479,7 @@ export default {
     .text-on-input label:hover,
     .text-on-input label.focused,
     .text-on-input label:focus {
-      color: var(--red-500) !important;
+      color: var(--red-500, var(--kui-color-text-danger, $kui-color-text-danger)) !important;
     }
   }
 }

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -79,6 +79,7 @@
 
 .k-input,
 .form-control {
+  // some properties are using kui design tokens because Kongponent styles relying on matching values
   &:not([type="checkbox"]):not([type="radio"]) {
     border: none;
     border-radius: 3px;
@@ -87,19 +88,21 @@
     display: block;
     font-size: var(--type-md, type(md));
     font-weight: 400;
-    line-height: 24px;
-    padding: 10px var(--spacing-md, spacing(md));
+    line-height: var(--kui-line-height-40, $kui-line-height-40);
+    padding: var(--kui-space-40, $kui-space-40) var(--spacing-md, var(--kui-space-60, $kui-space-60));
     width: 100%;
     @include input-default;
 
     &.k-input-small {
       font-size: var(--type-xs, type(xs));
-      padding: var(--spacing-xs, spacing(xs)) var(--spacing-sm, spacing(sm));
+      padding: var(--spacing-xs, var(--kui-space-40, $kui-space-40))
+        var(--spacing-sm, var(--kui-space-50, $kui-space-50));
     }
 
     &.k-input-large {
       font-size: var(--type-md, type(md));
-      padding: var(--spacing-md, spacing(md)) var(--spacing-lg, spacing(lg));
+      padding: var(--spacing-md, var(--kui-space-60, $kui-space-60))
+        var(--spacing-lg, var(--kui-space-80, $kui-space-80));
     }
 
     &:hover {

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,10 +815,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kong/design-tokens@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.5.1.tgz#cb405333bb17d4c0d6210f0bd725328902c723fa"
-  integrity sha512-OiC6yMYI1lM1aGEcFHzRLN/i4hpumJ+x55Uz2DD679IJe6Cff/lMTeVpCEwXlDt75xsxuVSsCPOE7rLXM8Ck3w==
+"@kong/design-tokens@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.6.1.tgz#35f5b9e285068e51fc088ecc8e29a7edf76da077"
+  integrity sha512-2PfOX+6sOnAwwqiQY/gcYqhzyiKuXaIPpr1TRyhzt02JeNcNuPMubQUovacMNSWwRhu7xv3/QcA4mOE4Oz4Awg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7709

Changes:
- introduces `kui-` design tokens in `KInput` component
- removes any usage of Kongponents utility classes in `KInput` component template (none found)

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
