### PR TITLE
fix(ktextarea): reskin component [KHCP-9004]

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -139,7 +139,7 @@ You can pass any input attribute and it will get properly bound to the element.
 <KInput type="number" model-value="1"/>
 <KInput type="email" model-value="john.doe@konghq.com"/>
 <KInput disabled model-value="disabled"/>
-<KInput read-only model-value="read-only"/>
+<KInput readonly model-value="read-only"/>
 <KInput type="search" model-value="search"/>
 ```
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -1,6 +1,6 @@
 # Input
 
-KInput provides a wrapper around general `text` inputs and provides contextual styling and states (error, focus, etc).
+KInput provides a wrapper around general `text` inputs, as well as contextual styling and states (error, focus, etc).
 
 <KInput placeholder="Placeholder text" />
 
@@ -251,7 +251,7 @@ Should you decide to use your own custom icons, you can use design tokens export
 We also recommend setting the icon style `color` property to a value of `currentColor` to utilize default KInput styling for slotted content.
 :::
 
-### label-tooltip
+### labelTooltip
 
 If you want to utilize HTML in the input label's tooltip, use the slot.
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -20,7 +20,7 @@ String to be used as the textarea label.
 <KTextArea label="Name" placeholder="I'm labelled!" />
 ```
 
-If the label is omitted it can be handled with another component, like KLabel. This is meant to be used before KTextArea will be styled appropriately.
+If the label is omitted it can be handled with another component, like KLabel. This is meant to be used before KTextArea and will be styled appropriately.
 
 <KLabel for="my-textarea">Label</KLabel>
 <KTextArea id="my-textarea" placeholder="I have a label" />
@@ -32,7 +32,7 @@ If the label is omitted it can be handled with another component, like KLabel. T
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the KLabel's [props](/components/label) if using the `label` prop. This example shows using the `labelAttributes` to set up a tooltip. See the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
+Use the `labelAttributes` prop to configure the KLabel's [props](/components/label) when using the `label` prop. This example shows using the `labelAttributes` to set up a tooltip. See the [slot](#slots) section if you want to slot HTML into the tooltip rather than using plain text.
 
 <KTextArea label="Name" :label-attributes="{ info: 'I use the KLabel `info` prop' }" />
 
@@ -42,7 +42,7 @@ Use the `labelAttributes` prop to configure the KLabel's [props](/components/lab
 
 ### rows
 
-You can specify `rows` to adjust the vertical size of the textarea.
+You can specify `rows` to adjust the height of the textarea.
 
 <KTextArea :rows="12" placeholder="12 rows" />
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -82,7 +82,7 @@ Boolean value to indicate whether the element has an error and should apply erro
 
 ### characterLimit
 
