### PR TITLE
fix(*): deprecate and update boolean props [KHCP-9548]

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -143,17 +143,17 @@ Text to display on hover if dropdown is disabled.
 />
 ```
 
-### isSelectionMenu
+### selectionMenu
 
 Defaults to `false`.
 
 Use this prop when a visual indication of the currently selected menu item is needed. 
 
-By default the dropdown has no notion of "selection". When `isSelectionMenu` is `true`, `selected` state is handled automatically when clicking a KDropdownItem if used in conjunction with the `items` prop. Each item should have a `label` and a `value`. To keep track of changes in your host app you can utilize [`@change` event](#events).
+By default the dropdown has no notion of "selection". When `selectionMenu` is `true`, `selected` state is handled automatically when clicking a KDropdownItem if used in conjunction with the `items` prop. Each item should have a `label` and a `value`. To keep track of changes in your host app you can utilize [`@change` event](#events).
 
 <ClientOnly>
   <KDropdown
-    is-selection-menu
+    selection-menu
     :items="selectionMenuItems"
     trigger-text="Select region"
     @change="handleSelectionMenuUpdate"
@@ -164,7 +164,7 @@ By default the dropdown has no notion of "selection". When `isSelectionMenu` is 
 ```vue
 <template>
   <KDropdown
-    is-selection-menu
+    selection-menu
     :items="[{ label: 'US (United States)', value: 'us' }, 
       { label: 'FR (France)', value: 'fr' }]"
     trigger-text="Select region"
