### PR TITLE
feat(kbreadcrumb): add icon slot

### DIFF
--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -148,6 +148,50 @@ Content to be displayed between breadcrumb items, defaults to a chevron.
 </KBreadcrumbs>
 ```
 
+### breadcrumb-icon
+
+You can slot individual breadcrumb icon content. Each breadcrumb will have an icon slot named after the item `key` or index (if no `key` provided).
+
+<KCard>
+  <template #body>
+    <KBreadcrumbs :items="iconBreadcrumbs">
+      <template #home-icon>
+        <KIcon icon="immunity" color="#169fcc" size="16" class="breadcrumb-icon" />
+      </template>
+      <template #breadcrumb-1-icon>
+        <KIcon icon="graduationHat" color="#473cfb" size="16" class="breadcrumb-icon" />
+      </template>
+    </KBreadcrumbs>
+  </template>
+</KCard>
+
+```html
+<template>
+  <KBreadcrumbs :items="breadcrumbItems">
+    <template #home-icon>
+      <KIcon icon="immunity" color="#169fcc" size="16" />
+    </template>
+    <template #breadcrumb-1-icon>
+      <KIcon icon="graduationHat" color="#473cfb" size="16" />
+    </template>
+  </KBreadcrumbs>
+</template>
+
+<script lang="ts" setup>
+  const breadcrumbItems = [{
+    key: 'home',
+    to: { path: '/' },
+    title: 'Go Home',
+    text: 'Home',
+  },
+  {
+    to: { path: '/components/breadcrumbs.html' },
+    title: 'Go to Breadcrumbs',
+    text: 'Breadcrumbs'
+  }]
+</script>
+```
+
 <script lang="ts">
 import { defineComponent } from 'vue'
 
@@ -163,9 +207,9 @@ export default defineComponent({
           icon: 'kong'
         },
         {
-          key: 'button',
+          key: 'breadcrumbs',
           to: { path: '/components/breadcrumbs.html' },
-          title: 'Go to Button',
+          title: 'Go to Breadcrumbs',
           text: 'Breadcrumbs'
         },
         {
@@ -220,6 +264,20 @@ export default defineComponent({
           title: 'My Service',
           text: 'My Service'
         },
+      ],
+      iconBreadcrumbs: [
+        {
+          key: 'home',
+          to: { path: '/' },
+          title: 'Go Home',
+          text: 'Home',
+          icon: 'kong'
+        },
+        {
+          to: { path: '/components/breadcrumbs.html' },
+          title: 'Go to Breadcrumbs',
+          text: 'Breadcrumbs'
+        }
       ]
     }
   }
@@ -231,6 +289,11 @@ export default defineComponent({
     font-size: 13px;
     font-weight: 300;
     line-height: 14px;
-    color: var(--kui-color-text-neutral-weak, $kui-color-text-neutral-weak);
+    color: #afb7c5;
+  }
+
+  .breadcrumb-icon {
+    align-self: center;
+    margin-right: 8px;
   }
 </style>

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -148,17 +148,17 @@ Content to be displayed between breadcrumb items, defaults to a chevron.
 </KBreadcrumbs>
 ```
 
-### breadcrumb-icon
+### `icon-${key}`
 
 You can slot individual breadcrumb icon content. Each breadcrumb will have an icon slot named after the item `key` or index (if no `key` provided).
 
 <KCard>
   <template #body>
     <KBreadcrumbs :items="iconBreadcrumbs">
-      <template #home-icon>
+      <template #icon-home>
         <KIcon icon="immunity" color="#169fcc" size="16" class="breadcrumb-icon" />
       </template>
-      <template #breadcrumb-1-icon>
+      <template #icon-breadcrumb-1>
         <KIcon icon="graduationHat" color="#473cfb" size="16" class="breadcrumb-icon" />
       </template>
     </KBreadcrumbs>
