### PR TITLE
feat(ktreelist): tokenization [khcp-7731]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,7 @@
 /src/components/KSelect @adamdehaven @jillztom @portikM
 /src/components/KTable @adamdehaven @jillztom @portikM
 /src/components/KTextArea @adamdehaven @jillztom @portikM
+/src/components/KTreeList @adamdehaven @jillztom @portikM
 /src/components/KTruncate @adamdehaven @jillztom @portikM
 
 # Dependabot approvals

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -171,7 +171,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
     {{ item.id === 'cats' ? '😸' : item.id === 'bunnies' ? '🐰' : '🐶' }}
   </template>
   <template #item-label="{ item }">
-    <span class="slot-color-purple-400">
+    <span class="slot-color-purple">
     Animal: {{ item.name }}
     </span>
   </template>
@@ -183,7 +183,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
     {{ item.id === 'cats' ? '😸' : item.id === 'bunnies' ? '🐰' : '🐶' }}
   </template>
   <template #item-label="{ item }">
-    <span class="slot-color-purple-400">
+    <span class="slot-color-purple">
     Animal: {{ item.name }}
     </span>
   </template>
@@ -503,7 +503,7 @@ const handleChildChange = (data) => {
   margin-top: 32px;
 }
 
-.slot-color-purple-400 {
+.slot-color-purple {
   color: #473cfb;
 }
 

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -19,10 +19,10 @@ The value provided to `v-model` should adhere to all the same constraints of the
 :::
 
 <div>
-  <KTreeList class="mt-2" v-model="myList" />
+  <KTreeList class="tree-wrapper" v-model="myList" />
   <br>
   <KButton @click="reset">Reset</KButton>
-  <div class="mt-6"><b>Value:</b> <pre class="json hide-from-percy">{{ JSON.stringify(myList) }}</pre></div>
+  <div class="value-wrapper"><b>Value:</b> <pre class="json hide-from-percy">{{ JSON.stringify(myList) }}</pre></div>
 </div>
 
 ```html
@@ -171,7 +171,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
     {{ item.id === 'cats' ? '😸' : item.id === 'bunnies' ? '🐰' : '🐶' }}
   </template>
   <template #item-label="{ item }">
-    <span class="color-purple-400">
+    <span class="slot-color-purple-400">
     Animal: {{ item.name }}
     </span>
   </template>
@@ -183,7 +183,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
     {{ item.id === 'cats' ? '😸' : item.id === 'bunnies' ? '🐰' : '🐶' }}
   </template>
   <template #item-label="{ item }">
-    <span class="color-purple-400">
+    <span class="slot-color-purple-400">
     Animal: {{ item.name }}
     </span>
   </template>
@@ -206,7 +206,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
   <pre class="json hide-from-percy">{{ JSON.stringify(eventItems) }}</pre>
   <KTreeList
     :items="eventItems"
-    class="mt-3"
+    class="tree-wrapper-2"
     @selected="(item) => mySelection = item"
     @change="({ items }) => eventItems = items"
     @child-change="handleChildChange"
@@ -239,14 +239,14 @@ You can pass a `width` string for the entire tree. By default it will take the f
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KTreeListItemText` | Text color for the item name
-| `--KTreeListItemSelectedBorder` | Border color of a selected item and color of indicator bar when dragging an item
-| `--KTreeListItemSelectedBackground` | Background color of a selected item
-| `--KTreeListItemUnselectedBorder` | Border color of an unselected item and color of connecting line between parents and children
-| `--KTreeListItemUnselectedBackground` | Background color of an unselected item
-| `--KTreeListDropZoneHeight` | Number of pixels between tree items
+| Variable                              | Purpose                                                                                      |
+| :------------------------------------ | :------------------------------------------------------------------------------------------- |
+| `--KTreeListItemText`                 | Text color for the item name                                                                 |
+| `--KTreeListItemSelectedBorder`       | Border color of a selected item and color of indicator bar when dragging an item             |
+| `--KTreeListItemSelectedBackground`   | Background color of a selected item                                                          |
+| `--KTreeListItemUnselectedBorder`     | Border color of an unselected item and color of connecting line between parents and children |
+| `--KTreeListItemUnselectedBackground` | Background color of an unselected item                                                       |
+| `--KTreeListDropZoneHeight`           | Number of pixels between tree items                                                          |
 
 An example of changing the theming might look like this:
 
@@ -259,11 +259,11 @@ An example of changing the theming might look like this:
 
 <style>
 .themed-tree {
-  --KTreeListItemText: var(--purple-400);
-  --KTreeListItemSelectedBorder: var(--yellow-300);
-  --KTreeListItemSelectedBackground: var(--yellow-200);
-  --KTreeListItemUnselectedBorder: var(--purple-300);
-  --KTreeListItemUnselectedBackground: var(--purple-100);
+  --KTreeListItemText: #473cfb;
+  --KTreeListItemSelectedBorder: #ffd68c;
+  --KTreeListItemSelectedBackground: #ffe6ba;
+  --KTreeListItemUnselectedBorder: #9396fc;
+  --KTreeListItemUnselectedBackground: #eaf4fb;
   --KTreeListDropZoneHeight: 8px;
 }
 </style>
@@ -491,12 +491,28 @@ const handleChildChange = (data) => {
   line-height: 1.4;
 }
 
+.tree-wrapper {
+  margin-top: 8px;
+}
+
+.tree-wrapper-2 {
+  margin-top: 12px;
+}
+
+.value-wrapper {
+  margin-top: 32px;
+}
+
+.slot-color-purple-400 {
+  color: #473cfb;
+}
+
 .themed-tree {
-  --KTreeListItemText: var(--purple-400);
-  --KTreeListItemSelectedBorder: var(--yellow-300);
-  --KTreeListItemSelectedBackground: var(--yellow-200);
-  --KTreeListItemUnselectedBorder: var(--purple-300);
-  --KTreeListItemUnselectedBackground: var(--purple-100);
+  --KTreeListItemText: #473cfb;
+  --KTreeListItemSelectedBorder: #ffd68c;
+  --KTreeListItemSelectedBackground: #ffe6ba;
+  --KTreeListItemUnselectedBorder: #9396fc;
+  --KTreeListItemUnselectedBackground: #eaf4fb;
   --KTreeListDropZoneHeight: 8px;
 }
 </style>

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -231,7 +231,7 @@ You can pass a `width` string for the entire tree. By default it will take the f
   const mySelection = ref(null)
   const handleChildChange = (data) => {
     const { parentId, children, target } = data
-    const changedParent = myItems.value.filter(item => item.id === parentId)?.[0]
+    const changedParent = myItems.value.find(item => item.id === parentId)
     changedParent.children = children
   }
 </script>
@@ -481,7 +481,7 @@ const reset = () => {
 
 const handleChildChange = (data) => {
   const { parentId, children, target } = data
-  const changedParent = eventItems.value.filter(item => item.id === parentId)?.[0]
+  const changedParent = eventItems.value.find(item => item.id === parentId)
   changedParent.children = children
 }
 </script>

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -35,7 +35,7 @@
               v-if="element.icon !== 'none'"
               :icon="element.icon ? element.icon : 'documentList'"
               :secondary-color="iconSecondaryColor(element)"
-              size="24"
+              :size="KUI_ICON_SIZE_50"
             />
           </slot>
         </template>
@@ -84,9 +84,10 @@
  */
 import { computed, ref, watch, onMounted, PropType } from 'vue'
 import { VueDraggableNext } from 'vue-draggable-next'
+import type { TreeListItem, ChangeEvent, ChildChangeEvent } from '@/types'
+import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTreeItem from '@/components/KTreeList/KTreeItem.vue'
-import type { TreeListItem, ChangeEvent, ChildChangeEvent } from '@/types'
 
 /**
  * Recursive check to get the maximum depth of an object.
@@ -152,7 +153,9 @@ const itemLabel = 'item-label'
 
 const iconSecondaryColor = (item: TreeListItem): string | undefined => {
   if (item.icon === 'documentList' || !item.icon) {
-    return item.selected ? 'var(--KTreeListItemSelectedBorder, var(--teal-200))' : 'var(--KTreeListItemUnselectedBorder, var(--grey-200))'
+    return item.selected
+      ? 'var(--KTreeListItemSelectedBorder, $tmp-color-teal-200)'
+      : 'var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker))'
   }
 
   return undefined
@@ -269,8 +272,8 @@ onMounted(() => {
 </script>
 
 <style lang="scss" scoped>
-@import '@/styles/variables';
 @import '@/styles/functions';
+@import '@/styles/tmp-variables';
 
 .k-tree-draggable {
   $defaultDropZoneHeight: 6px;
@@ -289,9 +292,9 @@ onMounted(() => {
     // the bar under the last child
     .has-no-children:last-of-type .child-drop-zone:last-of-type,
     &.has-no-children .child-drop-zone:last-of-type {
-      background-color: var(--KTreeListItemSelectedBorder, var(--teal-200));
-      border-radius: 100px;
-      margin-left: 0;
+      background-color: var(--KTreeListItemSelectedBorder, $tmp-color-teal-200);
+      border-radius: $kui-border-radius-round;
+      margin-left: $kui-space-0;
       min-height: 4px;
     }
 
@@ -305,6 +308,7 @@ onMounted(() => {
     display: none;
   }
 
+  // no tokens for these two since the math requires them to be static
   $indent: 16px;
   $bar: 12px;
   .k-tree-draggable {
@@ -313,7 +317,7 @@ onMounted(() => {
   }
 
   .k-tree-item-container {
-    $border: var(--KTreeListItemUnselectedBorder, var(--grey-200));
+    $border: var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
     $barLeft: -($bar);
     $dropZoneHalved: calc(var(--KTreeListDropZoneHeight, $defaultDropZoneHeight) / 2);
     margin: $dropZoneHalved 0 0 $dropZoneHalved;
@@ -321,8 +325,8 @@ onMounted(() => {
 
     // child connecting lines
     &:before {
-      border-bottom: 1px solid $border;
-      border-left: 1px solid $border;
+      border-bottom: $kui-border-width-10 solid $border;
+      border-left: $kui-border-width-10 solid $border;
       border-radius: 0 0 0 5px;
       content: "";
       height: calc(var(--KTreeListDropZoneHeight, $defaultDropZoneHeight) + 20px);
@@ -333,7 +337,7 @@ onMounted(() => {
     }
     // connects siblings
     &:after {
-      border-left: 1px solid $border;
+      border-left: $kui-border-width-10 solid $border;
       content: "";
       height: 100%;
       left: $barLeft;

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -327,7 +327,7 @@ onMounted(() => {
     &:before {
       border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid $border;
       border-left: var(--kui-border-width-10, $kui-border-width-10) solid $border;
-      border-radius: 0 0 0 5px;
+      border-radius: var(--kui-border-radius-0, $kui-border-radius-0) var(--kui-border-radius-0, $kui-border-radius-0) var(--kui-border-radius-0, $kui-border-radius-0) 5px;
       content: "";
       height: calc(var(--KTreeListDropZoneHeight, $defaultDropZoneHeight) + 20px);
       left: $barLeft;

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -293,8 +293,8 @@ onMounted(() => {
     .has-no-children:last-of-type .child-drop-zone:last-of-type,
     &.has-no-children .child-drop-zone:last-of-type {
       background-color: var(--KTreeListItemSelectedBorder, $tmp-color-teal-200);
-      border-radius: $kui-border-radius-round;
-      margin-left: $kui-space-0;
+      border-radius: var(--kui-border-radius-round, $kui-border-radius-round);
+      margin-left: var(--kui-space-0, $kui-space-0);
       min-height: 4px;
     }
 
@@ -325,8 +325,8 @@ onMounted(() => {
 
     // child connecting lines
     &:before {
-      border-bottom: $kui-border-width-10 solid $border;
-      border-left: $kui-border-width-10 solid $border;
+      border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid $border;
+      border-left: var(--kui-border-width-10, $kui-border-width-10) solid $border;
       border-radius: 0 0 0 5px;
       content: "";
       height: calc(var(--KTreeListDropZoneHeight, $defaultDropZoneHeight) + 20px);
@@ -337,7 +337,7 @@ onMounted(() => {
     }
     // connects siblings
     &:after {
-      border-left: $kui-border-width-10 solid $border;
+      border-left: var(--kui-border-width-10, $kui-border-width-10) solid $border;
       content: "";
       height: 100%;
       left: $barLeft;

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -85,7 +85,7 @@
 import { computed, ref, watch, onMounted, PropType } from 'vue'
 import { VueDraggableNext } from 'vue-draggable-next'
 import type { TreeListItem, ChangeEvent, ChildChangeEvent } from '@/types'
-import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_50, KUI_COLOR_BORDER_DISABLED } from '@kong/design-tokens'
 import KIcon from '@/components/KIcon/KIcon.vue'
 import KTreeItem from '@/components/KTreeList/KTreeItem.vue'
 
@@ -155,7 +155,7 @@ const iconSecondaryColor = (item: TreeListItem): string | undefined => {
   if (item.icon === 'documentList' || !item.icon) {
     return item.selected
       ? 'var(--KTreeListItemSelectedBorder, $tmp-color-teal-200)'
-      : 'var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker))'
+      : `var(--KTreeListItemUnselectedBorder, var(--kui-color-border-disabled, ${KUI_COLOR_BORDER_DISABLED}))`
   }
 
   return undefined
@@ -317,7 +317,7 @@ onMounted(() => {
   }
 
   .k-tree-item-container {
-    $border: var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
+    $border: var(--KTreeListItemUnselectedBorder, var(--kui-color-border-disabled, $kui-color-border-disabled));
     $barLeft: -($bar);
     $dropZoneHalved: calc(var(--KTreeListDropZoneHeight, $defaultDropZoneHeight) / 2);
     margin: $dropZoneHalved 0 0 $dropZoneHalved;

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -154,7 +154,7 @@ const itemLabel = 'item-label'
 const iconSecondaryColor = (item: TreeListItem): string | undefined => {
   if (item.icon === 'documentList' || !item.icon) {
     return item.selected
-      ? 'var(--KTreeListItemSelectedBorder, $tmp-color-teal-200)'
+      ? 'var(--KTreeListItemSelectedBorder, currentColor)'
       : `var(--KTreeListItemUnselectedBorder, var(--kui-color-border-disabled, ${KUI_COLOR_BORDER_DISABLED}))`
   }
 

--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -89,16 +89,16 @@ const handleClick = () => {
 .k-tree-item {
   align-items: center;
   background-color: var(--KTreeListItemUnselectedBackground, var(--kui-color-background, $kui-color-background));
-  border: $kui-border-width-10 solid var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
   border-radius: $kui-border-radius-40;
   color: var(--KTreeListItemText, var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest));
   display: flex;
-  padding: $kui-space-20;
+  padding: var(--kui-space-20, $kui-space-20);
   text-decoration: none;
 
   .k-tree-item-icon {
     line-height: 1;
-    margin-right: $kui-space-40 !important;
+    margin-right: var(--kui-space-40, $kui-space-40) !important;
   }
 
   &.selected {

--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -12,14 +12,14 @@
   >
     <div
       v-if="hasIcon"
-      class="k-tree-item-icon mr-2"
+      class="k-tree-item-icon"
       data-testid="k-tree-item-icon"
     >
       <slot name="item-icon">
         <KIcon
           :icon="itemIcon"
           :secondary-color="iconSecondaryColor"
-          size="20"
+          :size="KUI_ICON_SIZE_40"
         />
       </slot>
     </div>
@@ -36,8 +36,9 @@
 
 <script lang="ts">
 import { computed, PropType, useSlots } from 'vue'
-import KIcon from '@/components/KIcon/KIcon.vue'
 import { TreeListItem } from '@/types'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import KIcon from '@/components/KIcon/KIcon.vue'
 
 export const itemsHaveRequiredProps = (items: TreeListItem[]): boolean => {
   return items.every(i => i.name !== undefined && i.id !== undefined && (!i.children?.length || itemsHaveRequiredProps(i.children)))
@@ -68,7 +69,9 @@ const itemIcon = computed((): string => props.item.icon ? props.item.icon : 'doc
 
 const iconSecondaryColor = (): string | undefined => {
   if (itemIcon.value === 'documentList') {
-    return props.item.selected ? 'var(--KTreeListItemSelectedBorder, var(--teal-200))' : 'var(--KTreeListItemUnselectedBorder, var(--grey-200))'
+    return props.item.selected
+      ? 'var(--KTreeListItemSelectedBorder, $tmp-color-teal-200)'
+      : 'var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker))'
   }
 
   return undefined
@@ -80,30 +83,31 @@ const handleClick = () => {
 </script>
 
 <style lang="scss" scoped>
-@import '@/styles/variables';
 @import '@/styles/functions';
+@import '@/styles/tmp-variables';
 
 .k-tree-item {
   align-items: center;
-  background-color: var(--KTreeListItemUnselectedBackground, var(--white));
-  border: 1px solid var(--KTreeListItemUnselectedBorder, var(--grey-200));
-  border-radius: 8px;
-  color: var(--KTreeListItemText, var(--black-500));
+  background-color: var(--KTreeListItemUnselectedBackground, var(--kui-color-background, $kui-color-background));
+  border: $kui-border-width-10 solid var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
+  border-radius: $kui-border-radius-40;
+  color: var(--KTreeListItemText, var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest));
   display: flex;
-  padding: 4px;
+  padding: $kui-space-20;
   text-decoration: none;
 
   .k-tree-item-icon {
     line-height: 1;
+    margin-right: $kui-space-40 !important;
   }
 
   &.selected {
-    background-color: var(--KTreeListItemSelectedBackground, var(--teal-100));
-    border-color: var(--KTreeListItemSelectedBorder, var(--teal-200));
+    background-color: var(--KTreeListItemSelectedBackground, $tmp-color-teal-100);
+    border-color: var(--KTreeListItemSelectedBorder, $tmp-color-teal-200);
   }
 
   &:hover {
-    color: var(--KTreeListItemText, var(--black-500));
+    color: var(--KTreeListItemText, var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest));
     cursor: grab;
   }
 

--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -70,7 +70,7 @@ const itemIcon = computed((): string => props.item.icon ? props.item.icon : 'doc
 const iconSecondaryColor = (): string | undefined => {
   if (itemIcon.value === 'documentList') {
     return props.item.selected
-      ? 'var(--KTreeListItemSelectedBorder, $tmp-color-teal-200)'
+      ? 'var(--KTreeListItemSelectedBorder, currentColor)'
       : `var(--KTreeListItemUnselectedBorder, var(--kui-color-border-disabled, ${KUI_COLOR_BORDER_DISABLED}))`
   }
 
@@ -97,13 +97,17 @@ const handleClick = () => {
   text-decoration: none;
 
   .k-tree-item-icon {
-    line-height: 1;
+    line-height: var(--kui-line-height-20, $kui-line-height-20);
     margin-right: var(--kui-space-40, $kui-space-40) !important;
   }
 
   &.selected {
     background-color: var(--KTreeListItemSelectedBackground, $tmp-color-teal-100);
     border-color: var(--KTreeListItemSelectedBorder, $tmp-color-teal-200);
+
+    .k-tree-item-icon { /** so we can use currentColor in script section */
+      color: var(--KTreeListItemSelectedBorder, $tmp-color-teal-200);
+    }
   }
 
   &:hover {

--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -37,7 +37,7 @@
 <script lang="ts">
 import { computed, PropType, useSlots } from 'vue'
 import { TreeListItem } from '@/types'
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_40, KUI_COLOR_BORDER_DISABLED } from '@kong/design-tokens'
 import KIcon from '@/components/KIcon/KIcon.vue'
 
 export const itemsHaveRequiredProps = (items: TreeListItem[]): boolean => {
@@ -71,7 +71,7 @@ const iconSecondaryColor = (): string | undefined => {
   if (itemIcon.value === 'documentList') {
     return props.item.selected
       ? 'var(--KTreeListItemSelectedBorder, $tmp-color-teal-200)'
-      : 'var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker))'
+      : `var(--KTreeListItemUnselectedBorder, var(--kui-color-border-disabled, ${KUI_COLOR_BORDER_DISABLED}))`
   }
 
   return undefined
@@ -89,7 +89,7 @@ const handleClick = () => {
 .k-tree-item {
   align-items: center;
   background-color: var(--KTreeListItemUnselectedBackground, var(--kui-color-background, $kui-color-background));
-  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--KTreeListItemUnselectedBorder, var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker));
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--KTreeListItemUnselectedBorder, var(--kui-color-border-disabled, $kui-color-border-disabled));
   border-radius: $kui-border-radius-40;
   color: var(--KTreeListItemText, var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest));
   display: flex;

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -203,8 +203,8 @@ onMounted(() => {
 <style lang="scss">
 .k-tree-list {
   .k-tree-draggable {
-    margin: $kui-space-0;
-    padding: $kui-space-0;
+    margin: var(--kui-space-0, $kui-space-0);
+    padding: var(--kui-space-0, $kui-space-0);
   }
 
   & > .k-tree-draggable > .k-tree-item-container {

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -201,18 +201,22 @@ onMounted(() => {
 </script>
 
 <style lang="scss">
-.k-tree-list .k-tree-draggable {
-  margin: 0;
-  padding: 0;
-}
-.k-tree-list > .k-tree-draggable > .k-tree-item-container {
-  &:before {
-    display: none;
+.k-tree-list {
+  .k-tree-draggable {
+    margin: $kui-space-0;
+    padding: $kui-space-0;
   }
-  &:after {
-    display: none;
+
+  & > .k-tree-draggable > .k-tree-item-container {
+    &:before {
+      display: none;
+    }
+    &:after {
+      display: none;
+    }
   }
 }
+
 // override cursor as grabbing when an item is being dragged
 .k-tree-list-grabbing *,
 .k-tree-item-grabbing * {

--- a/src/styles/_tmp-variables.scss
+++ b/src/styles/_tmp-variables.scss
@@ -27,6 +27,9 @@ $tmp-color-steel-300: #a3b6d9;
 
 $tmp-color-blue-200: #bdd3f9;
 
+$tmp-color-teal-100: #cdf1fe;
+$tmp-color-teal-200: #91e1fc;
+
 // Opaque colors
 $tmp-color-black-10: rgba(0, 0, 0, 0.1);
 $tmp-color-black-60: rgba(0, 0, 0, 0.6);
@@ -35,8 +38,11 @@ $tmp-color-black-60: rgba(0, 0, 0, 0.6);
 $tmp-color-gray-weaker: #e0e4ea; // color-border-neutral-weaker
 
 // Shadows & backdrops
-$tmp-color-shadow: 0px 0.2px 0.6px rgba(0, 0, 0, 0.031), 0px 0.6px 1.8px rgba(0, 0, 0, 0.045),
-  0px 1.5px 4.2px rgba(0, 0, 0, 0.059), 0px 5px 14px rgba(0, 0, 0, 0.09);
+$tmp-color-shadow:
+  0px 0.2px 0.6px rgba(0, 0, 0, 0.031),
+  0px 0.6px 1.8px rgba(0, 0, 0, 0.045),
+  0px 1.5px 4.2px rgba(0, 0, 0, 0.059),
+  0px 5px 14px rgba(0, 0, 0, 0.09);
 $tmp-color-backdrop: rgba(11, 23, 45, 0.6);
 
 /* Spacing */


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Addresses: https://konghq.atlassian.net/browse/KHCP-7731

- introduces `kui-` design tokens in `KTreelist` component
- removes any usage of Kongponents utility classes in `KTreelist` component template

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
