### PR TITLE
fix(ktable): hide empty state cta if no text

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -73,9 +73,11 @@
             {{ emptyStateMessage }}
           </template>
 
-          <template #cta>
+          <template
+            v-if="emptyStateActionMessage"
+            #cta
+          >
             <KButton
-              v-if="emptyStateActionMessage"
               :appearance="searchInput ? 'tertiary' : 'primary'"
               :data-testid="getTestIdString(emptyStateActionMessage)"
               :icon="emptyStateActionButtonIcon"


### PR DESCRIPTION
# Summary

Ensure KTable does not render the CTA button if the `emptyStateActionMessage` is empty

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
