### PR TITLE
feat(kmenu): introduce kui tokens [KHCP-7712]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /src/components/KInput @adamdehaven @jillztom @portikM
 /src/components/KInputSwitch @adamdehaven @jillztom @portikM
 /src/components/KLabel @adamdehaven @jillztom @portikM
+/src/components/KMenu @adamdehaven @jillztom @portikM
 /src/components/KMethodBadge @adamdehaven @jillztom @portikM
 /src/components/KModal @adamdehaven @jillztom @portikM
 /src/components/KPop @adamdehaven @jillztom @portikM

--- a/docs/components/menu.md
+++ b/docs/components/menu.md
@@ -222,7 +222,7 @@ export default defineComponent({
 
 div.menu-content div {
   white-space: normal;
-  margin-right: 22px;
+  margin-right: $kui-space-70;
   text-align: justify;
 }
 </style>

--- a/src/components/KMenu/KMenu.vue
+++ b/src/components/KMenu/KMenu.vue
@@ -89,6 +89,7 @@ const proceed = (): void => {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-menu {
@@ -101,7 +102,7 @@ const proceed = (): void => {
 
 .clear-cta-button > :deep(button.k-button) {
   border: none;
-  color: var(--blue-300, var(--kui-color-background-primary-weak, $kui-color-background-primary-weak));
+  color: var(--blue-300, $tmp-color-blue-300);
   font-size: var(--kui-font-size-20, $kui-font-size-20);
   font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   line-height: var(--kui-line-height-20, $kui-line-height-20);

--- a/src/components/KMenu/KMenu.vue
+++ b/src/components/KMenu/KMenu.vue
@@ -93,7 +93,7 @@ const proceed = (): void => {
 
 .k-menu {
   background-color: var(--white, var(--kui-color-background, $kui-color-background));
-  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak));
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak));
   border-radius: var(--KCardBorderRadius, var(--kui-border-radius-20, $kui-border-radius-20));
   padding-bottom: var(--kui-space-40, $kui-space-40);
   padding-top: var(--kui-space-50, $kui-space-50);
@@ -101,7 +101,7 @@ const proceed = (): void => {
 
 .clear-cta-button > :deep(button.k-button) {
   border: none;
-  color: var(--blue-300, var(--kui-color-border-primary-weak, $kui-color-border-primary-weak));
+  color: var(--blue-300, var(--kui-color-background-primary-weak, $kui-color-background-primary-weak));
   font-size: var(--kui-font-size-20, $kui-font-size-20);
   font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   line-height: var(--kui-line-height-20, $kui-line-height-20);

--- a/src/components/KMenu/KMenu.vue
+++ b/src/components/KMenu/KMenu.vue
@@ -61,8 +61,8 @@ const props = defineProps({
     default: '284',
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+  * Test mode - for testing only, strips out generated ids
+  */
   testMode: {
     type: Boolean,
     default: false,
@@ -92,32 +92,32 @@ const proceed = (): void => {
 @import '@/styles/functions';
 
 .k-menu {
-  background-color: var(--white);
-  border: 1px solid var(--grey-300);
-  border-radius: 4px;
-  padding-bottom: 8px;
-  padding-top: 11px;
+  background-color: var(--white, var(--kui-color-background, $kui-color-background));
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak));
+  border-radius: var(--KCardBorderRadius, var(--kui-border-radius-20, $kui-border-radius-20));
+  padding-bottom: var(--kui-space-40, $kui-space-40);
+  padding-top: var(--kui-space-50, $kui-space-50);
 }
 
 .clear-cta-button > :deep(button.k-button) {
   border: none;
-  color: var(--blue-300);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 13px;
-  margin-bottom: 6px;
-  margin-top: 10px;
-  padding-top: 2px;
+  color: var(--blue-300, var(--kui-color-border-primary-weak, $kui-color-border-primary-weak));
+  font-size: var(--kui-font-size-20, $kui-font-size-20);
+  font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
+  line-height: var(--kui-line-height-20, $kui-line-height-20);
+  margin-bottom: var(--kui-space-30, $kui-space-30);
+  margin-top: var(--kui-space-40, $kui-space-40);
+  padding-top: var(--kui-space-10, $kui-space-10);
 
   &:active, &:hover {
-    background-color: transparent;
-    color: var(--blue-500);
+    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
+    color: var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary));
   }
 
   &:focus {
-    background-color: transparent;
+    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     box-shadow: none;
-    color: var(--blue-500);
+    color: var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary));
   }
 }
 

--- a/src/components/KMenu/KMenuDivider.vue
+++ b/src/components/KMenu/KMenuDivider.vue
@@ -15,7 +15,7 @@
 
   hr {
     border: none;
-    border-top: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak));
+    border-top: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak));
     margin: var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0);
   }
 }

