### PR TITLE
fix(kslideout): tooltip content being cut-off

### DIFF
--- a/docs/components/slideout.md
+++ b/docs/components/slideout.md
@@ -98,6 +98,12 @@ Tells the component whether or not to enable / disable overlay when the slideout
         <h2>Not only can you put any html in here like the paragraph below but you can also use other components</h2>
         <p>Anim officia eiusmod duis est consequat nulla tempor ad non magna Lorem ullamco nostrud amet. Occaecat voluptate dolor enim eiusmod do qui nulla pariatur enim. Et elit elit consequat do do duis enim est ullamco id sunt sunt amet eiusmod. Do minim mollit irure ea sunt officia minim sint eiusmod enim amet. Quis exercitation in ullamco quis aliqua.</p>
       </div>
+      <KTooltip
+        label="Tooltip overflowing the slideout content area"
+        placement="left"
+      >
+        <InfoIcon />
+      </KTooltip>
       <KButton appearance="primary">Buttons</KButton>
       <KCard class="vertical-spacing">
         <template #body>
@@ -120,6 +126,12 @@ Tells the component whether or not to enable / disable overlay when the slideout
         <h2>Not only can you put any html in here like the paragraph below but you can also use other components</h2>
         <p>Anim officia eiusmod duis est consequat nulla tempor ad non magna Lorem ullamco nostrud amet. Occaecat voluptate dolor enim eiusmod do qui nulla pariatur enim. Et elit elit consequat do do duis enim est ullamco id sunt sunt amet eiusmod. Do minim mollit irure ea sunt officia minim sint eiusmod enim amet. Quis exercitation in ullamco quis aliqua.</p>
       </div>
+      <KTooltip
+        label="Tooltip overflowing the slideout content area"
+        placement="left"
+      >
+        <InfoIcon />
+      </KTooltip>
       <KButton appearance="primary">Buttons</KButton>
       <KCard class="vertical-spacing">
         <template #body>
@@ -291,6 +303,10 @@ This prop takes a string that will be displayed as the title of the slide-out.
 ## Events
 
 - `close` - Emitted when the close button is clicked, anything outside the panel is clicked, or the `esc` key is pressed.
