### PR TITLE
feat(ktooltip): introduce kui tokens [KHCP-7730]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /src/components/KSelect @adamdehaven @jillztom @portikM
 /src/components/KTable @adamdehaven @jillztom @portikM
 /src/components/KTextArea @adamdehaven @jillztom @portikM
+/src/components/KTooltip @adamdehaven @jillztom @portikM
 /src/components/KTreeList @adamdehaven @jillztom @portikM
 /src/components/KTruncate @adamdehaven @jillztom @portikM
 

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -36,8 +36,8 @@ KTooltip won't be triggered if the element you pass through `default` slot has `
 
 <KCard>
   <template #body>
-    <div class="d-flex">
-      <KTooltip label="I won't pop up" class="mr-2">
+    <div class="k-tooltip">
+      <KTooltip label="I won't pop up" class="k-tooltip-label">
         <KButton disabled>❌</KButton>
       </KTooltip>
       <KTooltip label="I will pop up">
@@ -58,6 +58,15 @@ KTooltip won't be triggered if the element you pass through `default` slot has `
     <KButton disabled>✅</KButton>
   </span>
 </KTooltip>
+
+<style>
+.k-tooltip {
+  display: flex !important;
+}
+.k-tooltip-label {
+  margin-right: $kui-space-10 !important;
+}
+</style>
 ```
 
 ### placement
@@ -74,7 +83,7 @@ Here are the different options:
   </li>
 </ul>
 
-<div class="d-flex justify-content-around">
+<div class="k-tooltip">
   <KTooltip placement="bottom" label="A label that appears on the bottom">
     <KButton>bottom</KButton>
   </KTooltip>
@@ -93,6 +102,13 @@ Here are the different options:
 <KTooltip placement="bottom" label="A label that appears on the bottom">
   <KButton>Sample Button</KButton>
 </KTooltip>
+
+<style>
+.k-tooltip {
+  display: flex !important;
+  justify-content: space-around !important;
+}
+</style>
 ```
 
 ### positionFixed
