### PR TITLE
fix(*): remove utility classes from docs [KHCP-8146]

### DIFF
--- a/docs/.vitepress/components/ColorSwatch.vue
+++ b/docs/.vitepress/components/ColorSwatch.vue
@@ -5,8 +5,8 @@
       class="swatch" />
     <div class="description">
       <span>{{ colorName }}</span>
-      <code class="mb-2">--{{ colorName }}</code><br>
-      <code class="mb-2">{{ colorValue }}</code><br>
+      <code class="color-name-value">--{{ colorName }}</code><br>
+      <code class="color-name-value">{{ colorValue }}</code><br>
       <code>.color-{{ colorName }}</code>
     </div>
   </div>
@@ -56,6 +56,10 @@ const colorValue = computed((): string => getComputedStyle(document.body).getPro
         color: var(--vp-c-text, $kui-color-text);
         font-size: $kui-font-size-30;
       }
+    }
+
+    .color-name-value {
+      margin-bottom: $kui-space-40;
     }
   }
 }

--- a/docs/.vitepress/components/ColorSwatch.vue
+++ b/docs/.vitepress/components/ColorSwatch.vue
@@ -53,7 +53,7 @@ const colorValue = computed((): string => getComputedStyle(document.body).getPro
       }
 
       &:last-of-type {
-        color: var(--vp-c-text, $kui-color-text);
+        color: $kui-color-text;
         font-size: $kui-font-size-30;
       }
     }

--- a/docs/.vitepress/components/TypographyBlock.vue
+++ b/docs/.vitepress/components/TypographyBlock.vue
@@ -12,7 +12,7 @@
     <div class="example">
       <strong>Sample:</strong>
       <p
-        class="mt-2"
+        class="example-description"
         :class="[`${prefix}${variableName}`, fontType === 'mono' && 'mono', styleClasses]">
         Kong is a Lua application running in Nginx
       </p>
@@ -72,6 +72,11 @@ export default defineComponent({
     span {
       color: var(--vp-c-text, $kui-color-text);
       font-size: $kui-font-size-30;
+    }
+  }
+  .example {
+    .example-description {
+      margin-top: $kui-space-20;
     }
   }
 }

--- a/docs/.vitepress/components/TypographyBlock.vue
+++ b/docs/.vitepress/components/TypographyBlock.vue
@@ -70,7 +70,7 @@ export default defineComponent({
       font-weight: $kui-font-weight-semibold;
     }
     span {
-      color: var(--vp-c-text, $kui-color-text);
+      color: $kui-color-text;
       font-size: $kui-font-size-30;
     }
   }

