### PR TITLE
chore(ktabs): removes unnecessary pseudo element

### DIFF
--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -143,16 +143,6 @@ watch(() => props.modelValue, (newTabHash) => {
         margin-right: var(--kui-space-40, $kui-space-40);
       }
 
-      &:after {
-        bottom: -2px;
-        content: '';
-        display: block;
-        height: 2px;
-        left: 0;
-        position: absolute;
-        width: 100%;
-      }
-
       &.active,
       &:hover {
         .tab-link.has-panels,


### PR DESCRIPTION
# Summary

Removes the `.k-tabs ul .tab-item:after` pseudo element styles as they don’t seem to have a clear purpose and interfere with rendering of KTabs within overflowing containers.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
