### PR TITLE
fix(kbreadcrumbs): default divider color

### DIFF
--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -136,6 +136,7 @@ export default {
     }
 
     .k-breadcrumb-divider {
+      color: var(--kui-color-text-neutral-weak, $kui-color-text-neutral-weak);
       padding: var(--kui-space-0, $kui-space-0) var(--kui-space-20, $kui-space-20);
     }
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Change default color of divider slot content from teal to grey. No visible to changes to docs site.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
