### PR TITLE
feat(kfileupload): introduce kui tokens [KHCP-7706]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@
 /src/components/KDateTimePicker @adamdehaven @jillztom @portikM
 /src/components/KDropdownMenu @adamdehaven @jillztom @portikM
 /src/components/KEmptyState @adamdehaven @jillztom @portikM
+/src/components/KFileUpload @adamdehaven @jillztom @portikM
 /src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KPop @adamdehaven @jillztom @portikM
 /src/components/KPrompt @adamdehaven @jillztom @portikM

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -224,7 +224,7 @@ Specify an icon to display to the left of the `placeholder text` if prop `type` 
 
 ### iconSize
 
-The size of the `icon` being displayed (default is `26`).
+The size of the `icon` being displayed (default is `24px`).
 
 ### iconColor
 
@@ -232,13 +232,13 @@ The color of the `icon` being displayed.
 
 <KCard class="mt-6">
   <template v-slot:body>
-    <KFileUpload type="image" label="Upload File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" :accept="acceptedImageType" class="image-with-label" placeholder="Customized icon, iconColor & iconSize!" icon="immunity" iconColor="gold" iconSize="30" />
+    <KFileUpload type="image" label="Upload File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" :accept="acceptedImageType" class="image-with-label" placeholder="Customized icon, iconColor & iconSize!" icon="immunity" iconColor="gold" iconSize="30px" />
   </template>
 </KCard>
 
 ```html
 <KFileUpload
-  type="image" icon="immunity" iconColor="gold" iconSize="30"
+  type="image" icon="immunity" iconColor="gold" iconSize="30px"
   placeholder="You can change the text here!"
 />
 ```