+
+<script setup lang="ts">
+import { InfoIcon } from '@kong/icons'
+</script>
 
 <style lang="scss" scoped>
 .vertical-spacing {

--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -14,50 +14,52 @@
         :class="{ 'is-visible': isVisible, 'border-styles': !hasOverlay }"
         data-testid="slideout-panel"
       >
-        <div class="k-slideout-header-content">
-          <div
-            v-if="hasBeforeTitle"
-            class="k-slideout-before-title"
-          >
-            <slot name="before-title" />
-          </div>
-
-          <!-- title -->
-          <div class="k-slideout-main-title">
-            <p
-              class="k-slideout-title"
-              data-testid="k-slideout-title"
-              :title="title"
+        <div class="k-slideout-content-wrapper">
+          <div class="k-slideout-header-content">
+            <div
+              v-if="hasBeforeTitle"
+              class="k-slideout-before-title"
             >
-              {{ title }}
-            </p>
+              <slot name="before-title" />
+            </div>
+
+            <!-- title -->
+            <div class="k-slideout-main-title">
+              <p
+                class="k-slideout-title"
+                data-testid="k-slideout-title"
+                :title="title"
+              >
+                {{ title }}
+              </p>
+            </div>
+
+            <div
+              v-if="hasAfterTitle"
+              class="k-slideout-after-title"
+            >
+              <slot name="after-title" />
+            </div>
           </div>
 
-          <div
-            v-if="hasAfterTitle"
-            class="k-slideout-after-title"
+          <!-- cancelButton -->
+          <button
+            :class="closeButtonAlignment === 'start' ? 'close-button-start' : 'close-button-end'"
+            :data-testid="closeButtonAlignment === 'start' ? 'close-button-start' : 'close-button-end'"
+            @click="(event: any) => emit('close')"
           >
-            <slot name="after-title" />
+            <KIcon
+              :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
+              icon="close"
+              :size="KUI_ICON_SIZE_50"
+            />
+          </button>
+
+          <div class="content">
+            <KCard class="content-card">
+              <slot />
+            </KCard>
           </div>
-        </div>
-
-        <!-- cancelButton -->
-        <button
-          :class="closeButtonAlignment === 'start' ? 'close-button-start' : 'close-button-end'"
-          :data-testid="closeButtonAlignment === 'start' ? 'close-button-start' : 'close-button-end'"
-          @click="(event: any) => emit('close')"
-        >
-          <KIcon
-            :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-            icon="close"
-            :size="KUI_ICON_SIZE_50"
-          />
-        </button>
-
-        <div class="content">
-          <KCard class="content-card">
-            <slot />
-          </KCard>
         </div>
       </div>
     </transition>
@@ -160,6 +162,12 @@ const offsetTopValue = computed((): string => {
 @import '@/styles/tmp-variables';
 
 .k-slideout {
+  .k-slideout-content-wrapper {
+    // Ensures that positioned content extending past the slideout’s content area (e.g. KTooltips) isn’t cut-off. The key to this working is to not `position: fixed` the element that has the `overflow-y: auto` declaration.
+    overflow-y: auto;
+    position: relative;
+  }
+
   .k-slideout-header-content {
     display: flex;
     .k-slideout-before-title,
@@ -167,6 +175,9 @@ const offsetTopValue = computed((): string => {
       margin-top: var(--kui-space-60, $kui-space-60);
     }
     .k-slideout-main-title {
+      // Prevents long, non-wrapping titles from triggering a horizontal scrollbar in the content area. This also allows `.k-slideout-title` to actually truncate its text content.
+      min-width: 0;
+
       .k-slideout-title {
         color: var(--kui-color-text-neutral, $kui-color-text-neutral);
         flex:1;
@@ -188,7 +199,6 @@ const offsetTopValue = computed((): string => {
     flex-direction: column;
     height: calc(100vh - v-bind('offsetTopValue'));
     max-width: v-bind('props.maxWidth');
-    overflow-y: auto;
     position: fixed;
     right: 0;
     top: v-bind('offsetTopValue');
@@ -202,10 +212,12 @@ const offsetTopValue = computed((): string => {
       cursor: pointer;
       display: flex;
       height: auto;
+      left: 0;
       margin-left: var(--kui-space-50, $kui-space-50);
       margin-top: var(--kui-space-50, $kui-space-50);
       outline: inherit;
       position: absolute;
+      top: 0;
       transition: $tmp-animation-timing-2 ease;
 
       &:focus{
@@ -224,6 +236,8 @@ const offsetTopValue = computed((): string => {
       margin-top: var(--kui-space-50, $kui-space-50);
       outline: inherit;
       position: absolute;
+      right: 0;
+      top: 0;
       transition: $tmp-animation-timing-2 ease;
 
       &:focus{
@@ -231,17 +245,8 @@ const offsetTopValue = computed((): string => {
       }
     }
 
-    .content {
-      height: 100%;
-      -ms-overflow-style: none;  // IE 10+
-      scrollbar-width: none;  // Firefox
-      &::-webkit-scrollbar {
-        display: none;
-      }
-
-      .content-card {
-        border: none;
-      }
+    .content-card {
+      border: none;
     }
   }
 }


### PR DESCRIPTION
# Summary

Fix positioned content extending past the slideout’s content area (e.g. tooltips) being cut-off.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

| Before | After |
| ------ | ----- |
| ![image](https://github.com/Kong/kongponents/assets/5774638/8d7a4f87-0a9d-4df9-bdf1-963ffbb7371d) | ![image](https://github.com/Kong/kongponents/assets/5774638/c953e089-3348-443f-9b43-46d086e97617) |

## Notes

I tried to avoid introducing an additional element in the markup by using `.content` as the scroll container; however, since this element doesn’t include the header content, the scrollbars would be triggered offset from the top of the viewport.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README