--- a/docs/.vitepress/theme/_overrides.scss
+++ b/docs/.vitepress/theme/_overrides.scss
@@ -1,8 +1,8 @@
 // Theme overrides; all should be nested inside of the `.vp-doc` class
 .vp-doc {
-  --vp-custom-block-info-border: var(--blue-600, #003694);
-  --vp-custom-block-info-text: var(--blue-500, #1155cb);
-  --vp-custom-block-info-bg: var(--blue-100, #f2f6fe);
+  --vp-custom-block-info-border: #003694;
+  --vp-custom-block-info-text: #1155cb;
+  --vp-custom-block-info-bg: #f2f6fe;
 
   .kong-card li + li {
     margin-top: 0;

--- a/docs/.vitepress/theme/_overrides.scss
+++ b/docs/.vitepress/theme/_overrides.scss
@@ -5,12 +5,12 @@
   --vp-custom-block-info-bg: #f2f6fe;
 
   .kong-card li + li {
-    margin-top: 0;
+    margin-top: $kui-space-0;
   }
 
   table {
     display: table;
-    margin: 0;
+    margin: $kui-space-0;
 
     th {
       background: none;
@@ -18,11 +18,11 @@
   }
 
   h4 {
-    margin-top: 16px;
+    margin-top: $kui-space-60;
   }
 
   li + li {
-    margin-top: 0;
+    margin-top: $kui-space-0;
   }
 
   .k-tabs {

--- a/docs/.vitepress/theme/_variables.scss
+++ b/docs/.vitepress/theme/_variables.scss
@@ -2,13 +2,13 @@
 // https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css
 
 :root {
-  --vp-c-brand: var(--blue-500, #1456cb);
-  --vp-c-brand-light: var(--blue-400, #3972d5);
-  --vp-c-brand-lighter: var(--blue-300, #8ab3fa);
-  --vp-c-brand-dark: var(--blue-600, #003694);
-  --vp-c-brand-darker: var(--blue-700, #0a2b66);
+  --vp-c-brand: #1155cb;
+  --vp-c-brand-light: #3972d5;
+  --vp-c-brand-lighter: #8ab3fa;
+  --vp-c-brand-dark: #003694;
+  --vp-c-brand-darker: #0a2b66;
   // Homepage site name color
   --kongponents-theme-background-gradient: linear-gradient(120deg, #169fcc, #42d782);
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: var(--kongponents-theme-background-gradient, var(--vp-c-brand, #1456cb));
+  --vp-home-hero-name-background: var(--kongponents-theme-background-gradient, #1456cb);
 }

--- a/docs/.vitepress/theme/_variables.scss
+++ b/docs/.vitepress/theme/_variables.scss
@@ -8,7 +8,6 @@
   --vp-c-brand-dark: #003694;
   --vp-c-brand-darker: #0a2b66;
   // Homepage site name color
-  --kongponents-theme-background-gradient: linear-gradient(120deg, #169fcc, #42d782);
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: var(--kongponents-theme-background-gradient, #1456cb);
+  --vp-home-hero-name-background: linear-gradient(120deg, #169fcc, #42d782);
 }

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -663,17 +663,17 @@ Fixes KAlert to the top of the container.
 
 ### Long Content / Prose
 
-<KAlert appearance="info" class="mt-5">
+<KAlert appearance="info" class="vertical-spacing">
   <template #alertMessage>
-    <div class="mt-2 bold-600">Failure Modes</div>
+    <strong>Failure Modes</strong>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
 </KAlert>
 
 ```html
-<KAlert appearance="info" class="mt-5">
+<KAlert appearance="info" class="vertical-spacing">
   <template #alertMessage>
-    <div class="mt-2 bold-600">Failure Modes</div>
+    <strong>Failure Modes</strong>
     <p>Before you release that email you're writing to spin up a new centralized decision-making group, it's worth talking about the four ways these groups consistently fail. They tend to be <b>domineering</b>, <b>bottlenecked</b>, <b>status-oriented</b>, or <b>inert</b>.</p>
   </template>
 </KAlert>
@@ -681,14 +681,14 @@ Fixes KAlert to the top of the container.
 
 ### Word Wrap long urls
 
-<KAlert appearance="warning" class="mt-5">
+<KAlert appearance="warning" class="vertical-spacing">
   <template #alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
 </KAlert>
 
 ```html
-<KAlert appearance="warning" class="mt-5">
+<KAlert appearance="warning" class="vertical-spacing">
   <template #alertMessage>
     Proxy error: Could not proxy request /api/service_packages?fields=&s=%7B%22%24and%22%3A%5B%7B%22name%22%3A%7B%22%24contL%22%3A%22%22%7D%7D%5D%7D&filter=&or=&sort=created_at%2CDESC&join=&limit=100&offset=0&page=1 from localhost:8080 to http://localhost:3000 (ECONNREFUSED).
   </template>
@@ -775,5 +775,9 @@ export default defineComponent({
 .alert-wrapper {
   --KAlertSuccessBackground: lime;
   --KAlertSuccessColor: forestgreen;
+}
+
+.vertical-spacing {
+  margin-top: $kui-space-80;
 }
 </style>

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -22,7 +22,7 @@ The Badge component can take the following appearance values:
 - `neutral`
 - `custom`
 
-<div class="horizontal-spacing">
+<div class="horizontal-spacing-container">
   <KBadge appearance="success">SUCCESS</KBadge>
   <KBadge appearance="warning">WARNING</KBadge>
   <KBadge appearance="danger">DANGER</KBadge>
@@ -44,7 +44,7 @@ The Badge component can take the following appearance values:
 
 Use the `isBordered` prop for bordered badges. The border color matches the text color by default.
 
-<div class="horizontal-spacing">
+<div class="horizontal-spacing-container">
   <KBadge appearance="success" is-bordered>SUCCESS</KBadge>
   <KBadge appearance="warning" is-bordered>WARNING</KBadge>
   <KBadge appearance="danger" is-bordered>DANGER</KBadge>
@@ -69,7 +69,7 @@ The Badge has two shapes that can be changed with a `shape` property.
 - `rounded` - Default
 - `rectangular`
 
-<div class="horizontal-spacing">
+<div class="horizontal-spacing-container">
   <KBadge appearance="warning">Round</KBadge>
   <KBadge appearance="warning" shape="rectangular">Rectangular</KBadge>
 </div>
@@ -87,7 +87,7 @@ Use this prop to modify the badge text color
 
 Use this prop to modify the background color of the badge
 
-<div class="horizontal-spacing">
+<div class="horizontal-spacing-container">
   <KBadge color="brown" background-color="yellow">Custom</KBadge>
   <KBadge color="red" background-color="pink">Badge</KBadge>
   <KBadge color="blue" background-color="lightblue">Hello</KBadge>
@@ -181,7 +181,7 @@ The `hoverColor` is also utilized if you wrap the `KBadge` with an anchor tag, o
 Use this prop if you want the badge to be dismissable. If the badge text is long enough to need truncation, the label will truncate; the dismiss button is always visible.
 The color of the dismiss button is determined by the badge type and uses the same theming variables as the badge text. Clicking the dismiss button will trigger a `dismissed` event.
 
-<div class="horizontal-spacing">
+<div class="horizontal-spacing-container">
   <KBadge dismissable>Close me</KBadge>
   <KBadge dismissable shape="rectangular">No, close me!</KBadge>
 </div>
@@ -195,7 +195,7 @@ The color of the dismiss button is determined by the badge type and uses the sam
 
 Use this prop if you would like to conditionally display a tooltip when the badge text is truncated.
 
-<div class="horizontal-spacing">
+<div class="horizontal-spacing-container">
   <KBadge truncation-tooltip="Truncation unnecessary">Truncation unnecessary</KBadge>
   <KBadge truncation-tooltip="Hey! Let me see that awesome truncation">Hey! Let me see that awesome truncation</KBadge>
 </div>
@@ -381,7 +381,7 @@ const testClick = () => {
   }
 }
 
-.horizontal-spacing {
+.horizontal-spacing-container {
   display: flex;
   column-gap: 4px;
 }

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -23,12 +23,24 @@ The Button component can take 1 of 6 appearance values:
 - `btn-link`
 
 <div class="spacing-container">
-  <KButton appearance="primary">Primary</KButton>
-  <KButton appearance="secondary">Secondary</KButton>
-  <KButton appearance="outline">Outline</KButton>
-  <KButton appearance="danger">Danger</KButton>
-  <KButton appearance="creation">Creation</KButton>
-  <KButton appearance="btn-link">btn-link</KButton>
+  <div>
+    <KButton appearance="primary">Primary</KButton>
+  </div>
+  <div>
+    <KButton appearance="secondary">Secondary</KButton>
+  </div>
+  <div>
+    <KButton appearance="outline">Outline</KButton>
+  </div>
+  <div>
+    <KButton appearance="danger">Danger</KButton>
+  </div>
+  <div>
+    <KButton appearance="creation">Creation</KButton>
+  </div>
+  <div>
+    <KButton appearance="btn-link">btn-link</KButton>
+  </div>
 </div>
 
 ```html
@@ -55,7 +67,9 @@ We support `small`, `medium`, and `large` sizes, default to `medium`.
   <div>
     <KButton appearance="secondary" size="medium">Medium</KButton>
   </div>
-  <KButton appearance="secondary" size="large">Large</KButton>
+  <div>
+    <KButton appearance="secondary" size="large">Large</KButton>
+  </div>
 </div>
 
 ```html
@@ -108,8 +122,12 @@ Use this prop to customize the color of the caret
 The buttons are rounded by default. This can be disabled by setting `isRounded` prop to `false`.
 
 <div class="spacing-container">
-  <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
-  <KButton appearance="primary" >I'm a button</KButton>
+  <div>
+    <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
+  </div>
+  <div>
+    <KButton appearance="primary" >I'm a button</KButton>
+  </div>
 </div>
 
 ```html
@@ -195,17 +213,21 @@ Should you need to use a KTooltip component on a KButton with `disabled` attribu
 KButton supports using an icon either before the text or without text. If you are using the slot you must maintain the icon color yourself when the button is enabled or disabled.
 
 <div class="spacing-container">
-  <KButton appearance="secondary">
-    <template v-slot:icon>
-      <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
-    </template>
-    With Text
-  </KButton>
-  <KButton appearance="secondary" size="small">
-    <template v-slot:icon>
-      <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
-    </template>
-  </KButton>
+  <div>
+    <KButton appearance="secondary">
+      <template v-slot:icon>
+        <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
+      </template>
+      With Text
+    </KButton>
+  </div>
+  <div>
+    <KButton appearance="secondary" size="small">
+      <template v-slot:icon>
+        <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
+      </template>
+    </KButton>
+  </div>
 </div>
 
 ```html

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -193,13 +193,13 @@ KButton supports using an icon either before the text or without text. If you ar
 <div class="spacing-container">
   <KButton appearance="secondary">
     <template v-slot:icon>
-      <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
+      <KIcon icon="externalLink" color="#003694"/>
     </template>
     With Text
   </KButton>
   <KButton appearance="secondary" size="small">
     <template v-slot:icon>
-      <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
+      <KIcon icon="gear" color="#003694"/>
     </template>
   </KButton>
 </div>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -22,12 +22,14 @@ The Button component can take 1 of 6 appearance values:
 - `creation`
 - `btn-link`
 
-<KButton class="mr-2 mb-2" appearance="primary">Primary</KButton>
-<KButton class="mr-2 mb-2" appearance="secondary">Secondary</KButton>
-<KButton class="mr-2 mb-2" appearance="outline">Outline</KButton>
-<KButton class="mr-2 mb-2" appearance="danger">Danger</KButton>
-<KButton class="mr-2 mb-2" appearance="creation">Creation</KButton>
-<KButton class="mr-2 mb-2" appearance="btn-link">btn-link</KButton>
+<div class="spacing-container">
+  <KButton appearance="primary">Primary</KButton>
+  <KButton appearance="secondary">Secondary</KButton>
+  <KButton appearance="outline">Outline</KButton>
+  <KButton appearance="danger">Danger</KButton>
+  <KButton appearance="creation">Creation</KButton>
+  <KButton appearance="btn-link">btn-link</KButton>
+</div>
 
 ```html
 <KButton appearance="primary">Primary</KButton>
@@ -46,11 +48,15 @@ We support `small`, `medium`, and `large` sizes, default to `medium`.
 - `medium`
 - `large`
 
-<KButton class="mr-2" appearance="secondary" size="small">Small</KButton>
-
-<KButton class="mr-2" appearance="secondary" size="medium">Medium</KButton>
-
-<KButton appearance="secondary" size="large">Large</KButton>
+<div class="spacing-container">
+  <div>
+    <KButton appearance="secondary" size="small">Small</KButton>
+  </div>
+  <div>
+    <KButton appearance="secondary" size="medium">Medium</KButton>
+  </div>
+  <KButton appearance="secondary" size="large">Large</KButton>
+</div>
 
 ```html
 <KButton appearance="secondary" size="small">Small</KButton>
@@ -101,8 +107,10 @@ Use this prop to customize the color of the caret
 
 The buttons are rounded by default. This can be disabled by setting `isRounded` prop to `false`.
 
-<KButton class="mr-2" appearance="primary" :isRounded="false">I'm a button</KButton>
-<KButton appearance="primary" >I'm a button</KButton>
+<div class="spacing-container">
+  <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
+  <KButton appearance="primary" >I'm a button</KButton>
+</div>
 
 ```html
 <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
@@ -156,8 +164,8 @@ Should you need to use a KTooltip component on a KButton with `disabled` attribu
 
 <KCard>
   <template #body>
-    <div class="d-flex">
-      <KTooltip label="I won't pop up" class="mr-2">
+    <div class="spacing-container">
+      <KTooltip label="I won't pop up">
         <KButton disabled>❌</KButton>
       </KTooltip>
       <KTooltip label="I will pop up">
@@ -186,17 +194,19 @@ Should you need to use a KTooltip component on a KButton with `disabled` attribu
 
 KButton supports using an icon either before the text or without text. If you are using the slot you must maintain the icon color yourself when the button is enabled or disabled.
 
-<KButton class="mr-2" appearance="secondary">
-  <template v-slot:icon>
-    <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
-  </template>
-  With Text
-</KButton>
-<KButton appearance="secondary" size="small">
-  <template v-slot:icon>
-    <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
-  </template>
-</KButton>
+<div class="spacing-container">
+  <KButton appearance="secondary">
+    <template v-slot:icon>
+      <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
+    </template>
+    With Text
+  </KButton>
+  <KButton appearance="secondary" size="small">
+    <template v-slot:icon>
+      <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
+    </template>
+  </KButton>
+</div>
 
 ```html
 <KButton appearance="secondary">
@@ -259,15 +269,6 @@ look like.
 </style>
 ```
 
-There is also a `.non-visual-button` utility class that can be used for buttons that
-should not look like buttons.
-
-<KButton class="non-visual-button">Click Me</KButton>
-
-```html
-<KButton class="non-visual-button">Click Me</KButton>
-```
-
 <style scoped lang="scss">
 @import '@/styles/variables';
 
@@ -294,5 +295,9 @@ should not look like buttons.
   @media screen and (min-width: $viewport-sm) {
     flex-direction: row;
   }
+}
+.spacing-container {
+  display: flex;
+  gap: $kui-space-40;
 }
 </style>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -23,24 +23,12 @@ The Button component can take 1 of 6 appearance values:
 - `btn-link`
 
 <div class="spacing-container">
-  <div>
-    <KButton appearance="primary">Primary</KButton>
-  </div>
-  <div>
-    <KButton appearance="secondary">Secondary</KButton>
-  </div>
-  <div>
-    <KButton appearance="outline">Outline</KButton>
-  </div>
-  <div>
-    <KButton appearance="danger">Danger</KButton>
-  </div>
-  <div>
-    <KButton appearance="creation">Creation</KButton>
-  </div>
-  <div>
-    <KButton appearance="btn-link">btn-link</KButton>
-  </div>
+  <KButton appearance="primary">Primary</KButton>
+  <KButton appearance="secondary">Secondary</KButton>
+  <KButton appearance="outline">Outline</KButton>
+  <KButton appearance="danger">Danger</KButton>
+  <KButton appearance="creation">Creation</KButton>
+  <KButton appearance="btn-link">btn-link</KButton>
 </div>
 
 ```html
@@ -61,15 +49,9 @@ We support `small`, `medium`, and `large` sizes, default to `medium`.
 - `large`
 
 <div class="spacing-container">
-  <div>
-    <KButton appearance="secondary" size="small">Small</KButton>
-  </div>
-  <div>
-    <KButton appearance="secondary" size="medium">Medium</KButton>
-  </div>
-  <div>
-    <KButton appearance="secondary" size="large">Large</KButton>
-  </div>
+  <KButton appearance="secondary" size="small">Small</KButton>
+  <KButton appearance="secondary" size="medium">Medium</KButton>
+  <KButton appearance="secondary" size="large">Large</KButton>
 </div>
 
 ```html
@@ -122,12 +104,8 @@ Use this prop to customize the color of the caret
 The buttons are rounded by default. This can be disabled by setting `isRounded` prop to `false`.
 
 <div class="spacing-container">
-  <div>
-    <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
-  </div>
-  <div>
-    <KButton appearance="primary" >I'm a button</KButton>
-  </div>
+  <KButton appearance="primary" :isRounded="false">I'm a button</KButton>
+  <KButton appearance="primary" >I'm a button</KButton>
 </div>
 
 ```html
@@ -213,21 +191,17 @@ Should you need to use a KTooltip component on a KButton with `disabled` attribu
 KButton supports using an icon either before the text or without text. If you are using the slot you must maintain the icon color yourself when the button is enabled or disabled.
 
 <div class="spacing-container">
-  <div>
-    <KButton appearance="secondary">
-      <template v-slot:icon>
-        <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
-      </template>
-      With Text
-    </KButton>
-  </div>
-  <div>
-    <KButton appearance="secondary" size="small">
-      <template v-slot:icon>
-        <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
-      </template>
-    </KButton>
-  </div>
+  <KButton appearance="secondary">
+    <template v-slot:icon>
+      <KIcon icon="externalLink" color="var(--KButtonSecondaryColor, #003694)"/>
+    </template>
+    With Text
+  </KButton>
+  <KButton appearance="secondary" size="small">
+    <template v-slot:icon>
+      <KIcon icon="gear" color="var(--KButtonSecondaryColor, #003694)"/>
+    </template>
+  </KButton>
 </div>
 
 ```html
@@ -321,5 +295,6 @@ look like.
 .spacing-container {
   display: flex;
   gap: $kui-space-40;
+  flex-direction: row;
 }
 </style>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -296,5 +296,6 @@ look like.
   display: flex;
   gap: $kui-space-40;
   flex-direction: row;
+  align-items: baseline;
 }
 </style>

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -49,7 +49,7 @@ Example composing `KCard` with other Kongponents to make another component:
 <KCard :hasHover="true">
   <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
-    <div class="mx-4">
+    <div>
       <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2>Kong Enterprise Edition</h2>
         <KButton appearance="outline" to="https://docs.konghq.com/enterprise" target="_blank">
@@ -67,7 +67,7 @@ Example composing `KCard` with other Kongponents to make another component:
 <KCard :hasHover="true">
   <template v-slot:body>
     <KAlert alert-message="Welcome to Kong!" />
-    <div class="mx-4">
+    <div>
       <div>
         <h2>Kong Enterprise Edition</h2>
         <KButton appearance="outline" to="https://docs.konghq.com/enterprise" target="_blank">
@@ -125,10 +125,10 @@ Sets top border or no border. If neither set default will have border
 
 Set if card should have shadow state (shadow) on hover
 
-<KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" has-hover />
+<KCard title="hasHover" body="This card only has a shadow on hover" has-hover />
 
 ```html
-<KCard title="hasHover" class="mb-2" body="This card only has a shadow on hover" has-hover />
+<KCard title="hasHover" body="This card only has a shadow on hover" has-hover />
 ```
 
 ### hasShadow
@@ -145,31 +145,27 @@ Set if the card should always have shadow state (shadow)
 
 Cards can be arranged with flex box.
 
-<div class="d-flex flex-row">
+<div class="card-flex-container">
   <KCard
     title="Left"
-    class="w-auto"
     body="This card only has a title"
   />
   <KCard
     title="Center"
-    class="w-auto mx-5"
     body="This card always has a icon button"
   >
     <template v-slot:actions>
       <KButton size="small" appearance="outline">
         <KIcon
-            icon="gearFilled"
-            size="16"
-            view-box="0 0 16 16"
-            class="pr-0"
-          />
+          icon="gearFilled"
+          size="16"
+          view-box="0 0 16 16"
+        />
       </KButton>
     </template>
   </KCard>
   <KCard
     title="Right"
-    class="w-auto"
     body="This card always has a button"
   >
     <template v-slot:actions>
@@ -179,26 +175,33 @@ Cards can be arranged with flex box.
 </div>
 
 ```html
-<div class="d-flex flex-row">
-  <KCard title="Left" class="w-auto" body="This card only has a title" />
-  <KCard title="Center" class="w-auto mx-5" body="This card always has a icon button">
+<div class="">
+  <KCard title="Left" body="This card only has a title" />
+  <KCard title="Center" body="This card always has a icon button">
     <template v-slot:actions>
       <KButton>
         <KIcon
-            icon="gearFilled"
-            size="16"
-            view-box="0 0 16 16"
-            class="pr-0"
-          />
+          icon="gearFilled"
+          size="16"
+          view-box="0 0 16 16"
+        />
       </KButton>
     </template>
   </KCard>
-  <KCard title="Right" class="w-auto" body="This card always has a button">
+  <KCard title="Right" body="This card always has a button">
     <template v-slot:actions>
       <KButton>View All</KButton>
     </template>
   </KCard>
 </div>
+
+<style lang="scss">
+.card-flex-container {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}
+</style>
 ```
 
 ## Slots
@@ -214,9 +217,10 @@ Cards can be arranged with flex box.
   <template v-slot:statusHat>
     <KIcon
       icon="check"
+      class="horizontal-spacing"
       color="#07A88D"
-      class="mr-2"
-      size="24" />
+      size="24"
+    />
       Approved
   </template>
   <template v-slot:title>Look Mah!</template>
@@ -236,7 +240,6 @@ Cards can be arranged with flex box.
     <KIcon
       icon="check"
       color="#07A88D"
-      class="mr-2"
       size="24" />
       Approved
   </template>
@@ -254,14 +257,14 @@ Cards can be arranged with flex box.
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KCardPaddingY`| Vertical top/bottom spacing
-| `--KCardPaddingX` | Horizontal left/right padding
+| Variable              | Purpose                        |
+| :-------------------- | :----------------------------- |
+| `--KCardPaddingY`     | Vertical top/bottom spacing    |
+| `--KCardPaddingX`     | Horizontal left/right padding  |
 | `--KCardBorderRadius` |
-| `--KCardBorder`| Replaces border size & color
-| `--KCardShadow`| Replaces shadow size and color
-| `--KCardBackground`|
+| `--KCardBorder`       | Replaces border size & color   |
+| `--KCardShadow`       | Replaces shadow size and color |
+| `--KCardBackground`   |
 
 \
 An Example of changing the background might look like.
@@ -305,5 +308,13 @@ An Example of changing the background might look like.
   --KCardShadow: 0 4px 8px lavender;
   --KCardBorder: 2px solid purple;
   --KCardBorderRadius: 12px;
+}
+.horizontal-spacing {
+  margin-right: $kui-space-40;
+}
+.card-flex-container {
+  display: flex;
+  flex-direction: row;
+  gap: $kui-space-40;
 }
 </style>

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -56,7 +56,7 @@ Example composing `KCard` with other Kongponents to make another component:
           Docs
         </KButton>
       </div>
-      <div class="mt-2">
+      <div>
         <p>Kong Enterprise adds features, functionality, and performance to Kong. This documentation doesn’t cover the general practices that are common to both Kong and Kong Enterprise—learn the basics in Kong documentation.</p>
       </div>
     </div>
@@ -74,7 +74,7 @@ Example composing `KCard` with other Kongponents to make another component:
           Docs
         </KButton>
       </div>
-      <div class="mt-2">
+      <div>
         <p>Kong Enterprise adds features, functionality, and performance to Kong. This documentation doesn’t cover the general practices that are common to both Kong and Kong Enterprise—learn the basics in Kong documentation.</p>
       </div>
     </div>

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -175,25 +175,23 @@ Cards can be arranged with flex box.
 </div>
 
 ```html
-<div class="">
-  <KCard title="Left" body="This card only has a title" />
-  <KCard title="Center" body="This card always has a icon button">
-    <template v-slot:actions>
-      <KButton>
-        <KIcon
-          icon="gearFilled"
-          size="16"
-          view-box="0 0 16 16"
-        />
-      </KButton>
-    </template>
-  </KCard>
-  <KCard title="Right" body="This card always has a button">
-    <template v-slot:actions>
-      <KButton>View All</KButton>
-    </template>
-  </KCard>
-</div>
+<KCard title="Left" body="This card only has a title" />
+<KCard title="Center" body="This card always has a icon button">
+  <template v-slot:actions>
+    <KButton>
+      <KIcon
+        icon="gearFilled"
+        size="16"
+        view-box="0 0 16 16"
+      />
+    </KButton>
+  </template>
+</KCard>
+<KCard title="Right" body="This card always has a button">
+  <template v-slot:actions>
+    <KButton>View All</KButton>
+  </template>
+</KCard>
 
 <style lang="scss">
 .card-flex-container {

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -415,12 +415,12 @@ Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specif
 
 <KCatalog :fetcher="fetcherSm" title="Customized cards">
   <template v-slot:cardTitle="{ item }">
-    <div class="color-blue-500">
+    <div class="custom-title">
       {{ item.title }}
     </div>
   </template>
   <template v-slot:cardBody="{ item }">
-    <span class="color-purple-400">
+    <span class="custom-description">
     {{ item.description }}
     </span>
   </template>
@@ -429,12 +429,12 @@ Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specif
 ```html
 <KCatalog :fetcher="fetcher" title="Customized cards">
   <template v-slot:cardTitle="{ item }">
-    <div class="color-blue-500">
+    <div>
       {{ item.title }}
     </div>
   </template>
   <template v-slot:cardBody="{ item }">
-    <span class="color-purple-400">
+    <span>
     {{ item.description }}
     </span>
   </template>
@@ -458,7 +458,7 @@ If utilizing multiple elements, we recommend adding `display: flex; width: 100%;
 
 <KCatalog :fetcher="fetcherXs">
   <template #toolbar="{ state }">
-    <div class="d-flex w-100 justify-content-between">
+    <div class="toolbar-container">
       <KInput v-if="state.hasData" placeholder="Search" />
       <KSelect appearance="select" :items="[{ label: 'First option', value: '1', selected: true }, { label: 'Another option', value: '2'}]" />
     </div>
@@ -468,7 +468,7 @@ If utilizing multiple elements, we recommend adding `display: flex; width: 100%;
 ```html
 <KCatalog :fetcher="fetcher">
   <template #toolbar="{ state }">
-    <div class="d-flex w-100 justify-content-between">
+    <div class="toolbar-container">
       <KInput
         v-if="state.hasData"
         placeholder="Search"
@@ -483,6 +483,13 @@ If utilizing multiple elements, we recommend adding `display: flex; width: 100%;
     </div>
   </template>
 </KCatalog>
+
+<style lang="scss">
+.toolbar-container {
+  display: flex;
+  justify-content: space-between;
+}
+</style>
 ```
 
 
@@ -498,7 +505,7 @@ the section above or completely slot in your own content.
   <template v-slot:body>
     <KCatalog :fetcher="emptyFetcher">
       <template v-slot:empty-state>
-        <div class="w-100" style="text-align: center;">
+        <div style="text-align: center;">
           <KIcon icon="warning" />
           <div>No Content!!!</div>
         </div>
@@ -729,3 +736,18 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.custom-title {
+  color: $kui-color-text-primary;
+}
+
+.custom-description {
+  color: $kui-color-text-neutral;
+}
+
+.toolbar-container {
+  display: flex;
+  justify-content: space-between;
+}
+</style>

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -103,7 +103,7 @@ Any valid attribute will be added to the input. You can read more about `$attrs`
 
 <KCard>
   <template v-slot:body>
-    <div class="mb-2">
+    <div class="vertical-spacing">
       <KCheckbox v-model="disabled" label="Can't check this" disabled />
     </div>
     <div>
@@ -124,7 +124,7 @@ Anything passed in to the default slot will replace the label prop text
 
 <KCard>
   <template v-slot:body>
-    <div class="mb-2">
+    <div class="vertical-spacing">
       <KCheckbox v-model="slots1">
         Label goes here. The checkbox is {{ slots1 ? 'checked' : 'not checked' }}
       </KCheckbox>
@@ -276,6 +276,10 @@ An Example of changing the background color of KCheckbox to `blueviolet` might l
 <style lang="scss">
 .KCheckbox-wrapper {
   --KCheckboxPrimary: blueviolet;
+}
+
+.vertical-spacing {
+  margin-bottom: $kui-space-40;
 }
 </style>
 

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -161,7 +161,7 @@ To set the default state (collapsed or expanded) without binding to v-model you 
     <KCollapse title="Look Mah!">
       <template #trigger-content>
         <div class="trigger-wrapper">
-          <KIcon icon="help" :size="KUI_ICON_SIZE_30" class="icon-style" />
+          <KIcon icon="help" color="currentColor" :size="KUI_ICON_SIZE_30" class="icon-style" />
           Toggle
         </div>
       </template>
@@ -222,9 +222,9 @@ We provide the `isCollapsed` Vue 'ref' and the `toggle()` function as slot props
 
 ## Theming
 
-| Variable                       | Purpose                                     |
-| :---------------------         | :-------------------------------            |
-| `KCollapseTriggerColor`        | Color of trigger text/icon                  |
+| Variable                | Purpose                    |
+| :---------------------- | :------------------------- |
+| `KCollapseTriggerColor` | Color of trigger text/icon |
 
 An example of theming the collapse:
 
@@ -271,12 +271,12 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .collapse-wrapper {
-  margin-bottom: var(--kui-space-50, $kui-space-50) !important;
+  margin-bottom: $kui-space-50 !important;
 }
 
 .icon-style {
-  margin-right: var(--kui-space-40, $kui-space-40) !important;
-  color: var(--blue-500, var(--kui-color-text-primary, $kui-color-text-primary))
+  margin-right: $kui-space-40 !important;
+  color: $kui-color-text-primary;
 }
 
 .trigger-wrapper {

--- a/docs/components/datetime-picker.md
+++ b/docs/components/datetime-picker.md
@@ -19,7 +19,8 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
     width="250"
     :range="false"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ JSON.stringify(currentValue0) }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ JSON.stringify(currentValue0) }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -47,7 +48,8 @@ Set the `v-model` to [Single date time picker](#single-date-time-picker-v-model)
     :minute-increment="5"
     :range="false"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ JSON.stringify(currentValue1) }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ JSON.stringify(currentValue1) }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -74,7 +76,8 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
     mode="date"
     :range="true"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ currentValue2 }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ currentValue2 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -101,7 +104,8 @@ Set the `v-model` to [Range date time picker](#range-date-time-picker-v-model)
     :minute-increment="5"
     :range="true"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ currentValue3 }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ currentValue3 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -135,7 +139,8 @@ This instance also makes use of the `minDate` and `maxDate` parameters, which ar
     :range="true"
     :time-periods="exampleTimeFrames"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ currentValue4 }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ currentValue4 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -196,7 +201,8 @@ This instance also makes use of the `minDate` and `maxDate` parameters, which ar
     :range="true"
     :time-periods="exampleTimeFrames"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ currentValue5 }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ currentValue5 }}</pre></div>
 </ClientOnly>
 
 ```html
@@ -254,7 +260,8 @@ This utilizes the same time frames as the previous example; however, in this exa
     :range="true"
     :time-periods="exampleTimeFrames"
   />
-  <div class="mt-6">Emitted value: <pre class="json hide-from-percy">{{ currentValue6 }}</pre></div>
+  <br/>
+  <div>Emitted value: <pre class="json hide-from-percy">{{ currentValue6 }}</pre></div>
 </ClientOnly>
 
 ```html

--- a/docs/components/dropdown-menu.md
+++ b/docs/components/dropdown-menu.md
@@ -211,16 +211,14 @@ Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popo
     <template #actions>
       <KDropdownMenu
         :kpop-attributes="{
-          popoverClasses: 'mt-5',
           maxWidth: '100'
         }"
         :items="deepClone(defaultItemsUnselected)"
       >
         <template #default>
           <KButton
-            appearance="secondary"
+            appearance="btn-link"
             size="small"
-            class="non-visual-button"
           >
             <template #icon>
               <KIcon
@@ -244,16 +242,15 @@ Use the `kpopAttributes` prop to configure the **KPop** [props](/components/popo
   <template #actions>
     <KDropdownMenu
       :kpop-attributes="{
-        popoverClasses: 'mt-5',
+        popoverClasses: 'some-class',
         maxWidth: '100'
       }"
       :items="deepClone(defaultItemsUnselected)"
     >
       <template #default>
         <KButton
-          appearance="secondary"
+          appearance="btn-link"
           size="small"
-          class="non-visual-button"
         >
           <template #icon>
             <KIcon
@@ -398,19 +395,17 @@ There are 3 primary item types:
       <KDropdownItem
         has-divider
         is-dangerous
-        class="d-inline-block"
       >
         <a
           href="http://www.google.com"
           rel="noopener"
           target="_blank"
         >
-          External link
+          <span class="horizontal-spacing">External link</span>
           <KIcon
             icon="externalLink"
             size="12"
             color="red"
-            class="ml-2"
           />
         </a>
       </KDropdownItem>
@@ -454,7 +449,6 @@ There are 3 primary item types:
     <KDropdownItem
       has-divider
       is-dangerous
-      class="d-inline-block"
     >
       <a
         href="http://www.google.com"
@@ -466,7 +460,6 @@ There are 3 primary item types:
           icon="externalLink"
           size="12"
           color="red"
-          class="ml-2"
         />
       </a>
     </KDropdownItem>
@@ -546,5 +539,9 @@ export default defineComponent({
       fill: red;
     }
   }
+}
+
+.horizontal-spacing {
+  margin-right: $kui-space-40;
 }
 </style>

--- a/docs/components/external-link.md
+++ b/docs/components/external-link.md
@@ -24,7 +24,7 @@ The URL that the hyperlink points to.
 
 Must be a valid URL
 
-<h4><KIcon icon="check" size="22" color="green" style="vertical-align: sub;" class="mr-1" />Correct Usage</h4>
+<h4><KIcon icon="check" size="22" color="green" style="vertical-align: sub;" class="horizontal-spacing" />Correct Usage</h4>
 
 ```html
 <KExternalLink href="https://kongponents.konghq.com/">
@@ -32,7 +32,7 @@ Must be a valid URL
 </KExternalLink>
 ```
 
-<h4><KIcon icon="disabled" size="22" color="red" style="vertical-align: sub;" class="mr-1" />Incorrect Usage</h4>
+<h4><KIcon icon="disabled" size="22" color="red" style="vertical-align: sub;" class="horizontal-spacing" />Incorrect Usage</h4>
 
 ```html
 <KExternalLink href="https://kongponents">
@@ -101,5 +101,9 @@ like:
 .KExternalLink-wrapper {
   --KExternalLinkColor: red;
   --KExternalLinkColorHover: brown;
+}
+
+.horizontal-spacing {
+  margin-right: $kui-space-40;
 }
 </style>

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -35,7 +35,8 @@ KFileUpload has two supported types: `file` (default) and `image`.
 />
 ```
 
-<KCard class="mt-6">
+<br/>
+<KCard>
   <template v-slot:body>
     <KFileUpload type="image" label="Upload File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" class="image-with-label" icon="image" :accept="['image/*']" placeholder="Upload new image (Max 4 MB)" />
   </template>
@@ -71,7 +72,8 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 />
 ```
 
-<KCard class="mt-6">
+<br/>
+<KCard>
   <template v-slot:body>
     <KFileUpload type="image" label="Upload Image File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" class="image-with-label" icon="image" :accept="acceptedImageType" placeholder="Upload new image (Max 1 MB)" />
   </template>
@@ -134,7 +136,8 @@ String to be displayed as error message if `hasError` prop is `true`.
 
 Use the `placeholder` prop to display placeholder text. The `placeholder text` is `blue` to indicate the field is `clickable`.
 
-<KCard class="mt-6">
+<br/>
+<KCard>
   <template v-slot:body>
     <KFileUpload type="image" label="Upload File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" class="image-with-label" :accept="acceptedImageType" placeholder="You can change the text here!" icon="kong" >
     </KFileUpload>
@@ -169,7 +172,8 @@ A `cancel` button can be displayed, by default this is set to `true`. This butto
 />
 ```
 
-<KCard class="mt-6">
+<br/>
+<KCard>
   <template v-slot:body>
     <KFileUpload type="image" label="Upload File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" :removable="false" class="image-with-label" :accept="acceptedImageType" placeholder="No cancel button!" icon="kong" >
     </KFileUpload>
@@ -230,7 +234,8 @@ The size of the `icon` being displayed (default is `24px`).
 
 The color of the `icon` being displayed.
 
-<KCard class="mt-6">
+<br/>
+<KCard>
   <template v-slot:body>
     <KFileUpload type="image" label="Upload File" :label-attributes="{ help: `Accepted file types: ${acceptedImageType}` }" :accept="acceptedImageType" class="image-with-label" placeholder="Customized icon, iconColor & iconSize!" icon="immunity" iconColor="gold" iconSize="30px" />
   </template>
@@ -277,7 +282,8 @@ All of the above 3 events will emit a `JavaScript Array` of type `FileList`. Thi
 />
 ```
 
-<div class="mt-6">Emitted value:
+<br/>
+<div>Emitted value:
   <pre v-if="fileData.length" class="emitted-value">{{ `File Data:` }}
     <div v-for="(file) in fileData">
       <span>lastModified: {{file.lastModified}}</span>

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -19,8 +19,11 @@ The name of the icon. This required prop will only recognize icons from the foll
     <div>
       <KButton
         appearance="outline"
-        class="mb-4"
-        @click="toggle">Toggle viewbox {{ isToggled.value ? 'off' : 'on' }}</KButton>
+        @click="toggle"
+        class="toggle-viewbox-button"
+      >
+          Toggle viewbox {{ isToggled.value ? 'off' : 'on' }}
+      </KButton>
       <div class="icon-row">
         <div v-for="icon in $icons" :class="{ displayHidden: stateIcons.includes(String(icon)) }">
           <div v-if="!stateIcons.includes(String(icon))"
@@ -52,8 +55,11 @@ The `State icons` do not support the `color` prop.
     <div>
       <KButton
         appearance="outline"
-        class="mb-4"
-        @click="toggle">Toggle viewbox {{ isToggled.value ? 'off' : 'on' }}</KButton>
+        class="toggle-viewbox-button"
+        @click="toggle"
+      >
+        Toggle viewbox {{ isToggled.value ? 'off' : 'on' }}
+      </KButton>
       <div class="state-icon-row">
         <div v-for="icon in displayStateIcons"
           class="icon-cell"
@@ -128,8 +134,10 @@ e.g. `<path id="preserveColor" d="M9 11v2H7v-2h2zm0-8v6.5H7V3h2z" fill="#FFF"/>`
 
 The title to be announced by screenreaders and displayed on hover. If not provided, a default title will be used.
 
-<KIcon icon="warning" class="mr-2"/>
-<KIcon icon="warning" title="Custom Title" />
+<div class="spacing-container">
+  <KIcon icon="warning" />
+  <KIcon icon="warning" title="Custom Title" />
+</div>
 
 ```html
 <KIcon icon="warning" />
@@ -158,41 +166,43 @@ You can read more about the viewBox attribute
 
 - `svgElements` - Used to add svg customization elements
 
-<KIcon icon="check" size="48px" color="url('#linear-gradient')" class="mr-2">
-  <template v-slot:svgElements>
-    <defs>
-      <linearGradient id="linear-gradient" x1="0" x2="1">
-        <stop offset="0%" stop-color="#16BDCC" />
-        <stop offset="30%" stop-color="#16BDCC" />
-        <stop offset="100%" stop-color="#1BC263" />
-      </linearGradient>
-    </defs>
-  </template>
-</KIcon>
+<div class="spacing-container">
+  <KIcon icon="check" size="48px" color="url('#linear-gradient')">
+    <template v-slot:svgElements>
+      <defs>
+        <linearGradient id="linear-gradient" x1="0" x2="1">
+          <stop offset="0%" stop-color="#16BDCC" />
+          <stop offset="30%" stop-color="#16BDCC" />
+          <stop offset="100%" stop-color="#1BC263" />
+        </linearGradient>
+      </defs>
+    </template>
+  </KIcon>
 
-<KIcon icon="search" size="48px" color="url('#linear-gradient2')" class="mr-2">
-  <template v-slot:svgElements>
-    <defs>
-      <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
-        <stop offset="10%"  stop-color="gold" />
-        <stop offset="90%" stop-color="red" />
-      </linearGradient>
-    </defs>
-  </template>
-</KIcon>
+  <KIcon icon="search" size="48px" color="url('#linear-gradient2')">
+    <template v-slot:svgElements>
+      <defs>
+        <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
+          <stop offset="10%"  stop-color="gold" />
+          <stop offset="90%" stop-color="red" />
+        </linearGradient>
+      </defs>
+    </template>
+  </KIcon>
 
-<KIcon icon="cogwheel" size="48px" color="dark-grey">
-  <template v-slot:svgElements>
-    <animateTransform
-      attributeName="transform"
-      type="rotate"
-      from="0 0 0"
-      to="360 0 0"
-      dur="5s"
-      repeatCount="indefinite"
-    />
-  </template>
-</KIcon>
+  <KIcon icon="cogwheel" size="48px" color="dark-grey">
+    <template v-slot:svgElements>
+      <animateTransform
+        attributeName="transform"
+        type="rotate"
+        from="0 0 0"
+        to="360 0 0"
+        dur="5s"
+        repeatCount="indefinite"
+      />
+    </template>
+  </KIcon>
+</div>
 
 ```html
 <KIcon icon="check" size="48px" color="url('#linear-gradient')">
@@ -274,5 +284,13 @@ Check out the [contributing](/guide/adding-icons-to-kicon) docs to learn about a
   span {
     margin: 0 8px 8px;
   }
+}
+.spacing-container {
+  display: flex;
+  gap: $kui-space-40;
+}
+
+.toggle-viewbox-button {
+  margin-bottom: $kui-space-60;
 }
 </style>

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -288,6 +288,7 @@ Check out the [contributing](/guide/adding-icons-to-kicon) docs to learn about a
 .spacing-container {
   display: flex;
   gap: $kui-space-40;
+  flex-direction: row;
 }
 
 .toggle-viewbox-button {

--- a/docs/components/inline-edit.md
+++ b/docs/components/inline-edit.md
@@ -128,19 +128,7 @@ An HTML element must be passed in the slot. An error will be thrown if not passe
 
 ## Theming
 
-:lipstick: To theme, reference [KInput](/components/input.html#theming). The input takes up 100% of its parent container. To change, add a class or width styling to the wrapping component.
-
-<KComponent :data="{ inlineText: 'Im 50%!' }" v-slot="{ data }">
-  <KInlineEdit class="w-50" @changed="newVal => data.inlineText = newVal"><h3>{{ data.inlineText }}</h3></KInlineEdit>
-</KComponent>
-
-```html
-<KInlineEdit
-  class="w-50"
-  @changed="newVal => text = newVal">
-  <h3>{{ text }}</h3>
-</KInlineEdit>
-```
+Reference [KInput theming](/components/input.html#theming). The input takes up 100% of its parent container.
 
 <script>
 export default {

--- a/docs/components/input-switch.md
+++ b/docs/components/input-switch.md
@@ -180,7 +180,7 @@ To listen for changes to the `KInputSwitch` value, you can bind to the `@input`,
 <KComponent :data="{eventsSwitchEnabled2: true, changeCount: 0}" v-slot="{ data }">
   <div>
     <KInputSwitch v-model="data.eventsSwitchEnabled2" @change="e => (data.changeCount++)" label="Toggle Me" />
-    <div class="mt-2">You've toggled me {{ data.changeCount }} time(s)</div>
+    <div>You've toggled me {{ data.changeCount }} time(s)</div>
   </div>
 </KComponent>
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -2,10 +2,10 @@
 
 **KInput** provides a wrapper around general `text` input's and provides specific Kong styling and state treatments (error, focus, etc).
 
-<KInput class="w-100" placeholder="Placeholder text" />
+<KInput placeholder="Placeholder text" />
 
 ```html
-<KInput class="w-100" placeholder="Placeholder text" />
+<KInput placeholder="Placeholder text" />
 ```
 
 ## Props
@@ -24,11 +24,11 @@ To set the value of the input element without using `v-model`, you can set the `
 
 String to be used as the input label.
 
-<KInput label="Name" placeholder="I'm labelled!" class="mb-2" />
+<KInput label="Name" placeholder="I'm labelled!" class="vertical-spacing" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" />
 
 ```html
-<KInput label="Name" placeholder="I'm labelled!" class="mb-2" />
+<KInput label="Name" placeholder="I'm labelled!" />
 <KInput label="Disabled" disabled placeholder="I'm disabled!" />
 ```
 
@@ -70,8 +70,9 @@ maxWidth: '150px'
 Enable this prop to overlay the label on the input element's border. Defaults to `false`.
 Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
 
-<KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" class="mt-5" />
-<KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" class="mt-5" />
+<KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" class="vertical-spacing" />
+<br/>
+<KInput label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" />
 
 ```html
 <KInput label="Name" placeholder="I'm labelled!" :overlay-label="true" />
@@ -82,13 +83,13 @@ Make sure that if you are using the built in label you specify the `--KInputBack
 
 You can specify `small`, `medium` (default), or `large` for the size.
 
-<KInput label="Small" size="small" class="mb-2" />
-<KInput label="Medium" class="mb-2" />
+<KInput label="Small" size="small" class="vertical-spacing" />
+<KInput label="Medium" class="vertical-spacing" />
 <KInput label="Large" size="large" />
 
 ```html
-<KInput label="Small" size="small" class="mb-2" />
-<KInput label="Medium" class="mb-2" />
+<KInput label="Small" size="small" />
+<KInput label="Medium" />
 <KInput label="Large" size="large" />
 ```
 
@@ -118,10 +119,10 @@ You also have the option of using the `.help` utility class. This is meant to be
 
 Use this prop to specify a character limit for the input. See the [`@char-limit-exceeded` event](#char-limit-exceeded) for more details.
 
-<KInput model-value="This field has too many characters" :character-limit="10" class="w-100" placeholder="Placeholder text" />
+<KInput model-value="This field has too many characters" :character-limit="10" placeholder="Placeholder text" />
 
 ```html
-<KInput model-value="This field has too many characters" :character-limit="10" class="w-100" placeholder="Placeholder text" />
+<KInput model-value="This field has too many characters" :character-limit="10" placeholder="Placeholder text" />
 ```
 
 The character counter will only display below the input if the `characterLimit` is exceeded.
@@ -147,29 +148,29 @@ Boolean value to indicate whether the element has an error and should apply erro
 
 String to be displayed as error message if `hasError` prop is `true`.
 
-<KInput class="w-100" hasError errorMessage="Service name should not contain '_'" />
+<KInput hasError errorMessage="Service name should not contain '_'" />
 
 ```html
-<KInput class="w-100" hasError errorMessage="Service name should not contain '_'"/>
+<KInput hasError errorMessage="Service name should not contain '_'"/>
 ```
 
-<KInput label="Small" size="small" class="mb-2" help="Additional files can be uploaded from HomePage." hasError errorMessage="Service name should not contain '_'"/>
-<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" />
+<KInput label="Small" size="small" class="vertical-spacing" help="Additional files can be uploaded from HomePage." hasError errorMessage="Service name should not contain '_'"/>
+<KInput label="Medium" class="vertical-spacing" hasError errorMessage="Service name should not contain '_'" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" />
 
 ```html
-<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain '_'" />
-<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" />
+<KInput label="Small" size="small" hasError errorMessage="Service name should not contain '_'" />
+<KInput label="Medium" hasError errorMessage="Service name should not contain '_'" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" />
 ```
 
-<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
-<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
+<KInput label="Small" size="small" class="vertical-spacing" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
+<KInput label="Medium" class="vertical-spacing" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 
 ```html
-<KInput label="Small" size="small" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
-<KInput label="Medium" class="mb-2" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
+<KInput label="Small" size="small" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
+<KInput label="Medium" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 <KInput label="Large" size="large" hasError errorMessage="Service name should not contain '_'" :overlay-label="true" />
 ```
 
@@ -195,14 +196,14 @@ Controls position of the icon provided through the [slot](#slots). Accepted valu
 
 You can pass any input attribute and it will get properly bound to the element.
 
-<KInput class="mb-2" placeholder="placeholder" />
-<KInput class="mb-2" type="password" model-value="123" />
-<KInput class="mb-2" type="number" model-value="1"/>
-<KInput class="mb-2" type="email" model-value="john.doe@konghq.com"/>
-<KInput class="mb-2" disabled model-value="disabled"/>
-<KInput class="mb-2" readonly model-value="readonly"/>
-<KInput class="mb-2" type="search" model-value="search"/>
-<KInput class="mb-2 input-error" type="email" model-value="error"/>
+<KInput class="vertical-spacing" placeholder="placeholder" />
+<KInput class="vertical-spacing" type="password" model-value="123" />
+<KInput class="vertical-spacing" type="number" model-value="1"/>
+<KInput class="vertical-spacing" type="email" model-value="john.doe@konghq.com"/>
+<KInput class="vertical-spacing" disabled model-value="disabled"/>
+<KInput class="vertical-spacing" readonly model-value="readonly"/>
+<KInput class="vertical-spacing" type="search" model-value="search"/>
+<KInput class="vertical-spacing input-error" type="email" model-value="error"/>
 
 > Note: Add the `input-error` class to add custom error styling
 
@@ -239,16 +240,16 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 KInput works as regular inputs do using v-model for data binding:
 
 <KLabel>{{ myInput }}</KLabel>
-<div class="d-flex">
-  <KInput v-model="myInput"/>
-  <KButton class="ml-2" @click="clearMyInput">Clear</KButton>
+<div class="input-container">
+  <KInput class="horizontal-spacing" v-model="myInput"/>
+  <KButton @click="clearMyInput">Clear</KButton>
 </div>
 
 ```html
 <KLabel>{{ myInput }}</KLabel>
-<div class="d-flex">
+<div>
   <KInput v-model="myInput"/>
-  <KButton class="ml-2" @click="clearIt">Clear</KButton>
+  <KButton @click="clearIt">Clear</KButton>
 </div>
 
 <script lang="ts">
@@ -282,13 +283,13 @@ Whether you choose to use `KIcon` Kongponent or your own SVG, the component's st
 :::
 
 
-<KInput placeholder="Search" size="small" class="mb-2">
+<KInput placeholder="Search" size="small" class="vertical-spacing">
   <template #icon>
     <KIcon icon="search" />
   </template>
 </KInput>
 
-<KInput placeholder="Search" size="medium" class="mb-2">
+<KInput placeholder="Search" size="medium" class="vertical-spacing">
   <template #icon>
     <KIcon icon="search" />
   </template>
@@ -499,5 +500,13 @@ export default defineComponent({
       stroke: darkgrey;
     }
   }
+}
+
+.input-container {
+  display: flex;
+}
+
+.vertical-spacing {
+  margin-bottom: $kui-space-40;
 }
 </style>

--- a/docs/components/method-badge.md
+++ b/docs/components/method-badge.md
@@ -73,7 +73,7 @@ When `true`, the KMethodBadge will come with a switch input. You can use `v-mode
 
 <KCard>
   <template #body>
-    <div class="mb-2">Post method enabled: {{ toggleValue }}</div>
+    <div class="vertical-spacing">Post method enabled: {{ toggleValue }}</div>
     <KMethodBadge method="post" is-toggle v-model="toggleValue" />
   </template>
 </KCard>

--- a/docs/components/modal-fullscreen.md
+++ b/docs/components/modal-fullscreen.md
@@ -505,8 +505,8 @@ export default {
     width: 100%;
     height: 80%;
     border-radius: $kui-border-radius-20;
-    border: $kui-border-width-10 solid var(--grey-300, $kui-color-border-neutral-weak);
-    background-color: var(--white, $kui-color-background);
+    border: $kui-border-width-10 solid $kui-color-border-neutral-weak;
+    background-color: $kui-color-background;
     text-indent: $kui-space-40;
   }
 
@@ -515,8 +515,8 @@ export default {
     top: -10px;
     left: 15px;
     padding: $kui-space-20;
-    background-color: var(--white, $kui-color-background);
-    color: var(--grey-500, $kui-color-text-neutral);
+    background-color: $kui-color-background;
+    color: $kui-color-text-neutral;
     font-size: $kui-font-size-10;
   }
 }

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -163,12 +163,12 @@ Can be `dark` (default) or `light`. You might want to use this if displaying dar
       </div>
     </template>
     <template v-slot:header-content>
-      <KIcon icon="kong" class="mr-2" />
+      <KIcon icon="kong" class="horizontal-spacing" />
       Welcome!
     </template>
     <template v-slot:body-content>Get set up with the 2-step quickstart to see live data pushed through a gateway service within minutes.</template>
     <template v-slot:action-buttons>
-      <KButton appearance="btn-link" class="mr-2" @click="slottedIsOpen2 = false">Skip</KButton>
+      <KButton appearance="btn-link" class="horizontal-spacing" @click="slottedIsOpen2 = false">Skip</KButton>
       <KButton
         appearance="primary"
         @click="() => slottedIsOpen2 = false">Onboard me!</KButton>
@@ -191,12 +191,12 @@ Can be `dark` (default) or `light`. You might want to use this if displaying dar
     </div>
   </template>
   <template v-slot:header-content>
-    <KIcon icon="kong" class="mr-2" />
+    <KIcon icon="kong" />
     Welcome!
   </template>
   <template v-slot:body-content>Get set up with the quickstart to see live data pushed through a gateway service within minutes.</template>
   <template v-slot:action-buttons>
-    <KButton appearance="btn-link" class="mr-2" @click="isVisible = false">Skip</KButton>
+    <KButton appearance="btn-link" @click="isVisible = false">Skip</KButton>
     <KButton
       appearance="primary"
       @click="() => isVisible = false">Onboard me!</KButton>
@@ -229,11 +229,11 @@ There are 4 designated slots you can use to display content in the modal.
   >
     <template v-slot:header-image>
       <div class="slot-image-content">
-        <h4 class="mx-7 my-4">I'm slotted baby!</h4>
+        <h4>I'm slotted baby!</h4>
       </div>
     </template>
     <template v-slot:action-buttons>
-      <KButton appearance="btn-link" class="mr-2" @click="slottedIsOpen3 = false">Pass</KButton>
+      <KButton appearance="btn-link" class="horizontal-spacing" @click="slottedIsOpen3 = false">Pass</KButton>
       <KButton appearance="primary" @click="slottedIsOpen3 = false">I sure do!</KButton>
     </template>
   </KModal>
@@ -250,11 +250,11 @@ There are 4 designated slots you can use to display content in the modal.
   >
     <template v-slot:header-image>
       <div class="slot-image-content">
-        <h4 class="mx-7 my-4">I'm slotted baby!</h4>
+        <h4>I'm slotted baby!</h4>
       </div>
     </template>
     <template v-slot:action-buttons>
-      <KButton appearance="btn-link" class="mr-2" @click="slottedIsOpen3 = false">Pass</KButton>
+      <KButton appearance="btn-link" @click="slottedIsOpen3 = false">Pass</KButton>
       <KButton appearance="primary" @click="slottedIsOpen3 = false">I sure do!</KButton>
     </template>
   </KModal>
@@ -284,12 +284,12 @@ Notice that even though we are using the `header-content` slot we still specify 
 
 <KModal :isVisible="slottedIsOpen" actionButtonText="Delete" actionButtonAppearance="danger" @canceled="slottedIsOpen = false" title="Delete Item">
   <template v-slot:header-content>
-    <KIcon icon="dangerCircle" color="red" class="mr-2" />
+    <KIcon icon="dangerCircle" color="red" class="horizontal-spacing" />
     Delete Item
   </template>
   <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
   <template v-slot:action-buttons>
-    <KButton appearance="outline" class="mr-2" @click="slottedIsOpen = false">Back</KButton>
+    <KButton appearance="outline" class="horizontal-spacing" @click="slottedIsOpen = false">Back</KButton>
     <KButton appearance="danger" @click="slottedIsOpen = false">Delete</KButton>
   </template>
 </KModal>
@@ -303,12 +303,12 @@ Notice that even though we are using the `header-content` slot we still specify 
   title="Delete Item"
 >
   <template v-slot:header-content>
-    <KIcon icon="dangerCircle" color="red" class="mr-2" />
+    <KIcon icon="dangerCircle" color="red" />
     Delete Item
   </template>
   <template v-slot:body-content>Are you sure you want to delete this item? This action can not be undone.</template>
   <template v-slot:action-buttons>
-    <KButton appearance="outline" class="mr-2" @click="slottedIsOpen = false">Back</KButton>
+    <KButton appearance="outline" @click="slottedIsOpen = false">Back</KButton>
     <KButton appearance="danger" @click="slottedIsOpen = false">Delete</KButton>
   </template>
 </KModal>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -100,8 +100,8 @@ You cannot add an item if the `label` matches the `label` of a pre-existing item
 :::
 
 <ClientOnly>
-  <KLabel>Value:</KLabel> <pre class="json ma-0">{{ JSON.stringify(mySelections) }}</pre>
-  <KLabel>Added Items:</KLabel> <pre class="json ma-0">{{ JSON.stringify(addedItems) }}</pre>
+  <KLabel>Value:</KLabel> <pre class="json">{{ JSON.stringify(mySelections) }}</pre>
+  <KLabel>Added Items:</KLabel> <pre class="json">{{ JSON.stringify(addedItems) }}</pre>
   <KMultiselect
     v-model="mySelections"
     :items="deepClone(defaultItems)"
@@ -310,7 +310,7 @@ See [autosuggest](#autosuggest) for more details.
 `KMultiselect` works as regular inputs do using v-model for data binding:
 
 <ClientOnly>
-  <KLabel>Value:</KLabel> <pre class="json ma-0">{{ JSON.stringify(myVal) }}</pre>
+  <KLabel>Value:</KLabel> <pre class="json">{{ JSON.stringify(myVal) }}</pre>
   <KMultiselect v-model="myVal" :items="deepClone(defaultItems)" class="mt-2" />
   <br>
   <KButton @click="clearIt">Clear</KButton>
@@ -378,7 +378,7 @@ When using `autosuggest`, you **MUST** use `v-model` otherwise the Multiselect c
 :::
 
 <ClientOnly>
-  <KLabel>Value:</KLabel> <pre class="json ma-0">{{ JSON.stringify(myAutoVal) }}</pre>
+  <KLabel>Value:</KLabel> <pre class="json">{{ JSON.stringify(myAutoVal) }}</pre>
   <KMultiselect
     v-model="myAutoVal"
     autosuggest
@@ -735,7 +735,7 @@ Slot the content of the dropdown footer text. This slot will override the `dropd
 An example of hooking into events to modify newly created items (`enableItemCreation`) as they are added.
 
 <ClientOnly>
-  <KLabel>myItems:</KLabel> <pre class="json ma-0">{{ JSON.stringify(myEventItems) }}</pre>
+  <KLabel>myItems:</KLabel> <pre class="json">{{ JSON.stringify(myEventItems) }}</pre>
   <KMultiselect
     :items="myEventItems"
     enable-item-creation
@@ -1135,3 +1135,9 @@ export default defineComponent({
   }
 })
 </script>
+
+<style lang="scss">
+.json {
+  inset: 0 !important;
+}
+</style>

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -106,7 +106,6 @@ You cannot add an item if the `label` matches the `label` of a pre-existing item
     v-model="mySelections"
     :items="deepClone(defaultItems)"
     enable-item-creation
-    class="mt-2"
     @item:added="(item) => trackNewItems(item, true)"
     @item:removed="(item) => trackNewItems(item, false)"
   />
@@ -311,7 +310,7 @@ See [autosuggest](#autosuggest) for more details.
 
 <ClientOnly>
   <KLabel>Value:</KLabel> <pre class="json">{{ JSON.stringify(myVal) }}</pre>
-  <KMultiselect v-model="myVal" :items="deepClone(defaultItems)" class="mt-2" />
+  <KMultiselect v-model="myVal" :items="deepClone(defaultItems)" />
   <br>
   <KButton @click="clearIt">Clear</KButton>
 </ClientOnly>
@@ -384,7 +383,6 @@ When using `autosuggest`, you **MUST** use `v-model` otherwise the Multiselect c
     autosuggest
     :items="itemsForAutosuggest"
     :loading="loading"
-    class="mt-2"
     @query-change="onQueryChange"
   >
     <template v-slot:item-template="{ item }">
@@ -739,7 +737,6 @@ An example of hooking into events to modify newly created items (`enableItemCrea
   <KMultiselect
     :items="myEventItems"
     enable-item-creation
-    class="mt-2"
     @item:added="item => handleAddedItem(item, true)"
     @item:removed="item => handleAddedItem(item, false)"
     @selected="handleSelection"

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -227,9 +227,10 @@ Pass in a boolean value for whether or not the offset-based Next button should b
 
 ### Example
 
+<br/>
 <KComponent :data="{ names: ['Alice', 'Bob', 'Charlie', 'Derek', 'Ellie', 'Frank', 'George', 'Helen', 'Ingrid'], visibleNames: ['Alice', 'Bob', 'Charlie'], page: 1}" v-slot="{ data }">
   <div>
-    <KCard title="Cool names list" class="mb-4">
+    <KCard title="Cool names list">
       <template #body>
         <div v-for="name in data.visibleNames">
         {{name}}
@@ -285,16 +286,16 @@ export default defineComponent({
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KPaginationColor`| KPagination button text color
-| `--KPaginationBackgroundColor`| KPagination button background color
-| `--KPaginationBorderColor`| KPagination button border color
-| `--KPaginationPageSizeColor`| KPagination page size button text color
-| `--KPaginationActiveColor`| KPagination active button text color
-| `--KPaginationActiveBackgroundColor`| KPagination active button background color
-| `--KPaginationActiveBorderColor`| KPagination active button border color
-| `--KPaginationDisabledColor`| KPagination disabled button text color
+| Variable                             | Purpose                                    |
+| :----------------------------------- | :----------------------------------------- |
+| `--KPaginationColor`                 | KPagination button text color              |
+| `--KPaginationBackgroundColor`       | KPagination button background color        |
+| `--KPaginationBorderColor`           | KPagination button border color            |
+| `--KPaginationPageSizeColor`         | KPagination page size button text color    |
+| `--KPaginationActiveColor`           | KPagination active button text color       |
+| `--KPaginationActiveBackgroundColor` | KPagination active button background color |
+| `--KPaginationActiveBorderColor`     | KPagination active button border color     |
+| `--KPaginationDisabledColor`         | KPagination disabled button text color     |
 
 
 An Example of changing the border color of KPagination to lime might look like:

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -596,9 +596,9 @@ Example:
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <template v-slot:content>
-    <div style="justify-content: center;" class="d-flex">
+    <div style="justify-content: center;" class="loading-container">
       <KIcon v-if="currentState == 'pending'" icon="spinner" color="purple" />
-      <div class="pl-2" style="line-height: 24px;">{{ message }}</div>
+      <div style="line-height: 24px;">{{ message }}</div>
     </div>
   </template>
 </KPop>
@@ -678,9 +678,9 @@ export default defineComponent({
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
   <template v-slot:content>
-    <div style="justify-content: center;" class="d-flex">
+    <div style="justify-content: center;">
       <KIcon v-if="currentState == 'pending'" icon="spinner" color="purple" />
-      <div class="pl-2" style="line-height: 24px;">{{ message }}</div>
+      <div style="line-height: 24px;">{{ message }}</div>
     </div>
   </template>
 </KPop>
@@ -754,9 +754,13 @@ You will have to manually polyfill this functionality if you choose to support I
 :::
 
 <style scoped>
-  select {
-    height: 38px;
-    background-color: #fff !important;
-    width: 250px;
-  }
+select {
+  height: 38px;
+  background-color: #fff !important;
+  width: 250px;
+}
+
+.loading-container {
+  display: flex;
+}
 </style>

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -598,7 +598,7 @@ Example:
   <template v-slot:content>
     <div style="justify-content: center;" class="loading-container">
       <KIcon v-if="currentState == 'pending'" icon="spinner" color="purple" />
-      <div style="line-height: 24px;">{{ message }}</div>
+      <div>{{ message }}</div>
     </div>
   </template>
 </KPop>
@@ -680,7 +680,7 @@ export default defineComponent({
   <template v-slot:content>
     <div style="justify-content: center;">
       <KIcon v-if="currentState == 'pending'" icon="spinner" color="purple" />
-      <div style="line-height: 24px;">{{ message }}</div>
+      <div>{{ message }}</div>
     </div>
   </template>
 </KPop>

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -209,28 +209,28 @@ There are 3 designated slots you can use to display content in the modal.
 
 <KPrompt :is-visible="slotsIsOpen" @canceled="slotsIsOpen = false" @proceed="slotsIsOpen = false">
   <template v-slot:header-content>
-    <KIcon icon="immunity" color="#7F01FE" class="mr-2" size="20" />
+    <KIcon icon="immunity" color="#7F01FE" class="horizontal-spacing" size="20" />
     Look Mah!
   </template>
   <template v-slot:body-content>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
   </template>
   <template v-slot:action-buttons>
-    <KButton appearance="outline" @click="slotsIsOpen = false" class="non-visual-button">Close</KButton>
+    <KButton appearance="outline" @click="slotsIsOpen = false">Close</KButton>
   </template>
 </KPrompt>
 
 ```html
 <KPrompt :is-visible="slotsIsOpen" @canceled="slotsIsOpen = false" @proceed="slotsIsOpen = false">
   <template v-slot:header-content>
-    <KIcon icon="immunity" color="#7F01FE" class="mr-2" size="20" />
+    <KIcon icon="immunity" color="#7F01FE" size="20" />
     Look Mah!
   </template>
   <template v-slot:body-content>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
   </template>
   <template v-slot:action-buttons>
-    <KButton appearance="outline" @click="slotsIsOpen = false" class="non-visual-button">Close</KButton>
+    <KButton appearance="outline" @click="slotsIsOpen = false">Close</KButton>
   </template>
 </KPrompt>
 ```
@@ -242,9 +242,9 @@ There are 3 designated slots you can use to display content in the modal.
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KPromptMaxHeight` | Max height of body content in prompt
+| Variable             | Purpose                              |
+| :------------------- | :----------------------------------- |
+| `--KPromptMaxHeight` | Max height of body content in prompt |
 
 <script lang="ts">
 import { defineComponent } from 'vue'

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -4,7 +4,7 @@
 
 <KCard>
   <template #body>
-    <div class="mb-3">Selected: {{ radioGroup }}</div>
+    <div class="vertical-spacing">Selected: {{ radioGroup }}</div>
     <div>
       <KRadio name="test" :selected-value="true" v-model="radioGroup">Boolean</KRadio>
       <KRadio name="test" selected-value="string" v-model="radioGroup">String</KRadio>
@@ -16,7 +16,7 @@
 
 ```html
 <template>
-  <div class="mb-3">Selected: {{ radioGroup }}</div>
+  <div>Selected: {{ radioGroup }}</div>
   <KRadio name="test" :selected-value="true" v-model="radioGroup">Boolean</KRadio>
   <KRadio name="test" selected-value="string" v-model="radioGroup">String</KRadio>
   <KRadio name="test" :selected-value="objA" v-model="radioGroup">Object A</KRadio>
@@ -96,35 +96,35 @@ You can choose to utilize the `.k-radio-label` and `.k-radio-description` classe
 
 <KCard>
   <template #body>
-    <div class="d-flex">
+    <div class="vertical-spacing">
       <KRadio type="card" selected-value="foo" v-model="cardRadio">
-        <img class="mb-2" src="/img/kong-logomark.png" alt="Kong logo" />
+        <img class="vertical-spacing" src="/img/kong-logomark.png" alt="Kong logo" />
         <div class="k-radio-label">Foo</div>
         <div class="k-radio-description">This subheader</div>
       </KRadio>
       <KRadio type="card" selected-value="bar" v-model="cardRadio">
-        <img class="mb-2" src="/img/kong-logomark.png" alt="Kong logo" />
+        <img class="vertical-spacing" src="/img/kong-logomark.png" alt="Kong logo" />
         <div class="k-radio-label">Bar</div>
         <div class="k-radio-description">That subheader</div>
       </KRadio>
     </div>
-    <div class="mt-3">Selected: {{ cardRadio }}</div>
+    <div>Selected: {{ cardRadio }}</div>
   </template>
 </KCard>
 
 ```html
 <template>
   <KRadio type="card" selected-value="foo" v-model="cardRadio">
-    <img class="mb-2" src="/img/kong-logo.png" alt="Kong logo" />
+    <img src="/img/kong-logo.png" alt="Kong logo" />
     <div class="k-radio-label">Foo</div>
     <div class="k-radio-description">This subheader</div>
   </KRadio>
   <KRadio type="card" selected-value="bar" v-model="cardRadio">
-    <img class="mb-2" src="/img/kong-logo.png" alt="Kong logo" />
+    <img src="/img/kong-logo.png" alt="Kong logo" />
     <div class="k-radio-label">Bar</div>
     <div class="k-radio-description">That subheader</div>
   </KRadio>
-  <div class="mt-3">Selected: {{ cardRadio }}</div>
+  <div>Selected: {{ cardRadio }}</div>
 </template>
 
 <script lang="ts">

--- a/docs/components/renderless/clipboard-provider.md
+++ b/docs/components/renderless/clipboard-provider.md
@@ -4,7 +4,7 @@
 
 <KCard>
   <template v-slot:body>
-    <KInput :model-value="dataToCopy" @input="newValue => dataToCopy = newValue" type="text" class="mb-2 w-100" />
+    <KInput :model-value="dataToCopy" @input="newValue => dataToCopy = newValue" type="text" class="vertical-spacing" />
     <KClipboardProvider v-slot="{ copyToClipboard }">
       <KButton @click="() => { if (copyToClipboard(dataToCopy)) $toaster.open(`Copied: '${dataToCopy}'`) }">
         copy to clipboard
@@ -15,7 +15,7 @@
 
 ```html
 <template>
-  <KInput :model-value="dataToCopy" @input="newValue => dataToCopy = newValue" type="text" class="mb-2 w-100" />
+  <KInput :model-value="dataToCopy" @input="newValue => dataToCopy = newValue" type="text" />
   <KClipboardProvider v-slot="{ copyToClipboard }">
     <KButton @click="() => { if (copyToClipboard(dataToCopy)) alert(`Copied '${dataToCopy}'`) }">
       copy to clipboard
@@ -65,3 +65,9 @@ export default defineComponent({
   }
 })
 </script>
+
+<style lang="scss">
+.vertical-spacing {
+  margin-bottom: $kui-space-40;
+}
+</style>

--- a/docs/components/renderless/k-component.md
+++ b/docs/components/renderless/k-component.md
@@ -39,9 +39,9 @@ The state that the component should begin with.
 
 ## Slot Props
 
-| Props       | Type     | Description                     |
-| :---------- | :------- | :------------------------------ |
-| `data` | Object  | reactive component state |
+| Props  | Type   | Description              |
+| :----- | :----- | :----------------------- |
+| `data` | Object | reactive component state |
 
 ## Usage
 
@@ -50,7 +50,8 @@ them and placing them inside `KComponent`'s default slot.
 
 ### Select
 
-<KCard class="mt-2" style="min-height: 100px;">
+<br/>
+<KCard style="min-height: 100px;">
   <template v-slot:body>
     <KComponent :data="{ selected: '' }" v-slot="{ data }">
       <div>
@@ -69,7 +70,7 @@ them and placing them inside `KComponent`'s default slot.
 </KCard>
 
 ```html
-<KCard class="mt-2" style="min-height: 100px;">
+<KCard style="min-height: 100px;">
   <template v-slot:body>
     <KComponent :data="{ selected: '' }" v-slot="{ data }">
       <div>

--- a/docs/components/renderless/toggle.md
+++ b/docs/components/renderless/toggle.md
@@ -145,7 +145,8 @@ them and placing them inside `KToggle`'s default slot.
 
 ### Collapse/Expand
 
-<KCard class="mt-2" style="min-height: 100px;">
+<br/>
+<KCard style="min-height: 100px;">
   <template v-slot:body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
@@ -173,7 +174,8 @@ them and placing them inside `KToggle`'s default slot.
 
 #### Toggle with Animation
 
-<KCard class="mt-2" style="min-height: 100px;">
+<br/>
+<KCard style="min-height: 100px;">
   <template v-slot:body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>

--- a/docs/components/renderless/toggle.md
+++ b/docs/components/renderless/toggle.md
@@ -40,10 +40,10 @@ The toggled state that the component should begin with.
 
 ### Slot Props
 
-| Props       | Type     | Description                     |
-| :---------- | :------- | :------------------------------ |
-| `isToggled` | Ref(Boolean)  | the component is toggled or not |
-| `toggle`    | Function | function to toggle!             |
+| Props       | Type         | Description                     |
+| :---------- | :----------- | :------------------------------ |
+| `isToggled` | Ref(Boolean) | the component is toggled or not |
+| `toggle`    | Function     | function to toggle!             |
 
 You can trigger the `toggle` function to switch the state in any way you'd like.
 For instance, here we are toggling the state on `mouseover` and toggling back on
@@ -113,7 +113,8 @@ them and placing them inside `KToggle`'s default slot.
 
 ### KModal
 
-<KCard class="mt-3">
+<br/>
+<KCard>
   <template v-slot:body>
     <KToggle v-slot="{ isToggled, toggle }">
       <div>
@@ -148,12 +149,11 @@ them and placing them inside `KToggle`'s default slot.
   <template v-slot:body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
-        <KButton @click="toggle">
+        <KButton @click="toggle" class="vertical-spacing">
           {{ isToggled.value ? 'collapse' : 'expand' }}
         </KButton>
         <KAlert
           v-if="isToggled.value"
-          class="mt-3"
           alertMessage="Every day, once a day, give yourself a present." />
       </div>
     </KToggle>
@@ -166,7 +166,7 @@ them and placing them inside `KToggle`'s default slot.
     <KButton @click="toggle">
       {{ isToggled.value ? 'collapse' : 'expand' }}
     </KButton>
-    <KAlert v-if="isToggled.value" class="mt-3" alertMessage="Every day, once a day, give yourself a present." />
+    <KAlert v-if="isToggled.value" alertMessage="Every day, once a day, give yourself a present." />
   </div>
 </KToggle>
 ```
@@ -177,13 +177,12 @@ them and placing them inside `KToggle`'s default slot.
   <template v-slot:body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
-        <KButton @click="toggle">
+        <KButton @click="toggle" class="vertical-spacing">
           {{ isToggled.value ? 'collapse' : 'expand' }}
         </KButton>
         <transition name="expand">
           <KAlert
             v-if="isToggled.value"
-            class="mt-3"
             alertMessage="Every day, once a day, give yourself a present." />
         </transition>
       </div>
@@ -198,7 +197,7 @@ them and placing them inside `KToggle`'s default slot.
           {{ isToggled.value ? 'collapse' : 'expand' }}
         </KButton>
         <transition name="expand">
-          <KAlert v-if="isToggled.value" class="mt-3" alertMessage="Every day, once a day, give yourself a present." />
+          <KAlert v-if="isToggled.value" alertMessage="Every day, once a day, give yourself a present." />
         </transition>
       </div>
 </KToggle>

--- a/docs/components/segmented-control.md
+++ b/docs/components/segmented-control.md
@@ -236,24 +236,24 @@ An Example of changing the KSegmentedControl to a purple theme instead of blue m
 
 <style>
 .purple-segment {
-  --KSegmentedControlText: var(--purple-400, #{$kui-method-color-text-connect});
-  --KSegmentedControlSelectedBackground: var(--white, #{$kui-color-background});
-  --KSegmentedControlSelectedBorder: var(--purple-300, #9396fc);
-  --KSegmentedControlUnselectedBackground: var(--blue-100, #{$kui-color-background-primary-weakest});
-  --KSegmentedControlUnselectedBorder: var(--purple-200, #bec0fd);
-  --KSegmentedControlGap: var(--spacing-sm, #{$kui-space-50});
+  --KSegmentedControlText: #473cfb;
+  --KSegmentedControlSelectedBackground: white;
+  --KSegmentedControlSelectedBorder: #9396fc;
+  --KSegmentedControlUnselectedBackground: #f2f6fe;
+  --KSegmentedControlUnselectedBorder: #0364ac;
+  --KSegmentedControlGap: 12px;
 }
 </style>
 ```
 
 <style scoped lang="scss">
 .purple-segment {
-  --KSegmentedControlText: var(--purple-400, #{$kui-method-color-text-connect});
-  --KSegmentedControlSelectedBackground: var(--white, #{$kui-color-background});
-  --KSegmentedControlSelectedBorder: var(--purple-300, #9396fc);
-  --KSegmentedControlUnselectedBackground: var(--blue-100, #{$kui-color-background-primary-weakest});
-  --KSegmentedControlUnselectedBorder: var(--purple-200, #bec0fd);
-  --KSegmentedControlGap: var(--spacing-sm, #{$kui-space-50});
+  --KSegmentedControlText: #473cfb;
+  --KSegmentedControlSelectedBackground: white;
+  --KSegmentedControlSelectedBorder: #9396fc;
+  --KSegmentedControlUnselectedBackground: #f2f6fe;
+  --KSegmentedControlUnselectedBorder: #0364ac;
+  --KSegmentedControlGap: 12px;
 }
 </style>
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -576,7 +576,6 @@ You cannot add an item if the `label` matches the `label` of a pre-existing item
     v-model="myVal"
     :items="deepClone(defaultItems)"
     enable-item-creation
-    class="mt-2"
     @item:added="(item) => trackNewItems(item, true)"
     @item:removed="(item) => trackNewItems(item, false)"
   />

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -72,10 +72,13 @@ The label for the select.
 Enable this prop to overlay the label on the input element's border for `select` and `dropdown` appearances. Defaults to `false`.
 
 <ClientOnly>
-  <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
-  <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
-  <KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
-  <KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" class="mt-5" />
+  <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+  <br/>
+  <KSelect label="Name" placeholder="I'm labelled!" :overlay-label="true" appearance="select" :items="deepClone(defaultItemsUnselect)" />
+  <br/>
+  <KSelect label="Disabled" disabled placeholder="I'm disabled!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
+  <br/>
+  <KSelect label="Readonly" readonly placeholder="I'm readonly!" :overlay-label="true" :items="deepClone(defaultItemsUnselect)" />
 </ClientOnly>
 
 ```html
@@ -267,7 +270,7 @@ Use this prop to control whether or not the `KSelect` component with an `appeara
 `button` style `appearance` does not have filter support because it is a button.
 
 <ClientOnly>
-  <KSelect :items="deepClone(defaultItemsUnselect)" :enable-filtering="false" class="mb-2" />
+  <KSelect :items="deepClone(defaultItemsUnselect)" :enable-filtering="false" class="vertical-spacing" />
   <KSelect :items="deepClone(defaultItemsUnselect)" appearance="select" :enable-filtering="true" />
 </ClientOnly>
 
@@ -532,11 +535,11 @@ Use this prop to customize selected item element appearance by reusing content p
 <ClientOnly>
   <KSelect reuse-item-template appearance="select" :items="deepClone(defaultItems)">
     <template #item-template="{ item }">
-      <div class="d-inline-flex w-100">
-        <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
-        <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
-        <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-        <div class="select-item-label truncate">{{ item.label }}</div>
+      <div class="item-template-container">
+        <span v-if="item.value === 'cats'">🐈</span>
+        <span v-if="item.value === 'dogs'">🐕</span>
+        <span v-if="item.value === 'bunnies'">🐇</span>
+        <div class="select-item-label">{{ item.label }}</div>
       </div>
     </template>
   </KSelect>
@@ -545,11 +548,11 @@ Use this prop to customize selected item element appearance by reusing content p
 ```html
 <KSelect reuse-item-template appearance="select" :items="items">
   <template #item-template="{ item }">
-    <div class="d-inline-flex w-100">
-      <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
-      <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
-      <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
-      <div class="select-item-label truncate">{{ item.label }}</div>
+    <div>
+      <span v-if="item.value === 'cats'">🐈</span>
+      <span v-if="item.value === 'dogs'">🐕</span>
+      <span v-if="item.value === 'bunnies'">🐇</span>
+      <div class="select-item-label">{{ item.label }}</div>
     </div>
   </template>
 </KSelect>
@@ -568,7 +571,7 @@ You cannot add an item if the `label` matches the `label` of a pre-existing item
 :::
 
 <ClientOnly>
-  <KLabel>Added Item:</KLabel> <pre class="json ma-0">{{ JSON.stringify(addedItems) }}</pre>
+  <KLabel>Added Item:</KLabel> <pre class="json">{{ JSON.stringify(addedItems) }}</pre>
   <KSelect
     v-model="myVal"
     :items="deepClone(defaultItems)"
@@ -750,16 +753,16 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
 <ClientOnly>
   <KSelect appearance="select" autosuggest :items="deepClone(defaultItems)">
     <template #selected-item-template="{ item }">
-      <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
-      <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
-      <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+      <span class="horizontal-spacing" v-if="item.value === 'cats'">🐈</span>
+      <span class="horizontal-spacing" v-if="item.value === 'dogs'">🐕</span>
+      <span class="horizontal-spacing" v-if="item.value === 'bunnies'">🐇</span>
       {{ item.label }}
     </template>
     <template #item-template="{ item }">
-      <div class="d-inline-flex">
-        <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
-        <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
-        <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+      <div class="item-template-container">
+        <span v-if="item.value === 'cats'">🐈</span>
+        <span v-if="item.value === 'dogs'">🐕</span>
+        <span v-if="item.value === 'bunnies'">🐇</span>
         <div class="select-item-label">{{ item.label }}</div>
       </div>
     </template>
@@ -769,16 +772,16 @@ You can use the `.k-select-selected-item-label` class within the slot to leverag
 ```html
 <KSelect appearance="select" autosuggest :items="items">
   <template #selected-item-template="{ item }">
-    <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
-    <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
-    <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+    <span v-if="item.value === 'cats'">🐈</span>
+    <span v-if="item.value === 'dogs'">🐕</span>
+    <span v-if="item.value === 'bunnies'">🐇</span>
     {{ item.label }}
   </template>
   <template #item-template="{ item }">
-    <div class="d-inline-flex">
-      <span class="mr-2" v-if="item.value === 'cats'">🐈</span>
-      <span class="mr-2" v-if="item.value === 'dogs'">🐕</span>
-      <span class="mr-2" v-if="item.value === 'bunnies'">🐇</span>
+    <div>
+      <span v-if="item.value === 'cats'">🐈</span>
+      <span v-if="item.value === 'dogs'">🐕</span>
+      <span v-if="item.value === 'bunnies'">🐇</span>
       <div class="select-item-label">{{ item.label }}</div>
     </div>
   </template>
@@ -1011,3 +1014,22 @@ export default defineComponent({
   }
 })
 </script>
+
+<style lang="scss">
+.json {
+  inset: 0 !important;
+}
+
+.item-template-container {
+  width: 100%;
+  display: inline-flex;
+  gap: $kui-space-40;
+}
+
+.select-item-label {
+  line-height: initial;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -22,7 +22,7 @@ The number of milliseconds to wait before showing the skeleton state. Defaults t
 
 <KComponent :data="{ isLoading: false }" v-slot="{ data }">
   <div>
-    <KButton class="mb-2" @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</KButton>
+    <KButton class="vertical-spacing" @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</KButton>
       <div v-if="!data.isLoading">
         <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
       </div>
@@ -33,7 +33,7 @@ The number of milliseconds to wait before showing the skeleton state. Defaults t
 ```html
 <KComponent :data="{ isLoading: false }" v-slot="{ data }">
   <div>
-    <KButton class="mb-2" @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</KButton>
+    <KButton @click="()=>(data.isLoading=!data.isLoading)">Toggle loading - {{data.isLoading?'on':'off'}}</KButton>
       <div v-if="!data.isLoading">
         <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</div>
       </div>
@@ -135,7 +135,7 @@ Used for controlling the progress indicator.
 Defaults to `false`, you can use this prop to hide the progress indicator.
 
 <div>
-  <KButton class="mr-2" @click="clickNoProgress()">Click for no progress indicator</KButton>
+  <KButton class="horizontal-spacing" @click="clickNoProgress()">Click for no progress indicator</KButton>
   <KButton @click="clicked()">Click for default progress behavior</KButton>
   <KSkeleton
     v-if="loadingNone"
@@ -238,8 +238,8 @@ For example, here is a card skeleton with different arrangement of placeholders:
 
 <KSkeleton class="k-skeleton-modified" type="card" :card-count="3">
   <template v-slot:card-header>
-    <div class="w-100">
-      <div class="justify-content-center pb-3">
+    <div class="skeleton-header-container">
+      <div>
         <KSkeletonBox width="5" />
       </div>
       <hr>
@@ -249,8 +249,8 @@ For example, here is a card skeleton with different arrangement of placeholders:
     <KSkeletonBox width="100"/>
   </template>
   <template v-slot:card-footer>
-    <div class="w-100">
-      <div class="d-flex justify-content-center">
+    <div class="skeleton-header-container">
+      <div>
         <KSkeletonBox width="5" />
       </div>
     </div>
@@ -260,16 +260,16 @@ For example, here is a card skeleton with different arrangement of placeholders:
 ```html
 <KSkeleton type="card" :card-count="3">
   <template v-slot:card-header>
-    <div class="w-100">
-      <div class="d-flex justify-content-center pb-2">
+    <div>
+      <div>
         <KSkeletonBox width="5" />
       </div>
       <hr>
     </div>
   </template>
   <template v-slot:card-footer>
-    <div class="w-100">
-      <div class="d-flex justify-content-center pb-2">
+    <div>
+      <div>
         <KSkeletonBox width="5" />
       </div>
     </div>
@@ -282,14 +282,14 @@ And another example:
 <KSkeleton type="card">
   <template v-slot:card-header>
     <div>
-      <div class="d-flex justify-content-center pb-2">
+      <div>
         <KSkeletonBox width="5" />
       </div>
       <hr>
     </div>
   </template>
   <template v-slot:card-content>
-    <div class="d-block">
+    <div>
       <template v-for="i in 8">
         <KSkeletonBox width="5" />
         <KSkeletonBox width="5" />
@@ -308,14 +308,14 @@ And another example:
   <KSkeleton type="card">
     <template v-slot:card-header>
       <div>
-        <div class="d-flex justify-content-center pb-2">
+        <div>
           <KSkeletonBox width="5" />
         </div>
         <hr>
       </div>
     </template>
     <template v-slot:card-content>
-      <div class="d-block">
+      <div>
         <template v-for="i in 8">
           <KSkeletonBox width="5" />
           <KSkeletonBox width="5" />
@@ -345,13 +345,13 @@ And another example:
 
 To reveal the header on this docs page during full page loader, click the button below.
 
-<div class="mt-4 k-skeleton-full-screen-margin">
+<div class="k-skeleton-full-screen-margin">
   <KButton @click="clickedTheming()">themed full screen loader</KButton>
   <KSkeleton v-if="loadingTheming" type="fullscreen-kong" :delay-milliseconds="0" />
 </div>
 
 ```html
-<div class="mt-4 k-skeleton-full-screen-margin">
+<div class="k-skeleton-full-screen-margin">
   <KButton @click="clickedTheming()">themed full screen loader</KButton>
   <KSkeleton v-if="loadingTheming" type="fullscreen-kong" :delay-milliseconds="0" />
 </div>
@@ -422,5 +422,8 @@ export default defineComponent({
 }
 .k-skeleton-modified {
   --KSkeletonCardWidth: calc(33% - 16px);
+}
+.skeleton-header-container {
+  width: 100%;
 }
 </style>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -602,7 +602,7 @@ export default {
        */
       return {
         class: {
-          'truncate': headerKey === 'description' || headerKey === 'name',
+          'truncated-keys': headerKey === 'description' || headerKey === 'name',
         },
         'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
         style: {
@@ -614,6 +614,15 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.truncated-keys {
+  line-height: initial;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>
 ```
 
 ## Events
@@ -627,13 +636,13 @@ If you want to conditionally apply an event handler to `@row:click`, the value m
 
 If you always provide a function as the value for `@row:click` the table will not be able to correctly determine whether the row should be clickable without executing the callback.
 
-<h4><KIcon icon="check" size="22" color="green" style="vertical-align: sub;" class="mr-1" />Correct Usage</h4>
+<h4><KIcon icon="check" size="22" color="green" style="vertical-align: sub;" class="horizontal-spacing" />Correct Usage</h4>
 
 ```
 @row:click="isAllowedBool ? handleRowClick : undefined"
 ```
 
-<h4><KIcon icon="disabled" size="22" color="red" style="vertical-align: sub;" class="mr-1" />Incorrect Usage</h4>
+<h4><KIcon icon="disabled" size="22" color="red" style="vertical-align: sub;" class="horizontal-spacing" />Incorrect Usage</h4>
 
 ```
 @row:click="(evt, row) => isAllowedBool ? handleRowClick(evt, row) : undefined"
@@ -655,7 +664,7 @@ To avoid firing row clicks by accident, the row click handler ignores events com
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:actions>
-    <div class="float-right">
+    <div>
       <KButton appearance="secondary" @click="buttonHandler">
         Fire Button Handler!
       </KButton>
@@ -679,7 +688,7 @@ To avoid firing row clicks by accident, the row click handler ignores events com
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:actions>
-    <div class="float-right">
+    <div>
       <!-- .stop not needed on @click because we ignore clicks from buttons -->
       <KButton
         appearance="secondary"
@@ -734,7 +743,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
   <template v-slot:wrapped>
-    <div>Row click event <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
+    <div>Row click event <div class="eventful-row" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
   </template>
   <template v-slot:other>
     <div>
@@ -750,7 +759,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
         </KButton>
         <template v-slot:content>
           <div @click.stop>Clicking me does nothing!</div>
-          <div class="d-inline-block" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
+          <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
         </template>
       </KPop>
     </div>
@@ -931,7 +940,7 @@ If utilizing multiple elements, we recommend adding `display: flex; width: 100%;
 
 <KTable :fetcher="tableOptionsFetcher" :headers="tableOptionsHeaders" :hasHover="false">
   <template #toolbar="{ state }">
-    <div class="d-flex w-100 justify-content-between">
+    <div class="toolbar-container">
       <KInput v-if="state.hasData" placeholder="Search" />
       <KSelect appearance="select" :items="[{ label: 'First option', value: '1', selected: true }, { label: 'Another option', value: '2'}]" />
     </div>
@@ -941,12 +950,19 @@ If utilizing multiple elements, we recommend adding `display: flex; width: 100%;
 ```html
 <KTable :fetcher="fetcher" :headers="headers">
   <template #toolbar="{ state }">
-    <div class="d-flex w-100 justify-content-between">
+    <div class="toolbar-container">
       <KInput v-if="state.hasData" placeholder="Search" />
       <KSelect appearance="select" :items="[{ label: 'Ascending', value: 'asc', selected: true }, { label: 'Descending', value: 'desc'}]" />
     </div>
   </template>
 </KTable>
+
+<style lang="scss">
+.toolbar-container {
+  display: flex;
+  justify-content: space-between;
+}
+</style>
 ```
 
 ### Column Header and Cell
@@ -1005,9 +1021,8 @@ This example uses the [`KDropdownMenu`](/components/dropdown-menu) component as 
       <KDropdownMenu>
         <template #default>
           <KButton
-            appearance="secondary"
+            appearance="btn-link"
             size="small"
-            class="non-visual-button"
           >
             <template #icon>
               <KIcon
@@ -1051,9 +1066,8 @@ This example uses the [`KDropdownMenu`](/components/dropdown-menu) component as 
       <KDropdownMenu>
         <template #default>
           <KButton
-            appearance="secondary"
+            appearance="btn-link"
             size="small"
-            class="non-visual-button"
           >
             <template #icon>
               <KIcon
@@ -1113,10 +1127,10 @@ You can choose utilize the `.k-table-cell-title` and `.k-table-cell-description`
     hidePaginationWhenOptional
     >
     <template v-slot:name="{row}">
-      <img class="mr-2" src="/img/kong-logomark.png" :alt="row.img.alt">
-      <div class="d-flex flex-column">
+      <img class="horizontal-spacing" src="/img/kong-logomark.png" :alt="row.img.alt">
+      <div>
         <div class="k-table-cell-title">{{row.name}}</div>
-        <div class="k-table-cell-description truncate">{{row.description}}</div>
+        <div class="k-table-cell-description">{{row.description}}</div>
       </div>
     </template>
   </KTable>
@@ -1133,7 +1147,7 @@ You can choose utilize the `.k-table-cell-title` and `.k-table-cell-description`
   >
     <template #name="{row}">
       <img :alt="row.img.alt" class="mr-2" :src="row.img.src">
-      <div class="d-flex flex-column">
+      <div>
         <div class="k-table-cell-title">{{ row.name }}</div>
         <div class="k-table-cell-description">{{ row.description }}</div>
       </div>
@@ -1219,7 +1233,7 @@ the section below or completely slot in your own content.
   <template v-slot:body>
     <KTable :fetcher="emptyFetcher" :headers="headers">
       <template v-slot:empty-state>
-        <div class="w-100" style="text-align: center;">
+        <div style="text-align: center;">
           <KIcon icon="warning" />
           <div>No Content!!!</div>
         </div>
@@ -1266,7 +1280,8 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 
 #### Default Empty State Messaging
 
-<KCard class="my-2">
+<br/>
+<KCard>
   <template v-slot:body>
     <KTable :fetcher="() => { return { data: [] } }" />
   </template>
@@ -1284,7 +1299,8 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 
 #### Empty State Full Example
 
-<KCard class="my-2">
+<br/>
+<KCard>
   <template v-slot:body>
     <KTable
       :fetcher="() => { return { data: [] } }"
@@ -1361,7 +1377,8 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 #### Default Error State Messaging
 
-<KCard class="my-2">
+<br/>
+<KCard>
   <template v-slot:body>
     <KTable :fetcher="() => { return { data: [] } }" :hasError="true" />
   </template>
@@ -1379,7 +1396,8 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 #### Error State Full Example
 
-<KCard class="my-2">
+<br/>
+<KCard>
   <template v-slot:body>
     <KTable
       :fetcher="() => { return { data: [] } }"
@@ -1443,7 +1461,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 Set the `isLoading` prop to `true` to enable the loading state.
 
-<KCard class="pb-0 mt-2">
+<KCard>
   <template v-slot:body>
     <KTable
       :fetcher="() => { return { data: [] } }"
@@ -1875,7 +1893,7 @@ export default defineComponent({
        */
       return {
         class: {
-          'truncate': headerKey === 'description' || headerKey === 'name',
+          'truncated-keys': headerKey === 'description' || headerKey === 'name',
         },
         'datatest-id': `row-${rowIndex + 1}-col-${headerKey}`,
         style: {
@@ -2004,5 +2022,32 @@ export default defineComponent({
 
 .table-wrapper {
   --KTableHover: lavender;
+}
+
+.horizontal-spacing {
+  margin-right: $kui-space-40;
+}
+
+.truncated-keys {
+  line-height: initial;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.k-table-cell-description {
+  line-height: initial;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.eventful-row {
+  display: inline-block;
+}
+
+.toolbar-container {
+  display: flex;
+  justify-content: space-between;
 }
 </style>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1146,7 +1146,7 @@ You can choose utilize the `.k-table-cell-title` and `.k-table-cell-description`
     hidePaginationWhenOptional
   >
     <template #name="{row}">
-      <img :alt="row.img.alt" class="mr-2" :src="row.img.src">
+      <img :alt="row.img.alt" :src="row.img.src">
       <div>
         <div class="k-table-cell-title">{{ row.name }}</div>
         <div class="k-table-cell-description">{{ row.description }}</div>

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -320,12 +320,12 @@ export default defineComponent({
 
 ## Theming
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KTabsBottomBorderColor`| Border between the tabs and the tab content
-| `--KTabBottomBorderColor`| Border on the bottom of each tab
-| `--KTabsActiveColor`| Active color of tab and underline
-| `--KTabsColor`| Default text color of the tab items
+| Variable                   | Purpose                                     |
+| :------------------------- | :------------------------------------------ |
+| `--KTabsBottomBorderColor` | Border between the tabs and the tab content |
+| `--KTabBottomBorderColor`  | Border on the bottom of each tab            |
+| `--KTabsActiveColor`       | Active color of tab and underline           |
+| `--KTabsColor`             | Default text color of the tab items         |
 
 \
 An Example of changing the primary KButton variant to green instead of blue might

--- a/docs/components/toaster.md
+++ b/docs/components/toaster.md
@@ -235,14 +235,14 @@ export default defineComponent({
   margin-right: 4px !important;
 }
 .success.k-button {
-  --KButtonPrimaryBase: var(--green-400, #42d782);
-  --KButtonPrimaryHover: var(--green-300, #84e5ae);
-  --KButtonPrimaryActive: var(--green-500, #07a88d)
+  --KButtonPrimaryBase: #42d782;
+  --KButtonPrimaryHover: #84e5ae;
+  --KButtonPrimaryActive: #07a88d;
 }
 .warning.k-button {
-  --KButtonPrimaryBase: var(--yellow-300, #ffd68c);
-  --KButtonPrimaryHover: var(--yellow-200, #ffe6ba);
-  --KButtonPrimaryActive: var(--yellow-200, #ffe6ba);
-  color: var(--black-70, $kui-color-text) !important;
+  --KButtonPrimaryBase: #ffd68c;
+  --KButtonPrimaryHover: #ffe6ba;
+  --KButtonPrimaryActive: #ffe6ba;
+  color: $kui-color-text !important;
 }
 </style>

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -180,15 +180,15 @@ Example:
 
 <style>
 .tooltip-blue {
-  --KTooltipBackground: var(--blue-300, #{$kui-color-background-primary-weaker});
-  --KTooltipColor: var(--blue-500, #{$kui-color-text-primary});
+  --KTooltipBackground: blue;
+  --KTooltipColor: lightblue;
 }
 </style>
 ```
 
 <style>
 .tooltip-blue {
-  --KTooltipBackground: var(--blue-500, #{$kui-color-background-primary});
-  --KTooltipColor: var(--blue-200, #bdd3f9);
+  --KTooltipBackground: blue;
+  --KTooltipColor: lightblue;
 }
 </style>

--- a/docs/guide/styles/colors.md
+++ b/docs/guide/styles/colors.md
@@ -9,8 +9,8 @@ All color definitions below display in the following format:
     class="swatch" />
   <div class="description">
     <span>Color Name</span>
-    <div><code class="mb-2">--blue-500</code> (CSS variable)</div>
-    <div><code class="mb-2">#1155cb</code> (HEX value)</div>
+    <div><code>--blue-500</code> (CSS variable)</div>
+    <div><code>#1155cb</code> (HEX value)</div>
     <div><code>.color-blue-500</code> (CSS class)</div>
   </div>
 </div>

--- a/docs/guide/styles/forms.md
+++ b/docs/guide/styles/forms.md
@@ -6,27 +6,28 @@ Here is an example of html elements being styled using the including css.
 
 ## Text Inputs
 
-<br>
-<div class="k-input-wrapper mb-2"><input class="k-input" placeholder="placeholder" /></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="password" value="123" /></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="number" value="1"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="email" value="john.doe@konghq.com"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" disabled value="disabled"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" readonly value="readonly"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="search" value="search"/></div>
-<div class="k-input-wrapper mb-2 input-error"><input class="k-input" type="email" value="error"/></div>
+<div class="spacing-container">
+  <div class="k-input-wrapper"><input class="k-input" placeholder="placeholder" /></div>
+  <div class="k-input-wrapper"><input class="k-input" type="password" value="123" /></div>
+  <div class="k-input-wrapper"><input class="k-input" type="number" value="1"/></div>
+  <div class="k-input-wrapper"><input class="k-input" type="email" value="john.doe@konghq.com"/></div>
+  <div class="k-input-wrapper"><input class="k-input" disabled value="disabled"/></div>
+  <div class="k-input-wrapper"><input class="k-input" readonly value="readonly"/></div>
+  <div class="k-input-wrapper"><input class="k-input" type="search" value="search"/></div>
+  <div class="k-input-wrapper input-error"><input class="k-input" type="email" value="error"/></div>
+</div>
 
 > Note: Add the `input-error` class to add custom error styling
 
 ```html
-<div class="k-input-wrapper mb-2"><input class="k-input" placeholder="placeholder" /></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="password" value="123" /></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="number" value="1"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="email" value="john.doe@konghq.com"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" disabled value="disabled"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" readonly value="readonly"/></div>
-<div class="k-input-wrapper mb-2"><input class="k-input" type="search" value="search"/></div>
-<div class="k-input-wrapper mb-2 input-error"><input class="k-input" type="email" value="error"/></div>
+<div class="k-input-wrapper"><input class="k-input" placeholder="placeholder" /></div>
+<div class="k-input-wrapper"><input class="k-input" type="password" value="123" /></div>
+<div class="k-input-wrapper"><input class="k-input" type="number" value="1"/></div>
+<div class="k-input-wrapper"><input class="k-input" type="email" value="john.doe@konghq.com"/></div>
+<div class="k-input-wrapper"><input class="k-input" disabled value="disabled"/></div>
+<div class="k-input-wrapper"><input class="k-input" readonly value="readonly"/></div>
+<div class="k-input-wrapper"><input class="k-input" type="search" value="search"/></div>
+<div class="k-input-wrapper input-error"><input class="k-input" type="email" value="error"/></div>
 ```
 
 ## Checkboxes & Radios
@@ -50,21 +51,22 @@ Here is an example of html elements being styled using the including css.
 
 By default labels inherit body styles however you can add the `.k-input-label` class for kong styles
 Additionally you can add block level hint text by using the `.help` class.
-<br>
-<div class="mb-2">
-  <input id="checkbox" class="k-input" type="checkbox" />
-  <label for="checkbox">Label Text</label>
-</div>
-<div class="mb-2">
-  <input id="radio" class="k-input" type="radio" name="radio" value="off" />
-  <label for="radio">Label Text</label>
-</div>
-<div>
-  <label for="text" class="k-input-label">Label Text</label>
-  <div class="k-input-wrapper">
-    <input id="text" class="k-input" type="text" />
+<div class="spacing-container">
+  <div>
+    <input id="checkbox" class="k-input" type="checkbox" />
+    <label for="checkbox">Label Text</label>
   </div>
-  <p class="help">This is some helpful hint text!</p>
+  <div>
+    <input id="radio" class="k-input" type="radio" name="radio" value="off" />
+    <label for="radio">Label Text</label>
+  </div>
+  <div>
+    <label for="text" class="k-input-label">Label Text</label>
+    <div class="k-input-wrapper">
+      <input id="text" class="k-input" type="text" />
+    </div>
+    <p class="help">This is some helpful hint text!</p>
+  </div>
 </div>
 
 ```html
@@ -84,3 +86,11 @@ Additionally you can add block level hint text by using the `.help` class.
   <p class="help">This is some helpful hint text!</p>
 </div>
 ```
+
+<style lang="scss">
+.spacing-container {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-40;
+}
+</style>

--- a/docs/guide/styles/theming.md
+++ b/docs/guide/styles/theming.md
@@ -20,21 +20,21 @@ Take a look at individual components to see what properties are themable. Two ex
 
 ### `KInput` Example
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KInputBackground`| Default background
-| `--KInputBorder`| Default border
-| `--KInputColor`| Default font color
-| `--KInputFocus`| Focus color
-| `--KInputDisabledBackground`| Disabled background
-| `--KInputError`| Error border
-| `--KInputPlaceholderColor`| Placeholder text color
+| Variable                     | Purpose                |
+| :--------------------------- | :--------------------- |
+| `--KInputBackground`         | Default background     |
+| `--KInputBorder`             | Default border         |
+| `--KInputColor`              | Default font color     |
+| `--KInputFocus`              | Focus color            |
+| `--KInputDisabledBackground` | Disabled background    |
+| `--KInputError`              | Error border           |
+| `--KInputPlaceholderColor`   | Placeholder text color |
 
 ::: tip TIP
 Add the `input-error` class to add error styling
 :::
 
-<KInput id="theme-page-kinput" class="input-error w-50" type="email" value="error" label="This input has a custom error border color" />
+<KInput id="theme-page-kinput" class="input-error" type="email" value="error" label="This input has a custom error border color" />
 
 ```html{6-8}
 <template>
@@ -50,11 +50,11 @@ Add the `input-error` class to add error styling
 
 ### `KPop` Example
 
-| Variable | Purpose
-|:-------- |:-------
-| `--KPopBackground`| Default background
-| `--KPopBorder`| Default border
-| `--KPopColor`| Default font color
+| Variable           | Purpose            |
+| :----------------- | :----------------- |
+| `--KPopBackground` | Default background |
+| `--KPopBorder`     | Default border     |
+| `--KPopColor`      | Default font color |
 
 You can also scope the CSS variable to a single component by providing a parent selector. Here's an Example of changing the color of KPopover text
 

--- a/docs/guide/styles/utilities.md
+++ b/docs/guide/styles/utilities.md
@@ -236,7 +236,7 @@ We support both single line truncation as well as multi-line. Multi-line truncat
 <style lang="scss" scoped>
 table:not(:first-of-type) td {
   &:first-of-type { color: #6b46c1; }
-  &:last-of-type { color: var(--blue-700); }
+  &:last-of-type { color: var(--blue-700, #0a2b66); }
 }
 .multi-line-truncation {
   --TMaxLineLimit: 5;

--- a/docs/guide/styles/utilities.md
+++ b/docs/guide/styles/utilities.md
@@ -236,7 +236,7 @@ We support both single line truncation as well as multi-line. Multi-line truncat
 <style lang="scss" scoped>
 table:not(:first-of-type) td {
   &:first-of-type { color: #6b46c1; }
-  &:last-of-type { color: var(--blue-700, #0a2b66); }
+  &:last-of-type { color: #0a2b66; }
 }
 .multi-line-truncation {
   --TMaxLineLimit: 5;

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ features:
 /* Homepage Components button */
 .VPContent.is-home .VPButton.medium.alt[href^="/components/"] {
   color: #fff;
-  border-color: var(--green-500, #07a88d);
-  background-color: var(--green-500, #07a88d);
+  border-color: #07a88d;
+  background-color: #07a88d;
 }
 </style>

--- a/src/components/KDropdownMenu/KDropdownItem.vue
+++ b/src/components/KDropdownMenu/KDropdownItem.vue
@@ -200,7 +200,7 @@ li.k-dropdown-item {
   .k-dropdown-item-trigger.btn-link {
     color: var(--black-70, var(--kui-color-text, $kui-color-text));
     line-height: var(--kui-line-height-40, $kui-line-height-40);
-    padding: var(--spacing-md, spacing(md)) var(--spacing-lg, spacing(lg));
+    padding: var(--spacing-md, var(--kui-space-60, $kui-space-60)) var(--spacing-lg, var(--kui-space-80, $kui-space-80));
     text-align: left;
     text-decoration: none;
     width: 100%;

--- a/src/components/KDropdownMenu/KDropdownMenu.cy.ts
+++ b/src/components/KDropdownMenu/KDropdownMenu.cy.ts
@@ -169,7 +169,6 @@ describe('KDropdownMenu', () => {
     <KDropdownItem
       has-divider
       is-dangerous
-      class="d-inline-block"
     >
       <a
         href="http://www.google.com"

--- a/src/components/KSkeleton/TableSkeleton.vue
+++ b/src/components/KSkeleton/TableSkeleton.vue
@@ -58,7 +58,6 @@ $screen-md: $kui-breakpoint-phablet;
     /** Hide columns on smaller screens */
 
     .skeleton-cell {
-      // 'mr-6': cell !== columns
       margin-right: var(--kui-space-90, $kui-space-90) !important;
 
       &:last-child {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -22,50 +22,50 @@
 }
 
 @mixin input-default {
-  background-color: var(--KInputBackground, var(--white, color(white)));
-  box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
+  background-color: var(--KInputBackground, var(--white, #ffffff));
+  box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300, #e7e7ec)) !important;
   transition: color 0.1s ease, box-shadow 0.1s ease;
 }
 
 @mixin input-focus {
-  box-shadow: inset 0 0 0 1px var(--KInputFocus, var(--blue-400)) !important;
+  box-shadow: inset 0 0 0 1px var(--KInputFocus, var(--blue-400, #3972d5)) !important;
   outline: none !important;
   transition: all 0.1s ease;
 }
 
 @mixin textarea-default {
-  background-color: var(--KInputBackground, var(--white, color(white)));
+  background-color: var(--KInputBackground, var(--white, #ffffff));
   box-shadow: none !important;
-  outline: 1px solid var(--KInputBorder, var(--grey-300)) !important;
+  outline: 1px solid var(--KInputBorder, var(--grey-300, #e7e7ec)) !important;
   transition: color 0.1s ease, box-shadow 0.1s ease;
 }
 
 @mixin textarea-hover {
   box-shadow: none !important;
-  outline: 1px solid var(--KInputHover, var(--blue-200)) !important;
+  outline: 1px solid var(--KInputHover, var(--blue-200, #bdd3f9)) !important;
   transition: all 0.1s ease;
 }
 
 @mixin textarea-focus {
   box-shadow: none !important;
-  outline: 1px solid var(--blue-400) !important;
+  outline: 1px solid var(--blue-400, #3972d5) !important;
   transition: all 0.1s ease;
 }
 
 @mixin input-hover {
-  box-shadow: inset 0 0 0 1px var(--KInputHover, var(--blue-200)) !important;
+  box-shadow: inset 0 0 0 1px var(--KInputHover, var(--blue-200, #bdd3f9)) !important;
   transition: all 0.1s ease;
 }
 
 @mixin input-readonly {
-  background-color: var(--KInputReadonlyBackground, var(--grey-100, color(grey-100)));
-  box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
+  background-color: var(--KInputReadonlyBackground, var(--grey-100, #f8f8fa));
+  box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300, #e7e7ec)) !important;
   transition: all 0.1s ease;
 }
 
 @mixin input-disabled {
-  background-color: var(--KInputDisabledBackground, var(--grey-100, color(grey-100)));
-  box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300)) !important;
+  background-color: var(--KInputDisabledBackground, var(--grey-100, #f8f8fa));
+  box-shadow: inset 0 0 0 1px var(--KInputBorder, var(--grey-300, #e7e7ec)) !important;
   cursor: not-allowed;
   font-style: italic;
   transition: all 0.1s ease;
@@ -73,7 +73,7 @@
 
 @mixin fullscreen-loading-container {
   align-items: center;
-  background: var(--white, color(white));
+  background: var(--white, #ffffff);
   bottom: 0;
   display: flex;
   flex-direction: column;

--- a/src/styles/forms/_checkbox-radio.scss
+++ b/src/styles/forms/_checkbox-radio.scss
@@ -2,9 +2,9 @@
 
 input.k-input,
 input.form-control {
-  $borderColor: var(--KInputBorder, var(--grey-300, color(grey-300)));
-  $primaryCheckboxColor: var(--KCheckboxPrimary, var(--blue-500, color(blue-500)));
-  $primaryRadioColor: var(--KRadioPrimary, var(--blue-500, color(blue-500)));
+  $borderColor: var(--KInputBorder, var(--grey-300, #e7e7ec));
+  $primaryCheckboxColor: var(--KCheckboxPrimary, var(--blue-500, #1155cb));
+  $primaryRadioColor: var(--KRadioPrimary, var(--blue-500, #1155cb));
 
   &[type="checkbox"],
   &[type="radio"] {
@@ -70,13 +70,13 @@ input.form-control {
     }
 
     &:disabled:not(:checked) {
-      background-color: var(--KInputCheckboxDisabled, var(--grey-100, color(grey-100)));
-      border: 1px solid var(--KCheckboxDisabledChecked, var(--grey-400, color(grey-400)));
+      background-color: var(--KInputCheckboxDisabled, var(--grey-100, #f8f8fa));
+      border: 1px solid var(--KCheckboxDisabledChecked, var(--grey-400, #b6b6bd));
       border-radius: 2px;
     }
     &:disabled:checked {
-      background-color: var(--KCheckboxDisabledChecked, var(--grey-400, color(grey-400)));
-      // border: 1px solid var(--KCheckboxDisabledChecked, var(--grey-400, color(grey-400)));;
+      background-color: var(--KCheckboxDisabledChecked, var(--grey-400, #b6b6bd));
+      // border: 1px solid var(--KCheckboxDisabledChecked, var(--grey-400, #b6b6bd));;
     }
   }
 
@@ -108,10 +108,10 @@ input.form-control {
       }
 
       &:disabled {
-        border-color: var(--KInputRadioDisabled, var(--grey-400, color(grey-400)));
+        border-color: var(--KInputRadioDisabled, var(--grey-400, #b6b6bd));
 
         &:after {
-          background-color: var(--KInputRadioDisabled, var(--grey-400, color(grey-400)));
+          background-color: var(--KInputRadioDisabled, var(--grey-400, #b6b6bd));
         }
       }
     }
@@ -123,7 +123,7 @@ input.form-control {
     }
 
     &:disabled {
-      background-color: var(--KInputRadioDisabled, var(--grey-200, color(grey-200)));
+      background-color: var(--KInputRadioDisabled, var(--grey-200, #f1f1f5));
     }
   }
 }

--- a/src/styles/forms/_general.scss
+++ b/src/styles/forms/_general.scss
@@ -14,6 +14,7 @@
 .k-input-wrapper + .help {
   color: var(--black-45, rgba(0, 0, 0, 0.45));
   display: block;
-  font-size: var(--type-sm, 14px);
-  margin: var(--spacing-xs, 8px) 0 0;
+  font-size: var(--type-sm, var(--kui-font-size-30, $kui-font-size-30));
+  margin: var(--spacing-xs, var(--kui-space-40, $kui-space-40)) var(--kui-space-0, $kui-space-0)
+    var(--kui-space-0, $kui-space-0);
 }

--- a/src/styles/forms/_general.scss
+++ b/src/styles/forms/_general.scss
@@ -1,12 +1,12 @@
 .form-group {
   $borderColor: var(--KInputBorder, var(--grey-300, #e7e7ec));
   display: block;
-  margin-bottom: var(--lg, 24px);
+  margin-bottom: 24px;
   width: 100%;
 
   hr {
     border-color: $borderColor;
-    margin: var(--xl, 32px) 0;
+    margin: 32px 0;
   }
 }
 

--- a/src/styles/forms/_general.scss
+++ b/src/styles/forms/_general.scss
@@ -1,19 +1,19 @@
 .form-group {
-  $borderColor: var(--KInputBorder, var(--grey-300, color(grey--grey-300)));
+  $borderColor: var(--KInputBorder, var(--grey-300, #e7e7ec));
   display: block;
-  margin-bottom: var(--lg, spacing(lg));
+  margin-bottom: var(--lg, 24px);
   width: 100%;
 
   hr {
     border-color: $borderColor;
-    margin: var(--xl, spacing(xl)) 0;
+    margin: var(--xl, 32px) 0;
   }
 }
 
 .k-input + .help,
 .k-input-wrapper + .help {
-  color: var(--black-45, color(black-45));
+  color: var(--black-45, rgba(0, 0, 0, 0.45));
   display: block;
-  font-size: var(--type-sm, type(sm));
-  margin: var(--spacing-xs, spacing(xs)) 0 0;
+  font-size: var(--type-sm, 14px);
+  margin: var(--spacing-xs, 8px) 0 0;
 }

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -18,7 +18,7 @@
     color: var(--KLabelRequiredAsteriskColor, var(--KInputBorder, var(--grey-600, #3c4557)));
     font-size: 11px;
     font-weight: 500;
-    margin-left: var(--spacing-xxs);
+    margin-left: var(--spacing-xxs, var(--kui-space-20, $kui-space-20));
   }
 
   label {
@@ -86,7 +86,7 @@
     box-sizing: border-box;
     color: var(--KInputColor, var(--black-70, rgba(0, 0, 0, 0.7)));
     display: block;
-    font-size: var(--type-md, 16px);
+    font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
     font-weight: 400;
     line-height: var(--kui-line-height-40, $kui-line-height-40);
     padding: var(--kui-space-40, $kui-space-40) var(--spacing-md, var(--kui-space-60, $kui-space-60));
@@ -94,13 +94,13 @@
     @include input-default;
 
     &.k-input-small {
-      font-size: var(--type-xs, 12px);
+      font-size: var(--type-xs, var(--kui-font-size-20, $kui-font-size-20));
       padding: var(--spacing-xs, var(--kui-space-40, $kui-space-40))
         var(--spacing-sm, var(--kui-space-50, $kui-space-50));
     }
 
     &.k-input-large {
-      font-size: var(--type-md, 16px);
+      font-size: var(--type-md, var(--kui-font-size-40, $kui-font-size-40));
       padding: var(--spacing-md, var(--kui-space-60, $kui-space-60))
         var(--spacing-lg, var(--kui-space-80, $kui-space-80));
     }

--- a/src/styles/forms/_inputs.scss
+++ b/src/styles/forms/_inputs.scss
@@ -5,17 +5,17 @@
   position: relative;
 
   .hovered:not(.readonly) {
-    color: var(--KInputHover, var(--blue-500));
+    color: var(--KInputHover, var(--blue-500, #1155cb));
     transition: color 0.1s ease;
   }
 
   .focused:not(.readonly) {
-    color: var(--KInputFocus, var(--blue-500));
+    color: var(--KInputFocus, var(--blue-500, #1155cb));
     transition: color 0.1s ease;
   }
 
   .is-required {
-    color: var(--KLabelRequiredAsteriskColor, var(--KInputBorder, var(--grey-600)));
+    color: var(--KLabelRequiredAsteriskColor, var(--KInputBorder, var(--grey-600, #3c4557)));
     font-size: 11px;
     font-weight: 500;
     margin-left: var(--spacing-xxs);
@@ -23,7 +23,7 @@
 
   label {
     background-color: var(--KInputBackground, var(--white));
-    color: var(--KInputBorder, var(--grey-600));
+    color: var(--KInputBorder, var(--grey-600, #3c4557));
     display: inline-block;
     font-size: 11px;
     font-weight: 500;
@@ -38,28 +38,28 @@
     z-index: 1;
 
     &.hovered:not(.readonly) {
-      color: var(--KInputHover, var(--blue-500));
+      color: var(--KInputHover, var(--blue-500, #1155cb));
       transition: color 0.1s ease;
 
       .is-required {
-        color: var(--KInputHover, var(--blue-500));
+        color: var(--KInputHover, var(--blue-500, #1155cb));
       }
     }
 
     &.focused:not(.readonly) {
-      color: var(--KInputFocus, var(--blue-500));
+      color: var(--KInputFocus, var(--blue-500, #1155cb));
       transition: color 0.1s ease;
 
       .is-required {
-        color: var(--KInputFocus, var(--blue-500));
+        color: var(--KInputFocus, var(--blue-500, #1155cb));
       }
     }
 
     &.disabled {
-      color: var(--grey-500);
+      color: var(--grey-500, #6f7787);
 
       .is-required {
-        color: var(--grey-500);
+        color: var(--grey-500, #6f7787);
       }
     }
   }
@@ -84,9 +84,9 @@
     border: none;
     border-radius: 3px;
     box-sizing: border-box;
-    color: var(--KInputColor, var(--black-70, color(black-70)));
+    color: var(--KInputColor, var(--black-70, rgba(0, 0, 0, 0.7)));
     display: block;
-    font-size: var(--type-md, type(md));
+    font-size: var(--type-md, 16px);
     font-weight: 400;
     line-height: var(--kui-line-height-40, $kui-line-height-40);
     padding: var(--kui-space-40, $kui-space-40) var(--spacing-md, var(--kui-space-60, $kui-space-60));
@@ -94,13 +94,13 @@
     @include input-default;
 
     &.k-input-small {
-      font-size: var(--type-xs, type(xs));
+      font-size: var(--type-xs, 12px);
       padding: var(--spacing-xs, var(--kui-space-40, $kui-space-40))
         var(--spacing-sm, var(--kui-space-50, $kui-space-50));
     }
 
     &.k-input-large {
-      font-size: var(--type-md, type(md));
+      font-size: var(--type-md, 16px);
       padding: var(--spacing-md, var(--kui-space-60, $kui-space-60))
         var(--spacing-lg, var(--kui-space-80, $kui-space-80));
     }
@@ -109,7 +109,7 @@
       @include input-hover;
 
       &.k-input-large {
-        box-shadow: inset 0 0 0 2px var(--KInputHover, var(--blue-200)) !important;
+        box-shadow: inset 0 0 0 2px var(--KInputHover, var(--blue-200, #bdd3f9)) !important;
         transition: all 0.1s ease;
       }
     }
@@ -139,7 +139,7 @@
 
     /* Browser Overrides */
     &::placeholder {
-      color: var(--KInputPlaceholderColor, var(--black-45, color(black-45)));
+      color: var(--KInputPlaceholderColor, var(--black-45, rgba(0, 0, 0, 0.45)));
       font-weight: 400;
       opacity: 1;
     }
@@ -169,25 +169,25 @@
 .k-input-wrapper.input-error {
   textarea.k-input.form-control {
     box-shadow: none !important;
-    outline: 1px solid var(--red-500) !important;
+    outline: 1px solid var(--red-500, #d44324) !important;
     transition: color 0.1s ease;
   }
 
   .k-input,
   .k-input:hover,
   .k-input:focus {
-    box-shadow: inset 0 0 0 1.5px var(--KInputError, var(--red-500, color(red-500))) !important;
+    box-shadow: inset 0 0 0 1.5px var(--KInputError, var(--red-500, #d44324)) !important;
     outline: none !important;
     transition: color 0.1s ease;
 
     &.k-input-large {
-      box-shadow: inset 0 0 0 2px var(--KInputError, var(--red-500, color(red-500))) !important;
+      box-shadow: inset 0 0 0 2px var(--KInputError, var(--red-500, #d44324)) !important;
       transition: color 0.1s ease;
     }
   }
 
   .text-on-input label {
-    color: var(--KInputError, var(--red-500, color(red-500)));
+    color: var(--KInputError, var(--red-500, #d44324));
     transition: color 0.1s ease;
   }
 }
@@ -197,7 +197,7 @@ select.k-input {
   &:not([type="checkbox"]):read-only,
   &:not([type="radio"]),
   &:not([type="radio"]):read-only {
-    background-color: var(--KInputSelectBackground, var(--white, color(white)));
+    background-color: var(--KInputSelectBackground, var(--white, #ffffff));
     height: 38px;
   }
 }

--- a/src/styles/forms/_labels.scss
+++ b/src/styles/forms/_labels.scss
@@ -4,15 +4,15 @@
   display: inline-flex;
   font-family: var(--KInputLabelFont, var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text)));
   font-size: var(--KInputLabelSize, var(--type-sm, var(--kui-font-size-30, $kui-font-size-30)));
-  font-weight: var(--KInputLabelWeight, 600);
+  font-weight: var(--KInputLabelWeight, var(--kui-font-weight-semibold, $kui-font-weight-semibold));
   line-height: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30)));
   margin-bottom: var(--KInputLabelMargin, var(--spacing-xs, var(--kui-space-40, $kui-space-40)));
 
   .is-required {
     color: var(--KLabelRequiredAsteriskColor, var(--KInputLabelColor));
-    font-size: var(--KInputLabelSize, var(--type-sm, 14px));
-    font-weight: var(--KInputLabelWeight, 600);
-    margin-left: var(--spacing-xxs);
+    font-size: var(--KInputLabelSize, var(--type-sm, var(--kui-font-size-30, $kui-font-size-30)));
+    font-weight: var(--KInputLabelWeight, var(--kui-font-weight-semibold, $kui-font-weight-semibold));
+    margin-left: var(--spacing-xxs, var(--kui-space-20, $kui-space-20));
   }
 
   .label-tooltip {
@@ -21,7 +21,7 @@
   }
 
   .kong-icon {
-    margin-left: var(--spacing-xxs);
+    margin-left: var(--spacing-xxs, var(--kui-space-20, $kui-space-20));
   }
 }
 
@@ -33,8 +33,8 @@
       --KInputCheckboxLabelFont,
       var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text))
     );
-    font-size: var(--KInputCheckboxLabelSize, var(--type-md, 16px));
+    font-size: var(--KInputCheckboxLabelSize, var(--type-md, var(--kui-font-size-40, $kui-font-size-40)));
     font-weight: normal;
-    margin-bottom: 0;
+    margin-bottom: var(--kui-space-0, $kui-space-0);
   }
 }

--- a/src/styles/forms/_labels.scss
+++ b/src/styles/forms/_labels.scss
@@ -10,7 +10,7 @@
 
   .is-required {
     color: var(--KLabelRequiredAsteriskColor, var(--KInputLabelColor));
-    font-size: var(--KInputLabelSize, var(--type-sm, type(sm)));
+    font-size: var(--KInputLabelSize, var(--type-sm, 14px));
     font-weight: var(--KInputLabelWeight, 600);
     margin-left: var(--spacing-xxs);
   }
@@ -28,9 +28,9 @@
 .k-inputCheckbox,
 .k-inputRadio {
   &.k-input-label {
-    color: var(--KInputCheckboxLabel, var(--black-70, color(black-70)));
+    color: var(--KInputCheckboxLabel, var(--black-70, rgba(0, 0, 0, 0.7)));
     font-family: var(--KInputCheckboxLabelFont, var(--font-family-sans, font(sans)));
-    font-size: var(--KInputCheckboxLabelSize, var(--type-md, type(md)));
+    font-size: var(--KInputCheckboxLabelSize, var(--type-md, 16px));
     font-weight: normal;
     margin-bottom: 0;
   }

--- a/src/styles/forms/_labels.scss
+++ b/src/styles/forms/_labels.scss
@@ -2,7 +2,7 @@
 .k-input-label {
   color: var(--KInputLabelColor, var(--black-85));
   display: inline-flex;
-  font-family: var(--KInputLabelFont, var(--font-family-sans, font(sans)));
+  font-family: var(--KInputLabelFont, var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text)));
   font-size: var(--KInputLabelSize, var(--type-sm, var(--kui-font-size-30, $kui-font-size-30)));
   font-weight: var(--KInputLabelWeight, 600);
   line-height: var(--KInputLabelLineHeight, var(--type-lg, var(--kui-line-height-30, $kui-line-height-30)));
@@ -29,7 +29,10 @@
 .k-inputRadio {
   &.k-input-label {
     color: var(--KInputCheckboxLabel, var(--black-70, rgba(0, 0, 0, 0.7)));
-    font-family: var(--KInputCheckboxLabelFont, var(--font-family-sans, font(sans)));
+    font-family: var(
+      --KInputCheckboxLabelFont,
+      var(--font-family-sans, var(--kui-font-family-text, $kui-font-family-text))
+    );
     font-size: var(--KInputCheckboxLabelSize, var(--type-md, 16px));
     font-weight: normal;
     margin-bottom: 0;

--- a/src/styles/forms/_switch.scss
+++ b/src/styles/forms/_switch.scss
@@ -3,7 +3,7 @@
 
 $width: 44px;
 $height: 24px;
-$color_checkbox_success: var(--KInputSwitchOn, var(--green-500, color(green-500)));
+$color_checkbox_success: var(--KInputSwitchOn, var(--green-500, #07a88d));
 $transition: 0.2s linear;
 
 .k-switch {
@@ -22,7 +22,7 @@ $transition: 0.2s linear;
     left: 26px;
   }
   .switch-control {
-    background-color: var(--KInputSwitchBackground, var(--grey-400, color(grey-400)));
+    background-color: var(--KInputSwitchBackground, var(--grey-400, #b6b6bd));
     border-radius: 12px;
     display: block;
     height: $height;
@@ -38,7 +38,7 @@ $transition: 0.2s linear;
 
     // Toggle
     &:after {
-      background-color: var(--white, color(white));
+      background-color: var(--white, #ffffff);
       border-radius: 50%;
       content: "";
       display: block;
@@ -72,6 +72,6 @@ $transition: 0.2s linear;
   }
 
   span {
-    color: var(--KInputSwitchLabel, var(--black-70, color(black-70)));
+    color: var(--KInputSwitchLabel, var(--black-70, rgba(0, 0, 0, 0.7)));
   }
 }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-8146

Replaces all usage of Kongponents utilities:
- utility classes (e.g. `w-100, mb-4, d-flex`, etc.)
- provides hardcoded value fallbacks for color/type/spacing variables and removes functions

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
