### PR TITLE
fix(kdropdownitem): remove disabled class

### DIFF
--- a/src/components/KDropdown/KDropdown.cy.ts
+++ b/src/components/KDropdown/KDropdown.cy.ts
@@ -252,5 +252,7 @@ describe('KDropdownItem', () => {
 
     cy.getTestId('dropdown-item').should('be.visible').should('have.class', 'disabled')
     cy.get('router-link[data-testid="dropdown-item-trigger"]').should('have.attr', 'disabled')
+    // ensure disabled class doesn't leak to trigger element
+    cy.getTestId('dropdown-item-trigger').should('have.attr', 'class', 'dropdown-item-trigger')
   })
 })

--- a/src/components/KDropdown/KDropdown.cy.ts
+++ b/src/components/KDropdown/KDropdown.cy.ts
@@ -216,6 +216,7 @@ describe('KDropdownItem', () => {
 
   it('correctly binds attributes to wrapper and trigger elements', () => {
     const testIdAttr = 'dropdown-item-test'
+    const boundClass = 'some-random-class'
 
     mount(KDropdownItem, {
       props: {
@@ -227,11 +228,29 @@ describe('KDropdownItem', () => {
       attrs: {
         target: '_blank',
         'data-testid': testIdAttr,
+        class: boundClass,
       },
     })
 
     cy.getTestId('dropdown-item').should('not.exist')
     cy.getTestId(testIdAttr).should('be.visible')
     cy.getTestId(testIdAttr).find('[data-testid="dropdown-item-trigger"]').should('have.attr', 'target', '_blank')
+    // making sure classes don't leak to trigger element
+    cy.getTestId('dropdown-item-trigger').not(`.${boundClass}`).should('have.length', 1)
+  })
+
+  it('correctly handles disabled state', () => {
+    mount(KDropdownItem, {
+      props: {
+        item: {
+          label: 'You are here',
+          to: { path: '/' },
+        },
+        disabled: true,
+      },
+    })
+
+    cy.getTestId('dropdown-item').should('be.visible').should('have.class', 'disabled')
+    cy.get('router-link[data-testid="dropdown-item-trigger"]').should('have.attr', 'disabled')
   })
 })

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -143,7 +143,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
   link: {
     tag: 'a',
     attrs: {
-      class: `dropdown-item-trigger ${props.disabled ? 'disabled' : ''} ${attrs.class || ''}`,
+      class: 'dropdown-item-trigger',
       href: to.value as string,
       // only add disabled attribute if props.disabled returns truthy value, otherwise it will be added as disabled="false" which will be treaded as disabled
       ...(!!props.disabled && { disabled: true, tabindex: -1 }),
@@ -154,7 +154,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     tag: 'router-link',
     onClick: handleClick,
     attrs: {
-      class: `dropdown-item-trigger ${props.disabled ? 'disabled' : ''} ${attrs.class || ''}`,
+      class: 'dropdown-item-trigger',
       to: to.value,
       // only add disabled attribute if props.disabled returns truthy value, otherwise it will be added as disabled="false" which will be treaded as disabled
       ...(!!props.disabled && { disabled: true, tabindex: -1 }),
@@ -165,7 +165,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     tag: 'button',
     onClick: handleClick,
     attrs: {
-      class: `dropdown-item-trigger ${props.disabled ? 'disabled' : ''} ${attrs.class || ''}`,
+      class: 'dropdown-item-trigger',
       disabled: props.disabled,
       ...strippedAttrs.value,
     },
@@ -209,12 +209,12 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     .dropdown-item-trigger {
       color: var(--kui-color-text-danger, $kui-color-text-danger);
 
-      &:hover:not(:disabled):not(.disabled):not(:focus):not(:active) {
+      &:hover:not(:disabled):not(:focus):not(:active) {
         background-color: var(--kui-color-background-danger-weakest, $kui-color-background-danger-weakest);
         color: var(--kui-color-text-danger, $kui-color-text-danger);
       }
 
-      &:focus:not(:disabled):not(.disabled), &:active:not(:disabled):not(.disabled) {
+      &:focus:not(:disabled), &:active:not(:disabled) {
         background-color: var(--kui-color-background-danger-weaker, $kui-color-background-danger-weaker);
         color: var(--kui-color-text-danger, $kui-color-text-danger);
       }
@@ -251,15 +251,15 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
       z-index: 1; // need this to prevent box shadow being cut off by the next/previous sibling
     }
 
-    &:hover:not(:disabled):not(.disabled):not(:focus):not(:active) {
+    &:hover:not(:disabled):not(:focus):not(:active) {
       background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
     }
 
-    &:focus:not(:disabled):not(.disabled), &:active:not(:disabled):not(.disabled) {
+    &:focus:not(:disabled), &:active:not(:disabled) {
       background-color: var(--kui-color-background-neutral-weak, $kui-color-background-neutral-weak);
     }
 
-    &:disabled, &[disabled], &.disabled {
+    &:disabled, &[disabled] {
       color: var(--kui-color-text-disabled, $kui-color-text-disabled);
       cursor: not-allowed;
     }

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -139,11 +139,14 @@ const strippedAttrs = computed((): typeof attrs => {
   return modifiedAttrs
 })
 
+// do not change this value, it's used in tests
+const dropdownItemTriggerClass = 'dropdown-item-trigger'
+
 const availableComponents = computed((): DropdownItemRenderedRecord => ({
   link: {
     tag: 'a',
     attrs: {
-      class: 'dropdown-item-trigger',
+      class: dropdownItemTriggerClass,
       href: to.value as string,
       // only add disabled attribute if props.disabled returns truthy value, otherwise it will be added as disabled="false" which will be treaded as disabled
       ...(!!props.disabled && { disabled: true, tabindex: -1 }),
@@ -154,7 +157,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     tag: 'router-link',
     onClick: handleClick,
     attrs: {
-      class: 'dropdown-item-trigger',
+      class: dropdownItemTriggerClass,
       to: to.value,
       // only add disabled attribute if props.disabled returns truthy value, otherwise it will be added as disabled="false" which will be treaded as disabled
       ...(!!props.disabled && { disabled: true, tabindex: -1 }),
@@ -165,7 +168,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     tag: 'button',
     onClick: handleClick,
     attrs: {
-      class: 'dropdown-item-trigger',
+      class: dropdownItemTriggerClass,
       disabled: props.disabled,
       ...strippedAttrs.value,
     },
@@ -173,7 +176,7 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
   div: {
     tag: 'div',
     attrs: {
-      class: 'dropdown-item-trigger',
+      class: dropdownItemTriggerClass,
       ...strippedAttrs.value,
     },
   },


### PR DESCRIPTION
# Summary

Removes `disabled` class from `.dropdown-item-trigger` element in `KDropdownItem`

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