@@ -186,7 +186,7 @@ If using the [`items` slot](#items-1), you will have access to the `handleSelect
 
 <ClientOnly>
   <KDropdown
-    is-selection-menu
+    selection-menu
     trigger-text="Select region (with items slot)"
     @change="handleSelectionMenuUpdate"
     show-caret
@@ -206,7 +206,7 @@ If using the [`items` slot](#items-1), you will have access to the `handleSelect
 ```vue
 <template>
   <KDropdown
-    is-selection-menu
+    selection-menu
     trigger-text="Select region (with items slot)"
     @change="handleSelectionMenuUpdate"
     show-caret
@@ -265,7 +265,7 @@ Slot props:
   - Function that triggers dropdown close.
 - `handleSelection`
   - type: `Function`
-  - Function that lets KDropdown track selected item when `isSelectionMenu` is `true`.
+  - Function that lets KDropdown track selected item when `selectionMenu` is `true`.
 
 KDropdownItem takes care of icon color, size and spacing as long as you use icons provided by [@kong/icons](https://github.com/Kong/icons) package.
 
@@ -341,13 +341,13 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
 
 ### Props
 
-| Prop          | Description                                                                                                                                                                                                                                                                                                                                         |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `item`        | The properties the link is built from, it expects a `label` and optionally a `to` or `value` (when `isSelectionMenu` is `true`). If `to` is `typeof object`, the item will be rendered as a `<router-link>`. Otherwise, if `to` is `typeof string`, it will be rendered as an `<a>` element with the value of `to` applied to the `href` attribute. |
-| `disabled`    | A boolean (defaults to `false`), indicating whether or not to disable the item.                                                                                                                                                                                                                                                                     |
-| `selected`    | A boolean (defaults to `false`), indicating whether or not the item is selected when the `isSelectionMenu` prop is `true`.                                                                                                                                                                                                                          |
-| `hasDivider`  | A boolean (defaults to `false`), indicating whether or not the item should have a divider bar displayed above it.                                                                                                                                                                                                                                   |
-| `isDangerous` | A boolean (defaults to `false`), indicating whether or not to apply danger styles (text color is red).                                                                                                                                                                                                                                              |
+| Prop          | Description                                                                                                                                                                                                                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `item`        | The properties the link is built from, it expects a `label` and optionally a `to` or `value` (when `selectionMenu` is `true`). If `to` is `typeof object`, the item will be rendered as a `<router-link>`. Otherwise, if `to` is `typeof string`, it will be rendered as an `<a>` element with the value of `to` applied to the `href` attribute. |
+| `disabled`    | A boolean (defaults to `false`), indicating whether or not to disable the item.                                                                                                                                                                                                                                                                   |
+| `selected`    | A boolean (defaults to `false`), indicating whether or not the item is selected when the `selectionMenu` prop is `true`.                                                                                                                                                                                                                          |
+| `hasDivider`  | A boolean (defaults to `false`), indicating whether or not the item should have a divider bar displayed above it.                                                                                                                                                                                                                                 |
+| `isDangerous` | A boolean (defaults to `false`), indicating whether or not to apply danger styles (text color is red).                                                                                                                                                                                                                                            |
 
 <ClientOnly>
   <KDropdown trigger-text="All kinds of dropdown items">
@@ -511,7 +511,7 @@ You can bind event handlers to `@click` event just like you would normally do wi
 
 #### change
 
-Fires when items are clicked when `isSelectionMenu` is `true`. Returns the selected menu item object or `null`.
+Fires when items are clicked when `selectionMenu` is `true`. Returns the selected menu item object or `null`.
 
 #### toggleDropdown
 

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -341,13 +341,13 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
 
 ### Props
 
-| Prop          | Description                                                                                                                                                                                                                                                                                                                                       |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `item`        | The properties the link is built from, it expects a `label` and optionally a `to` or `value` (when `selectionMenu` is `true`). If `to` is `typeof object`, the item will be rendered as a `<router-link>`. Otherwise, if `to` is `typeof string`, it will be rendered as an `<a>` element with the value of `to` applied to the `href` attribute. |
-| `disabled`    | A boolean (defaults to `false`), indicating whether or not to disable the item.                                                                                                                                                                                                                                                                   |
-| `selected`    | A boolean (defaults to `false`), indicating whether or not the item is selected when the `selectionMenu` prop is `true`.                                                                                                                                                                                                                          |
-| `hasDivider`  | A boolean (defaults to `false`), indicating whether or not the item should have a divider bar displayed above it.                                                                                                                                                                                                                                 |
-| `isDangerous` | A boolean (defaults to `false`), indicating whether or not to apply danger styles (text color is red).                                                                                                                                                                                                                                            |
+| Prop         | Description                                                                                                                                                                                                                                                                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `item`       | The properties the link is built from, it expects a `label` and optionally a `to` or `value` (when `selectionMenu` is `true`). If `to` is `typeof object`, the item will be rendered as a `<router-link>`. Otherwise, if `to` is `typeof string`, it will be rendered as an `<a>` element with the value of `to` applied to the `href` attribute. |
+| `disabled`   | A boolean (defaults to `false`), indicating whether or not to disable the item.                                                                                                                                                                                                                                                                   |
+| `selected`   | A boolean (defaults to `false`), indicating whether or not the item is selected when the `selectionMenu` prop is `true`.                                                                                                                                                                                                                          |
+| `hasDivider` | A boolean (defaults to `false`), indicating whether or not the item should have a divider bar displayed above it.                                                                                                                                                                                                                                 |
+| `dangerous`  | A boolean (defaults to `false`), indicating whether or not to apply danger styles (text color is red).                                                                                                                                                                                                                                            |
 
 <ClientOnly>
   <KDropdown trigger-text="All kinds of dropdown items">
@@ -402,7 +402,7 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
       </KDropdownItem>
       <KDropdownItem
         has-divider
-        is-dangerous
+        dangerous
         @click="clickHandler"
       >
         Danger button
@@ -464,7 +464,7 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
       </KDropdownItem>
       <KDropdownItem
         has-divider
-        is-dangerous
+        dangerous
         @click="clickHandler"
       >
         Danger button

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -347,7 +347,7 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
 | `disabled`   | A boolean (defaults to `false`), indicating whether or not to disable the item.                                                                                                                                                                                                                                                                   |
 | `selected`   | A boolean (defaults to `false`), indicating whether or not the item is selected when the `selectionMenu` prop is `true`.                                                                                                                                                                                                                          |
 | `hasDivider` | A boolean (defaults to `false`), indicating whether or not the item should have a divider bar displayed above it.                                                                                                                                                                                                                                 |
-| `dangerous`  | A boolean (defaults to `false`), indicating whether or not to apply danger styles (text color is red).                                                                                                                                                                                                                                            |
+| `danger`     | A boolean (defaults to `false`), indicating whether or not to apply danger styles (text color is red).                                                                                                                                                                                                                                            |
 
 <ClientOnly>
   <KDropdown trigger-text="All kinds of dropdown items">
@@ -402,7 +402,7 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
       </KDropdownItem>
       <KDropdownItem
         has-divider
-        dangerous
+        danger
         @click="clickHandler"
       >
         Danger button
@@ -464,7 +464,7 @@ KDropdown generates a KDropdownItem for each object in the `items` prop array. A
       </KDropdownItem>
       <KDropdownItem
         has-divider
-        dangerous
+        danger
         @click="clickHandler"
       >
         Danger button

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -132,7 +132,6 @@ You can pass any input attribute and it will get properly bound to the element.
 <KInput class="vertical-spacing" disabled model-value="disabled"/>
 <KInput class="vertical-spacing" readonly model-value="readonly"/>
 <KInput class="vertical-spacing" type="search" model-value="search"/>
-<KInput class="vertical-spacing" type="email" model-value="email@example.com"/>
 
 ```html
 <KInput placeholder="placeholder" />
@@ -142,7 +141,6 @@ You can pass any input attribute and it will get properly bound to the element.
 <KInput disabled model-value="disabled"/>
 <KInput read-only model-value="read-only"/>
 <KInput type="search" model-value="search"/>
-<KInput type="email" model-value="email@example.com"/>
 ```
 
 ### required

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -75,26 +75,26 @@ String to be displayed as help text.
 <KInput help="I can help with that." placeholder="Need help?" />
 ```
 
-If [`hasError`](#haserror) is true, the `help` prop text will be styled as error message.
+If [`error`](#error) is true, the `help` prop text will be styled as error message.
 
-<KInput has-error help="I can help with that." />
+<KInput error help="I can help with that." />
 
 ```html
-<KInput has-error help="I can help with that." />
+<KInput error help="I can help with that." />
 ```
 
-### hasError
+### error
 
 Boolean to indicate whether the element is in an error state and should apply error styling. Defaults to `false`.
 
 ### errorMessage
 
-String to be displayed as an error message if `hasError` prop is `true`. This prop will supersede the `help` prop if both have a value and `hasError` is `true`.
+String to be displayed as an error message if `error` prop is `true`. This prop will supersede the `help` prop if both have a value and `error` is `true`.
 
-<KInput has-error error-message="Service name should not contain '_'" help="Service name can be anything with only a few exceptions." />
+<KInput error error-message="Service name should not contain '_'" help="Service name can be anything with only a few exceptions." />
 
 ```html
-<KInput has-error error-message="Service name should not contain '_'" help="Service name can be anything with only a few exceptions." />
+<KInput error error-message="Service name should not contain '_'" help="Service name can be anything with only a few exceptions." />
 ```
 
 ### characterLimit

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1039,7 +1039,7 @@ This example uses the [`KDropdown`](/components/dropdown) component as the slot 
           </KDropdownItem>
           <KDropdownItem
             has-divider
-            dangerous
+            danger
             @click="clickHandler('Delete clicked!')"
           >
             Delete
@@ -1084,7 +1084,7 @@ This example uses the [`KDropdown`](/components/dropdown) component as the slot 
           </KDropdownItem>
           <KDropdownItem
             has-divider
-            dangerous
+            danger
             @click="clickHandler('Delete clicked!')"
           >
             Delete

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1039,7 +1039,7 @@ This example uses the [`KDropdown`](/components/dropdown) component as the slot 
           </KDropdownItem>
           <KDropdownItem
             has-divider
-            is-dangerous
+            dangerous
             @click="clickHandler('Delete clicked!')"
           >
             Delete
@@ -1084,7 +1084,7 @@ This example uses the [`KDropdown`](/components/dropdown) component as the slot 
           </KDropdownItem>
           <KDropdownItem
             has-divider
-            is-dangerous
+            dangerous
             @click="clickHandler('Delete clicked!')"
           >
             Delete

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -188,6 +188,8 @@ In order to prevent component styles from leaking out into the consuming applica
 
 2. All component styles must be wrapped in a unique wrapper class so that styles do not leak out into the consuming application.
 
+  TODO: update class naming guidelines
+
     The class name should follow the syntax `.k-{component-name}-*`
 
    This is a good practice even if you go with option one outlined above.
@@ -205,6 +207,12 @@ In order to prevent component styles from leaking out into the consuming applica
 Kongponent styles should **never** use relative font units; specifically, do not use `rem` or `em` units.
 
 We cannot control the `html` base font size and therefore these relative units are not predictable within a host application. Use `px` (pixels) or a similar unit instead.
+
+### Code best practices
+
+#### Prop naming
+
+TODO: wip
 
 ## Testing your component
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -125,7 +125,7 @@ Component has been renamed to `KDropdown`
 #### Props
 
 * `label` prop has been deprecated in favor of the new `trigger-text` prop (usage is the same)
-* `appearance` prop has been changed in favor of the `isSelectionMenu` prop for the selection menu functionality. `appearance` now controls the underlying `KButton` `appearance` prop (note that default `appearance` for component when `isSelectionMenu` is `true` changed from `tertiary` to `primary`)
+* `appearance` prop has been changed in favor of the `selectionMenu` prop for the selection menu functionality. `appearance` now controls the underlying `KButton` `appearance` prop (note that default `appearance` for component when `selectionMenu` is `true` changed from `tertiary` to `primary`)
 * `buttonAppearance` prop has been removed in favor of `appearance`, still controlling the `KButton` `appearance` prop
 * `testMode` prop has been removed
 * `icon` prop is removed (TODO: [beta])

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -116,7 +116,6 @@ Component has been renamed to `KDropdown`
 * `k-dropdown-item-trigger` class has been renamed to `dropdown-item-trigger`
 * `k-dropdown-item-trigger-label` class has been renamed to `dropdown-item-trigger-label`
 * dynamic `k-dropdown-item` `testid` data attribute has been renamed to `dropdown-item`
-* `danger` class in `KDropdownItem` has been changed to `dangerous`
 
 #### Constants, Types & Interfaces
 
@@ -131,7 +130,7 @@ Component has been renamed to `KDropdown`
 * `testMode` prop has been removed
 * `icon` prop is removed (TODO: [beta])
 * `caretColor` prop is removed
-* `isDangerous` `KDropdownItem` prop has been deprecated in favor of `dangerous`
+* `isDangerous` `KDropdownItem` prop has been deprecated in favor of `danger`
 
 #### Slots
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -116,6 +116,7 @@ Component has been renamed to `KDropdown`
 * `k-dropdown-item-trigger` class has been renamed to `dropdown-item-trigger`
 * `k-dropdown-item-trigger-label` class has been renamed to `dropdown-item-trigger-label`
 * dynamic `k-dropdown-item` `testid` data attribute has been renamed to `dropdown-item`
+* `danger` class in `KDropdownItem` has been changed to `dangerous`
 
 #### Constants, Types & Interfaces
 
@@ -130,6 +131,7 @@ Component has been renamed to `KDropdown`
 * `testMode` prop has been removed
 * `icon` prop is removed (TODO: [beta])
 * `caretColor` prop is removed
+* `isDangerous` `KDropdownItem` prop has been deprecated in favor of `dangerous`
 
 #### Slots
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -156,9 +156,8 @@ Component has been renamed to `KDropdown`
 
 * `form-control` class has been removed
 * `over-char-limit` class has been removed
-* `has-error` class has been removed
 * `help` class has been changed to `help-text`
-* `input-error` class has been changed to `has-error`
+* `input-error` class has been changed to `error`
 
 #### Constants, Types & Interfaces
 
@@ -173,6 +172,7 @@ Component has been renamed to `KDropdown`
 * `iconPosition` prop has been removed
 * `testMode` prop has been removed
 * `help` property was removed from `labelAttributes` prop (TODO: after KLabel is reskinned)
+* `hasError` prop has been deprecated in favor of `error`
 
 #### Slots
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -158,7 +158,6 @@ Component has been renamed to `KDropdown`
 * `form-control` class has been removed
 * `over-char-limit` class has been removed
 * `help` class has been changed to `help-text`
-* `input-error` class has been changed to `error`
 
 #### Constants, Types & Interfaces
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "@kong/icons": "^1.7.7",
+    "@kong/icons": "^1.7.8",
     "@popperjs/core": "^2.11.8",
     "axios": "^0.27.2",
     "date-fns": "^2.30.0",

--- a/sandbox/pages/SandboxDropdown.vue
+++ b/sandbox/pages/SandboxDropdown.vue
@@ -206,7 +206,7 @@
             Disabled external link
           </KDropdownItem>
           <KDropdownItem
-            dangerous
+            danger
             has-divider
             @click="handleItemClick"
           >

--- a/sandbox/pages/SandboxDropdown.vue
+++ b/sandbox/pages/SandboxDropdown.vue
@@ -290,7 +290,7 @@
     </SandboxSectionComponent>
     <SandboxSectionComponent
       description="The old KDropdownMenu component that utilizes the KDropdown under the hood still works as expected."
-      title="Deprecated KDropdownMenu"
+      title="KDropdownMenu (deprecated)"
     >
       <KDropdownMenu
         trigger-text="KDropdownMenu"
@@ -327,6 +327,20 @@
           </KDropdownItem>
         </template>
       </KDropdownMenu>
+    </SandboxSectionComponent>
+    <SandboxSectionComponent
+      title="KDropdownItem isDangerous prop (deprecated)"
+    >
+      <KDropdown trigger-text="Deprecated KDropdownItem prop">
+        <template #items>
+          <KDropdownItem
+            is-dangerous
+            @click="handleItemClick"
+          >
+            I am dangerous
+          </KDropdownItem>
+        </template>
+      </KDropdown>
     </SandboxSectionComponent>
   </div>
 </template>

--- a/sandbox/pages/SandboxDropdown.vue
+++ b/sandbox/pages/SandboxDropdown.vue
@@ -28,11 +28,11 @@
       />
     </SandboxSectionComponent>
     <SandboxSectionComponent
-      title="isSelectionMenu (replacement for `appearance` prop)"
+      title="selectionMenu (replacement for `appearance` prop)"
     >
       <KDropdown
-        is-selection-menu
         :items="selectionMenuItems"
+        selection-menu
         trigger-text="Selection menu"
         @change="handleSelectionMenuUpdate"
       />
@@ -93,7 +93,7 @@
           trigger-text="Show caret"
         />
         <KDropdown
-          is-selection-menu
+          selection-menu
           show-caret
           trigger-text="Selection menu with caret"
           @change="handleSelectionMenuUpdate"

--- a/sandbox/pages/SandboxDropdown.vue
+++ b/sandbox/pages/SandboxDropdown.vue
@@ -206,8 +206,8 @@
             Disabled external link
           </KDropdownItem>
           <KDropdownItem
+            dangerous
             has-divider
-            is-dangerous
             @click="handleItemClick"
           >
             <TrashIcon />

--- a/sandbox/pages/SandboxInput.vue
+++ b/sandbox/pages/SandboxInput.vue
@@ -165,6 +165,8 @@
         </template>
       </KInput>
     </SandboxSectionComponent>
+
+    <!-- Examples -->
     <SandboxTitleComponent
       is-subtitle
       title="Examples"
@@ -181,6 +183,20 @@
           Submit
         </KButton>
       </div>
+    </SandboxSectionComponent>
+
+    <!-- Legacy -->
+    <SandboxTitleComponent
+      is-subtitle
+      title="Legacy"
+    />
+    <SandboxSectionComponent
+      title="hasError prop (deprecated)"
+    >
+      <KInput
+        has-error
+        label="Label"
+      />
     </SandboxSectionComponent>
   </div>
 </template>

--- a/sandbox/pages/SandboxInput.vue
+++ b/sandbox/pages/SandboxInput.vue
@@ -28,8 +28,8 @@
         <KToggle v-slot="{isToggled, toggle}">
           <KInput
             class="full-width-input"
-            :has-error="isToggled.value"
-            help="This is help text. When hasError is true, this text will be red."
+            :error="isToggled.value"
+            help="This is help text. When error is true, this text will be red."
             label="Label"
           />
           <KButton
@@ -41,9 +41,9 @@
         </KToggle>
       </div>
     </SandboxSectionComponent>
-    <SandboxSectionComponent title="hasError">
+    <SandboxSectionComponent title="error">
       <KInput
-        has-error
+        error
         label="Label"
       />
     </SandboxSectionComponent>
@@ -54,9 +54,9 @@
         <KToggle v-slot="{isToggled, toggle}">
           <KInput
             class="full-width-input"
+            :error="isToggled.value"
             error-message="This is errorMessage."
-            :has-error="isToggled.value"
-            help="This is help text. When hasError is true, this text will be red. When hasError is true and errorMessage is set, this text will be replaced by the errorMessage."
+            help="This is help text. When error is true, this text will be red. When error is true and errorMessage is set, this text will be replaced by the errorMessage."
             label="Label"
           />
           <KButton
@@ -77,9 +77,9 @@
           <KInput
             :character-limit="67"
             class="full-width-input"
+            :error="isToggled.value"
             error-message="This is errorMessage. When character limit is exceeded, this text will be replaced by character limit error message."
-            :has-error="isToggled.value"
-            help="This is help text. When hasError is true, this text will be red. When hasError is true and errorMessage is set, this text will be replaced by the errorMessage. When character limit is exceeded, errorMessage text will be replaced by character limit error message."
+            help="This is help text. When error is true, this text will be red. When error is true and errorMessage is set, this text will be replaced by the errorMessage. When character limit is exceeded, errorMessage text will be replaced by character limit error message."
             label="Label"
             model-value="Type in 1 more character to see the character limit error message: "
           />

--- a/sandbox/pages/SandboxTable.vue
+++ b/sandbox/pages/SandboxTable.vue
@@ -26,7 +26,7 @@
             Edit
           </KDropdownItem>
           <KDropdownItem
-            dangerous
+            danger
             has-divider
           >
             Delete

--- a/sandbox/pages/SandboxTable.vue
+++ b/sandbox/pages/SandboxTable.vue
@@ -26,8 +26,8 @@
             Edit
           </KDropdownItem>
           <KDropdownItem
+            dangerous
             has-divider
-            is-dangerous
           >
             Delete
           </KDropdownItem>

--- a/src/components/KDropdown/KDropdown.cy.ts
+++ b/src/components/KDropdown/KDropdown.cy.ts
@@ -76,10 +76,10 @@ describe('KDropdown', () => {
     cy.get('.k-tooltip').should('contain.text', tooltipText)
   })
 
-  it('renders correctly when isSelectionMenu', () => {
+  it('renders correctly when selectionMenu', () => {
     mount(KDropdown, {
       props: {
-        isSelectionMenu: true,
+        selectionMenu: true,
         items: selectionMenuItems,
       },
     })

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -145,7 +145,7 @@ const props = defineProps({
     default: '',
     validator: (value: string) => {
       if (value) {
-        console.warn('KDropdown: `label` prop is deprecated. Please use `triggerText` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
+        console.warn('KDropdown: `label` prop is deprecated. Please use `triggerText` prop instead. See the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
       }
 
       return true

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="k-dropdown"
-    :class="{ 'selection-dropdown-menu': isSelectionMenu }"
+    :class="{ 'selection-dropdown-menu': selectionMenu }"
   >
     <KToggle v-slot="{ toggle, isToggled }">
       <KPop
@@ -56,7 +56,7 @@
                 v-bind="item"
                 :key="`${item.label}-${idx}`"
                 :item="item"
-                :selection-menu-child="isSelectionMenu"
+                :selection-menu-child="selectionMenu"
                 @change="handleSelection"
               />
             </slot>
@@ -80,7 +80,7 @@ import KDropdownItem from './KDropdownItem.vue'
 import { ChevronDownIcon } from '@kong/icons'
 
 const props = defineProps({
-  isSelectionMenu: {
+  selectionMenu: {
     type: Boolean,
     default: false,
   },
@@ -182,7 +182,7 @@ const triggerButtonText = computed((): string => selectedItem.value?.label || pr
 const selectedItem = ref<DropdownItem>()
 
 const handleSelection = (item: DropdownItem): void => {
-  if (!props.isSelectionMenu) {
+  if (!props.selectionMenu) {
     return
   }
 

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -145,7 +145,7 @@ const props = defineProps({
     default: '',
     validator: (value: string) => {
       if (value) {
-        console.warn('KDropdown: label prop is deprecated. Please use `triggerText` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
+        console.warn('KDropdown: `label` prop is deprecated. Please use `triggerText` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
       }
 
       return true

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -76,7 +76,7 @@ const props = defineProps({
     default: false,
     validator: (value: boolean): boolean => {
       if (value) {
-        console.warn('KInput: `isDangerous` prop is deprecated. Please use `danger` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
+        console.warn('KDropdownItem: `isDangerous` prop is deprecated. Please use `danger` prop instead. See the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
       }
 
       return true

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -4,7 +4,7 @@
     :class="{
       'has-divider': hasDivider,
       'disabled': disabled,
-      'dangerous': dangerous || isDangerous,
+      'danger': danger || isDangerous,
       'dropdown-selected-option': selected
     }"
     data-testid="dropdown-item"
@@ -45,7 +45,7 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  dangerous: {
+  danger: {
     type: Boolean,
     default: false,
   },
@@ -69,7 +69,7 @@ const props = defineProps({
     default: undefined,
   },
   /**
-   * @deprecated in favor of `dangerous`
+   * @deprecated in favor of `danger`
    */
   isDangerous: {
     type: Boolean,
@@ -192,7 +192,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     }
   }
 
-  &.dangerous {
+  &.danger {
     .dropdown-item-trigger {
       color: var(--kui-color-text-danger, $kui-color-text-danger);
 

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -74,6 +74,13 @@ const props = defineProps({
   isDangerous: {
     type: Boolean,
     default: false,
+    validator: (value: boolean): boolean => {
+      if (value) {
+        console.warn('KInput: `isDangerous` prop is deprecated. Please use `danger` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kdropdownmenu')
+      }
+
+      return true
+    },
   },
 })
 

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -4,7 +4,7 @@
     :class="{
       'has-divider': hasDivider,
       'disabled': disabled,
-      'danger': isDangerous,
+      'dangerous': dangerous || isDangerous,
       'dropdown-selected-option': selected
     }"
     data-testid="dropdown-item"
@@ -45,7 +45,7 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  isDangerous: {
+  dangerous: {
     type: Boolean,
     default: false,
   },
@@ -67,6 +67,13 @@ const props = defineProps({
   onClick: {
     type: Function,
     default: undefined,
+  },
+  /**
+   * @deprecated in favor of `dangerous`
+   */
+  isDangerous: {
+    type: Boolean,
+    default: false,
   },
 })
 
@@ -185,7 +192,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     }
   }
 
-  &.danger {
+  &.dangerous {
     .dropdown-item-trigger {
       color: var(--kui-color-text-danger, $kui-color-text-danger);
 

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -18,8 +18,8 @@
       :class="{
         'image-upload': type === 'image'
       }"
+      :error="hasUploadError"
       :error-message="errorMessage"
-      :has-error="hasUploadError"
       :help="help"
       :max-file-size="maximumFileSize"
       type="file"

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -110,7 +110,7 @@ describe('KInput', () => {
 
     cy.get('.k-input-wrapper .over-char-limit').should('not.exist')
     cy.get('.k-input-wrapper input.k-input').type(`This input has ${textCharCount} characters`)
-    cy.get('.k-input-wrapper.has-error .help-text').should('contain.text', `${textCharCount} / ${charLimit}`)
+    cy.get('.k-input-wrapper.error .help-text').should('contain.text', `${textCharCount} / ${charLimit}`)
   })
 
   it('reacts to text changes', () => {

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -110,7 +110,7 @@ describe('KInput', () => {
 
     cy.get('.k-input-wrapper .over-char-limit').should('not.exist')
     cy.get('.k-input-wrapper input.k-input').type(`This input has ${textCharCount} characters`)
-    cy.get('.k-input-wrapper.error .help-text').should('contain.text', `${textCharCount} / ${charLimit}`)
+    cy.get('.k-input-wrapper.input-error .help-text').should('contain.text', `${textCharCount} / ${charLimit}`)
   })
 
   it('reacts to text changes', () => {

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -2,7 +2,7 @@
   <!-- TODO: [beta] change wrapper class to k-input -->
   <div
     class="k-input-wrapper"
-    :class="[$attrs.class, { 'error' : charLimitExceeded || error || hasError }]"
+    :class="[$attrs.class, { 'input-error' : charLimitExceeded || error || hasError }]"
   >
     <KLabel
       v-if="label"
@@ -113,7 +113,7 @@ const props = defineProps({
     default: false,
     validator: (value: boolean): boolean => {
       if (value) {
-        console.warn('KInput: `hasError` prop is deprecated. Please use `error` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kinput')
+        console.warn('KInput: `hasError` prop is deprecated. Please use `error` prop instead. See the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kinput')
       }
 
       return true
@@ -274,7 +274,7 @@ $kInputIconSize: var(--kui-icon-size-40, $kui-icon-size-40);
   width: 100%;
 
   // error styles
-  &.error {
+  &.input-error {
     .k-input {
       box-shadow: var(--kui-shadow-border-danger, $kui-shadow-border-danger);
 

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -1,7 +1,8 @@
 <template>
+  <!-- TODO: [beta] change wrapper class to k-input -->
   <div
     class="k-input-wrapper"
-    :class="[$attrs.class, { 'has-error' : charLimitExceeded || hasError }]"
+    :class="[$attrs.class, { 'error' : charLimitExceeded || error || hasError }]"
   >
     <KLabel
       v-if="label"
@@ -30,9 +31,10 @@
         <slot name="before" />
       </div>
 
+      <!-- TODO: [beta] change input class to text-input -->
       <input
         v-bind="modifiedAttrs"
-        :aria-invalid="hasError || charLimitExceeded ? 'true' : undefined"
+        :aria-invalid="error || hasError || charLimitExceeded ? 'true' : undefined"
         class="k-input"
         :value="getValue()"
         @input="handleInput"
@@ -89,7 +91,7 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  hasError: {
+  error: {
     type: Boolean,
     default: false,
   },
@@ -102,6 +104,13 @@ const props = defineProps({
     default: null,
     // Ensure the characterLimit is greater than zero
     validator: (limit: number): boolean => limit > 0,
+  },
+  /**
+   * @deprecated in favor of `error`
+   */
+  hasError: {
+    type: Boolean,
+    default: false,
   },
 })
 
@@ -183,13 +192,13 @@ const helpText = computed((): string => {
     return charLimitExceededErrorMessage.value
   }
 
-  // if hasError prop is true and there is an error message, return that
-  if (props.hasError && props.errorMessage) {
+  // if error prop is true and there is an error message, return that
+  if ((props.error || props.hasError) && props.errorMessage) {
     return props.errorMessage
   }
 
   // otherwise return the help text
-  // if hasError prop is true it danger styles will be applied
+  // if error prop is true it danger styles will be applied
   return props.help
 })
 
@@ -258,7 +267,7 @@ $kInputIconSize: var(--kui-icon-size-40, $kui-icon-size-40);
   width: 100%;
 
   // error styles
-  &.has-error {
+  &.error {
     .k-input {
       box-shadow: var(--kui-shadow-border-danger, $kui-shadow-border-danger);
 

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -111,6 +111,13 @@ const props = defineProps({
   hasError: {
     type: Boolean,
     default: false,
+    validator: (value: boolean): boolean => {
+      if (value) {
+        console.warn('KInput: `hasError` prop is deprecated. Please use `error` prop instead. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kinput')
+      }
+
+      return true
+    },
   },
 })
 

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -142,7 +142,7 @@ const props = defineProps({
     default: '',
     validator: (value: RadioTypes): boolean => {
       if (value) {
-        console.warn('KRadio: `type` prop is deprecated in favor of `card`. Please see the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kradio')
+        console.warn('KRadio: `type` prop is deprecated. Please use `card` prop instead. See the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#kradio')
       }
 
       return RadioTypesArray.includes(value)

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,10 +768,10 @@
   resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.11.6.tgz#a5bdc240a2b935c329f81aa8117db7e20c2de35e"
   integrity sha512-K09zObaYWD7rm9FrJCHI7muKI3npWeDeqdY64unAjmlFW17Ox+bFGsJkaJIOXzsssXMGspHqVkl41vmUEhY8OQ==
 
-"@kong/icons@^1.7.7":
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.7.7.tgz#fbf11f02830ffb4319e7c20248e09ae1421c5bab"
-  integrity sha512-CQHOXZ/S0SRTjW43ItRKFoA9e+roW/jh8vXE1X0HVHDy0LAymvX9nadoVUmtdjNHQnJvr4XZfGgdyXE+fYh6Fw==
+"@kong/icons@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.7.8.tgz#1ce11d3004f23e4b569f5fde1192bb650f49f9b3"
+  integrity sha512-beURbCjLY7ihYXQjf8EoA9smh/K4MrxgVZ4xEGSfZx6y8YdocyHMZ4oZC3/UuopURzjUfiMbl+KZ9yEhGTTNIw==
 
 "@ljharb/through@^2.3.9":
   version "2.3.9"


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-9548

Changes:
- `KInput`:
  - deprecate `hasError` prop in favor of `error`
  - update underlying class structure to match the change
- `KDropdown`:
  -  change `isSelectionMenu` prop to `selectionMenu`
  - `KDropdownItem`:
    - deprecate `isDangerous` prop in favor of `danger`

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
