### PR TITLE
fix(ktooltip, klabel): remove tooltip slot wrapper

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -8,7 +8,7 @@
 
 ```html
 <KTooltip label="Video Games">
-  <KButton>🎮</KButton>
+  <KButton>What is your hobby?</KButton>
 </KTooltip>
 ```
 

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -3,7 +3,7 @@
 **KTooltip** is a tooltip component that is used when you need a simple label to be displayed when hovering over an element. KTooltip has a single slot that takes in the element that you want the tooltip to trigger over. At least the label prop must be passed in for the tooltip to display anything. For example a button:
 
 <KTooltip label="Video Games">
-  <KButton>🎮</KButton>
+  <KButton>What is your hobby?</KButton>
 </KTooltip>
 
 ```html

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -13,6 +13,7 @@
       <InfoIcon
         class="tooltip-trigger-icon"
         :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
+        tabindex="0"
       />
       <template #content>
         <slot name="tooltip">{{ info }}</slot>

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -11,9 +11,7 @@
     trigger="hover"
     width="auto"
   >
-    <div :tabindex="$slots.default ? '0' : '-1'">
-      <slot />
-    </div>
+    <slot />
 
     <template
       v-if="showTooltip"


### PR DESCRIPTION
# Summary

Remove slot wrapper div and add `tabindex` to label tooltip trigger icon

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