--- a/src/components/KMenu/KMenuDivider.vue
+++ b/src/components/KMenu/KMenuDivider.vue
@@ -11,12 +11,12 @@
 @import '@/styles/functions';
 
 .k-menu-item-divider {
-  padding: 0 19px;
+  padding: var(--kui-space-0, $kui-space-0) var(--kui-space-70, $kui-space-70);
 
   hr {
     border: none;
-    border-top: 1px solid var(--grey-300);
-    margin: 16px 0;
+    border-top: var(--kui-border-width-10, $kui-border-width-10) solid var(--grey-300, var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak));
+    margin: var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0);
   }
 }
 </style>

--- a/src/components/KMenu/KMenuItem.vue
+++ b/src/components/KMenu/KMenuItem.vue
@@ -10,7 +10,7 @@
       v-if="type !== 'divider'"
       :aria-expanded="isOpen && expandable || undefined"
       :aria-labelledby="menuItemId || undefined"
-      class="menu-button non-visual-button"
+      class="menu-button"
       :is-rounded="false"
       type="button"
       @click="toggleMenuItem"
@@ -29,9 +29,9 @@
         class="span-icon-container"
       >
         <KIcon
-          color="var(--grey-400)"
+          :color="`var(--grey-400, var(--kui-color-text-neutral-weak, ${KUI_COLOR_TEXT_NEUTRAL_WEAK}))`"
           :icon="isOpen ? 'chevronUp' : 'chevronDown'"
-          size="16"
+          :size="KUI_ICON_SIZE_30"
         />
       </span>
     </KButton>
@@ -39,7 +39,7 @@
     <div
       v-if="expandable"
       class="menu-content"
-      :class="isOpen ? 'd-flex' : 'd-none'"
+      :class="isOpen ? 'is-open' : 'is-close'"
     >
       <slot name="itemBody">
         <div v-if="(type === 'string' || type === 'divider') && expandable">
@@ -65,6 +65,7 @@ import KMenuDivider from '@/components/KMenu/KMenuDivider.vue'
 import { v1 as uuidv1 } from 'uuid'
 import type { MenuItem, MenuType } from '@/types'
 import { MenuTypeArray } from '@/types'
