### PR TITLE
fix(kprompt): body spacing fix

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -609,12 +609,12 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 <ClientOnly>
   <KSelect label="Name" required :items="deepClone(defaultItems)" />
   <br>
-  <KSelect label="Name" required overlay-label :items="deepClone(defaultItems)" />
+  <KSelect label="Name" required :items="deepClone(defaultItems)" />
 </ClientOnly>
 
 ```html
 <KSelect label="Name" required :items="items" />
-<KSelect label="Name" required overlay-label :items="items" />
+<KSelect label="Name" required :items="items" />
 ```
 
 ## Slots

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -44,10 +44,10 @@ Use the `labelAttributes` prop to configure the **KLabel's** [props](/components
 
 Enable this prop to overlay the label on the input element's border. Defaults to `false`. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
 
-<KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
+<KTextArea label="Name" placeholder="I'm labelled!" />
 
 ```html
-<KTextArea label="Name" placeholder="I'm labelled!" :overlay-label="true" />
+<KTextArea label="Name" placeholder="I'm labelled!" />
 ```
 
 ### cols
@@ -129,11 +129,11 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 :::
 
 <KTextArea label="Name" required />
-<KTextArea label="Name" overlay-label required />
+<KTextArea label="Name" required />
 
 ```html
 <KTextArea label="Name" required />
-<KTextArea label="Name" overlay-label required />
+<KTextArea label="Name" required />
 ```
 
 ### v-model

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -58,37 +58,37 @@ import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const props = defineProps({
   /**
-    * Text displayed before the copyable text when
-    * `badge` is true
-    */
+   * Text displayed before the copyable text when
+   * `badge` is true
+   */
   badgeLabel: {
     type: String,
     default: '',
   },
   /**
-    * The copyable text
-    */
+   * The copyable text
+   */
   text: {
     type: String,
     required: true,
   },
   /**
-    * Tooltip text displayed on hover over the `text`
-    */
+   * Tooltip text displayed on hover over the `text`
+   */
   textTooltip: {
     type: String,
     default: '',
   },
   /**
-    * Tooltip text displayed on hover over copy button
-    */
+   * Tooltip text displayed on hover over copy button
+   */
   copyTooltip: {
     type: String,
     default: '',
   },
   /**
-    * Formatting for copyable text (default, hidden, redacted, deleted)
-    */
+   * Formatting for copyable text (default, hidden, redacted, deleted)
+   */
   format: {
     type: String as PropType<'default' | 'hidden' | 'redacted' | 'deleted'>,
     required: false,
@@ -96,36 +96,36 @@ const props = defineProps({
     validator: (val: string) => ['default', 'hidden', 'redacted', 'deleted'].includes(val),
   },
   /**
-    * Whether or not to display as a badge
-    */
+   * Whether or not to display as a badge
+   */
   badge: {
     type: Boolean,
     default: false,
   },
   /**
-    * False if `badge` is true
-    */
+   * False if `badge` is true
+   */
   monospace: {
     type: Boolean,
     default: true,
   },
   /**
-    * Whether or not the text should be truncated
-    */
+   * Whether or not the text should be truncated
+   */
   truncate: {
     type: Boolean,
     default: false,
   },
   /**
-    * Tooltip text displayed on successful copy
-    */
+   * Tooltip text displayed on successful copy
+   */
   successTooltip: {
     type: String,
     default: 'Copied!',
   },
   /**
-    * Number of characters to truncate at
-    */
+   * Number of characters to truncate at
+   */
   truncationLimit: {
     type: Number,
     default: 8,

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -296,6 +296,7 @@ onBeforeUnmount(() => {
             max-height: v-bind('$props.maxHeight');
             overflow-x: hidden;
             overflow-y: auto;
+            padding: 4px; // temporary fix for KInput focus ring
             padding-bottom: var(--kui-space-60, $kui-space-60);
             text-align: start;
             white-space: normal; // in case inside KTable


### PR DESCRIPTION
# Summary

Temporary fix for KPrompt body spacing cutting off input focus ring (permanent fix will be implemented during component reskin)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