@@ -168,10 +168,10 @@ You can slot individual breadcrumb icon content. Each breadcrumb will have an ic
 ```html
 <template>
   <KBreadcrumbs :items="breadcrumbItems">
-    <template #home-icon>
+    <template #icon-home>
       <KIcon icon="immunity" color="#169fcc" size="16" />
     </template>
-    <template #breadcrumb-1-icon>
+    <template #icon-breadcrumb-1>
       <KIcon icon="graduationHat" color="#473cfb" size="16" />
     </template>
   </KBreadcrumbs>

--- a/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
@@ -99,7 +99,7 @@ describe('KBreadcrumbs', () => {
         ],
       },
       slots: {
-        'docs-icon': customIcon,
+        'icon-docs': customIcon,
       },
     })
 

--- a/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.cy.ts
@@ -85,6 +85,28 @@ describe('KBreadcrumbs', () => {
     cy.get('.k-breadcrumbs .k-breadcrumb-divider').should('contain.text', customDivider)
   })
 
+  it('renders custom icon when using slot', () => {
+    const customIcon = 'custom_icon'
+
+    mount(KBreadcrumbs, {
+      props: {
+        items: [
+          {
+            key: 'docs',
+            to: 'https://docs.konghq.com',
+            text: 'Go to Kong Docs',
+          },
+        ],
+      },
+      slots: {
+        'docs-icon': customIcon,
+      },
+    })
+
+    cy.get('.k-breadcrumbs').find('li').its('length').should('eq', 1)
+    cy.get('.k-breadcrumbs .k-breadcrumb-icon-wrapper').should('contain.text', customIcon)
+  })
+
   it('renders breadcrumb links without needing a router', () => {
     mount(KBreadcrumbs, {
       props: {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -102,13 +102,7 @@ const getComponentAttrs = (item: BreadcrumbItem) => {
   }
 }
 
-const getBreadcrumbKey = (item: BreadcrumbItem, idx: number): string => {
-  if (item.key) {
-    return item.key
-  } else {
-    return `breadcrumb-${idx}`
-  }
-}
+const getBreadcrumbKey = (item: BreadcrumbItem, idx: number): string => item.key || `breadcrumb-${idx}`
 </script>
 
 <script lang="ts">

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -5,7 +5,7 @@
   >
     <li
       v-for="(item, idx) in items"
-      :key="item.key || item.text"
+      :key="getBreadcrumbKey(item, idx)"
       class="k-breadcrumbs-item"
     >
       <component
@@ -13,16 +13,18 @@
         v-bind="getComponentAttrs(item).attrs"
         class="no-underline"
       >
-        <slot name="icon">
-          <KIcon
-            v-if="item.icon"
-            :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
-            :color="`var(--kui-color-text-decorative, ${KUI_COLOR_TEXT_DECORATIVE})`"
-            hide-title
-            :icon="item.icon"
-            :size="KUI_ICON_SIZE_30"
-          />
-        </slot>
+        <div class="k-breadcrumb-icon-wrapper">
+          <slot :name="`${getBreadcrumbKey(item, idx)}-icon`">
+            <KIcon
+              v-if="item.icon"
+              :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"
+              :color="`var(--kui-color-text-decorative, ${KUI_COLOR_TEXT_DECORATIVE})`"
+              hide-title
+              :icon="item.icon"
+              :size="KUI_ICON_SIZE_30"
+            />
+          </slot>
+        </div>
         <span
           v-if="item.text"
           class="k-breadcrumb-text"
@@ -99,6 +101,14 @@ const getComponentAttrs = (item: BreadcrumbItem) => {
     }
   }
 }
+
+const getBreadcrumbKey = (item: BreadcrumbItem, idx: number): string => {
+  if (item.key) {
+    return item.key
+  } else {
+    return `breadcrumb-${idx}`
+  }
+}
 </script>
 
 <script lang="ts">
@@ -123,6 +133,10 @@ export default {
   list-style: none;
   margin-bottom: var(--kui-space-60, $kui-space-60);
   padding: var(--kui-space-0, $kui-space-0);
+
+  .k-breadcrumb-icon-wrapper {
+    display: inline-flex;
+  }
 
   .k-breadcrumbs-item {
     @include truncate;

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -14,7 +14,7 @@
         class="no-underline"
       >
         <div class="k-breadcrumb-icon-wrapper">
-          <slot :name="`${getBreadcrumbKey(item, idx)}-icon`">
+          <slot :name="`icon-${getBreadcrumbKey(item, idx)}`">
             <KIcon
               v-if="item.icon"
               :class="['k-breadcrumb-icon', { 'has-no-text': !item.text }]"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add icon slot for each breadcrumb (needed for Runtime Manager breadcrumbs).

![image](https://github.com/Kong/kongponents/assets/67973710/a26b8d45-1d84-48b5-9074-8d03c2684166)


## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
