### PR TITLE
fix(kcard): body line-height in table cells

### DIFF
--- a/src/components/KCard/KCard.vue
+++ b/src/components/KCard/KCard.vue
@@ -221,6 +221,7 @@ const showCardTitleWithStatus = computed((): boolean => useStatusHatLayout.value
 
     .k-table td, table td, :deep(.k-table) td {
       font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
+      line-height: var(--kui-line-height-40, $kui-line-height-40);
     }
   }
 


### PR DESCRIPTION
# Summary

Fixes the line-height of table cells nested inside a KCard body. Currently, the `font-size` and `line-height` will be the same pixel value (16px) unless overridden.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
