### PR TITLE
fix(ktruncate): stop click propagation [KHCP 10009]

### DIFF
--- a/src/components/KTruncate/KTruncate.vue
+++ b/src/components/KTruncate/KTruncate.vue
@@ -21,7 +21,7 @@
         >
           <button
             class="expand-trigger"
-            @click="handleToggleClick"
+            @click.stop="handleToggleClick"
           >
             {{ truncatedCount }}
           </button>
@@ -46,7 +46,7 @@
             :color="KUI_COLOR_TEXT_PRIMARY"
             role="button"
             tabindex="0"
-            @click="handleToggleClick"
+            @click.stop="handleToggleClick"
           />
         </slot>
       </div>
@@ -67,7 +67,7 @@
           <KButton
             appearance="tertiary"
             size="small"
-            @click="handleToggleClick"
+            @click.stop="handleToggleClick"
           >
             Show more
           </KButton>
@@ -81,7 +81,7 @@
           <KButton
             appearance="tertiary"
             size="small"
-            @click="handleToggleClick"
+            @click.stop="handleToggleClick"
           >
             Show less
           </KButton>


### PR DESCRIPTION
# Summary

Stop click propagation on the KTruncate expand/collapse buttons to prevent it bubbling up to a table row, etc.