### PR TITLE
feat(kcatalog): emit on card click

### DIFF
--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -602,6 +602,10 @@ fetcher(payload) {
 
 ## Events
 
+### @card:click
+
+Emitted when a `KCatalogItem` is clicked, the payload is the clicked item's object.
+
 ### CTA Clicks
 
 - `@kcatalog-empty-state-cta-clicked` - If using a CTA button in the empty state, this event is fired when clicked.

--- a/src/components/KCatalog/KCatalog.cy.ts
+++ b/src/components/KCatalog/KCatalog.cy.ts
@@ -302,7 +302,7 @@ describe('KCatalog', () => {
         },
       })
 
-      cy.get('.k-card-large .catalog-item').first().click().then(() => {
+      cy.get('.k-card-catalog .catalog-item').first().click().then(() => {
         // Check for emitted event
         cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'card:click')
       })

--- a/src/components/KCatalog/KCatalog.cy.ts
+++ b/src/components/KCatalog/KCatalog.cy.ts
@@ -289,6 +289,24 @@ describe('KCatalog', () => {
         .should('have.callCount', 3) // fetcher's 3rd call
         .should('returned', { data: [{ query: '' }], total: 1 })
     })
+
+    it('emits an event when card is clicked', () => {
+      mount(KCatalog, {
+        props: {
+          testMode: 'true',
+          cacheIdentifier: 'general-props-long',
+          fetcher: () => {
+            return { data: [longItem], total: 1 }
+          },
+          noTruncation: true,
+        },
+      })
+
+      cy.get('.k-card-large .catalog-item').first().click().then(() => {
+        // Check for emitted event
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'card:click')
+      })
+    })
   })
 
   describe('states', () => {

--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -137,6 +137,7 @@
           :item="(item as CatalogItem)"
           :test-mode="!!testMode || undefined"
           :truncate="!noTruncation"
+          @click="$emit('card:click', item)"
         >
           <template #cardTitle>
             <slot
@@ -435,6 +436,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits<{
+  (e: 'card:click', item: CatalogItem): void
   (e: 'kcatalog-error-cta-clicked'): void
   (e: 'kcatalog-empty-state-cta-clicked'): void
   (e: 'update:catalog-preferences', preferences: CatalogPreferences): void

--- a/src/components/KCatalog/KCatalogItem.vue
+++ b/src/components/KCatalog/KCatalogItem.vue
@@ -51,10 +51,10 @@ defineProps({
   },
 })
 
-const emit = defineEmits(['clicked'])
+const emit = defineEmits(['card:click'])
 
 const handleCardClick = (evt: Event, item: CatalogItem): void => {
-  emit('clicked', {
+  emit('card:click', {
     evt,
     item,
   })


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Add an event emission for when a `KCatalogItem` is clicked.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
