### PR TITLE
fix(ktable): error state CTA

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -38,9 +38,11 @@
             {{ errorStateMessage }}
           </template>
 
-          <template #cta>
+          <template
+            v-if="errorStateActionMessage"
+            #cta
+          >
             <KButton
-              v-if="errorStateActionMessage"
               appearance="primary"
               :data-testid="getTestIdString(errorStateActionMessage)"
               :to="errorStateActionRoute ? errorStateActionRoute : undefined"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes an empty button in the `cta` slot when `errorStateActionMessage` is not passed to `<KTable>`. As a reference, this is how we handle `emptyStateActionMessage`: https://github.com/Kong/kongponents/blob/93397a42ccbfb05cd2d922d66934ae4bbfb1a501/src/components/KTable/KTable.vue#L76-L89 
 
<img width="1611" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/f1d09e28-0b72-4986-88f3-e2d5d52ad663">

The `main` branch does not have this problem.

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
