### PR TITLE
fix(style): line height for truncate

### DIFF
--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -155,6 +155,7 @@ $sides: (top, right, bottom, left);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: initial;
 }
 .multi-line-truncation {
   -webkit-box-orient: vertical;

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -152,10 +152,10 @@ $sides: (top, right, bottom, left);
 /*  Text
 ========================================================================== */
 .truncate {
+  line-height: initial;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  line-height: initial;
 }
 .multi-line-truncation {
   -webkit-box-orient: vertical;


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

Fix line height issue for truncating texts. 

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
