### PR TITLE
fix(kpagination): select widget too thin for wide content

### DIFF
--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -122,7 +122,7 @@
           :placeholder="`${ currentPageSize } items per page`"
           position-fixed
           :test-mode="!!testMode || undefined"
-          width="170"
+          width="190"
           @selected="updatePageSize"
         />
       </div>


### PR DESCRIPTION
# Summary

Changes the KSelect’s `props.width` value from `170` to `190` to account for the widest default content (i.e. "100 items per page"). This otherwise triggers the pagination to overflow (e.g. causes a horizontal scrollbar in KTable).

Before:

![image](https://github.com/Kong/kongponents/assets/5774638/27c666bc-e8dd-45f4-9c3c-5c18f5c4bf7a)

After:

![image](https://github.com/Kong/kongponents/assets/5774638/fac546da-9733-4e29-92d6-ecae0c3ef585)


## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
