### PR TITLE
fix(kslideout): content being taller than viewport when using props.offsetTop

### DIFF
--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -184,7 +184,7 @@ const offsetTopValue = computed((): string => {
     background-color: var(--kui-color-background, $kui-color-background);
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: calc(100vh - v-bind('offsetTopValue'));
     max-width: 500px;
     overflow-y: auto;
     position: fixed;


### PR DESCRIPTION
# Summary

Fixes the content area always as tall as the viewport when using `props.offsetTop` making it too tall.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