+import { KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 
 const props = defineProps({
   item: {
@@ -85,8 +86,8 @@ const props = defineProps({
     default: false,
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+  * Test mode - for testing only, strips out generated ids
+  */
   testMode: {
     type: Boolean,
     default: false,
@@ -114,64 +115,73 @@ const toggleMenuItem = (): void => {
 <style lang="scss" scoped>
 @import '@/styles/variables';
 @import '@/styles/functions';
+@import '@/styles/mixins';
 
 .k-menu-item {
-  color: var(--grey-500);
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 24px;
+  color: var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral));
+  font-size: var(--kui-font-size-20, $kui-font-size-20);
+  font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
+  line-height: var(--kui-line-height-20, $kui-line-height-20);
   list-style: none;
-  margin: 0;
-  padding-left: 2px;
+  margin: var(--kui-space-0, $kui-space-0);
+  padding-left: var(--kui-space-10, $kui-space-10);
   position: relative;
   white-space: nowrap;
 }
 
 .span-icon-container {
-  height: 24px;
+  height: var(--spacing-lg, '24px');
   margin-left: auto;
-  width: 24px;
+  width: var(--spacing-lg, '24px');
 }
 
 .title-dark {
-  color: var(--grey-600);
+  color: var(--grey-600, var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest));
 }
 
 .k-menu-item .menu-button {
+  @include non-visual-button;
   cursor: pointer !important;
-  padding-left: 19px;
-  padding-right: 24px;
+  padding-left: var(--kui-space-70, $kui-space-70);
+  padding-right: var(--kui-space-80, $kui-space-80);
   &:hover {
-    color: var(--grey-600);
+    color: var(--grey-600, var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest));
   }
 }
 
 .menu-content {
-  color: var(--grey-500);
-  padding-left: 19px;
-  padding-right: 24px;
+  color: var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral));
+  padding-left: var(--kui-space-70, $kui-space-70);
+  padding-right: var(--kui-space-80, $kui-space-80);
+  &.is-open {
+    display: flex !important;
+  }
+
+  &.is-close {
+    display: none !important;
+  }
 }
 
 .k-button.menu-button {
-  color: var(--KButtonOutlineColor, var(--grey-500));
+  color: var(--KButtonOutlineColor, var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral)));
   font-family: var(--font-family-sans);
-  font-size: 13px;
-  font-weight: 400 !important;
-  line-height: 24px;
+  font-size: var(--kui-font-size-20, $kui-font-size-20);
+  font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular) !important;
+  line-height: var(--kui-line-height-40, $kui-line-height-40);
   width: 100%;
   &:focus {
-    box-shadow: 0 0 0 1px var(--blue-200);
+    box-shadow: 0 0 0 1px var(--blue-200, var(--kui-color-border-primary-weaker, $kui-color-border-primary-weaker));
   }
 }
 
 .k-button.medium {
-  padding-bottom: 8px;
-  padding-top: 8px;
+  padding-bottom: var(--kui-space-40, $kui-space-40);
+  padding-top: var(--kui-space-40, $kui-space-40);
 }
 .k-menu-item.expando-item > button + div + hr,
 .last-menu-item,
 .last-menu-item > button + div + hr,
 .k-menu-item:last-of-type {
-  border: 0;
+  border: var(--kui-border-width-0, $kui-border-width-0);
 }
 </style>

--- a/src/components/KMenu/KMenuItem.vue
+++ b/src/components/KMenu/KMenuItem.vue
@@ -39,7 +39,7 @@
     <div
       v-if="expandable"
       class="menu-content"
-      :class="isOpen ? 'is-open' : 'is-close'"
+      :class="isOpen ? 'is-open' : 'is-closed'"
     >
       <slot name="itemBody">
         <div v-if="(type === 'string' || type === 'divider') && expandable">
@@ -157,14 +157,14 @@ const toggleMenuItem = (): void => {
     display: flex !important;
   }
 
-  &.is-close {
+  &.is-closed {
     display: none !important;
   }
 }
 
 .k-button.menu-button {
   color: var(--KButtonOutlineColor, var(--grey-500, var(--kui-color-text-neutral, $kui-color-text-neutral)));
-  font-family: var(--font-family-sans);
+  font-family: var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text));
   font-size: var(--kui-font-size-20, $kui-font-size-20);
   font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular) !important;
   line-height: var(--kui-line-height-40, $kui-line-height-40);

--- a/src/styles/_tmp-variables.scss
+++ b/src/styles/_tmp-variables.scss
@@ -26,6 +26,7 @@ $tmp-color-yellow-600: #a05604;
 $tmp-color-steel-300: #a3b6d9;
 
 $tmp-color-blue-200: #bdd3f9;
+$tmp-color-blue-300: #8ab3fa;
 
 // Opaque colors
 $tmp-color-black-10: rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
# Summary
https://konghq.atlassian.net/browse/KHCP-7712
<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

**Changes:**

- introduces `kui-` design tokens in `KMenu`, `KMenuDivider`, and `KMenuItem` component
- removes any usage of Kongponents utility classes in `KMenu`, `KMenuDivider`, and `KMenuItem` component template

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
