### PR TITLE
fix(KSelect): add optional chaining for props.items [KHCP-8828]

### DIFF
--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -59,10 +59,10 @@ const emit = defineEmits(['selected'])
 
 const handleItemSelect = (item: MultiselectItem, isNew?: boolean) => emit('selected', item, isNew)
 
-const nonGroupedItems = computed((): MultiselectItem[] => props.items.filter(item => !item.group))
-const groups = computed((): string[] => [...new Set((props.items.filter(item => item.group) as unknown as MultiselectItemWithGroup[]).map(item => item.group))].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())))
+const nonGroupedItems = computed((): MultiselectItem[] => props.items?.filter(item => !item.group))
+const groups = computed((): string[] => [...new Set((props.items?.filter(item => item.group) as unknown as MultiselectItemWithGroup[]).map(item => item.group))].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())))
 
-const getGroupItems = (group: string) => props.items.filter(item => item.group === group)
+const getGroupItems = (group: string) => props.items?.filter(item => item.group === group)
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -58,12 +58,12 @@ const emit = defineEmits<{
 
 const handleItemSelect = (item: SelectItem) => emit('selected', item)
 
-const nonGroupedItems = computed((): SelectItem[] => props.items.filter(item => !item.group))
+const nonGroupedItems = computed((): SelectItem[] => props.items?.filter(item => !item.group))
 const groups = computed((): string[] =>
-  [...new Set((props.items.filter(item => item.group) as unknown as SelectItemWithGroup[])
+  [...new Set((props.items?.filter(item => item.group) as unknown as SelectItemWithGroup[])
     .map(item => item.group))].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())))
 
-const getGroupItems = (group: string) => props.items.filter(item => item.group === group)
+const getGroupItems = (group: string) => props.items?.filter(item => item.group === group)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
https://konghq.atlassian.net/browse/KHCP-8828

Fix DD error [https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A6e430333-9e0f-4d6b-ac63-5f7d4ad9a641 env%3Aprod -%40browser.name%3AHeadlessChrome %40issue.age%3A<%3D300000&issueId=bed92134-467c-11ee-9f79-da7ad0900002&from_ts=1693320929000&to_ts=1693321229000&live=false](https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A6e430333-9e0f-4d6b-ac63-5f7d4ad9a641%20env%3Aprod%20-%40browser.name%3AHeadlessChrome%20%40issue.age%3A%3C%3D300000&issueId=bed92134-467c-11ee-9f79-da7ad0900002&from_ts=1693320929000&to_ts=1693321229000&live=false)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
