### PR TITLE
fix: kselect selectedItem should reset to null

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -712,6 +712,7 @@ watch(() => props.items, (newValue, oldValue) => {
   }
 
   selectItems.value = JSON.parse(JSON.stringify(props.items))
+  selectedItem.value = null
   for (let i = 0; i < selectItems.value?.length; i++) {
     // Ensure each item has a `selected` property
     if (selectItems.value[i].selected === undefined) {


### PR DESCRIPTION
# Summary

This resolves an issue where sometimes the selectedItems can have duplicate `selected = true` state.

Essentially you have reactive `items` value that can look like this:
```json
[
    {
        "value": "b81af73c-a556-446a-a0a3-16980a791e12",
        "label": "v1",
        "selected": true
    },
    {
        "value": "cd026175-cafa-46b0-b269-4a40c1f79b68",
        "label": "v2",
        "selected": false
    },
    {
        "value": "10cb8ed7-d0a4-409b-89a6-551df65e8963",
        "label": "v3",
        "selected": false
    }
]
```
Next you update the props to be as follows:
```json
[
    {
        "value": "b81af73c-a556-446a-a0a3-16980a791e12",
        "label": "v1",
        "selected": false
    },
    {
        "value": "cd026175-cafa-46b0-b269-4a40c1f79b68",
        "label": "v2",
        "selected": false
    },
    {
        "value": "10cb8ed7-d0a4-409b-89a6-551df65e8963",
        "label": "v3",
        "selected": true
    }
]
```

On the second loop, [Line 723](https://github.com/Kong/kongponents/pull/1843/files#diff-68c30a7348bc67fac2678056261caf1e95de49eac77fe252f3efa4c7fe2eecf9R723) can yield false (skipping the update), but [line 733](https://github.com/Kong/kongponents/pull/1843/files#diff-68c30a7348bc67fac2678056261caf1e95de49eac77fe252f3efa4c7fe2eecf9R733) will set `selected = true`, resulting in two selected items.


## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
