### PR TITLE
feat(kstepper): introduce kui tokens [KHCP-7725]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /src/components/KSegmentedControl @adamdehaven @jillztom @portikM
 /src/components/KSelect @adamdehaven @jillztom @portikM
 /src/components/KSlideout @adamdehaven @jillztom @portikM
+/src/components/KStepper @adamdehaven @jillztom @portikM
 /src/components/KTable @adamdehaven @jillztom @portikM
 /src/components/KTabs @adamdehaven @jillztom @portikM
 /src/components/KTextArea @adamdehaven @jillztom @portikM

--- a/docs/components/stepper.md
+++ b/docs/components/stepper.md
@@ -130,19 +130,19 @@ The width of step labels (default is `170px`). We support numbers (will be conve
 
 ## Theming
 
-| Variable                       | Purpose                                     |
-| :---------------------         | :-------------------------------            |
-| `KStepIconSize`                | Height and width of step state icon         |
-| `KStepBackgroundColor`         | Background color of the step state icon     |
-| `KStepDividerColorCompleted`   | Color of divider for completed steps        |
-| `KStepDividerColorDefault`     | Color of divider for non-completed steps    |
-| `KStepActiveColor`             | Primary color of active state icon          |
-| `KStepCompletedColor`          | Primary color of completed state icon       |
-| `KStepCompletedSecondaryColor` | Secondary color of completed state icon     |
-| `KStepDefaultColor`            | Primary color of default state icon         |
-| `KStepErrorColor`              | Primary color of error state icon           |
-| `KStepErrorSecondaryColor`     | Secondary color of error state icon         |
-| `KStepPendingColor`            | Primary color for pending state icon        |
+| Variable                       | Purpose                                  |
+| :----------------------------- | :--------------------------------------- |
+| `KStepIconSize`                | Height and width of step state icon      |
+| `KStepBackgroundColor`         | Background color of the step state icon  |
+| `KStepDividerColorCompleted`   | Color of divider for completed steps     |
+| `KStepDividerColorDefault`     | Color of divider for non-completed steps |
+| `KStepActiveColor`             | Primary color of active state icon       |
+| `KStepCompletedColor`          | Primary color of completed state icon    |
+| `KStepCompletedSecondaryColor` | Secondary color of completed state icon  |
+| `KStepDefaultColor`            | Primary color of default state icon      |
+| `KStepErrorColor`              | Primary color of error state icon        |
+| `KStepErrorSecondaryColor`     | Secondary color of error state icon      |
+| `KStepPendingColor`            | Primary color for pending state icon     |
 
 
 An example of theming the stepper:
@@ -163,13 +163,13 @@ An example of theming the stepper:
 <style lang="scss">
 .k-stepper-wrapper {
   --KStepIconSize: 40px;
-  --KStepDividerColorCompleted: var(--purple-300);
-  --KStepDividerColorDefault: var(--purple-100);
-  --KStepActiveColor: var(--purple-300);
-  --KStepCompletedColor: var(--purple-300);
-  --KStepDefaultColor: var(--purple-100);
-  --KStepErrorColor: var(--steel-400);
-  --KStepPendingColor: var(--yellow-400);
+  --KStepDividerColorCompleted: green;
+  --KStepDividerColorDefault: lightgrey;
+  --KStepActiveColor: slateblue;
+  --KStepCompletedColor: green;
+  --KStepDefaultColor: lightgrey;
+  --KStepErrorColor: red;
+  --KStepPendingColor: sandybrown;
 }
 </style>
 ```
@@ -206,12 +206,12 @@ export default defineComponent({
 <style lang="scss">
 .k-stepper-wrapper {
   --KStepIconSize: 40px;
-  --KStepDividerColorCompleted: var(--purple-300);
-  --KStepDividerColorDefault: var(--purple-100);
-  --KStepActiveColor: var(--purple-300);
-  --KStepCompletedColor: var(--purple-300);
-  --KStepDefaultColor: var(--purple-100);
-  --KStepErrorColor: var(--steel-400);
-  --KStepPendingColor: var(--yellow-400);
+  --KStepDividerColorCompleted: green;
+  --KStepDividerColorDefault: lightgrey;
+  --KStepActiveColor: slateblue;
+  --KStepCompletedColor: green;
+  --KStepDefaultColor: lightgrey;
+  --KStepErrorColor: red;
+  --KStepPendingColor: sandybrown;
 }
 </style>

--- a/src/components/KStepper/KStep.vue
+++ b/src/components/KStepper/KStep.vue
@@ -7,7 +7,7 @@
       <KStepState :state="state" />
 
       <div
-        class="k-step-label px-3"
+        class="k-step-label"
         :class="{
           'bolder': state === 'active' || state === 'pending' || state === 'error',
           'error': state === 'error'
@@ -56,12 +56,13 @@ const labelStyle = computed(() => {
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-step {
   display: list-item;
   flex: 1 1 0%;
-  padding: var(--spacing-sm) 0;
+  padding: var(--spacing-sm, var(--kui-space-50, $kui-space-50)) var(--kui-space-0, $kui-space-0);
 
   // For Divider
   --divider-spacing: 8px;
@@ -75,20 +76,22 @@ const labelStyle = computed(() => {
     display: flex;
     flex-direction: column;
     margin: auto;
-    padding-bottom: var(--spacing-xxs);
+    padding-bottom: var(--spacing-xxs, var(--kui-space-20, $kui-space-20));
     position: relative;
 
     .k-step-label {
-      --KInputLabelColor: var(--grey-500);
-      --KInputLabelSize: var(--type-md);
-      --KInputLabelWeight: 500;
       min-width: 100px;
-      padding-top: var(--spacing-sm);
+      padding-left: var(--kui-space-50, $kui-space-50) !important;
+      padding-right: var(--kui-space-50, $kui-space-50) !important;
+      padding-top: var(--spacing-sm, var(--kui-space-50, $kui-space-50));
       text-align: center;
+      --KInputLabelColor: var(--grey-500, var(--kui-color-text-neutral, #{$kui-color-text-neutral}));
+      --KInputLabelSize: var(--type-md, var(--kui-font-size-40, #{$kui-font-size-40}));
+      --KInputLabelWeight: var(--kui-font-weight-medium, #{$kui-font-weight-medium});
 
       &.bolder {
-        --KInputLabelWeight: 600;
-        --KInputLabelColor: var(--black-500);
+        --KInputLabelWeight: var(--kui-font-weight-semibold, #{$kui-font-weight-semibold});
+        --KInputLabelColor: var(--black-500, var(--kui-color-text, #{$kui-color-text}));
       }
     }
 
@@ -96,17 +99,17 @@ const labelStyle = computed(() => {
      * Divider styles
      */
     &::after {
-      background-color: var(--KStepDividerColorDefault, var(--grey-300));
+      background-color: var(--KStepDividerColorDefault, var(--grey-300, var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak)));
       content: "";
       height: 2px;
       left: calc(50% + calc(var(--KStepIconSize, 26px) / 1.5 + var(--divider-spacing)));
       position: absolute;
-      top: calc(#{var(--KStepIconSize, var(--spacing-lg, spacing(lg)))} / 2);
+      top: calc(#{var(--KStepIconSize, var(--spacing-lg, 24px))} / 2);
       width: calc(100% - var(--KStepIconSize, 26px) - calc(var(--divider-spacing) * 2));
     }
 
     &.completed::after {
-      background-color: var(--KStepDividerColorCompleted, var(--teal-300));
+      background-color: var(--KStepDividerColorCompleted, var(--teal-300, $tmp-color-teal-300));
     }
   }
 }
@@ -119,7 +122,7 @@ const labelStyle = computed(() => {
 .k-step {
   .k-step-label {
     &.error .k-input-label {
-      color: var(--red-500);
+      color: var(--red-500, var(--kui-color-text-danger, $kui-color-text-danger));
     }
   }
 }

--- a/src/components/KStepper/KStepState.vue
+++ b/src/components/KStepper/KStepState.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="k-step-state px-3">
+  <div class="k-step-state">
     <component :is="renderedComponent" />
   </div>
 </template>
@@ -46,7 +46,9 @@ const renderedComponent = computed(() => {
 
 <style lang="scss" scoped>
 .k-step-state {
-  background: var(--KStepBackgroundColor, var(--white));
+  background: var(--KStepBackgroundColor, var(--white, var(--kui-color-background, $kui-color-background)));
+  padding-left: var(--kui-space-50, $kui-space-50) !important;
+  padding-right: var(--kui-space-50, $kui-space-50) !important;
 }
 </style>
 

--- a/src/components/KStepper/stepper-icons/KActiveState.vue
+++ b/src/components/KStepper/stepper-icons/KActiveState.vue
@@ -30,7 +30,7 @@ defineProps({
 
 .k-step-state-icon {
   circle {
-    stroke: var(--KStepActiveColor, var(--teal-300));
+    stroke: var(--KStepActiveColor, var(--kui-color-text-decorative, $kui-color-text-decorative));
   }
 }
 </style>

--- a/src/components/KStepper/stepper-icons/KCompletedState.vue
+++ b/src/components/KStepper/stepper-icons/KCompletedState.vue
@@ -41,11 +41,11 @@ defineProps({
 
 .k-step-state-icon {
   .k-step-icon-primary {
-    fill: var(--KStepCompletedColor, var(--teal-300));
+    fill: var(--KStepCompletedColor, var(--kui-color-text-decorative, $kui-color-text-decorative));
   }
 
   .k-step-icon-secondary {
-    stroke: var(--KStepCompletedSecondaryColor, var(--white));
+    stroke: var(--KStepCompletedSecondaryColor, var(--kui-color-text-inverse, $kui-color-text-inverse));
   }
 }
 </style>

--- a/src/components/KStepper/stepper-icons/KDefaultState.vue
+++ b/src/components/KStepper/stepper-icons/KDefaultState.vue
@@ -30,7 +30,7 @@ defineProps({
 
 .k-step-state-icon {
   circle {
-    stroke: var(--KStepDefaultColor, var(--grey-300));
+    stroke: var(--KStepDefaultColor, var(--grey-300, var(--kui-color-text-neutral-weak, $kui-color-text-neutral-weak)));
   }
 }
 </style>

--- a/src/components/KStepper/stepper-icons/KErrorState.vue
+++ b/src/components/KStepper/stepper-icons/KErrorState.vue
@@ -36,11 +36,11 @@ defineProps({
 
 .k-step-state-icon {
   .k-step-icon-primary {
-    fill: var(--KStepErrorColor, var(--red-500));
+    fill: var(--KStepErrorColor, var(--red-500, var(--kui-color-text-danger, $kui-color-text-danger)));
   }
 
   .k-step-icon-secondary {
-    fill: var(--KStepErrorSecondaryColor, var(--white));
+    fill: var(--KStepErrorSecondaryColor, var(--white, var(--kui-color-text-inverse, $kui-color-text-inverse)));
   }
 }
 </style>

--- a/src/components/KStepper/stepper-icons/KPendingState.vue
+++ b/src/components/KStepper/stepper-icons/KPendingState.vue
@@ -28,6 +28,7 @@ defineProps({
 
 <style lang="scss" scoped>
 @import '@/styles/variables';
+@import '@/styles/tmp-variables';
 @import '@/styles/functions';
 
 .k-step-spinner > svg {
@@ -35,7 +36,7 @@ defineProps({
 
   circle {
     animation: dash 1.5s ease-in-out infinite;
-    stroke: var(--KStepPendingColor, var(--teal-300));
+    stroke: var(--KStepPendingColor, var(--teal-300, var(--kui-color-text-decorative, $kui-color-text-decorative)));
     stroke-linecap: round;
   }
 }

--- a/src/styles/_tmp-variables.scss
+++ b/src/styles/_tmp-variables.scss
@@ -32,6 +32,7 @@ $tmp-color-aqua-50: #00abd2;
 
 $tmp-color-teal-100: #cdf1fe;
 $tmp-color-teal-200: #91e1fc;
+$tmp-color-teal-300: #169fcc;
 
 // Opaque colors
 $tmp-color-black-10: rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-7725

Changes:

- introduces `kui-` design tokens in `KStepper` component
- removes any usage of Kongponents utility classes in `KStepper` component template

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
