### PR TITLE
fix(kcodeblock): not searching long content with short queries

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -613,12 +613,9 @@ function updateMatchingLineNumbers(): void {
   isProcessingInternally.value = true
   regExpError.value = null
 
-  // Avoids searching when one can expect a very large number of results. The numbers here are determined purely by gut feel and not by any scientific reasoning. Feel free to tweak them.
-  const isSmallEnoughForCostlySearch = query.value.length >= 3 || props.code.length < 1000
-  const shouldPerformSearch = query.value.length > 0 && (isRegExpMode.value || (!isRegExpMode.value && isSmallEnoughForCostlySearch))
   let totalMatchingLineNumbers: number[] = []
 
-  if (shouldPerformSearch) {
+  if (query.value.length > 0) {
     try {
       totalMatchingLineNumbers = getMatchingLineNumbers(props.code.toLowerCase(), query.value.toLowerCase(), isRegExpMode.value)
     } catch (error) {


### PR DESCRIPTION
# Summary

Removes the limitation to only trigger a search when (1) a piece of code is shorter than 1000 characters or (2) the query is greater than 2 characters.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [X] **Docs:** includes a technically accurate README
