### PR TITLE
fix(kcodeblock): not resetting current match on query change

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -623,6 +623,7 @@ function updateMatchingLineNumbers(): void {
     }
   }
 
+  currentLineIndex.value = null
   numberOfMatches.value = totalMatchingLineNumbers.length
   matchingLineNumbers.value = Array.from(new Set(totalMatchingLineNumbers))
 


### PR DESCRIPTION
# Summary

Fixes a bug with the code block not resetting its currently matched line UI when updating the query which led to the UI showing text like "4 of 1".

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
