### PR TITLE
fix(kinput): add box-sizing rule

### DIFF
--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -6,6 +6,7 @@
   border: 0;
   border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
   box-shadow: var(--kui-shadow-border, $kui-shadow-border);
+  box-sizing: border-box; // Ensure the padding is calculated in the element's width
   color: var(--kui-color-text, $kui-color-text);
   font-family: var(--kui-font-family-text, $kui-font-family-text);
   font-size: var(


### PR DESCRIPTION
# Summary

The `KInput` is missing the `box-sizing` property, meaning the element's padding will cause it to exceed it's container's width

## Before

![image](https://github.com/Kong/kongponents/assets/2229946/9ff625ff-b9a2-4bc9-ba13-a4deab4da9b5)


## After

![image](https://github.com/Kong/kongponents/assets/2229946/26ff7099-e5c5-432a-9ae3-b149f0953a0b)


## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
