### PR TITLE
feat(kinlineedit): introduce kui tokens [KHCP-7708]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 /src/components/KExternalLink @adamdehaven @jillztom @portikM
 /src/components/KFileUpload @adamdehaven @jillztom @portikM
 /src/components/KIcon @adamdehaven @jillztom @portikM
+/src/components/KInlineEdit @adamdehaven @jillztom @portikM
 /src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KInputSwitch @adamdehaven @jillztom @portikM
 /src/components/KLabel @adamdehaven @jillztom @portikM

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -43,7 +43,7 @@ If true, will not set the value of the input when enabled/clicked. This is usefu
 Styles to set when the input is active. Useful when styling the default state differently.
 
 <KComponent :data="{ inlineText: '' }" v-slot="{ data }">
-  <KInlineEdit :ignore-value="data.inlineText.length === 0" :style-overrides="{color: 'var(--black-85)'}" @changed="newVal => data.inlineText = newVal"><p :class="data.inlineText.length > 0 ? 'color-black-85' :'color-black-45 text-italic'">{{ data.inlineText || 'cool placeholder' }}</p></KInlineEdit>
+  <KInlineEdit :ignore-value="data.inlineText.length === 0" :style-overrides="{color: 'black'}" @changed="newVal => data.inlineText = newVal"><p :class="{ 'decorated-text': data.inlineText.length > 0 }">{{ data.inlineText || 'cool placeholder' }}</p></KInlineEdit>
 </KComponent>
 
 > The `KComponent` component is used in this example to create state.
@@ -52,13 +52,19 @@ Styles to set when the input is active. Useful when styling the default state di
 <KComponent :data="{ inlineText: '' }" v-slot="{ data }">
   <KInlineEdit
     :ignore-value="data.inlineText.length === 0"
-    :style-overrides="{ color: 'var(--black-85)' }"
+    :style-overrides="{ color: 'black' }"
     @changed="newVal => data.inlineText = newVal">
-    <p :class="data.inlineText.length > 0 ? 'color-black-85' :'color-black-45 text-italic'">
+    <p :class="{ 'decorated-text': data.inlineText.length > 0 }">
       {{ data.inlineText || 'cool placeholder' }}
     </p>
   </KInlineEdit>
 </KComponent>
+
+<style>
+.decorated-text { 
+  font-style: italic; 
+}
+</style>
 ```
 
 ## Events
@@ -147,5 +153,7 @@ export default {
 </script>
 
 <style>
-.text-italic { font-style: italic; }
+.decorated-text { 
+  font-style: italic; 
+}
 </style>

--- a/src/components/KInlineEdit/KInlineEdit.vue
+++ b/src/components/KInlineEdit/KInlineEdit.vue
@@ -126,10 +126,11 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-inline-edit {
-  --padding: var(--spacing-xxs) var(--spacing-xs);
+  --padding: var(--spacing-xxs, var(--kui-space-20, #{$kui-space-20})) var(--spacing-xs, var(--kui-space-40, #{$kui-space-40}));
   box-sizing: border-box;
 
   > :deep(div) {
@@ -138,19 +139,19 @@ onMounted(() => {
     width: 100%;
 
     > * {
-      border: 1px solid transparent;
-      border-radius: 3px;
+      border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border-transparent, $kui-color-border-transparent);
+      border-radius: var(--kui-border-radius-10, $kui-border-radius-10);
       line-height: 1.25;
-      margin-left: calc(-1 * var(--spacing-xs)); // align the left side of content
-      margin-top: 0; // prevent a shift
+      margin-left: calc(-1 * var(--spacing-xs, var(--kui-space-40, $kui-space-40))); // align the left side of content
+      margin-top: var(--kui-space-0, $kui-space-0); // prevent a shift
       overflow: hidden;
       padding: var(--padding);
-      transition: background-color 200ms ease;
+      transition: background-color $tmp-animation-timing-2 ease;
       width: 100%;
     }
 
     &:hover > * {
-      background-color: var(--grey-200);
+      background-color: var(--grey-200, var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest));
     }
   }
 
@@ -161,7 +162,7 @@ onMounted(() => {
 
     &:focus,
     &:hover {
-      background-color: var(--white);
+      background-color: var(--white, var(--kui-color-background, $kui-color-background));
     }
   }
 }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7708

Changes:

- introduces `kui-` design tokens in `KInlineEdit` component
- removes any usage of Kongponents utility classes in `KInlineEdit` component template

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
