### PR TITLE
feat(kprompt): introduce kui tokens [KHCP-7719]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /src/components/KDateTimePicker @adamdehaven @jillztom @portikM
 /src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KPop @adamdehaven @jillztom @portikM
+/src/components/KPrompt @adamdehaven @jillztom @portikM
 /src/components/KSelect @adamdehaven @jillztom @portikM
 /src/components/KTable @adamdehaven @jillztom @portikM
 

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -13,7 +13,7 @@
             <KIcon
               v-if="type === 'warning'"
               class="warning-icon"
-              :color="`var(--white, ${KUI_COLOR_TEXT_INVERSE})`"
+              :color="`var(--white, var(--kui-color-text-inverse, ${KUI_COLOR_TEXT_INVERSE}))`"
               icon="warning"
               secondary-color="currentColor"
               :size="KUI_ICON_SIZE_40"
@@ -26,7 +26,7 @@
               @click="close"
             >
               <KIcon
-                :color="`var(--grey-600, ${KUI_COLOR_TEXT_NEUTRAL})`"
+                :color="`var(--grey-600, var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL}))`"
                 icon="close"
                 :size="KUI_ICON_SIZE_30"
               />
@@ -79,7 +79,7 @@
             <template #icon>
               <KIcon
                 v-if="actionPending"
-                :color="`var(--grey-400, ${KUI_COLOR_TEXT_NEUTRAL_WEAK})`"
+                :color="`var(--grey-400, var(--kui-color-text-neutral-weak, ${KUI_COLOR_TEXT_NEUTRAL_WEAK}))`"
                 icon="spinner"
                 :size="KUI_ICON_SIZE_30"
               />

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -13,9 +13,9 @@
             <KIcon
               v-if="type === 'warning'"
               class="mr-2"
-              color="var(--white)"
+              :color="`var(--white, ${KUI_COLOR_TEXT_INVERSE})`"
               icon="warning"
-              secondary-color="var(--yellow-400)"
+              :secondary-color="`var(--yellow-400, ${KUI_COLOR_TEXT_WARNING})`"
               size="20"
             />
             {{ displayTitle }}
@@ -27,7 +27,7 @@
               @click="close"
             >
               <KIcon
-                color="var(--grey-600)"
+                :color="`var(--grey-600, ${KUI_COLOR_TEXT_NEUTRAL})`"
                 icon="close"
                 size="15"
               />
@@ -81,7 +81,7 @@
             <template #icon>
               <KIcon
                 v-if="actionPending"
-                color="var(--grey-400)"
+                :color="`var(--grey-400, ${KUI_COLOR_TEXT_NEUTRAL_WEAK})`"
                 icon="spinner"
                 size="16"
               />
@@ -101,6 +101,7 @@ import KIcon from '@/components/KIcon/KIcon.vue'
 import KInput from '@/components/KInput/KInput.vue'
 import KModal from '@/components/KModal/KModal.vue'
 import { PromptVariants, PromptVariantsArray } from '@/types'
