### PR TITLE
fix(ktable): allow users to select table cell text

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -1123,11 +1123,6 @@ export const defaultSorter = (key: string, previousKey: string, sortOrder: strin
   }
 
   &.is-clickable {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-
     tbody tr {
       cursor: pointer;
     }


### PR DESCRIPTION
# Summary

Allow users to select the text within a clickable table row/cell

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
