### PR TITLE
feat(klabel): introduce kui tokens [KHCP-7711]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 /src/components/KFileUpload @adamdehaven @jillztom @portikM
 /src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KInputSwitch @adamdehaven @jillztom @portikM
+/src/components/KLabel @adamdehaven @jillztom @portikM
 /src/components/KPop @adamdehaven @jillztom @portikM
 /src/components/KPrompt @adamdehaven @jillztom @portikM
 /src/components/KSelect @adamdehaven @jillztom @portikM

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,7 +35,7 @@
   "cssVariables.lookupFiles": [
     "**/*.css",
     "**/*.scss",
-    "node_modules/@kong/design-tokens/dist/tokens/css/variables.css"
+    "node_modules/@kong/design-tokens/dist/tokens/css/custom-properties.css"
   ],
   "scss.scannerExclude": [
     "**/.git",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@cypress/vite-dev-server": "^5.0.5",
     "@digitalroute/cz-conventional-changelog-for-jira": "^7.3.1",
     "@evilmartians/lefthook": "^1.4.1",
-    "@kong/design-tokens": "^1.6.1",
+    "@kong/design-tokens": "^1.7.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/inquirer": "^8.2.3",

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -1,7 +1,5 @@
 <template>
-  <label
-    class="k-input-label"
-  >
+  <label class="k-input-label">
     <slot />
     <span
       v-if="required"
@@ -15,10 +13,10 @@
       :test-mode="!!testMode || undefined"
     >
       <KIcon
-        color="var(--black-25)"
+        :color="`var(--black-25, var(--kui-color-text-neutral-weak, ${KUI_COLOR_TEXT_NEUTRAL_WEAK}))`"
         hide-title
         :icon="help ? 'help' : 'infoFilled'"
-        :size="help ? '16' : '14'"
+        :size="KUI_ICON_SIZE_30"
       />
       <template #content>
         <slot name="tooltip">{{ help || info }}</slot>
@@ -32,6 +30,7 @@ import { computed, PropType, useSlots } from 'vue'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import type { TooltipAttributes } from '@/types'
+import { KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 
 const props = defineProps({
   help: {
@@ -51,8 +50,8 @@ const props = defineProps({
     default: () => ({}),
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+  * Test mode - for testing only, strips out generated ids
+  */
   testMode: {
     type: Boolean,
     default: false,
@@ -79,11 +78,11 @@ const hasTooltip = computed((): boolean => !!(props.info || props.help || slots.
     }
 
     :deep(.k-tooltip) {
-      font-weight: 400;
+      font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
 
       code {
-        background-color: var(--grey-500, color(grey-500));
-        color: var(--white, #fff);
+        background-color: var(--grey-500, var(--kui-color-background-neutral, $kui-color-background-neutral));
+        color: var(--white, var(--kui-color-text-inverse, $kui-color-text-inverse));
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,7 +700,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kong/design-tokens@^1.6.1":
+"@kong/design-tokens@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.7.1.tgz#e0e63c0422829c47260d69c4725793d4e51358c8"
   integrity sha512-gKM0WuduLHotY3zbqiRYqLtyj+Qth0bEN2yKi8hjYTGDW/ri2fr5OAbXbwDzi7E6fpE4SOm0qTuIhuWXoEc5KA==


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7711

Changes:

- introduces `kui-` design tokens in `KLabel` component
- removes any usage of Kongponents utility classes in `KLabel` component template

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
