### PR TITLE
feat(ktooltip): render a plain slot if no label or content

### DIFF
--- a/src/components/KTooltip/KTooltip.cy.ts
+++ b/src/components/KTooltip/KTooltip.cy.ts
@@ -38,7 +38,7 @@ describe('KTooltip', () => {
   // Loop through varients
   positions.map(p => rendersCorrectPosition(p))
 
-  it('does not render the tooltip if the `label` prop is empty', () => {
+  it('renders the default slot content but not the tooltip if the `label` prop is empty', () => {
     const text = 'Button text'
 
     mount(KTooltip, {
@@ -47,11 +47,11 @@ describe('KTooltip', () => {
         trigger: 'click',
       },
       slots: {
-        default: () => h('button', {}, text),
+        default: () => h('button', { 'data-testid': 'my-button' }, text),
       },
     })
 
-    cy.get('button').click()
+    cy.getTestId('my-button').should('be.visible').click()
 
     cy.get('.k-tooltip').should('not.exist')
   })

--- a/src/components/KTooltip/KTooltip.cy.ts
+++ b/src/components/KTooltip/KTooltip.cy.ts
@@ -53,6 +53,6 @@ describe('KTooltip', () => {
 
     cy.get('button').click()
 
-    cy.get('.k-tooltip').should('have.class', 'k-tooltip-hidden').and('not.be.visible')
+    cy.get('.k-tooltip').should('not.exist')
   })
 })

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -1,5 +1,6 @@
 <template>
   <KPop
+    v-if="showTooltip"
     v-bind="$attrs"
     hide-caret
     :max-width="maxWidth"
@@ -13,10 +14,7 @@
   >
     <slot />
 
-    <template
-      v-if="showTooltip"
-      #content
-    >
+    <template #content>
       <div role="tooltip">
         <slot
           :label="label"
@@ -27,6 +25,10 @@
       </div>
     </template>
   </KPop>
+
+  <template v-else>
+    <slot />
+  </template>
 </template>
 
 <script setup lang="ts">
@@ -83,27 +85,23 @@ const slots = useSlots()
 const showTooltip = computed((): boolean => !!props.label || !!slots.content)
 
 const computedClass = computed((): string => {
-  const result = []
+  let result = ''
   switch (props.placement) {
     case 'top':
-      result.push('k-tooltip-top')
+      result = 'k-tooltip-top'
       break
     case 'right':
-      result.push('k-tooltip-right')
+      result = 'k-tooltip-right'
       break
     case 'bottom':
-      result.push('k-tooltip-bottom')
+      result = 'k-tooltip-bottom'
       break
     case 'left':
-      result.push('k-tooltip-left')
+      result = 'k-tooltip-left'
       break
   }
 
-  if (!showTooltip.value) {
-    result.push('k-tooltip-hidden')
-  }
-
-  return result.join(' ')
+  return result
 })
 </script>
 
@@ -120,10 +118,6 @@ const computedClass = computed((): string => {
   --KPopBorder: none;
   pointer-events: none;
   z-index: 9999;
-
-  &.k-tooltip-hidden {
-    display: none;
-  }
 }
 
 .k-tooltip-top {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
This PR removes KPop entirely if no label or content is provided. Instead, it'll only render the default slot.

Before:
<img width="1182" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/927663fe-76bf-4d40-89e8-e6666fe32ca9">

After:
<img width="1147" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/75755367-8322-46ba-bcf7-6392dcbe3c2c">

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
