### PR TITLE
fix(kslideout): long titles not truncating

### DIFF
--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -167,6 +167,9 @@ const offsetTopValue = computed((): string => {
       margin-top: var(--kui-space-60, $kui-space-60);
     }
     .k-slideout-main-title {
+      // Prevents long, non-wrapping titles from triggering a horizontal scrollbar in the content area. This also allows `.k-slideout-title` to actually truncate its text content.
+      min-width: 0;
+
       .k-slideout-title {
         color: var(--kui-color-text-neutral, $kui-color-text-neutral);
         flex:1;


### PR DESCRIPTION
# Summary

Fix an issue with long, non-wrapping titles not truncating and triggering a horizontal scrollbar in the content area.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

| Before | After |
| ------ | ----- |
| ![image](https://github.com/Kong/kongponents/assets/5774638/b79edd26-0511-47d9-89d5-43b9465ea602) | ![image](https://github.com/Kong/kongponents/assets/5774638/1d55b9f8-9fa4-4f7b-9627-d95e9770867a) |

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
