### PR TITLE
fix(kemptystate): rendering empty cta element

### DIFF
--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -30,10 +30,12 @@
       >
         <slot name="message" />
       </div>
-      <div class="k-empty-state-cta">
+      <div
+        v-if="$slots.cta || (!ctaIsHidden && ctaText)"
+        class="k-empty-state-cta"
+      >
         <slot name="cta">
           <KButton
-            v-if="!ctaIsHidden && ctaText"
             appearance="primary"
             size="small"
             @click.prevent="() => handleClick && handleClick()"


### PR DESCRIPTION
# Summary

Fixes KEmptyState rendering an empty `.k-empty-state-cta` element when `props.ctaIsHidden` is set.

## Notes

This was previously fixed in #1474 but that change introduced the issue that content slotted into `cta` was hidden except if `props.ctaText` was set.

In #1486 that regression was fixed, but that change also undid the fix to rendering an empty `.k-empty-state-cta` element if no CTA was to be shown.

This change makes sure that the element is rendered if (1) the `cta ` slot is provided or (2) `props.ctaIsHidden` is `false` and `props.ctaText` is provided.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
