### PR TITLE
fix(*): fix icon size in components with design tokens

### DIFF
--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -93,7 +93,7 @@
         :class="appearance"
         :color="appearance"
         icon="close"
-        size="14"
+        :size="KUI_ICON_SIZE_20"
       />
     </button>
 
@@ -130,6 +130,7 @@ import { computed, PropType, useSlots } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import type { AlertAppearance, AlertDismissType, AlertAppearanceRecord, AlertSize, AlertType } from '@/types'
+import { KUI_ICON_SIZE_20 } from '@kong/design-tokens'
 
 defineProps({
   /**

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -38,7 +38,7 @@
       <KIcon
         :color="color"
         icon="close"
-        size="10"
+        :size="KUI_ICON_SIZE_10"
         title="Remove"
       />
     </KButton>
@@ -53,6 +53,7 @@ import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import type { BadgeAppearance, BadgeShape } from '@/types'
 import { BadgeAppearances, BadgeShapes } from '@/types'
 import useUtilities from '@/composables/useUtilities'
+import { KUI_ICON_SIZE_10 } from '@kong/design-tokens'
 
 const { getSizeFromString } = useUtilities()
 

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -15,7 +15,7 @@
         class="k-button-icon"
         :color="iconColor"
         :icon="icon"
-        size="16"
+        :size="KUI_ICON_SIZE_30"
       />
     </slot>
 
@@ -25,7 +25,7 @@
       v-if="showCaret"
       :color="iconColor"
       icon="chevronDown"
-      size="16"
+      :size="KUI_ICON_SIZE_30"
       view-box="2 2 15 15"
     />
   </a>
@@ -46,7 +46,7 @@
         class="k-button-icon"
         :color="iconColor"
         :icon="icon"
-        size="16"
+        :size="KUI_ICON_SIZE_30"
       />
     </slot>
 
@@ -57,7 +57,7 @@
       :class="['caret']"
       :color="caretColor || iconColor"
       icon="chevronDown"
-      size="16"
+      :size="KUI_ICON_SIZE_30"
       view-box="2 2 15 15"
     />
   </component>
@@ -67,7 +67,14 @@
 import { computed, PropType, useSlots, useAttrs } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import type { ButtonAppearance, ButtonAppearanceRecord, ButtonSize, ButtonSizeRecord } from '@/types'
-import { KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_PRIMARY_STRONGER, KUI_COLOR_TEXT_PRIMARY, KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
+import {
+  KUI_COLOR_TEXT_NEUTRAL_WEAK,
+  KUI_COLOR_TEXT_INVERSE,
+  KUI_COLOR_TEXT_PRIMARY_STRONGER,
+  KUI_COLOR_TEXT_PRIMARY,
+  KUI_COLOR_TEXT_DANGER,
+  KUI_ICON_SIZE_30,
+} from '@kong/design-tokens'
 
 const props = defineProps({
   /**

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -27,7 +27,7 @@
           class="calendar-icon"
           :color="`var(--grey-500, var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL}))`"
           icon="calendar"
-          size="18"
+          :size="KUI_ICON_SIZE_30"
         />
         <div
           class="timepicker-display"
@@ -146,7 +146,7 @@ import KSegmentedControl from '@/components/KSegmentedControl/KSegmentedControl.
 import 'v-calendar/dist/style.css'
 import type { DateTimePickerState, TimeFrameSection, TimePeriod, TimeRange, Mode, CSSProperties } from '@/types'
 import { ModeArray } from '@/types'
-import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 
 const props = defineProps({
   clearButton: {

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -139,7 +139,7 @@
                   class="caret"
                   :color="`var(--KTableColor, var(--black-70, var(--kui-color-text, ${KUI_COLOR_TEXT})))`"
                   icon="chevronDown"
-                  size="12"
+                  :size="KUI_ICON_SIZE_20"
                 />
               </span>
             </th>
@@ -217,7 +217,7 @@ import type {
   PageChangedData,
   PageSizeChangedData,
 } from '@/types'
-import { KUI_COLOR_TEXT } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT, KUI_ICON_SIZE_20 } from '@kong/design-tokens'
 
 const { useDebounce, useRequest, useSwrvState } = useUtilities()
 


### PR DESCRIPTION
# Summary

Fixes icon size in Kongponents that were completed prior to introduction of `kui-icon-size-*` tokens

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
