### PR TITLE
feat(kdropdownmenu): introduce kui tokens [KHCP-7703]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@
 /src/components/KCatalog @adamdehaven @jillztom @portikM
 /src/components/KCheckbox @adamdehaven @jillztom @portikM
 /src/components/KDateTimePicker @adamdehaven @jillztom @portikM
+/src/components/KDropdownMenu @adamdehaven @jillztom @portikM
 /src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KPop @adamdehaven @jillztom @portikM
 /src/components/KPrompt @adamdehaven @jillztom @portikM

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -151,16 +151,16 @@ Use this prop to customize the color of the caret
 
 <ClientOnly>
   <KDropdownMenu
-    caret-color="var(--steel-300)"
+    caret-color="lightgreen"
     label="Select Type"
-    :items="items"
+    :items="deepClone(defaultItemsUnselected)"
     show-caret
   />
 </ClientOnly>
 
 ```html
 <KDropdownMenu
-  caret-color="var(--steel-300)"
+  caret-color="lightgreen"
   label="Select Type"
   :items="items"
   show-caret
@@ -225,7 +225,7 @@ Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popo
             <template #icon>
               <KIcon
                 icon="more"
-                color="var(--black-400)"
+                color="blue"
                 size="16"
               />
             </template>
@@ -258,7 +258,7 @@ Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popo
           <template #icon>
             <KIcon
               icon="more"
-              color="var(--black-400)"
+              color="blue"
               size="16"
             />
           </template>
@@ -409,7 +409,7 @@ There are 3 primary item types:
           <KIcon
             icon="externalLink"
             size="12"
-            color="var(--red-500)"
+            color="red"
             class="ml-2"
           />
         </a>
@@ -465,7 +465,7 @@ There are 3 primary item types:
         <KIcon
           icon="externalLink"
           size="12"
-          color="var(--red-500)"
+          color="red"
           class="ml-2"
         />
       </a>
@@ -543,7 +543,7 @@ export default defineComponent({
 
   &:hover {
     svg path {
-      fill: var(--red-500);
+      fill: red;
     }
   }
 }

--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -159,22 +159,23 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
 <style lang="scss">
 // Must leave this block unscoped as it sometimes causes issues with slotted/nested styles
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 li.k-dropdown-item {
   align-items: center;
   display: flex;
-  font-size: var(--type-md, 16px);
-  line-height: 1;
+  font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
+  line-height: var(--kui-line-height-40, $kui-line-height-40);
 
   &:not(:first-of-type).has-divider {
-    $k-dropdown-item-divider-container-height: var(--spacing-lg, spacing(lg)); // set to the same value as --spacing-lg without the units
+    $k-dropdown-item-divider-container-height: var(--spacing-lg, var(--kui-space-80, $kui-space-80)); // set to the same value as --spacing-lg without the units
     $k-dropdown-item-divider-position: -13px; // this should be negative (<container-height> / 2 + 1)
     margin-top: $k-dropdown-item-divider-container-height;
     position: relative;
 
     &:before {
-      background: var(--grey-200, #f1f1f5);
+      background: var(--grey-200, var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest));
       content: '';
       display: block;
       height: 1px;
@@ -185,18 +186,18 @@ li.k-dropdown-item {
   }
 
   svg {
-    margin-right: var(--spacing-sm, spacing(sm));
+    margin-right: var(--spacing-sm, var(--kui-space-50, $kui-space-50));
   }
 
   &:hover {
-    background-color: var(--grey-100, #f8f8fa);
+    background-color: var(--grey-100, var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest));
   }
 
   .k-dropdown-item-trigger,
   // Override .btn-link styles
   .k-dropdown-item-trigger.btn-link {
-    color: var(--black-70, rgba(0, 0, 0, 0.7));
-    line-height: var(--type-lg, type(lg));
+    color: var(--black-70, var(--kui-color-text-neutral, $kui-color-text-neutral));
+    line-height: var(--type-lg, var(--kui-line-height-50, $kui-line-height-50));
     padding: var(--spacing-md, spacing(md)) var(--spacing-lg, spacing(lg));
     text-align: left;
     text-decoration: none;
@@ -204,11 +205,11 @@ li.k-dropdown-item {
 
     &:disabled,
     &.disabled {
-      color: var(--grey-400, #b6b6bd) !important;
+      color: var(--grey-400, var(--kui-color-text-disabled, $kui-color-text-disabled)) !important;
       cursor: not-allowed !important;
 
       &:hover {
-        background-color: var(--grey-200, #f1f1f5) !important;
+        background-color: var(--grey-200, var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest)) !important;
       }
     }
   }
@@ -217,7 +218,7 @@ li.k-dropdown-item {
 .k-dropdown-item {
   a, button {
     &.k-dropdown-item-trigger {
-      line-height: var(--type-lg, type(lg));
+      line-height: var(--type-lg, var(--kui-line-height-50, $kui-line-height-50));
       text-decoration: none !important;
     }
   }
@@ -225,11 +226,11 @@ li.k-dropdown-item {
   &.danger {
     button:not(:disabled),
     a:not(:disabled) {
-      color: var(--red-500, #d44324);
-      transition: all 300ms;
+      color: var(--red-500, var(--kui-color-text-danger, $kui-color-text-danger));
+      transition: all $tmp-animation-timing-2;
 
       &:hover {
-        color: var(--red-500, #d44324);
+        color: var(--red-500, var(--kui-color-text-danger, $kui-color-text-danger));
       }
     }
   }

--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    class="k-dropdown-item w-100"
+    class="k-dropdown-item"
     :class="{
       'has-divider': hasDivider,
       'disabled': type === 'default' && disabled,
@@ -16,7 +16,7 @@
       @click="availableComponents[componentType].onClick"
     >
       <span
-        class="truncate"
+        class="k-dropdown-item-trigger-label"
         :title="label"
       >
 
@@ -142,7 +142,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     tag: KButton,
     onClick: handleClick,
     attrs: {
-      class: 'k-dropdown-item-trigger btn-link k-button non-visual-button',
+      class: 'k-dropdown-item-trigger k-button btn-link',
       disabled: props.disabled,
       isRounded: false,
     },
@@ -161,12 +161,14 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
 @import '@/styles/variables';
 @import '@/styles/tmp-variables';
 @import '@/styles/functions';
+@import '@/styles/mixins';
 
 li.k-dropdown-item {
   align-items: center;
   display: flex;
   font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
   line-height: var(--kui-line-height-40, $kui-line-height-40);
+  width: 100% !important;
 
   &:not(:first-of-type).has-divider {
     $k-dropdown-item-divider-container-height: var(--spacing-lg, var(--kui-space-80, $kui-space-80)); // set to the same value as --spacing-lg without the units
@@ -196,7 +198,7 @@ li.k-dropdown-item {
   .k-dropdown-item-trigger,
   // Override .btn-link styles
   .k-dropdown-item-trigger.btn-link {
-    color: var(--black-70, var(--kui-color-text-neutral, $kui-color-text-neutral));
+    color: var(--black-70, var(--kui-color-text, $kui-color-text));
     line-height: var(--type-lg, var(--kui-line-height-50, $kui-line-height-50));
     padding: var(--spacing-md, spacing(md)) var(--spacing-lg, spacing(lg));
     text-align: left;
@@ -218,8 +220,13 @@ li.k-dropdown-item {
 .k-dropdown-item {
   a, button {
     &.k-dropdown-item-trigger {
+      @include non-visual-button;
       line-height: var(--type-lg, var(--kui-line-height-50, $kui-line-height-50));
       text-decoration: none !important;
+
+      .k-dropdown-item-trigger-label {
+        @include truncate;
+      }
     }
   }
 

--- a/src/components/KDropdownMenu/KDropdownMenu.vue
+++ b/src/components/KDropdownMenu/KDropdownMenu.vue
@@ -217,36 +217,26 @@ onMounted(() => {
 
 .k-dropdown-menu {
   width: fit-content;
-  .drodpown-trigger:after {
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-    border-top: 6px solid;
-    content: "";
-    display: inline-block;
-    height: 0;
-    margin-left: var(--spacing-xs, spacing(xs));
-    vertical-align: middle;
-    width: 0;
-  }
 }
 </style>
 
 <style lang="scss">
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-popover.k-dropdown-popover {
-  --KPopPaddingY: var(--spacing-sm, spacing(sm));
-  --KPopPaddingX: 0;
-  border: 1px solid var(--black-10, rgba(0, 0, 0, 0.1));
+  --KPopPaddingY: var(--spacing-sm, var(--kui-space-50, #{$kui-space-50}));
+  --KPopPaddingX: var(--kui-space-0, #{$kui-space-0});
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--black-10, $tmp-color-black-10);
 
   ul {
-    margin: 0;
-    padding: 0;
+    margin: var(--kui-space-0, $kui-space-0);
+    padding: var(--kui-space-0, $kui-space-0);
   }
 
   a {
-    color: var(--black-70, rgba(0, 0, 0, 0.7));
+    color: var(--black-70, var(--kui-color-text-neutral, $kui-color-text-neutral));
     flex: 1;
 
     &:hover,
@@ -259,8 +249,8 @@ onMounted(() => {
 
 .selection-dropdown-menu {
   .dropdown-trigger .k-button {
-    border: 0;
-    color: var(--grey-600, #3c4557);
+    border: var(--kui-border-width-0, $kui-border-width-0);
+    color: var(--grey-600, var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong));
     white-space: nowrap;
 
     &:focus {
@@ -268,15 +258,15 @@ onMounted(() => {
     }
 
     &:active:disabled {
-      background-color: var(--white, #ffffff);
+      background-color: var(--white, var(--kui-color-background, $kui-color-background));
     }
 
     &.is-active {
-      background-color: var(--grey-100, #f8f8fa);
+      background-color: var(--grey-100, var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest));
     }
 
     // Set dropdown icon color
-    --KButtonOutlineColor: var(--grey-500, #6f7787);
+    --KButtonOutlineColor: var(--grey-500, var(--kui-color-text-neutral, #{$kui-color-text-neutral}));
   }
 
   .k-popover.k-dropdown-popover {
@@ -284,14 +274,14 @@ onMounted(() => {
 
     li {
       .non-visual-button {
-        font-weight: 400 !important;
+        font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular) !important;
       }
 
       &.k-dropdown-selected-option {
-        background-color: var(--blue-100, #f2f6fe);
+        background-color: var(--blue-100, var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest));
 
         .non-visual-button {
-          font-weight: 500 !important;
+          font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium) !important;
         }
       }
     }

--- a/src/components/KDropdownMenu/KDropdownMenu.vue
+++ b/src/components/KDropdownMenu/KDropdownMenu.vue
@@ -152,7 +152,7 @@ const tooltipComponent = computed(() => props.disabledTooltip ? Kooltip : 'div')
 
 const defaultKPopAttributes = {
   hideCaret: true,
-  popoverClasses: 'k-dropdown-popover mt-1',
+  popoverClasses: 'k-dropdown-popover',
   popoverTimeout: 0,
   positionFixed: true,
   placement: 'bottomStart' as PopPlacements,
@@ -226,9 +226,10 @@ onMounted(() => {
 @import '@/styles/functions';
 
 .k-popover.k-dropdown-popover {
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--black-10, $tmp-color-black-10);
+  margin-top: var(--kui-space-20, $kui-space-20) !important;
   --KPopPaddingY: var(--spacing-sm, var(--kui-space-50, #{$kui-space-50}));
   --KPopPaddingX: var(--kui-space-0, #{$kui-space-0});
-  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--black-10, $tmp-color-black-10);
 
   ul {
     margin: var(--kui-space-0, $kui-space-0);
@@ -236,7 +237,7 @@ onMounted(() => {
   }
 
   a {
-    color: var(--black-70, var(--kui-color-text-neutral, $kui-color-text-neutral));
+    color: var(--black-70, var(--kui-color-text, $kui-color-text));
     flex: 1;
 
     &:hover,

--- a/src/types/dropdown-menu.ts
+++ b/src/types/dropdown-menu.ts
@@ -26,7 +26,7 @@ export interface DropdownItemRenderedComponent {
     isRounded?: boolean
     disabled?: boolean
     to?: string | object
-    href?: string;
+    href?: string
   }
 }
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7703

Changes:
- introduces `kui-` design tokens in `KDropdownMenu` component
- removes any usage of Kongponents utility classes in `KDropdownMenu` component template (none found)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