@@ -164,15 +180,15 @@ Example:
 
 <style>
 .tooltip-blue {
-  --KTooltipBackground: var(--blue-300);
-  --KTooltipColor: var(--blue-500);
+  --KTooltipBackground: var(--blue-300, #{$kui-color-background-primary-weaker});
+  --KTooltipColor: var(--blue-500, #{$kui-color-text-primary});
 }
 </style>
 ```
 
 <style>
 .tooltip-blue {
-  --KTooltipBackground: var(--blue-500);
-  --KTooltipColor: var(--blue-200);
+  --KTooltipBackground: var(--blue-500, #{$kui-color-background-primary});
+  --KTooltipColor: var(--blue-200, #bdd3f9);
 }
 </style>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -36,8 +36,8 @@ KTooltip won't be triggered if the element you pass through `default` slot has `
 
 <KCard>
   <template #body>
-    <div class="k-tooltip">
-      <KTooltip label="I won't pop up" class="k-tooltip-label">
+    <div class="my-tooltip">
+      <KTooltip label="I won't pop up" class="my-tooltip-label">
         <KButton disabled>❌</KButton>
       </KTooltip>
       <KTooltip label="I will pop up">
@@ -49,6 +49,15 @@ KTooltip won't be triggered if the element you pass through `default` slot has `
   </template>
 </KCard>
 
+<style>
+.my-tooltip {
+  display: flex !important;
+}
+.my-tooltip-label {
+  margin-right: 4px !important;
+}
+</style>
+
 ```html
 <KTooltip label="I won't show up">
   <KButton disabled>❌</KButton>
@@ -58,15 +67,6 @@ KTooltip won't be triggered if the element you pass through `default` slot has `
     <KButton disabled>✅</KButton>
   </span>
 </KTooltip>
-
-<style>
-.k-tooltip {
-  display: flex !important;
-}
-.k-tooltip-label {
-  margin-right: $kui-space-10 !important;
-}
-</style>
 ```
 
 ### placement
@@ -83,7 +83,7 @@ Here are the different options:
   </li>
 </ul>
 
-<div class="k-tooltip">
+<div class="custom-tooltip">
   <KTooltip placement="bottom" label="A label that appears on the bottom">
     <KButton>bottom</KButton>
   </KTooltip>
@@ -98,17 +98,17 @@ Here are the different options:
   </KTooltip>
 </div>
 
-```html
-<KTooltip placement="bottom" label="A label that appears on the bottom">
-  <KButton>Sample Button</KButton>
-</KTooltip>
-
 <style>
-.k-tooltip {
+.custom-tooltip {
   display: flex !important;
   justify-content: space-around !important;
 }
 </style>
+
+```html
+<KTooltip placement="bottom" label="A label that appears on the bottom">
+  <KButton>Sample Button</KButton>
+</KTooltip>
 ```
 
 ### positionFixed
@@ -145,7 +145,7 @@ You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWid
 <KTooltip label="Video Games">
   <KButton>&nbsp;✌🏻</KButton>
   <template v-slot:content>
-    <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
+    <span><b>yoyo</b> <em>kooltip</em></span>
   </template>
 </KTooltip>
 
@@ -153,7 +153,7 @@ You can set the maximum width of a Tooltip with the `maxWidth` property. `maxWid
 <KTooltip>
   <KButton>&nbsp;✌🏻</KButton>
   <template v-slot:content>
-    <span><b>yoyo</b> <span class="color-red-500">kooltip</span></span>
+    <span><b>yoyo</b> <em>kooltip</em></span>
   </template>
 </KTooltip>
 ```

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -33,8 +33,8 @@ import { PopPlacementsArray, PopPlacements } from '@/types'
 
 const props = defineProps({
   /**
-     * Text to show in tooltip
-     */
+  * Text to show in tooltip
+  */
   label: {
     type: String,
     required: false,
@@ -42,8 +42,8 @@ const props = defineProps({
   },
 
   /**
-     * Define which side the tooltip displays
-     */
+  * Define which side the tooltip displays
+  */
   placement: {
     type: String as PropType<PopPlacements>,
     default: 'bottom',
@@ -52,22 +52,22 @@ const props = defineProps({
     },
   },
   /**
-     * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
-     */
+  * A flag to use fixed positioning of the popover to avoid content being clipped by parental boundaries.
+  */
   positionFixed: {
     type: Boolean,
     default: false,
   },
   /**
-     * Set the max-width of the ktooltip
-     */
+  * Set the max-width of the ktooltip
+  */
   maxWidth: {
     type: String,
     default: 'auto',
   },
   /**
-     * Test mode - for testing only, strips out generated ids
-     */
+  * Test mode - for testing only, strips out generated ids
+  */
   testMode: {
     type: Boolean,
     default: false,
@@ -79,16 +79,16 @@ const computedClass = computed((): string => {
   let result = ''
   switch (props.placement) {
     case 'top':
-      result = 'mb-2'
+      result = 'k-tooltip-top'
       break
     case 'right':
-      result = 'ml-2'
+      result = 'k-tooltip-right'
       break
     case 'bottom':
-      result = 'mt-2'
+      result = 'k-tooltip-bottom'
       break
     case 'left':
-      result = 'mr-2'
+      result = 'k-tooltip-left'
       break
   }
 
@@ -101,13 +101,29 @@ const computedClass = computed((): string => {
 @import '@/styles/functions';
 
 .k-tooltip.k-popover {
-  --KPopColor: var(--KTooltipColor, var(--white, color(white)));
-  --KPopBackground: var(--KTooltipBackground, var(--black-400, color(black-400)));
-  --KPopBodySize: var(--type-sm);
-  --KPopPaddingX: var(--spacing-xs);
-  --KPopPaddingY: var(--spacing-xs);
+  --KPopColor: var(--KTooltipColor, var(--white, var(--kui-color-text-inverse, #{$kui-color-text-inverse})));
+  --KPopBackground: var(--KTooltipBackground, var(--black-400, var(--kui-color-background-neutral-stronger, #{$kui-color-background-neutral-stronger})));
+  --KPopBodySize: var(--type-sm, var(--kui-font-size-30, #{$kui-font-size-30}));
+  --KPopPaddingX: var(--spacing-xs, var(--kui-space-40, #{$kui-space-40}));
+  --KPopPaddingY: var(--spacing-xs, var(--kui-space-40, #{$kui-space-40}));
   --KPopBorder: none;
   pointer-events: none;
   z-index: 9999;
+}
+
+.k-tooltip-top {
+  margin-bottom: var(--kui-space-10, $kui-space-10) !important;
+}
+
+.k-tooltip-right {
+  margin-left: var(--kui-space-10, $kui-space-10) !important;
+}
+
+.k-tooltip-bottom {
+  margin-top: var(--kui-space-10, $kui-space-10) !important;
+}
+
+.k-tooltip-left {
+  margin-right: var(--kui-space-10, $kui-space-10) !important;
 }
 </style>


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/KHCP-7730

**Changes:**

- introduces `kui-` design tokens in `KTooltip` component
- removes any usage of Kongponents utility classes in `KTooltip` component template

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
