### PR TITLE
fix(*): update fcont family scss vars

### DIFF
--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -83,8 +83,8 @@ $type-sizes: (
   xxs: 10px,
 );
 $fonts: (
-  sans: sans-serif,
-  mono: monospace,
+  sans: 'Inter', Roboto, Helvetica, sans-serif,
+  mono: 'JetBrains Mono', Consolas, monospace,
 );
 
 // Set up CSS variables as a mixin so consuming packages can import if they desire and add to scoped styles

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -60,7 +60,7 @@ $colors: (
   black-300: #6f7787,
   black-400: #3c4557,
   black-500: #0b172d,
-  white: #ffffff,
+  white: #ffffff
 );
 $spacing: (
   xxs: 4px,
@@ -70,7 +70,7 @@ $spacing: (
   lg: 24px,
   xl: 32px,
   xxl: 48px,
-  xxxl: 64px,
+  xxxl: 64px
 );
 $type-sizes: (
   xxxl: 32px,
@@ -80,11 +80,11 @@ $type-sizes: (
   md: 16px,
   sm: 14px,
   xs: 12px,
-  xxs: 10px,
+  xxs: 10px
 );
 $fonts: (
-  sans: 'Inter', Roboto, Helvetica, sans-serif,
-  mono: 'JetBrains Mono', Consolas, monospace,
+  sans: "'Inter', Roboto, Helvetica, sans-serif",
+  mono: "'JetBrains Mono', Consolas, monospace"
 );
 
 // Set up CSS variables as a mixin so consuming packages can import if they desire and add to scoped styles


### PR DESCRIPTION
# Summary

Update the default font family variables.

![image](https://github.com/Kong/kongponents/assets/2229946/08622a49-004e-42ee-a7db-0b98ce029dcc)



## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
