### PR TITLE
feat(ktextarea): introduce kui tokens [KHCP-7728]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@
 /src/components/KPop @adamdehaven @jillztom @portikM
 /src/components/KSelect @adamdehaven @jillztom @portikM
 /src/components/KTable @adamdehaven @jillztom @portikM
+/src/components/KTextArea @adamdehaven @jillztom @portikM
 
 # Dependabot approvals
 # Allow Kongponents BOT to approve dependabot updates

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -1,12 +1,12 @@
 <template>
   <div
-    class="k-input-wrapper mb-2"
+    class="k-input-wrapper"
     :class="[$attrs.class, {'input-error' : hasError || charLimitExceeded}]"
   >
     <textarea
       v-if="!label"
       v-bind="modifiedAttrs"
-      class="form-control k-input style-body-lg"
+      class="form-control k-input"
       :class="[isResizable ? 'is-resizable' : undefined]"
       :cols="cols"
       :rows="rows"
@@ -16,7 +16,7 @@
 
     <div
       v-else-if="label && overlayLabel"
-      class="mt-5"
+      class="k-textarea"
     >
       <div class="text-on-input">
         <label
@@ -34,7 +34,7 @@
           v-bind="modifiedAttrs"
           :id="textAreaId"
           :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
-          class="form-control k-input style-body-lg"
+          class="form-control k-input"
           :class="[isResizable ? 'is-resizable' : undefined]"
           :cols="cols"
           :rows="rows"
@@ -50,7 +50,7 @@
 
     <div
       v-else
-      class="mt-5"
+      class="k-textarea"
     >
       <KLabel
         :for="textAreaId"
@@ -70,7 +70,7 @@
         v-bind="modifiedAttrs"
         :id="textAreaId"
         :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
-        class="form-control k-input style-body-lg"
+        class="form-control k-input"
         :class="[isResizable ? 'is-resizable' : undefined]"
         :cols="cols"
         :rows="rows"
@@ -85,7 +85,7 @@
 
     <div
       v-if="!disableCharacterLimit"
-      class="char-limit type-sm color-black-45 mt-2"
+      class="char-limit"
       :class="{ 'over-char-limit': charLimitExceeded }"
     >
       {{ currValue.length || modelValue.length }} / {{ characterLimit }}
@@ -230,18 +230,25 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/mixins';
 @import '@/styles/functions';
 
 .k-input-wrapper {
   display: grid;
+  margin-bottom: var(--kui-space-40, $kui-space-40);
   width: fit-content;
+
+  .k-textarea {
+    margin-top: var(--kui-space-80, $kui-space-80) !important;
+  }
 
   textarea.k-input {
     -webkit-appearance: none;
   }
 
   textarea.form-control {
-    font-family: var(--font-family-sans);
+    @include text-lg;
+    font-family: var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text));
     resize: none;
 
     &.is-resizable {
@@ -255,16 +262,19 @@ export default {
   }
 
   .char-limit {
-    margin-left: auto;
+    color: var(--kui-color-text, $kui-color-text) !important;
+    font-size: var(--kui-font-size-30, $kui-font-size-30) !important;
+    margin-left: var(--kui-space-auto, $kui-space-auto);
+    margin-top: var(--kui-space-40, $kui-space-40) !important;
   }
 
   .over-char-limit {
-    color: var(--red-600);
+    color: var(--red-600, var(--kui-color-text-danger, $kui-color-text-danger));
   }
 
   .text-on-input label.hovered,
   .text-on-input label:hover {
-    color: var(--KInputHover, var(--blue-500));
+    color: var(--KInputHover, var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary)));
   }
 }
 </style>

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -230,7 +230,6 @@ export default {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
-@import '@/styles/mixins';
 @import '@/styles/functions';
 
 .k-input-wrapper {
@@ -247,8 +246,10 @@ export default {
   }
 
   textarea.form-control {
-    @include text-lg;
     font-family: var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text));
+    font-size: var(--kui-font-size-40, $kui-font-size-40) !important;
+    font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular) !important;
+    line-height: var(--kui-line-height-40, $kui-line-height-40) !important;
     resize: none;
 
     &.is-resizable {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -108,9 +108,3 @@
     @include non-visual-button-rules;
   }
 }
-
-@mixin text-lg {
-  font-size: var(--kui-font-size-40, $kui-font-size-40) !important;
-  font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular) !important;
-  line-height: var(--kui-line-height-40, $kui-line-height-40) !important;
-}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -108,3 +108,9 @@
     @include non-visual-button-rules;
   }
 }
+
+@mixin text-lg {
+  font-size: var(--kui-font-size-40, $kui-font-size-40) !important;
+  font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular) !important;
+  line-height: var(--kui-line-height-40, $kui-line-height-40) !important;
+}


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7728

Changes:
- introduces `kui-` design tokens in `KTextArea` component
- removes any usage of Kongponents utility classes in `KTextArea` component template

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
