### PR TITLE
fix(ktable): reset offsets after sort key changes

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -807,10 +807,12 @@ const sortClickHandler = (header: TableHeader): void => {
     } else {
       sortColumnKey.value = key
       sortColumnOrder.value = 'asc'
+      offsets.value = [null]
     }
   } else {
     sortColumnKey.value = key
     sortColumnOrder.value = 'asc'
+    offsets.value = [null]
   }
 
   // Use deprecated sort function to sort data passed in via


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

When `sortColumnKey` is changed, the `offsets` array needs to be reset to avoid using the previous `offset` of the old sort key.

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
