### PR TITLE
feat(kslideout): support optional title slot

### DIFF
--- a/docs/components/slideout.md
+++ b/docs/components/slideout.md
@@ -274,7 +274,9 @@ This prop takes a string that will be displayed as the title of the slide-out.
 
 ## Slots
 
-- `default` - used to place content into the slideout panel
+### default
+
+Used to place content into the slideout panel.
 
 ```html
 <KSlideout :is-visible="isToggled" @close="toggle">
@@ -285,8 +287,18 @@ This prop takes a string that will be displayed as the title of the slide-out.
 </KSlideout>
 ```
 
-- `before-title` - used to customize the header to add content before title
-- `after-title` - used to customize the header to add content after title
+### before-title
+
+Used to customize the header to add content before title.
+
+### title
+
+Used to place title content into the header area.
+
+### after-title
+
+Used to customize the header to add content after title.
+
 
 ## Events
 

--- a/docs/components/slideout.md
+++ b/docs/components/slideout.md
@@ -295,6 +295,44 @@ Used to customize the header to add content before title.
 
 Used to place title content into the header area.
 
+<KToggle v-slot="{ isToggled, toggle }">
+  <div>
+    <KButton @click="toggle">Toggle Panel With Title</KButton>
+    <KSlideout :is-visible="isToggled.value" @close="toggle" :has-overlay="false" close-button-alignment="end">
+      <template #before-title>
+        <KIcon icon="kong" />
+      </template>
+      <template #title>
+        <router-link to="route">Title</router-link>
+      </template>
+      <template #after-title>
+        <KIcon icon="check" />
+      </template>
+      Default content
+    </KSlideout>
+  </div>
+</KToggle>
+
+```html
+<KToggle v-slot="{ isToggled, toggle }">
+  <div>
+    <KButton @click="toggle">Toggle Panel With Title</KButton>
+    <KSlideout :is-visible="isToggled.value" @close="toggle" :has-overlay="false" close-button-alignment="end">
+      <template #before-title>
+        <KIcon icon="kong" />
+      </template>
+      <template #title>
+        <router-link to="route">Title</router-link>
+      </template>
+      <template #after-title>
+        <KIcon icon="check" />
+      </template>
+      Default content
+    </KSlideout>
+  </div>
+</KToggle>
+```
+
 ### after-title
 
 Used to customize the header to add content after title.

--- a/src/components/KSlideout/KSlideout.cy.ts
+++ b/src/components/KSlideout/KSlideout.cy.ts
@@ -36,6 +36,22 @@ describe('KSlideout', () => {
     cy.getTestId('k-slideout-title').should('be.visible')
   })
 
+  it('renders title slot when providing both title prop and slot', () => {
+    mount(KSlideout, {
+      props: {
+        isVisible: true,
+        title: 'Title prop',
+      },
+      slots: {
+        title: () => h('div', {}, [
+          h('span', {}, 'Title slot'),
+        ]),
+      },
+    })
+
+    cy.getTestId('k-slideout-title').contains('Title slot')
+  })
+
   it('renders cancel button on right when prop is used', () => {
     const closeButtonAlignmentProp = 'end'
 

--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -27,9 +27,16 @@
             <p
               class="k-slideout-title"
               data-testid="k-slideout-title"
-              :title="title"
+              :title="title ? title : undefined"
             >
-              {{ title }}
+              <slot
+                v-if="$slots.title"
+                name="title"
+              />
+
+              <template v-else>
+                {{ title }}
+              </template>
             </p>
           </div>
 


### PR DESCRIPTION
# Summary

Adds support for an optional `title` slot so that additional markup can be used in titles (e.g. a link). The slot takes priority over the prop.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: Workaround for users of Kongponents v8: Use the `before-title` slot for both before title and title content and don’t provide `props.title`.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
