### PR TITLE
docs(*): fix vitepress colors

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
   lastUpdated: true,
   markdown: {
     lineNumbers: true,
+    theme: 'material-theme-palenight'
   },
   appearance: false, // Disable dark mode (If enabled, we'd first need to update Kongponent CSS to handle accordingly)
   themeConfig: {

--- a/docs/.vitepress/theme/_variables.scss
+++ b/docs/.vitepress/theme/_variables.scss
@@ -2,12 +2,21 @@
 // https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css
 
 :root {
-  --vp-c-brand: #1155cb;
-  --vp-c-brand-light: #3972d5;
-  --vp-c-brand-lighter: #8ab3fa;
-  --vp-c-brand-dark: #003694;
-  --vp-c-brand-darker: #0a2b66;
+  --vp-button-brand-bg: #{$kui-color-background-primary};
+  --vp-button-brand-hover-bg: #{$kui-color-background-primary-strong};
+
   // Homepage site name color
   --vp-home-hero-name-color: transparent;
   --vp-home-hero-name-background: linear-gradient(120deg, #169fcc, #42d782);
+
+  // Code block
+  --vp-code-block-bg: #{$kui-color-background-neutral-strongest};
+  --vp-code-line-number-color: #{$kui-color-text-neutral};
+  --vp-code-block-divider-color: #{$kui-color-background-neutral-stronger};
+  // copy button
+  --vp-code-copy-code-border-color: rgba(128, 128, 128, 1); // grey to match default icon color
+  --vp-code-copy-code-bg: #{$kui-color-background-neutral-stronger};
+  --vp-code-copy-code-hover-border-color: rgba(128, 128, 128, 1); // grey to match default icon color
+  --vp-code-copy-code-hover-bg: #{$kui-color-background-neutral-stronger};
+  --vp-code-copy-code-active-text: rgba(128, 128, 128, 1); // grey to match default icon color
 }


### PR DESCRIPTION
# Summary

Fixes theming variables and default theme change released in recent [vitepress version breaking change](https://github.com/vuejs/vitepress/blob/main/CHANGELOG.md#100-rc9-2023-08-28).

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
