### PR TITLE
fix(multi-select): optimize overflow detection for selected items container

### DIFF
--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -576,4 +576,23 @@ describe('KMultiselect', () => {
     cy.get('.k-multiselect-item').eq(3).should('contain.text', items[2].label)
     cy.get('.k-multiselect-item').eq(4).should('contain.text', items[4].label)
   })
+
+  it('should able to handle tons of items with no obvious lag', () => {
+    const items = Array.from(new Array(500)).map((_, i) => ({
+      label: `Item ${i}`,
+      value: `${i}`,
+      selected: i < 400,
+    }))
+
+    const startTime = Date.now()
+
+    mount(KMultiselect, {
+      props: {
+        testMode: true,
+        items,
+      },
+    }).then(() => {
+      expect(Date.now() - startTime).to.be.lessThan(3000)
+    })
+  })
 })

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -604,10 +604,19 @@ const stageSelections = () => {
     if (elem) {
       const height = elem.clientHeight
       if (height > selectionsMaxHeight.value) {
-        const item = visibleSelectedItemsStaging.value.pop()
-        if (item && !invisibleSelectedItemsStagingSet.has(item.value)) {
-          invisibleSelectedItemsStagingSet.add(item.value)
-          invisibleSelectedItemsStaging.value.push(item)
+        // populate as much items as possible by checking the offsetTop
+        const overflowedElements = Array.from(elem.querySelectorAll('.k-multiselect-selection-badge'))
+          .filter(badge => (badge as HTMLElement).offsetTop >= selectionsMaxHeight.value)
+
+        // if there are overflowed items, move them to the invisibleSelectedItemsStaging array
+        const cutPoint = visibleSelectedItemsStaging.value.length - overflowedElements.length
+        const overflowedItems = visibleSelectedItemsStaging.value.splice(cutPoint, overflowedElements.length)
+
+        for (const item of overflowedItems) {
+          if (!invisibleSelectedItemsStagingSet.has(item.value)) {
+            invisibleSelectedItemsStagingSet.add(item.value)
+            invisibleSelectedItemsStaging.value.push(item)
+          }
         }
       }
       stagingKey.value++
@@ -888,9 +897,9 @@ watch(() => props.items, (newValue, oldValue) => {
         visibleSelectedItemsStaging.value.push(selectedItem)
       }
     }
-
-    stageSelections()
   }
+
+  stageSelections()
 
   // Trigger an update to the popper element to cause the popover to redraw
   // This prevents the popover from displaying "detached" from the KSelect


### PR DESCRIPTION
Issues observed with `<MultiSelect />`:
1. Excessive calls to `stageSelections()`. The current implementation schedules `items.length` macro tasks while `items` changed, leading to forced DOM reflows due to frequent access to `clientHeight`, and multiple changes to `stagingKey`.

2. The current strategy to prevent item container flickering involves the use of an offscreen div to gauge the maximum number of pills it can accommodate. This involves populating the pills and checking for remaining space sequentially, leading to a fixed `len(selected)` times DOM updates. Large selected items adversely affect performance.

Optimizations:
- Moved `stageSelections()` outside the loop to schedule only a single task post processing of all items.
- Modified the pill measurement strategy to maximize population at once by checking the `offsetTop`, reducing unnecessary DOM updates.

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
