### PR TITLE
feat(ktable): adds props.paginationPageNumber

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -485,6 +485,10 @@ If not provided the fetcher response should return a top-level property `total` 
 
 Pass in a number of pagination neighbors to be used by the pagination component. See more detail in the [Pagination](/components/pagination.html#neighbors) docs.
 
+### paginationPageNumber
+
+Can be used to update the current page from a source external to KTable (e.g. in response to a browser history navigation). Behaves exactly as interactions with the built-in pagination do.
+
 ### paginationPageSizes
 
 Pass in an array of page sizes for the page size dropdown. If not provided will default to the following:

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -473,6 +473,13 @@ const props = defineProps({
     default: 1,
   },
   /**
+   * Can be used to update the current page from a source external to KTable (e.g. in response to a browser history navigation). Behaves exactly as interactions with the built-in pagination do.
+   */
+  paginationPageNumber: {
+    type: Number,
+    default: null,
+  },
+  /**
    * A prop to pass in an array of page sizes used by the pagination component
    */
   paginationPageSizes: {
@@ -961,6 +968,12 @@ watch([query, page, pageSize], async (newData, oldData) => {
     isRevalidating.value = false
   }
 }, { deep: true, immediate: true })
+
+watch(() => props.paginationPageNumber, () => {
+  if (props.paginationPageNumber !== page.value) {
+    page.value = props.paginationPageNumber
+  }
+})
 
 onMounted(() => {
   initData()


### PR DESCRIPTION
# Summary

Adds support for `props.paginationPageNumber` which allows one to set KTable’s current page from an external source. This behaves exactly as interactions with the built-in pagination do.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- I think this ability should be built into KTable. Currently, the only alternative would be updating the table’s `key` prop whenever a page changes externally. This would trigger `KTable`’s `onMounted` hook and let it read the now-changed page number from `props.initialFetcherParams`. While this works, I consider it a hack. It shouldn’t require a re-mount of KTable to change the page number in situations that KTable can’t control (e.g. browser history navigation).

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [x] **Tests pass:** check the output of yarn test
* [x] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [x] **Framework style:** abides by the essential rules in Vue's style guide
* [x] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [x] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
