### PR TITLE
fix(kbadge): non-interactive badge being focusable

### DIFF
--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -8,7 +8,7 @@
       'clickable': isClickable
     } ]"
     :style="badgeCustomStyles"
-    :tabindex="hidden ? -1 : 0"
+    :tabindex="hidden ? -1 : isClickable ? 0 : undefined"
   >
     <component
       :is="truncationTooltip && (forceTooltip || isTruncated) ? 'KTooltip' : 'div'"
@@ -31,7 +31,7 @@
       class="k-badge-dismiss-button"
       data-testid="k-badge-dismiss-button"
       :is-rounded="shape === 'rounded'"
-      :tabindex="hidden ? -1 : 0"
+      :tabindex="hidden ? -1 : undefined"
       @click="handleDismiss"
       @click.stop
     >


### PR DESCRIPTION
# Summary

Fixes KBadge being able to receive focus when it’s not interactive. It now will only have `tabindex="0"` if a `click` handler is present.

Removes `tabindex="0"` from KBadge’s dismiss button if `props.hidden` isn’t true. Setting `tabindex="0"` is unnecessary as KButton is already focusable by virtue of being a button.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
