### PR TITLE
feat(kcodeblock): add filter and regexp mode props and events

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -51,6 +51,46 @@ No additional formatting of the code takes places. It will be used as-is.
 
 The syntax language of `props.code` (e.g. `'json'`).
 
+### initialFilterMode
+
+* **Type**: `boolean`
+* **Required**: no
+* **Default**: `false`
+
+Controls whether the filter mode is initially active. Can be used together with the [`filter-mode-change` event](#filter-mode-change) to persist a code block’s filter mode setting.
+
+### initialRegExpMode
+
+* **Type**: `boolean`
+* **Required**: no
+* **Default**: `false`
+
+Controls whether the regular expression mode is initially active. Can be used together with the [`reg-exp-mode-change` event](#reg-exp-mode-change) to persist a code block’s regular expression mode setting.
+
+<ClientOnly>
+  <KCodeBlock
+    id="code-block-initial-reg-exp-mode"
+    :code="code"
+    language="json"
+    query="(true|false)"
+    initial-filter-mode
+    initial-reg-exp-mode
+    is-searchable
+  />
+</ClientOnly>
+
+```html
+<KCodeBlock
+  id="code-block-initial-reg-exp-mode"
+  :code="code"
+  language="json"
+  query="(true|false)"
+  initial-filter-mode
+  initial-reg-exp-mode
+  is-searchable
+/>
+```
+
 ### isSearchable
 
 * **Type**: `boolean`
@@ -354,6 +394,11 @@ function highlight({ preElement, codeElement, language, code }) {
 }
 ```
 
+### filter-mode-change
+
+- **Type**: `boolean`
+- **Trigger**: Fired when the toggles the filter mode.
+
 ### matching-lines-change
 
 - **Type**: [`CodeBlockEventData`](#codeblockeventdata)
@@ -363,6 +408,11 @@ function highlight({ preElement, codeElement, language, code }) {
 
 - **Type**: `string`
 - **Trigger**: Fired when the component’s internal query state is updated. This happens when the user finished typing (with a delay of a few hundred milliseconds to avoid repeatedly triggering computations while the user is still typing).
+
+### reg-exp-mode-change
+
+- **Type**: `boolean`
+- **Trigger**: Fired when the toggles the regular expression mode.
 
 ## Default shortcuts
 

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -178,4 +178,38 @@ describe('KCodeBlock', () => {
 
     cy.get('pre.k-highlighted-code-block').should('have.class', 'is-single-line')
   })
+
+  it('initializes in regular expression mode with search correctly executed', () => {
+    const id = 'code-block'
+    renderComponent({
+      id,
+      initialRegExpMode: true,
+      query: 'key[12]',
+    })
+
+    const expectedLineNumbersForRegExp = [2, 3]
+
+    cy.get('.k-line-is-match').should('have.length', expectedLineNumbersForRegExp.length)
+    for (const lineNumber of expectedLineNumbersForRegExp) {
+      cy.get(`.k-line-is-match .k-line-anchor#${id}-L${lineNumber}`).should('exist')
+    }
+  })
+
+  it('initializes in filter mode with search correctly executed', () => {
+    renderComponent({
+      id: 'code-block',
+      initialFilterMode: true,
+      initialRegExpMode: true,
+      query: 'key[12]',
+    })
+
+    const expectedMatchedTerms = ['key1', 'key2']
+    const expectedNumberOfMatches = 2
+
+    cy.get('.k-matched-term')
+      .should('have.length', expectedNumberOfMatches)
+      .each(([matchedTerm]) => {
+        expect(expectedMatchedTerms.includes(matchedTerm.textContent as string))
+      })
+  })
 })

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -321,6 +321,24 @@ const props = defineProps({
   },
 
   /**
+   * Whether filter mode is initially active. **Default: `false`**.
+   */
+  initialFilterMode: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+
+  /**
+   * Whether regular expression mode is initially active. **Default: `false`**.
+   */
+  initialRegExpMode: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+
+  /**
    * Shows an actions bar with a search input and related action buttons. **Default: `false`**.
    */
   isSearchable: {
@@ -410,14 +428,24 @@ const emit = defineEmits<{
    * Fired when the search query is updated.
    */
   (event: 'query-change', data: string): void
+
+  /**
+   * Fired when the filter mode is toggled.
+   */
+  (event: 'filter-mode-change', data: boolean): void
+
+  /**
+   * Fired when the regular expression mode is toggled.
+   */
+  (event: 'reg-exp-mode-change', data: boolean): void
 }>()
 
 const slots = useSlots()
 
 const query = ref<string>(props.query)
 const isProcessingInternally = ref<boolean>(false)
-const isRegExpMode = ref<boolean>(false)
-const isFilterMode = ref<boolean>(false)
+const isRegExpMode = ref<boolean>(props.initialRegExpMode)
+const isFilterMode = ref<boolean>(props.initialFilterMode)
 const regExpError = ref<Error | null>(null)
 const codeBlock = ref<HTMLElement | null>(null)
 const codeBlockSearchInput = ref<HTMLInputElement | null>(null)
@@ -688,6 +716,7 @@ function clearQuery(): void {
 
 function toggleRegExpMode(): void {
   isRegExpMode.value = !isRegExpMode.value
+  emit('reg-exp-mode-change', isRegExpMode.value)
 
   // Resets regexp error when toggling off regexp mode.
   if (!isRegExpMode.value) {
@@ -697,6 +726,7 @@ function toggleRegExpMode(): void {
 
 function toggleFilterMode(): void {
   isFilterMode.value = !isFilterMode.value
+  emit('filter-mode-change', isFilterMode.value)
 }
 
 function jumpToNextMatch(): void {


### PR DESCRIPTION
# Summary

Adds the new optional `props.initialFilterMode` and `props.initialRegExpMode` which both default to `false`. They control whether filter and regular expression mode are initially active. These props can be used to initialize a code block with some state stored in the application (e.g. via URL query parameters or client-side storage).

Adds the new optional events `filter-mode-change` and `reg-exp-mode-change` which both emit a boolean value representing whether filter and regular expression mode are currently active. These events can be used to persist the modes in the application’s state so that they can later been restored using `props.initialFilterMode` and `props.initialRegExpMode`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
