### PR TITLE
fix(kselect): autosuggest query

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -657,6 +657,7 @@ const clearSelection = (): void => {
   selectedItem.value = null
   if (props.appearance === 'select') {
     filterStr.value = ''
+    emit('query-change', '')
   }
   // this 'input' event must be emitted for v-model binding to work properly
   emit('input', null)
@@ -678,8 +679,10 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
 }
 
 const onQueryChange = (query: string) => {
-  filterStr.value = query
-  emit('query-change', query)
+  if (filterStr.value !== query) {
+    filterStr.value = query
+    emit('query-change', query)
+  }
 }
 
 const onInputFocus = (): void => {


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a bug where extra `query-change` events are fired after the user clicks on an item in autosuggest mode, making the item lose its "selected" status (because in the `query-change` event handler of the autosuggest select, users will fetch new `items` based on user input, which will then trigger the `props.items` watcher and [set `selectedItem.value` to null](https://github.com/Kong/kongponents/blob/27e460f6460dfdf299bd279c44664a77874d1deb/src/components/KSelect/KSelect.vue#L718)).

Before the fix:

![Kapture 2023-11-15 at 15 02 14](https://github.com/Kong/kongponents/assets/10095631/c41a79fd-11e2-4638-b46f-535bdcb71cd2)

After the fix:

![Kapture 2023-11-15 at 15 04 29](https://github.com/Kong/kongponents/assets/10095631/a8bbd94c-6de9-41a8-a825-8eb89c17a595)


## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
