### PR TITLE
fix(kcodeblock): buttons not being bordered in light theme

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1189,19 +1189,16 @@ $dark-backgroundColor: var(--kui-color-background-neutral-strongest, $kui-color-
   .k-button:not(.increase-specificity) {
     @media (min-width: $kui-breakpoint-phablet) {
       background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-      border-color: var(--kui-color-border-transparent, $kui-color-border-transparent);
     }
 
     &:hover {
       background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
-      border-color: var(--kui-color-border-transparent, $kui-color-border-transparent) !important;
     }
 
     &:active,
     &.action-active:hover,
     &:hover:active {
       background-color: var(--kui-color-background-neutral, $kui-color-background-neutral);
-      border-color: $tmp-color-steel-500;
       color: var(--kui-color-text-inverse, $kui-color-text-inverse);
     }
   }

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1186,7 +1186,7 @@ $dark-backgroundColor: var(--kui-color-background-neutral-strongest, $kui-color-
 
   // TODO: If and once KButton has `props.theme` support, these styles should live in KButton.vue.
   // TODO: Fix these styles not always providing a solid background color for the copy button allowing content to clip through it.
-  .k-button:not(.increase-specificity) {
+  &.theme-light .k-button:not(.increase-specificity) {
     @media (min-width: $kui-breakpoint-phablet) {
       background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     }

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1191,7 +1191,7 @@ $dark-backgroundColor: var(--kui-color-background-neutral-strongest, $kui-color-
       background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
     }
 
-    &:hover {
+    &:hover:not(:disabled) {
       background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
     }
 
@@ -1215,27 +1215,18 @@ $dark-backgroundColor: var(--kui-color-background-neutral-strongest, $kui-color-
       border-color: var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
     }
 
-    &:hover {
+    &:hover:not(:disabled) {
       background-color: $tmp-color-steel-400;
       border-color: $tmp-color-steel-400;
       color: $dark-backgroundColor;
-
-      &:disabled {
-        background-color: $dark-backgroundColor;
-      }
     }
 
     &:active,
+    &.action-active:hover,
     &:hover:active {
       background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
       border-color: var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
       color: var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest);
-    }
-
-    &.action-active {
-      background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
-      border-color: var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
-      color: $dark-backgroundColor;
     }
   }
 }

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1072,7 +1072,7 @@ $dark-focusColor: $tmp-color-green-500;
 
 .k-code-block-secondary-actions {
   display: flex;
-  gap: var(--kui-space-20, $kui-space-20);
+  gap: var(--kui-space-40, $kui-space-40);
   position: absolute;
   right: 16px;
   top: 8px;

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -1198,8 +1198,10 @@ $dark-backgroundColor: var(--kui-color-background-neutral-strongest, $kui-color-
     &:active,
     &.action-active:hover,
     &:hover:active {
-      background-color: var(--kui-color-background-neutral, $kui-color-background-neutral);
-      color: var(--kui-color-text-inverse, $kui-color-text-inverse);
+      &:not(:disabled) {
+        background-color: var(--kui-color-background-neutral, $kui-color-background-neutral);
+        color: var(--kui-color-text-inverse, $kui-color-text-inverse);
+      }
     }
   }
 
@@ -1224,9 +1226,11 @@ $dark-backgroundColor: var(--kui-color-background-neutral-strongest, $kui-color-
     &:active,
     &.action-active:hover,
     &:hover:active {
-      background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
-      border-color: var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
-      color: var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest);
+      &:not(:disabled) {
+        background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
+        border-color: var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
+        color: var(--kui-color-text-neutral-strongest, $kui-color-text-neutral-strongest);
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

Changes the style of buttons inside the code block to have borders in the light theme.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
