### PR TITLE
fix(kbreadcrumbs): divider line height

### DIFF
--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -115,6 +115,7 @@ export default {
       align-self: center;
       color: var(--grey-500, color(grey-500));
       display: inline-flex;
+      line-height: 1;
     }
 
     .k-breadcrumb-divider {


### PR DESCRIPTION
# Summary

Properly adjusts the line-height of the icon divider to respect the `align-items: center` rule to fix the vertical alignment.

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
