### PR TITLE
fix(kcopy): icon having left margin when format is hidden

### DIFF
--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -187,10 +187,6 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
   align-items: center;
   display: flex;
 
-  &-badge-text {
-    margin-right: var(--kui-space-40, $kui-space-40);
-  }
-
   .copy-element {
     align-items: center;
     display: inline-flex;

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="k-copy">
     <span
-      v-if="badge"
+      v-if="badge && badgeLabel"
       class="copy-badge-text"
     >
       {{ badgeLabel }}

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -202,7 +202,6 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
 
     .truncate-content {
       display: inline-block;
-      margin-right: var(--kui-space-30, $kui-space-30);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -224,6 +223,7 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
     cursor: pointer;
     display: flex;
     font-size: var(--kui-font-size-20, $kui-font-size-20);
+    gap: var(--kui-space-30, $kui-space-30);
     line-height: var(--kui-line-height-20, $kui-line-height-20);
     padding: var(--kui-space-10, $kui-space-10) var(--kui-space-30, $kui-space-30);
     white-space: nowrap;
@@ -237,7 +237,6 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
     align-items: center;
     cursor: pointer;
     display: flex;
-    margin-left: var(--kui-space-30, $kui-space-30);
   }
 
   .text-icon {


### PR DESCRIPTION
# Summary

**fix(kcopy): icon having left margin when format is hidden**

Fix an issue when using KCopy’s `props.format` being set to `'hidden'` that adds an unnecessary left margin to the icon even though no text is shown.

**chore(kcopy): remove unused styles**

**fix(kcopy): rendering badgeLabel content when badgeLabel isn’t set**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- This slightly narrows the gap between text and copy icon when using `props.badge` on account of `.truncate-content` adding a right marging and `.text-icon-wrapper` adding a left margin. It seems like this gap is unintentionally big currently.
- There is one more instance in KCopy where using `gap` on a container would be a more robust strategy to create space between elements: `.copy-badge-text`. I left this untouched as it’s not strictly speaking a visual bug.
- Is `.k-copy { &-badge-text { margin-right: var(--kui-space-40, $kui-space-40); } }` a dead style? I think nothing is actually using it so I’m removing it in https://github.com/Kong/kongponents/pull/1897/commits/466ba91701f927cedaa4a6004ec6777f996ba210.

## Screenshots

Note the difference in gap for format `hidden` to the blue box.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/Kong/kongponents/assets/5774638/acec5d0e-2637-4314-8582-a9d882803f35) | ![image](https://github.com/Kong/kongponents/assets/5774638/e15f597b-4398-488f-8927-f895b2e2d49d) |
| ![image](https://github.com/Kong/kongponents/assets/5774638/43bdf75c-0b7a-440d-a3c2-b19d490f986f) | ![image](https://github.com/Kong/kongponents/assets/5774638/6cde63c6-7903-4e50-8f19-34932ae0d7e7) |

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