+import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_WARNING, KUI_COLOR_TEXT_NEUTRAL, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
 
 const props = defineProps({
   title: {
@@ -230,33 +231,34 @@ onBeforeUnmount(() => {
 @import '@/styles/functions';
 
 .k-prompt {
-  --KModalBottomMargin: var(--spacing-md);
+  --KModalBottomMargin: var(--spacing-md, var(--kui-space-60, #{$kui-space-60}));
 
   :deep(.k-modal-dialog.modal-dialog) {
-    padding: var(--spacing-lg);
-    padding-bottom: var(--spacing-md);
+    $kPromptModalPadding: var(--spacing-lg, var(--kui-space-80, $kui-space-80));
+
+    padding: $kPromptModalPadding;
+    padding-bottom: var(--spacing-md, var(--kui-space-60, $kui-space-60));
 
     .close-button {
-      margin-left: auto;
+      margin-left: var(--kui-space-auto, $kui-space-auto);
     }
 
     .divider {
       border: none;
-      border-top: 1px solid var(--grey-300);
+      border-top: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak));
       /* subtract parents padding from margin to take full width of modal */
-      /* use interpolation for the var in calc to not break postcss */
-      margin: 16px calc(#{var(--spacing-lg)} * -1) 0;
+      margin: var(--kui-space-60, $kui-space-60) calc($kPromptModalPadding * -1) var(--kui-space-0, $kui-space-0);
     }
 
     .k-modal-content {
       .k-modal-header.modal-header {
         display: flex;
-        padding-bottom: var(--spacing-xs);
+        padding-bottom: var(--spacing-xs, var(--kui-space-40, $kui-space-40));
         width: 100%;
 
         .close-button .k-button {
-          margin-top: -8px;
-          padding: var(--spacing-xs);
+          margin-top: calc(-1 * var(--kui-space-40, $kui-space-40));
+          padding: var(--spacing-xs, var(--kui-space-40, $kui-space-40));
         }
       }
 
@@ -264,23 +266,23 @@ onBeforeUnmount(() => {
         width: 100%;
 
         .k-prompt-body .k-prompt-body-content {
-          color: var(--grey-600);
-          font-size: var(--type-md);
-          line-height: 24px;
+          color: var(--grey-600, var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong));
+          font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
+          line-height: var(--kui-line-height-40, $kui-line-height-40);
           max-height: var(--KPromptMaxHeight, 300px);
           overflow-x: hidden;
           overflow-y: auto;
-          padding-bottom: var(--spacing-md);
+          padding-bottom: var(--spacing-md, var(--kui-space-60, $kui-space-60));
           text-align: start;
           white-space: normal; // in case inside KTable
           width: 99%;
 
-          @media screen and (min-width: $viewport-md) {
+          @media screen and (min-width: $kui-breakpoint-phablet) {
             max-height: var(--KPromptMaxHeight, 500px);
           }
 
           .k-prompt-confirm-text {
-            margin-top: var(--spacing-lg);
+            margin-top: var(--spacing-lg, var(--kui-space-80, $kui-space-80));
             .k-input {
               width: 100%;
             }

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -7,29 +7,28 @@
     :title="displayTitle"
   >
     <template #header-content>
-      <div class="k-prompt-header w-100">
-        <div class="k-prompt-header-content d-flex align-items-center w-100">
+      <div class="k-prompt-header">
+        <div class="k-prompt-header-content">
           <slot name="header-content">
             <KIcon
               v-if="type === 'warning'"
-              class="mr-2"
+              class="warning-icon"
               :color="`var(--white, ${KUI_COLOR_TEXT_INVERSE})`"
               icon="warning"
-              :secondary-color="`var(--yellow-400, ${KUI_COLOR_TEXT_WARNING})`"
-              size="20"
+              secondary-color="currentColor"
+              :size="KUI_ICON_SIZE_40"
             />
             {{ displayTitle }}
           </slot>
           <div class="close-button">
             <KButton
               aria-label="Close"
-              class="non-visual-button"
               @click="close"
             >
               <KIcon
                 :color="`var(--grey-600, ${KUI_COLOR_TEXT_NEUTRAL})`"
                 icon="close"
-                size="15"
+                :size="KUI_ICON_SIZE_30"
               />
             </KButton>
           </div>
@@ -38,23 +37,22 @@
       </div>
     </template>
     <template #body-content>
-      <div class="k-prompt-body w-100">
-        <div class="k-prompt-body-content w-100">
+      <div class="k-prompt-body">
+        <div class="k-prompt-body-content">
           <slot name="body-content">
             {{ message }}
           </slot>
 
           <div
             v-if="confirmationText"
-            class="k-prompt-confirm-text w-100"
+            class="k-prompt-confirm-text"
           >
-            Type "<span class="bold-600">{{ confirmationText }}</span>" to confirm your action.
+            Type "<span class="confirm-text">{{ confirmationText }}</span>" to confirm your action.
 
             <KInput
               v-model="confirmationInput"
               autocapitalize="off"
               autocomplete="off"
-              class="mt-2"
               data-testid="confirmation-input"
             />
           </div>
@@ -67,7 +65,7 @@
         <slot name="action-buttons">
           <KButton
             appearance="outline"
-            class="k-prompt-cancel mr-2"
+            class="k-prompt-cancel"
             @click="close"
           >
             {{ cancelButtonText }}
@@ -83,7 +81,7 @@
                 v-if="actionPending"
                 :color="`var(--grey-400, ${KUI_COLOR_TEXT_NEUTRAL_WEAK})`"
                 icon="spinner"
-                size="16"
+                :size="KUI_ICON_SIZE_30"
               />
             </template>
             {{ actionButtonText }}
@@ -101,7 +99,7 @@ import KIcon from '@/components/KIcon/KIcon.vue'
 import KInput from '@/components/KInput/KInput.vue'
 import KModal from '@/components/KModal/KModal.vue'
 import { PromptVariants, PromptVariantsArray } from '@/types'
-import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_WARNING, KUI_COLOR_TEXT_NEUTRAL, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_NEUTRAL, KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_ICON_SIZE_30, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const props = defineProps({
   title: {
@@ -228,6 +226,8 @@ onBeforeUnmount(() => {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
+@import '@/styles/mixins';
 @import '@/styles/functions';
 
 .k-prompt {
@@ -239,8 +239,23 @@ onBeforeUnmount(() => {
     padding: $kPromptModalPadding;
     padding-bottom: var(--spacing-md, var(--kui-space-60, $kui-space-60));
 
-    .close-button {
-      margin-left: var(--kui-space-auto, $kui-space-auto);
+    .k-prompt-header {
+      width: 100% !important;
+
+      .k-prompt-header-content {
+        align-items: center !important;
+        display: flex !important;
+        width: 100% !important;
+
+        .warning-icon {
+          color: $tmp-color-yellow-400;
+          margin-right: var(--kui-space-40, $kui-space-40) !important;
+        }
+
+        .close-button {
+          margin-left: var(--kui-space-auto, $kui-space-auto);
+        }
+      }
     }
 
     .divider {
@@ -257,6 +272,7 @@ onBeforeUnmount(() => {
         width: 100%;
 
         .close-button .k-button {
+          @include non-visual-button;
           margin-top: calc(-1 * var(--kui-space-40, $kui-space-40));
           padding: var(--spacing-xs, var(--kui-space-40, $kui-space-40));
         }
@@ -265,26 +281,37 @@ onBeforeUnmount(() => {
       .k-modal-body.modal-body {
         width: 100%;
 
-        .k-prompt-body .k-prompt-body-content {
-          color: var(--grey-600, var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong));
-          font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
-          line-height: var(--kui-line-height-40, $kui-line-height-40);
-          max-height: var(--KPromptMaxHeight, 300px);
-          overflow-x: hidden;
-          overflow-y: auto;
-          padding-bottom: var(--spacing-md, var(--kui-space-60, $kui-space-60));
-          text-align: start;
-          white-space: normal; // in case inside KTable
-          width: 99%;
+        .k-prompt-body {
+          width: 100% !important;
 
-          @media screen and (min-width: $kui-breakpoint-phablet) {
-            max-height: var(--KPromptMaxHeight, 500px);
-          }
+          .k-prompt-body-content {
+            color: var(--grey-600, var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong));
+            font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
+            line-height: var(--kui-line-height-40, $kui-line-height-40);
+            max-height: var(--KPromptMaxHeight, 300px);
+            overflow-x: hidden;
+            overflow-y: auto;
+            padding-bottom: var(--spacing-md, var(--kui-space-60, $kui-space-60));
+            text-align: start;
+            white-space: normal; // in case inside KTable
+            width: 100% !important;
 
-          .k-prompt-confirm-text {
-            margin-top: var(--spacing-lg, var(--kui-space-80, $kui-space-80));
-            .k-input {
-              width: 100%;
+            @media screen and (min-width: $kui-breakpoint-phablet) {
+              max-height: var(--KPromptMaxHeight, 500px);
+            }
+
+            .k-prompt-confirm-text {
+              margin-top: var(--spacing-lg, var(--kui-space-80, $kui-space-80));
+              width: 100% !important;
+
+              .confirm-text {
+                font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold) !important;
+              }
+
+              .k-input {
+                margin-top: var(--kui-space-40, $kui-space-40) !important;
+                width: 100%;
+              }
             }
           }
         }
@@ -293,6 +320,10 @@ onBeforeUnmount(() => {
       .k-modal-footer.modal-footer {
         .k-prompt-action-buttons {
           margin-left: auto;
+
+          .k-prompt-cancel {
+            margin-right: var(--kui-space-40, $kui-space-40) !important;
+          }
         }
       }
     }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7719

Changes:
- introduces `kui-` design tokens in `KPrompt` component
- removes any usage of Kongponents utility classes in `KPrompt` component template

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