-Use this prop to specify a character limit for the textarea. See the [`@char-limit-exceeded` event](#events) for more details.
+Use this prop to specify a character limit for the textarea. Defaults to `2048`. You can pass a boolean `false` if you want to disable character limit. See the [`@char-limit-exceeded` event](#events) for more details.
 
 <KTextArea model-value="Type in 1 more character to see the character limit error message: " :character-limit="67" help="Character limit error supersedes `help` prop when it's been exceeded." />
 
@@ -100,6 +100,12 @@ You can pass any input attribute and it will get properly bound to the element.
 <KTextArea label="Name" placeholder="I'm disabled!" disabled />
 ```
 
+<KTextArea label="Name" placeholder="I'm read-only!" readonly />
+
+```html
+<KTextArea label="Name" placeholder="I'm read-only!" readonly />
+```
+
 ### required
 
 KTextArea will display a red dot next to the label to indicate a field is required if you set the required attribute and provide a label value. See KLabel's required prop for more information.
@@ -112,7 +118,7 @@ KTextArea will display a red dot next to the label to indicate a field is requir
 
 ### v-model
 
-KTextArea works as regular textarea do using `v-model` for data binding:
+KTextArea works with `v-model` for two-way data binding:
 
 <KComponent :data="{ myInput: 'hello' }" v-slot="{ data }">
   <div>
@@ -148,11 +154,11 @@ If you want to utilize HTML in the textarea label's tooltip, use the slot.
 
 ## Events
 
-KTextArea has a couple of natural event bindings.
+KTextArea has a couple of event bindings.
 
 ### input and update:modelValue
 
-Fired on change, returns the content of the textarea.
+To listen for changes to the KTextArea value, you can bind to the `@input` or `@update:modelValue` events.
 
 ### char-limit-exceeded
 

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -1,6 +1,6 @@
 # TextArea
 
-**KTextArea** - Text areas are primarily used in modal views (wizards).
+KTextArea provides a wrapper around textarea element, as well as contextual styling and states (error, focus, etc).
 
 <KTextArea />
 
@@ -20,94 +20,74 @@ String to be used as the textarea label.
 <KTextArea label="Name" placeholder="I'm labelled!" />
 ```
 
-If the label is omitted it can be handled with another component, like **KLabel**. This is meant to be used before **KTextArea** will be styled appropriately.
+If the label is omitted it can be handled with another component, like KLabel. This is meant to be used before KTextArea will be styled appropriately.
 
-<KLabel>Label</KLabel>
-<KTextArea placeholder="I have a label" />
+<KLabel for="my-textarea">Label</KLabel>
+<KTextArea id="my-textarea" placeholder="I have a label" />
 
 ```html
-<KLabel>Label</KLabel>
-<KTextArea placeholder="I have a label" />
+<KLabel for="my-textarea">Label</KLabel>
+<KTextArea id="my-textarea" placeholder="I have a label" />
 ```
 
 ### labelAttributes
 
-Use the `labelAttributes` prop to configure the **KLabel's** [props](/components/label) if using the `label` prop. This example shows using the `label-attributes` to set up a tooltip, see the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
+Use the `labelAttributes` prop to configure the KLabel's [props](/components/label) if using the `label` prop. This example shows using the `labelAttributes` to set up a tooltip. See the [slot](#slots) section if you want to slot HTML into the tooltip rather than use plain text.
 
-<KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
-
-```html
-<KTextArea label="Name" :label-attributes="{ help: 'I use the KLabel `help` prop' }" />
-```
-
-### overlayLabel
-
-Enable this prop to overlay the label on the input element's border. Defaults to `false`. Make sure that if you are using the built in label you specify the `--KInputBackground` theming variable. This variable is used for the background of the label as well as the input element.
-
-<KTextArea label="Name" placeholder="I'm labelled!" />
+<KTextArea label="Name" :label-attributes="{ info: 'I use the KLabel `info` prop' }" />
 
 ```html
-<KTextArea label="Name" placeholder="I'm labelled!" />
-```
-
-### cols
-
-You can specify `cols` to adjust the horizontal size of the textarea
-
-<KTextArea :cols="12" placeholder="cols:12" />
-
-```html
-<KTextArea :cols="12" placeholder="cols:12" />
+<KTextArea label="Name" :label-attributes="{ info: 'I use the KLabel `info` prop' }" />
 ```
 
 ### rows
 
-You can specify `rows` to adjust the vertical size of the textarea
+You can specify `rows` to adjust the vertical size of the textarea.
 
-<KTextArea :rows="12" placeholder="rows:12" />
+<KTextArea :rows="12" placeholder="12 rows" />
 
 ```html
-<KTextArea :rows="12" placeholder="rows:12" />
+<KTextArea :rows="12" placeholder="12 rows" />
 ```
 
-### isResizable
+### resizable
 
-Boolean value to allow vertically resizing using the drag handle in the right-hand corner of the textarea
+Boolean value to allow vertically resizing using the drag handle in the right-hand corner of the textarea.
 
-<KTextArea is-resizable />
+<KTextArea resizable />
 
 ```html
-<KTextArea is-resizable />
+<KTextArea resizable />
+```
+
+### help
+
+String to be displayed as help text.
+
+<KTextArea help="Hint or other helpful text." />
+
+```html
+<KTextArea help="Hint or other helpful text." />
+```
+
+### error
+
+Boolean value to indicate whether the element has an error and should apply error styling. By default this is `false`.
+
+<KTextArea error help="Text passed through `help` prop takes error styling when `error` prop is `true`." />
+
+```html
+<KTextArea error help="Text passed through `help` prop takes error styling when `error` prop is `true`." />
 ```
 
 ### characterLimit
 
-Use this prop to specify a character limit for the textarea, defaults to `2048`.
+Use this prop to specify a character limit for the textarea. See the [`@char-limit-exceeded` event](#events) for more details.
 
-<KTextArea :characterLimit="20" />
-
-```html
-<KTextArea :characterLimit="20" />
-```
-
-### disableCharacterLimit
-
-Use this prop to remove the character limit on the textarea. Defaults to `false`.
-
-<KTextArea disable-character-limit />
+<KTextArea model-value="Type in 1 more character to see the character limit error message: " :character-limit="67" help="Character limit error supersedes `help` prop when it's been exceeded." />
 
 ```html
-<KTextArea disable-character-limit />
-```
-
-### hasError
-
-Boolean value to indicate whether the element has an error and should apply error styling. By default this is `false`.
-
-<KTextArea has-error />
-
-```html
-<KTextArea has-error />
+<KTextArea model-value="Type in 1 more character to see the character limit error message: " :character-limit="67" help="Character limit error supersedes `help` prop when it's been exceeded." />
 ```
 
 ## Attribute Binding
@@ -122,25 +102,19 @@ You can pass any input attribute and it will get properly bound to the element.
 
 ### required
 
-KTextArea will display an `*` to indicate a field is required if you set the `required` attribute and provide a `label`. See **KLabel's** [`required`](/components/label#required) prop for more information.
+KTextArea will display a red dot next to the label to indicate a field is required if you set the required attribute and provide a label value. See KLabel's required prop for more information.
 
-:::tip NOTE
-Text passed in for the `label` will automatically strip any trailing `*` when used with the `required` attribute to try to prevent duplicate asterisks.
-:::
-
-<KTextArea label="Name" required />
 <KTextArea label="Name" required />
 
 ```html
-<KTextArea label="Name" required />
 <KTextArea label="Name" required />
 ```
 
 ### v-model
 
-`KTextArea` works as regular texarea do using v-model for data binding:
+KTextArea works as regular textarea do using `v-model` for data binding:
 
-<KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
+<KComponent :data="{ myInput: 'hello' }" v-slot="{ data }">
   <div>
     {{ data.myInput }}
     <KTextArea v-model="data.myInput" />
@@ -148,7 +122,7 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 </KComponent>
 
 ```html
-<KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
+<KComponent :data="{ myInput: 'hello' }" v-slot="{ data }">
   {{ myInput }}
   <KTextArea v-model="data.myInput" />
 </KComponent>
@@ -156,73 +130,61 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 
 ## Slots
 
-- `label-tooltip` - slot for tooltip content if textarea has a label and label has tooltip (note: this slot overrides `help`/`info` content specified in `label-attributes`)
+### labelTooltip
+
+Slot for tooltip content if textarea has a label and label has tooltip (note: this slot overrides `info` content specified in `labelAttributes`)
 
 If you want to utilize HTML in the textarea label's tooltip, use the slot.
 
-<KTextArea label="My Tooltip">
-  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+<KTextArea label="My tooltip">
+  <template #label-tooltip>Id: <code>8576925e-d7e0-4ecd-8f14-15db1765e69a</code></template>
 </KTextArea>
 
 ```html
-<KTextArea label="My Tooltip">
-  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
-</KTextArea>
-```
-
-:::tip Note:
-When utilizing the `label-tooltip` slot, the `info` `KIcon` will be shown by default. To utilize the the `help` icon instead, set the `label-attributes` `help` property to any non-empty string value.
-:::
-
-<KTextArea label="My Tooltip" :label-attributes="{ help: 'true' }">
-  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
-</KTextArea>
-
-```html
-<KTextArea
-  label="My Tooltip"
-  :label-attributes="{ help: 'true' }"
->
-  <template #label-tooltip>Brings all the <code>devs</code> to the yard</template>
+<KTextArea label="My tooltip">
+  <template #label-tooltip>Id: <code>8576925e-d7e0-4ecd-8f14-15db1765e69a</code></template>
 </KTextArea>
 ```
 
 ## Events
 
-`KTextArea` has a couple of natural event bindings.
+KTextArea has a couple of natural event bindings.
 
-- `input` - Fired on change, returns the content of the textarea
-- `char-limit-exceeded` - Fired when the text starts or stops exceeding the limit, returns an object:
+### input and update:modelValue
 
-    ```json
-    {
-        value,          // current value
-        length,         // length of current value
-        characterLimit, // character limit
-        limitExceeded   // whether or not the limit has been exceeded
-    }
-    ```
+Fired on change, returns the content of the textarea.
 
-`KTextArea` also transparently binds to events:
+### char-limit-exceeded
 
-<KComponent :data="{myInput2: 'hello'}" v-slot="{ data }">
-  <div>
-    <KTextArea
-      v-model="data.myInput2"
-      @blur="e => (data.myInput2 = 'blurred')"
-      @focus="e => (data.myInput2 = 'focused')"
-    />
-  </div>
+Fired when the text starts or stops exceeding the limit, returns an object:
+
+```json
+{
+  value,          // current value
+  length,         // length of current value
+  characterLimit, // character limit
+  limitExceeded   // whether or not the limit has been exceeded
+}
+```
+
+### DOM events
+
+KTextArea also allows you to listen to DOM events:
+
+<KComponent :data="{ myInput: 'hello' }" v-slot="{ data }">
+  <KTextArea
+    v-model="data.myInput"
+    @blur="e => (data.myInput = 'blurred')"
+    @focus="e => (data.myInput = 'focused')"
+  />
 </KComponent>
 
 ```html
-<KComponent :data="{myInput: 'hello'}" v-slot="{ data }">
-  <div>
-    <KTextArea
-      v-model="data.myInput"
-      @blur="e => (data.myInput = 'blurred')"
-      @focus="e => (data.myInput = 'focused')"
-    />
-  </div>
+<KComponent :data="{ myInput: 'hello' }" v-slot="{ data }">
+  <KTextArea
+    v-model="data.myInput"
+    @blur="e => (data.myInput = 'blurred')"
+    @focus="e => (data.myInput = 'focused')"
+  />
 </KComponent>
 ```

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -299,7 +299,7 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 * `testMode` prop is removed
 * `isResizable` prop is deprecated in favor of `resizable` prop
 * `hasError` prop is deprecated in favor of `error` prop
-* `cols` prop has been removed (use CSS to control width of the textarea)
+* `cols` prop has been removed (use CSS to control the width of the textarea)
 * `disableCharacterLimit` prop has been removed. You can pass a boolean `false` to `characterLimit` prop to disable character limit
 
 #### Structure

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -113,7 +113,7 @@ Component has been renamed to `KDropdown`
 
 #### Props
 
-* `label` prop has been deprecated in favor of the new `trigger-text` prop (usage is the same)
+* `label` prop has been deprecated in favor of the new `triggerText` prop (usage is the same)
 * `appearance` prop has been changed in favor of the `selectionMenu` prop for the selection menu functionality. `appearance` now controls the underlying `KButton` `appearance` prop (note that default `appearance` for component when `selectionMenu` is `true` changed from `tertiary` to `primary`)
 * `buttonAppearance` prop has been removed in favor of `appearance`, still controlling the `KButton` `appearance` prop
 * `testMode` prop has been removed

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -293,6 +293,17 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 
 ### KTextarea
 
+#### Props
+
+* `testMode` prop is removed
+
+#### Structure
+
+* `k-input-wrapper` class has been changed to `k-textarea`
+* `has-error` class has been changed to `input-error`
+* `k-input` class has been changed to `input-textarea`
+* `form-control` class has been removed
+* `is-resizable` class has been changed to `resizable`
 
 ### KToaster
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -299,6 +299,8 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 * `isResizable` prop is deprecated in favor of `resizable` prop
 * `hasError` prop is deprecated in favor of `error` prop
 * `cols` prop has been removed (use CSS to control width of the textarea)
+* `disableCharacterLimit` prop has been removed. KTextArea doesn't display character count unless `characterLimit` prop is set and character count is exceeded
+* default value for `characterLimit` prop has changed to `null`
 
 #### Structure
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -291,11 +291,14 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 ### KTabs
 
 
-### KTextarea
+### KTextArea
 
 #### Props
 
 * `testMode` prop is removed
+* `isResizable` prop is deprecated in favor of `resizable` prop
+* `hasError` prop is deprecated in favor of `error` prop
+* `cols` prop has been removed (use CSS to control width of the textarea)
 
 #### Structure
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -198,6 +198,7 @@ Component has been renamed to `KDropdown`
 #### Structure
 
 * `k-input-label` class has been renamed to `k-label`
+* `is-required` class has been renamed to `required`
 
 ### KMenu
 
@@ -299,8 +300,7 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 * `isResizable` prop is deprecated in favor of `resizable` prop
 * `hasError` prop is deprecated in favor of `error` prop
 * `cols` prop has been removed (use CSS to control width of the textarea)
-* `disableCharacterLimit` prop has been removed. KTextArea doesn't display character count unless `characterLimit` prop is set and character count is exceeded
-* default value for `characterLimit` prop has changed to `null`
+* `disableCharacterLimit` prop has been removed. You can pass a boolean `false` to `characterLimit` prop to disable character limit
 
 #### Structure
 

--- a/sandbox/index.ts
+++ b/sandbox/index.ts
@@ -27,6 +27,7 @@ const sandboxAppLinks: SandboxNavigationItem[] = ([
   { name: 'KRadio', to: { name: 'radio' } },
   { name: 'KTable', to: { name: 'table' } },
   { name: 'KTabs', to: { name: 'tabs' } },
+  { name: 'KTextarea', to: { name: 'textarea' } },
 ])
 
 // Provide the app links to the SandboxLayout components

--- a/sandbox/pages/SandboxInput.vue
+++ b/sandbox/pages/SandboxInput.vue
@@ -22,7 +22,10 @@
         <KInput label="Label" />
       </SandboxSectionComponent>
       <SandboxSectionComponent title="labelAttributes">
-        <KInput label="Label" />
+        <KInput
+          label="Label"
+          :label-attributes="{ info: 'I use the KLabel `info` prop' }"
+        />
       </SandboxSectionComponent>
       <SandboxSectionComponent
         title="help"

--- a/sandbox/pages/SandboxTextarea.vue
+++ b/sandbox/pages/SandboxTextarea.vue
@@ -1,0 +1,133 @@
+<template>
+  <SandboxLayout
+    :links="inject('app-links', [])"
+    title="KTextarea"
+  >
+    <div class="ktextarea-sandbox">
+      <!-- Figma -->
+      <SandboxTitleComponent
+        is-subtitle
+        title="Figma"
+      />
+      <KExternalLink href="https://www.figma.com/file/Yze0SWXl5nKjR0rFdilljK/Components?type=design&node-id=737%3A10936&mode=dev">
+        Figma
+      </KExternalLink>
+
+      <!-- Props -->
+      <SandboxTitleComponent
+        is-subtitle
+        title="Props"
+      />
+      <SandboxSectionComponent title="label">
+        <KTextArea
+          label="Label"
+          resizable
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent title="labelAttributes">
+        <KTextArea
+          label="Label"
+          :label-attributes="{ info: 'I use the KLabel `info` prop' }"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
+        title="help"
+      >
+        <div class="toggle-container">
+          <KToggle v-slot="{isToggled, toggle}">
+            <KTextArea
+              class="full-width-input"
+              :error="isToggled.value"
+              help="This is help text. When error is true, this text will be red."
+              label="Label"
+            />
+            <KButton
+              size="small"
+              @click="toggle"
+            >
+              Toggle error
+            </KButton>
+          </KToggle>
+        </div>
+      </SandboxSectionComponent>
+      <SandboxSectionComponent title="error">
+        <KTextArea
+          error
+          label="Label"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
+        title="characterLimit"
+      >
+        <KTextArea
+          :character-limit="67"
+          label="Label"
+          model-value="Type in 1 more character to see the character limit error message: "
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent title="cols">
+        <KTextArea
+          :cols="10"
+          label="Label"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent title="rows">
+        <KTextArea
+          label="Label"
+          :rows="2"
+        />
+      </SandboxSectionComponent>
+
+      <!-- Attributes -->
+      <SandboxTitleComponent
+        is-subtitle
+        title="Attributes"
+      />
+      <SandboxSectionComponent>
+        <KTextArea
+          label="Placeholder"
+          placeholder="This input has a placeholder"
+        />
+        <KTextArea
+          label="Required"
+          required
+        />
+        <KTextArea
+          disabled
+          label="Disabled"
+          model-value="This input is disabled"
+        />
+      </SandboxSectionComponent>
+
+      <!-- Slots -->
+      <SandboxTitleComponent
+        is-subtitle
+        title="Slots"
+      />
+      <SandboxSectionComponent title="label-tooltip">
+        <KTextArea label="Label">
+          <template #label-tooltip>
+            Id: <code>123</code>
+          </template>
+        </KTextArea>
+      </SandboxSectionComponent>
+    </div>
+  </SandboxLayout>
+</template>
+
+<script setup lang="ts">
+import { inject } from 'vue'
+import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
+import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
+</script>
+
+<style lang="scss" scoped>
+.ktextarea-sandbox {
+  .toggle-container {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: column;
+    gap: $kui-space-70;
+  }
+}
+</style>

--- a/sandbox/pages/SandboxTextarea.vue
+++ b/sandbox/pages/SandboxTextarea.vue
@@ -65,12 +65,6 @@
           model-value="Type in 1 more character to see the character limit error message: "
         />
       </SandboxSectionComponent>
-      <SandboxSectionComponent title="cols">
-        <KTextArea
-          :cols="10"
-          label="Label"
-        />
-      </SandboxSectionComponent>
       <SandboxSectionComponent title="rows">
         <KTextArea
           label="Label"
@@ -96,6 +90,11 @@
           disabled
           label="Disabled"
           model-value="This input is disabled"
+        />
+        <KTextArea
+          label="Read-only"
+          model-value="This input is read-only"
+          readonly
         />
       </SandboxSectionComponent>
 

--- a/sandbox/router/sandbox-routes.ts
+++ b/sandbox/router/sandbox-routes.ts
@@ -74,6 +74,12 @@ const componentRoutes: RouteRecordRaw[] = [
     meta: { title: 'Tabs Sandbox' },
     component: () => import('../pages/SandboxTabs.vue'),
   },
+  {
+    path: '/textarea',
+    name: 'textarea',
+    meta: { title: 'Textarea Sandbox' },
+    component: () => import('../pages/SandboxTextarea.vue'),
+  },
 ]
 
 export default componentRoutes

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -82,8 +82,15 @@ describe('KInput', () => {
     cy.get('.k-label .tooltip-trigger-icon').should('exist').and('be.visible')
   })
 
-  it.skip('renders label with required symbol when `required` attribute is set', () => {
-    // TODO: implement when KLabel component is reskinned
+  it('handles `required` attribute correctly', () => {
+    mount(KInput, {
+      props: {
+        label: 'A label',
+        required: true,
+      },
+    })
+
+    cy.get('.k-label').should('have.class', 'required')
   })
 
   it('renders help when value is passed', () => {
@@ -108,7 +115,6 @@ describe('KInput', () => {
       },
     })
 
-    cy.get('.k-input-wrapper .over-char-limit').should('not.exist')
     cy.get('.k-input-wrapper input.k-input').type(`This input has ${textCharCount} characters`)
     cy.get('.k-input-wrapper.input-error .help-text').should('contain.text', `${textCharCount} / ${charLimit}`)
   })

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -48,13 +48,10 @@
       </div>
     </div>
 
-    <!-- use transition here so it's not flaky when the help text changes -->
     <Transition
       mode="out-in"
       name="kongponents-fade-transition"
     >
-      <!-- one element for characters limit exceeded error message as well as errorMessage and help props -->
-      <!-- see the logic in helpText computed property -->
       <p
         v-if="helpText"
         :key="String(helpTextKey)"
@@ -224,6 +221,9 @@ watch(charLimitExceeded, (newVal, oldVal) => {
       characterLimit: props.characterLimit,
       limitExceeded: newVal,
     })
+
+    // bump the key to trigger the transition
+    helpTextKey.value += 1
   }
 })
 
@@ -254,9 +254,11 @@ const getValue = (): string | number => {
   return currValue.value || modelValueChanged.value ? currValue.value : props.modelValue
 }
 
-watch(helpText, () => {
-  // bump the key to trigger the transition
-  helpTextKey.value += 1
+watch(() => props.error, (newVal, oldVal) => {
+  if (newVal !== oldVal) {
+    // bump the key to trigger the transition
+    helpTextKey.value += 1
+  }
 })
 </script>
 
@@ -270,7 +272,7 @@ export default {
 /* Component variables */
 // Only add variables here sparingly for ease of use when the same value needs to be referenced for display logic.
 
-$kInputPaddingX: var(--kui-space-50, $kui-space-50);
+$kInputPaddingX: var(--kui-space-50, $kui-space-50); // corresponds to mixin, search for variable name in mixins
 $kInputIconSize: var(--kui-icon-size-40, $kui-icon-size-40);
 
 /* Component styles */

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -283,14 +283,14 @@ $kInputIconSize: var(--kui-icon-size-40, $kui-icon-size-40);
   // error styles
   &.input-error {
     .k-input {
-      box-shadow: var(--kui-shadow-border-danger, $kui-shadow-border-danger);
+      @include inputError;
 
       &:hover {
-        box-shadow: var(--kui-shadow-border-danger-strong, $kui-shadow-border-danger-strong);
+        @include inputErrorHover;
       }
 
       &:focus {
-        box-shadow: var(--kui-shadow-border-danger, $kui-shadow-border-danger), var(--kui-shadow-focus, $kui-shadow-focus);
+        @include inputErrorFocus;
       }
     }
 

--- a/src/components/KLabel/KLabel.cy.ts
+++ b/src/components/KLabel/KLabel.cy.ts
@@ -26,7 +26,7 @@ describe('KLabel', () => {
       },
     })
 
-    cy.get('.k-label.is-required').should('exist')
+    cy.get('.k-label.required').should('exist')
   })
 
   it('renders a tooltip when `info` prop is provided', () => {

--- a/src/components/KLabel/KLabel.cy.ts
+++ b/src/components/KLabel/KLabel.cy.ts
@@ -27,6 +27,18 @@ describe('KLabel', () => {
     })
 
     cy.get('.k-label.required').should('exist')
+
+    // access element's before pseudo element
+    cy.get('.k-label.required').then($els => {
+      // get Window reference from element
+      const win = $els[0].ownerDocument.defaultView
+      // use getComputedStyle to read the pseudo selector
+      const before = win?.getComputedStyle($els[0], 'before')
+      // read the value of the `content` CSS property
+      const contentValue = before?.getPropertyValue('content')
+      // the returned value will be an empty string with double quotes around it
+      expect(contentValue).to.eq('""')
+    })
   })
 
   it('renders a tooltip when `info` prop is provided', () => {

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -1,7 +1,7 @@
 <template>
   <label
     class="k-label"
-    :class="{ 'is-required': required }"
+    :class="{ 'required': required }"
   >
     <slot />
     <KTooltip
@@ -79,7 +79,7 @@ $kLabelRequiredDotSize: 6px;
   display: inline-flex;
   margin-bottom: var(--kui-space-40, $kui-space-40);
 
-  &.is-required {
+  &.required {
     margin-left: calc($kLabelSpacingX + $kLabelRequiredDotSize); // 6px to compensate for the 6px width of the dot
     position: relative;
 

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -1,33 +1,22 @@
 import { mount } from 'cypress/vue'
 import KTextArea from '@/components/KTextArea/KTextArea.vue'
 
-/**
- * ALL TESTS MUST USE testMode: true
- * We generate unique IDs for reference by aria properties. Debug mode strips these out
- * allowing for successful snapshot verification.
- * props: {
- *   testMode: true
- * }
- */
-
 describe('KTextArea', () => {
   it('renders text when value is passed', () => {
     const value = 'Howdy!'
     mount(KTextArea, {
       props: {
-        testMode: true,
-        modelValue: value, // v-model
+        modelValue: value,
       },
     })
 
     cy.get('textarea').should('have.value', value)
   })
 
-  it('renders label when value is passed', () => {
+  it('renders `label` when value is passed', () => {
     const labelText = 'A Label!'
     mount(KTextArea, {
       props: {
-        testMode: true,
         label: labelText,
       },
     })
@@ -35,14 +24,13 @@ describe('KTextArea', () => {
     cy.get('.k-label').should('contain.text', labelText)
   })
 
-  it('renders label with labelAttributes applied', () => {
+  it('renders label with `labelAttributes` applied', () => {
     const labelText = 'A Label'
     mount(KTextArea, {
       props: {
-        testMode: true,
         label: labelText,
         labelAttributes: {
-          info: 'some help text',
+          info: 'some info text',
         },
       },
     })
@@ -51,54 +39,34 @@ describe('KTextArea', () => {
     cy.get('.k-label .tooltip-trigger-icon').should('be.visible')
   })
 
-  it('renders overlayed label when value is passed', () => {
-    const labelText = 'A Label'
+  it('handles `required` attribute correctly', () => {
     mount(KTextArea, {
       props: {
-        testMode: true,
-        label: labelText,
-        overlayLabel: true,
-      },
-    })
-
-    cy.get('.text-on-input label').should('contain.text', labelText)
-  })
-
-  it('renders an asterisk when `overlayLabel` is true and `required` attr is set', () => {
-    const label = 'A label'
-    mount(KTextArea, {
-      props: {
-        testMode: true,
-        label,
-        overlayLabel: true,
-      },
-      attrs: {
+        label: 'A label',
         required: true,
       },
     })
 
-    cy.get('.text-on-input  .is-required').should('exist')
+    cy.get('.k-label').should('have.class', 'required')
   })
 
-  it('renders textarea when rows and cols are passed in', () => {
+  it('renders textarea when `rows` prop is passed in', () => {
     mount(KTextArea, {
       props: {
-        testMode: true,
         rows: 2,
-        cols: 15,
       },
     })
 
-    cy.get('textarea').should('be.visible')
+    cy.get('textarea').should('be.visible').should('have.attr', 'rows', '2')
   })
 
   it('reacts to text changes', () => {
     const value1 = 'hey'
     const value2 = 'hey, dude'
+
     mount(KTextArea, {
       props: {
-        testMode: true,
-        modelValue: value1, // v-model
+        modelValue: value1,
       },
     })
 
@@ -112,50 +80,27 @@ describe('KTextArea', () => {
     cy.get('textarea').should('have.value', value2)
   })
 
-  it('can configure character limit', () => {
-    const charLimit = 500
+  it('shows character count when `characterLimit` prop is set and exceeded', () => {
+    const textCharCount = 28
+    const charLimit = 5
+
     mount(KTextArea, {
       props: {
-        testMode: true,
         characterLimit: charLimit,
       },
     })
 
-    cy.get('.char-limit').should('contain.text', charLimit)
+    cy.get('textarea').type(`This input has ${textCharCount} characters`)
+    cy.get('.k-textarea.input-error .help-text').should('contain.text', `${textCharCount} / ${charLimit}`)
   })
 
-  it('should have style when value exceeds the character limit', () => {
-    const charLimit = 20
+  it('should handle `resizable` prop correctly', () => {
     mount(KTextArea, {
       props: {
-        testMode: true,
-        characterLimit: charLimit,
+        resizable: true,
       },
     })
 
-    cy.get('textarea').type('a'.repeat(charLimit + 1))
-    cy.get('textarea').should('have.value', 'a'.repeat(charLimit + 1))
-    cy.get('div.over-char-limit').should('be.visible')
-  })
-
-  it('should allow disabling character limit', () => {
-    mount(KTextArea, {
-      props: {
-        testMode: true,
-        disableCharacterLimit: true,
-      },
-    })
-
-    cy.get('.char-limit').should('not.exist')
-  })
-
-  it('should have `is-resizable` class when is-resizable prop is enabled', () => {
-    mount(KTextArea, {
-      props: {
-        isResizable: true,
-      },
-    })
-
-    cy.get('textarea').should('have.class', 'is-resizable')
+    cy.get('textarea').should('have.class', 'resizable')
   })
 })

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -74,7 +74,7 @@ const props = defineProps({
   },
   characterLimit: {
     type: Number,
-    default: 2048,
+    default: null,
     // Ensure the characterLimit is greater than zero
     validator: (limit: number): boolean => limit > 0,
   },
@@ -166,7 +166,13 @@ const modifiedAttrs = computed((): Record<string, any> => {
   return $attrs
 })
 
-const charLimitExceeded = computed((): boolean => currValue.value.length > props.characterLimit)
+const charLimitExceeded = computed((): boolean => {
+  if (props.characterLimit === null) {
+    return false
+  }
+
+  return currValue.value.length > props.characterLimit
+})
 
 const inputHandler = (e: any): void => {
   // avoid pass by ref

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -10,7 +10,6 @@
       :required="isRequired"
     >
       {{ strippedLabel }}
-
       <template
         v-if="hasLabelTooltip"
         #tooltip

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -76,7 +76,7 @@ const props = defineProps({
     type: Number,
     default: 2048,
     // Ensure the characterLimit is greater than zero
-    validator: (limit: number):boolean => limit > 0,
+    validator: (limit: number): boolean => limit > 0,
   },
   rows: {
     type: Number,
@@ -100,6 +100,13 @@ const props = defineProps({
   isResizable: {
     type: Boolean,
     default: false,
+    validator: (value: boolean): boolean => {
+      if (value) {
+        console.warn('KTextArea: the `isResizable` prop is deprecated in favor of the `resizable` prop. See the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#ktextarea')
+      }
+
+      return true
+    },
   },
   /**
    * @deprecated in favor of `error` prop
@@ -107,6 +114,13 @@ const props = defineProps({
   hasError: {
     type: Boolean,
     default: false,
+    validator: (value: boolean): boolean => {
+      if (value) {
+        console.warn('KTextArea: the `hasError` prop is deprecated in favor of the `error` prop. See the migration guide for more details: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html#ktextarea')
+      }
+
+      return true
+    },
   },
 })
 

--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -15,7 +15,7 @@
   font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
   line-height: var(--kui-line-height-40, $kui-line-height-40);
   outline: none;
-  padding: var(--kui-space-40, $kui-space-40) $kInputPaddingX;
+  padding: var(--kui-space-40, $kui-space-40) var(--kui-space-50, $kui-space-50);
   transition: box-shadow $kongponentsTransitionDurTimingFunc;
   width: 100%;
 
@@ -51,4 +51,18 @@
 
 @mixin inputReadOnly {
   @include inputDisabledReadOnly;
+}
+
+// error state styles
+
+@mixin inputError {
+  box-shadow: var(--kui-shadow-border-danger, $kui-shadow-border-danger);
+}
+
+@mixin inputErrorHover {
+  box-shadow: var(--kui-shadow-border-danger-strong, $kui-shadow-border-danger-strong);
+}
+
+@mixin inputErrorFocus {
+  box-shadow: var(--kui-shadow-border-danger, $kui-shadow-border-danger), var(--kui-shadow-focus, $kui-shadow-focus);
 }

--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -13,9 +13,9 @@
     $kui-font-size-40
   ); // needs to be at least 16px to prevent automatic zoom in on focus on mobile
   font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
-  line-height: var(--kui-line-height-40, $kui-line-height-40);
+  line-height: var(--kui-line-height-40, $kui-line-height-40); // $kTextAreaLineHeight
   outline: none;
-  padding: var(--kui-space-40, $kui-space-40) var(--kui-space-50, $kui-space-50);
+  padding: var(--kui-space-40, $kui-space-40) var(--kui-space-50, $kui-space-50); // $kInputPaddingX, $kTextAreaPaddingY
   transition: box-shadow $kongponentsTransitionDurTimingFunc;
   width: 100%;
 


### PR DESCRIPTION
# Summary

[Jira](https://konghq.atlassian.net/browse/KHCP-9004)
[Figma](https://www.figma.com/file/Yze0SWXl5nKjR0rFdilljK/Components?type=design&node-id=737%3A10936&mode=dev)

KTextarea component reskinning.

Links:

- [Kongponents sandbox](https://deploy-preview-1826--kongponents-sandbox.netlify.app/#/textarea)
- [Kongponents docs preview](https://deploy-preview-1826--kongponents.netlify.app/components/textarea.html)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
