### PR TITLE
feat(kcodeblock): assign Enter to jump to next match action

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -368,13 +368,13 @@ function highlight({ preElement, codeElement, language, code }) {
 
 This component has a few shortcuts for interacting with its search and filter features. All of them are scoped to the code block. When invoking them while focus is placed outside of a code block, their associated actions won’t trigger.
 
-| Shortcut                             | Description             |
-| :----------------------------------- | :---------------------- |
-| <kbd>Alt+F</kbd> or <kbd>Alt+G</kbd> | Toggles filter mode     |
-| <kbd>Alt+R</kbd>                     | Toggles RegExp mode     |
-| <kbd>Alt+C</kbd>                     | Copies the code         |
-| <kbd>F3</kbd>                        | Jumps to next match     |
-| <kbd>Shift+F3</kbd>                  | Jumps to previous match |
+| Shortcut                                      | Description             |
+| :-------------------------------------------- | :---------------------- |
+| <kbd>Alt+F</kbd> or <kbd>Alt+G</kbd>          | Toggles filter mode     |
+| <kbd>Alt+R</kbd>                              | Toggles RegExp mode     |
+| <kbd>Alt+C</kbd>                              | Copies the code         |
+| <kbd>F3</kbd> or <kbd>Enter</kbd>             | Jumps to next match     |
+| <kbd>Shift+F3</kbd> or <kbd>Shift+Enter</kbd> | Jumps to previous match |
 
 ## Types
 

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -498,6 +498,8 @@ const keyMap: Record<string, CommandKeywords> = {
   'alt+r': 'toggleRegExpMode',
   f3: 'jumpToNextMatch',
   'shift+f3': 'jumpToPreviousMatch',
+  enter: 'jumpToNextMatch',
+  'shift+enter': 'jumpToPreviousMatch',
 }
 
 /**


### PR DESCRIPTION
# Summary

Assigns Enter to the "Jump to next match" action.

Assigns Shift+Enter to the "Jump to previous match" action.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
