### PR TITLE
fix: renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,16 +28,8 @@
   "encrypted": {
     "npmToken": "wcFMA/xDdHCJBTolAQ//XFopBP9S7JuWKQTwVozdJvlVb+riW/S+U84WkQf66rxeJAqSnM3WgOK5PszWD7a84zb6FpOsr1YZTwVXBmkZBsQGQ4XUGCM+42Fs2etKSQHfUCLLGO3HDMAnz0s1Y2F3U6TbZzb2nsXwSNwyXHKSC6jK+wRvmUMs1z4uSQjhsldlb1q358oiIY7DSS2x9HzplltxSFeV2TfJdq3/AEwgPAJuaAV1+cAxiFAP2hwCY7goOTSx0OC39LHApiZgCoEJPYgdIbOtLyu5qmExenu1JUBNrt+3SNN9p7vXZiNcFcdIkZHoDmlwWdMyxOupqoxBvvlzTIVqqz16LA2k1s1P6e9SigKLv470v5KmnyMiXOk0h0GrR+fMnrq6GveZ7R9PToek1yRCwX4SAeAzLABFz4F3O2UXXQqQG/Q6SxmaGOcidIDEdXvbJ3NIcYbwPhPg0X12/vvFdDQpeSTJlOVlsy0+WIyENkfjtHN7WshzqTy2tGGacZWKeK7+qbjJAV7hKw366UlKhDHDSyRCa6zaHIIujEB/JKNgjhb/wiNy8LWzxyFhA8m/djjvnFlldzod+VbR3gM5aW1LXEEAlgzy3gfDQu0QaAhliqw5+Bx36zB20NXKTVcqZYKoa12p8mFoxGZmtMcunw0ZYHFQY6Ml+Yi4w81fMSwJh8OSYPVE0kLSbwE5f2wH72CFWu9XW4+y7yPhHhff+GRnmDkkyJSX8F4XI+OQJhNMJX0sJmO2X/RiKfz0IOLVP3YMj/NT9CUmdcAdyljjmvD1z9yZ/GNoe4XRa1I9kDN5SM782yJ8mlQlzxMX3JBaoyj5vz5GIKZdsg"
   },
-  "stabilityDays": 14,
+  "minimumReleaseAge": "14 days",
   "packageRules": [
-    {
-      "matchPackagePatterns": [
-        "^@kong\/",
-        "^@kong-ui\/",
-        "^@kong-ui-public\/"
-      ],
-      "stabilityDays": 0
-    },
     {
       "automerge": true,
       "groupName": "all non-major dependencies with stable version",
@@ -50,7 +42,18 @@
         "minor",
         "patch"
       ],
-      "stabilityDays": 10
+      "minimumReleaseAge": "10 days"
+    },
+    {
+      "automerge": true,
+      "groupName": "all kong scoped dependencies",
+      "groupSlug": "all-kong-scopes",
+      "matchPackagePatterns": [
+        "^@kong\/",
+        "^@kong-ui\/",
+        "^@kong-ui-public\/"
+      ],
+      "minimumReleaseAge": "2 hours"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -25,9 +25,6 @@
     "every weekday"
   ],
   "npmrcMerge": true,
-  "encrypted": {
-    "npmToken": "wcFMA/xDdHCJBTolAQ//XFopBP9S7JuWKQTwVozdJvlVb+riW/S+U84WkQf66rxeJAqSnM3WgOK5PszWD7a84zb6FpOsr1YZTwVXBmkZBsQGQ4XUGCM+42Fs2etKSQHfUCLLGO3HDMAnz0s1Y2F3U6TbZzb2nsXwSNwyXHKSC6jK+wRvmUMs1z4uSQjhsldlb1q358oiIY7DSS2x9HzplltxSFeV2TfJdq3/AEwgPAJuaAV1+cAxiFAP2hwCY7goOTSx0OC39LHApiZgCoEJPYgdIbOtLyu5qmExenu1JUBNrt+3SNN9p7vXZiNcFcdIkZHoDmlwWdMyxOupqoxBvvlzTIVqqz16LA2k1s1P6e9SigKLv470v5KmnyMiXOk0h0GrR+fMnrq6GveZ7R9PToek1yRCwX4SAeAzLABFz4F3O2UXXQqQG/Q6SxmaGOcidIDEdXvbJ3NIcYbwPhPg0X12/vvFdDQpeSTJlOVlsy0+WIyENkfjtHN7WshzqTy2tGGacZWKeK7+qbjJAV7hKw366UlKhDHDSyRCa6zaHIIujEB/JKNgjhb/wiNy8LWzxyFhA8m/djjvnFlldzod+VbR3gM5aW1LXEEAlgzy3gfDQu0QaAhliqw5+Bx36zB20NXKTVcqZYKoa12p8mFoxGZmtMcunw0ZYHFQY6Ml+Yi4w81fMSwJh8OSYPVE0kLSbwE5f2wH72CFWu9XW4+y7yPhHhff+GRnmDkkyJSX8F4XI+OQJhNMJX0sJmO2X/RiKfz0IOLVP3YMj/NT9CUmdcAdyljjmvD1z9yZ/GNoe4XRa1I9kDN5SM782yJ8mlQlzxMX3JBaoyj5vz5GIKZdsg"
-  },
   "minimumReleaseAge": "14 days",
   "packageRules": [
     {


### PR DESCRIPTION
# Summary

Modify the `renovate.json` config so that the package rules are ordered from least important to most important.

> Renovate evaluates all `packageRules` and does not stop after the first match. Order your `packageRules` so the **least important rules are at the top**, and the **most important rules at the bottom**. This way important rules override settings from earlier rules if needed.

Also updates `stabilityDays` (deprecated) to the [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) property.

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
