### PR TITLE
fix(ktable): add truncate class styles

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -1174,6 +1174,10 @@ export const defaultSorter = (key: string, previousKey: string, sortOrder: strin
           transform: rotate(-180deg);
         }
       }
+
+      &.truncate {
+        @include truncate;
+      }
     }
   }
 
@@ -1193,6 +1197,10 @@ export const defaultSorter = (key: string, previousKey: string, sortOrder: strin
         color: var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong);
         font-size: var(--kui-font-size-40, $kui-font-size-40);
         font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
+      }
+
+      &.truncate {
+        @include truncate;
       }
     }
   }

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -1175,7 +1175,7 @@ export const defaultSorter = (key: string, previousKey: string, sortOrder: strin
         }
       }
 
-      &.truncate {
+      &.truncate, .truncate {
         @include truncate;
       }
     }
@@ -1199,7 +1199,7 @@ export const defaultSorter = (key: string, previousKey: string, sortOrder: strin
         font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
       }
 
-      &.truncate {
+      &.truncate, .truncate {
         @include truncate;
       }
     }


### PR DESCRIPTION
# Summary

Add `.truncate` class styles in `th` and `td` elements

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