--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -130,7 +130,7 @@ import { computed, PropType, useSlots } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import type { AlertAppearance, AlertDismissType, AlertAppearanceRecord, AlertSize, AlertType } from '@/types'
-import { KUI_ICON_SIZE_20 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_20, KUI_ICON_SIZE_60 } from '@kong/design-tokens'
 
 defineProps({
   /**
@@ -201,7 +201,7 @@ defineProps({
      */
   iconSize: {
     type: String,
-    default: '32',
+    default: KUI_ICON_SIZE_60,
   },
   /**
      * Set alert box type of icon

--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -355,7 +355,7 @@ export const appearances: AlertAppearanceRecord = {
   }
 
   .close {
-    background-color: transparent;
+    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     border: var(--kui-border-width-0, $kui-border-width-0);
     bottom: var(--kui-space-0, $kui-space-0);
     cursor: pointer;

--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -49,7 +49,7 @@
 <script lang="ts" setup>
 import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGEST } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_NEUTRAL_STRONGEST, KUI_ICON_SIZE_80 } from '@kong/design-tokens'
 
 defineProps({
   isError: {
@@ -58,7 +58,7 @@ defineProps({
   },
   iconSize: {
     type: String,
-    default: '50',
+    default: KUI_ICON_SIZE_80,
   },
   icon: {
     type: String,

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    class="k-file-upload w-100"
+    class="k-file-upload"
   >
     <KLabel
       v-if="label"
       v-bind="labelAttributes"
-      class="cursor-pointer"
+      class="k-file-upload-label"
       data-testid="k-file-upload-label"
       :for="customInputId"
     >
@@ -16,7 +16,7 @@
       :id="customInputId"
       :key="fileInputKey"
       :accept="accept"
-      class="w-100 upload-input"
+      class="upload-input"
       :class="{
         'image-upload': type === 'image'
       }"
@@ -77,7 +77,7 @@
     </KButton>
     <a
       v-if="type === 'file'"
-      class="cursor-pointer display-name"
+      class="display-name"
       :class="[label ? 'has-label' : 'has-no-label']"
       href="#"
       @click="updateFile"
@@ -266,12 +266,20 @@ const resetInput = (): void => {
 @import '@/styles/functions';
 
 .k-file-upload {
+  position: relative;
+  width: 100 !important;
   $kInputPaddingY: var(--kui-space-40, $kui-space-40);
   $kInputLabelMarginBottom: var(--KInputLabelMargin, var(--spacing-xs, var(--kui-space-40, $kui-space-40))); // matching KLabel margin bottom
   $kInputLabelLineHeight: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30))); // matching KLabel line height
   $kInputLineHeight: var(--kui-line-height-40, $kui-line-height-40); // matching KInput line height
 
-  position: relative;
+  .k-file-upload-label {
+    cursor: pointer !important;
+  }
+
+  .upload-input {
+    width: 100% !important;
+  }
 
   .k-file-upload-btn.k-button {
     border-radius: var(--kui-border-radius-round, $kui-border-radius-round);
@@ -349,11 +357,6 @@ const resetInput = (): void => {
 
 <style lang="scss">
 .k-file-upload {
-  // duplicate variables because of scoped styles
-  $kInputPaddingY: var(--kui-space-40, $kui-space-40);
-  $kInputLabelMarginBottom: var(--KInputLabelMargin, var(--spacing-xs, var(--kui-space-40, $kui-space-40))); // matching KLabel margin bottom
-  $kInputLabelLineHeight: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30))); // matching KLabel line height
-
   .k-input {
     height: 44px;
 
@@ -372,17 +375,18 @@ const resetInput = (): void => {
 
   .display-name {
     color: var(--black-70, var(--kui-color-text, $kui-color-text));
+    cursor: pointer !important;
     left: var(--kui-space-70, $kui-space-70);
     pointer-events: none;
     position: absolute;
-  }
 
-  .has-label {
-    top: calc($kInputLabelLineHeight + $kInputLabelMarginBottom + $kInputPaddingY);
-  }
+    &.has-label {
+      top: var(--kui-space-100, $kui-space-100);
+    }
 
-  .has-no-label {
-    top: var(--kui-space-50, $kui-space-50);
+    &.has-no-label {
+      top: var(--kui-space-50, $kui-space-50);
+    }
   }
 }
 </style>

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -315,7 +315,7 @@ const resetInput = (): void => {
     border: none;
     cursor: pointer;
     height: var(--spacing-lg);
-    padding: $var(--kui-space-30, $kui-space-30);
+    padding: var(--kui-space-30, $kui-space-30);
     position: absolute;
     right: $tmp-spacing-120;
 

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="k-file-upload"
-  >
+  <div class="k-file-upload">
     <KLabel
       v-if="label"
       v-bind="labelAttributes"
@@ -108,8 +106,8 @@ const props = defineProps({
     default: '',
   },
   /**
-    * Test mode - for testing only, strips out generated ids
-    */
+  * Test mode - for testing only, strips out generated ids
+  */
   testMode: {
     type: Boolean,
     default: false,
@@ -139,8 +137,8 @@ const props = defineProps({
     default: 'No file selected',
   },
   /**
-    * Set whether its file upload or image upload type
-    */
+  * Set whether its file upload or image upload type
+  */
   type: {
     type: String as PropType<FileUploadType>,
     default: 'file',
@@ -157,8 +155,8 @@ const props = defineProps({
     default: null,
   },
   /**
-    * Set icon size
-    */
+  * Set icon size
+  */
   iconSize: {
     type: String,
     default: KUI_ICON_SIZE_50,
@@ -168,8 +166,8 @@ const props = defineProps({
     default: 'image',
   },
   /**
-    * Set icon color
-    */
+  * Set icon color
+  */
   iconColor: {
     type: String,
     default: undefined,
@@ -215,7 +213,7 @@ const onFileChange = (evt: any): void => {
 
   const fileSize = fileInput?.value[0]?.size
 
-  hasUploadError.value = fileSize as Number > maximumFileSize.value
+  hasUploadError.value = Number(fileSize) as Number > maximumFileSize.value
 
   if (hasUploadError.value) {
     fileInputKey.value++
@@ -313,12 +311,11 @@ const resetInput = (): void => {
   }
 
   .remove-button {
-    $kFileUploadRemoveButtonPadding: var(--kui-space-30, $kui-space-30);
     background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     border: none;
     cursor: pointer;
     height: var(--spacing-lg);
-    padding: $kFileUploadRemoveButtonPadding;
+    padding: $var(--kui-space-30, $kui-space-30);
     position: absolute;
     right: $tmp-spacing-120;
 

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -49,7 +49,7 @@
       v-if="fileValue && removable"
       appearance="primary"
       class="remove-button"
-      :class="type !== 'file' ? 'move-btn-right' : ''"
+      :class="[label ? 'k-file-upload-btn-with-label' : 'k-file-upload-btn-without-label', { 'move-btn-right': type !== 'file' }]"
       data-testid="remove-button"
       size="small"
       type="reset"
@@ -96,6 +96,7 @@ import KButton from '@/components/KButton/KButton.vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import { v1 as uuidv1 } from 'uuid'
 import type { FileUploadType, ButtonAppearance } from '@/types'
+import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 
 const props = defineProps({
   labelAttributes: {
@@ -107,8 +108,8 @@ const props = defineProps({
     default: '',
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+    * Test mode - for testing only, strips out generated ids
+    */
   testMode: {
     type: Boolean,
     default: false,
@@ -138,8 +139,8 @@ const props = defineProps({
     default: 'No file selected',
   },
   /**
-     * Set whether its file upload or image upload type
-     */
+    * Set whether its file upload or image upload type
+    */
   type: {
     type: String as PropType<FileUploadType>,
     default: 'file',
@@ -156,19 +157,19 @@ const props = defineProps({
     default: null,
   },
   /**
-     * Set icon size
-     */
+    * Set icon size
+    */
   iconSize: {
     type: String,
-    default: '26',
+    default: KUI_ICON_SIZE_50,
   },
   icon: {
     type: String,
     default: 'image',
   },
   /**
-     * Set icon color
-     */
+    * Set icon color
+    */
   iconColor: {
     type: String,
     default: undefined,
@@ -214,7 +215,7 @@ const onFileChange = (evt: any): void => {
 
   const fileSize = fileInput?.value[0]?.size
 
-  hasUploadError.value = fileSize > maximumFileSize.value
+  hasUploadError.value = fileSize as Number > maximumFileSize.value
 
   if (hasUploadError.value) {
     fileInputKey.value++
@@ -261,24 +262,30 @@ const resetInput = (): void => {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-file-upload {
+  $kInputPaddingY: var(--kui-space-40, $kui-space-40);
+  $kInputLabelMarginBottom: var(--KInputLabelMargin, var(--spacing-xs, var(--kui-space-40, $kui-space-40))); // matching KLabel margin bottom
+  $kInputLabelLineHeight: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30))); // matching KLabel line height
+  $kInputLineHeight: var(--kui-line-height-40, $kui-line-height-40); // matching KInput line height
+
   position: relative;
 
   .k-file-upload-btn.k-button {
-    border-radius: 100px;
+    border-radius: var(--kui-border-radius-round, $kui-border-radius-round);
     height: 29px;
     position: absolute;
-    right: var(--type-xs);
+    right: var(--type-xs, var(--kui-space-40, $kui-space-40));
   }
 
   .k-file-upload-btn-with-label.k-button {
-    top: 35px;
+    top: calc($kInputLabelLineHeight + $kInputLabelMarginBottom + $kInputPaddingY);
   }
 
   .k-file-upload-btn-without-label.k-button {
-    top: 7px;
+    top: $kInputPaddingY;
   }
 
   // To hide the button and thumbnail that appears in Safari and firefox after uploading a file
@@ -298,43 +305,43 @@ const resetInput = (): void => {
   }
 
   .remove-button {
-    background-color: transparent;
+    $kFileUploadRemoveButtonPadding: var(--kui-space-30, $kui-space-30);
+    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     border: none;
     cursor: pointer;
     height: var(--spacing-lg);
-    padding: var(--type-xxs) 6px;
+    padding: $kFileUploadRemoveButtonPadding;
     position: absolute;
-    right: 118px;
-    top: 38px;
+    right: $tmp-spacing-120;
 
     &:hover,
     &:active {
-      background-color: transparent !important;
-      box-shadow: 0 0 0 2px var(--white, #ffffff), 0 0 0 4px var(--KButtonPrimaryBase, var(--blue-500, #1155cb));
+      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent) !important;
+      box-shadow: 0 0 0 2px var(--white, var(--kui-color-background, $kui-color-background)), 0 0 0 4px var(--KButtonPrimaryBase, var(--blue-500, var(--kui-color-background-primary, $kui-color-background-primary)));
     }
   }
 
   .move-btn-right {
-    right: 10px;
+    right: var(--kui-space-40, $kui-space-40);
   }
 
   .image-upload-icon {
     cursor: pointer;
-    left: var(--spacing-xs);
+    left: var(--spacing-xs, var(--kui-space-40, $kui-space-40));
     position: absolute;
-    top: var(--type-xxs);
+    top: var(--type-xxs, var(--kui-space-20, $kui-space-20));
   }
 
   .image-upload-description {
-    color: var(--blue-500);
+    color: var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary));
     cursor: pointer;
-    font-size: 13px;
-    left: 44px;
-    line-height: 20px;
+    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    left: var(--kui-space-100, $kui-space-100);
+    line-height: var(--kui-line-height-20, $kui-line-height-20);
     overflow: hidden;
     position: absolute;
     text-overflow: ellipsis;
-    top: var(--type-xs);
+    top: var(--kui-space-50, $kui-space-50);
     white-space: nowrap;
   }
 }
@@ -342,6 +349,11 @@ const resetInput = (): void => {
 
 <style lang="scss">
 .k-file-upload {
+  // duplicate variables because of scoped styles
+  $kInputPaddingY: var(--kui-space-40, $kui-space-40);
+  $kInputLabelMarginBottom: var(--KInputLabelMargin, var(--spacing-xs, var(--kui-space-40, $kui-space-40))); // matching KLabel margin bottom
+  $kInputLabelLineHeight: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30))); // matching KLabel line height
+
   .k-input {
     height: 44px;
 
@@ -351,7 +363,7 @@ const resetInput = (): void => {
   }
 
   input[type=file]{
-    color:transparent;
+    color: transparent;
 
     &:hover {
       cursor: pointer;
@@ -359,18 +371,18 @@ const resetInput = (): void => {
   }
 
   .display-name {
-    color: var(--black-70);
-    left: 20px;
+    color: var(--black-70, var(--kui-color-text, $kui-color-text));
+    left: var(--kui-space-70, $kui-space-70);
     pointer-events: none;
     position: absolute;
   }
 
   .has-label {
-    top: 40px;
+    top: calc($kInputLabelLineHeight + $kInputLabelMarginBottom + $kInputPaddingY);
   }
 
   .has-no-label {
-    top: var(--type-xs);
+    top: var(--kui-space-50, $kui-space-50);
   }
 }
 </style>

--- a/src/styles/_tmp-variables.scss
+++ b/src/styles/_tmp-variables.scss
@@ -42,5 +42,8 @@ $tmp-color-shadow: 0px 0.2px 0.6px rgba(0, 0, 0, 0.031), 0px 0.6px 1.8px rgba(0,
 $tmp-border-spacing-0: 0px;
 $tmp-border-spacing-2: 2px;
 
+$tmp-spacing-120: 120px;
+
 /* Border width */
+
 $tmp-border-width-10: 10px;

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -1,3 +1,4 @@
+// some properties in this file are using kui design tokens because Kongponent styles are relying on matching values
 @import "labels";
 
 .k-input-wrapper .text-on-input {
@@ -79,7 +80,6 @@
 
 .k-input,
 .form-control {
-  // some properties are using kui design tokens because Kongponent styles relying on matching values
   &:not([type="checkbox"]):not([type="radio"]) {
     border: none;
     border-radius: 3px;

--- a/src/styles/forms/_labels.scss
+++ b/src/styles/forms/_labels.scss
@@ -1,11 +1,12 @@
+// some properties in this file are using kui design tokens because Kongponent styles are relying on matching values
 .k-input-label {
   color: var(--KInputLabelColor, var(--black-85));
   display: inline-flex;
   font-family: var(--KInputLabelFont, var(--font-family-sans, font(sans)));
-  font-size: var(--KInputLabelSize, var(--type-sm, type(sm)));
+  font-size: var(--KInputLabelSize, var(--type-sm, var(--kui-font-size-30, $kui-font-size-30)));
   font-weight: var(--KInputLabelWeight, 600);
-  line-height: var(--KInputLabelLineHeight, var(--type-lg, type(lg)));
-  margin-bottom: var(--KInputLabelMargin, var(--spacing-xs, spacing(xs)));
+  line-height: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30)));
+  margin-bottom: var(--KInputLabelMargin, var(--spacing-xs, var(--kui-space-40, $kui-space-40)));
 
   .is-required {
     color: var(--KLabelRequiredAsteriskColor, var(--KInputLabelColor));


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7706

Changes:
- introduces `kui-` design tokens in `KFileUpload` component
- removes any usage of Kongponents utility classes in `KFileUpload` component template

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
