### PR TITLE
fix(kselect): fix klabel and help text elements

### DIFF
--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -428,6 +428,8 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 * `k-select-loading` `data-testid` attribute has been changed to `select-loading`
 * `k-select-group-title` class has been changed to `select-group-title`
 * `k-select-selected-item` `data-testid` attribute has been changed to `selected-item`
+* `k-select-list` class has been changed to `select-items-container`
+* `k-select-label` `data-testid` attribute has been changed to `select-label`
 
 #### Constants, Types & Interfaces
 

--- a/sandbox/pages/SandboxSelect.vue
+++ b/sandbox/pages/SandboxSelect.vue
@@ -79,6 +79,7 @@
       >
         <KSelect
           error
+          help="Help text."
           :items="selectItems"
         />
       </SandboxSectionComponent>
@@ -212,7 +213,9 @@
         <p>Truncation of long content is NOT handled by the component.</p>
         <KSelect
           clearable
+          help="Help text."
           :items="selectItems"
+          label="Label"
           width="300"
         >
           <template #selected-item-template="{ item }">

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -3,6 +3,23 @@
     class="k-select"
     :class="[$attrs.class]"
   >
+    <KLabel
+      v-if="label"
+      v-bind="labelAttributes"
+      data-testid="select-label"
+      :for="selectId"
+      :required="isRequired"
+    >
+      {{ strippedLabel }}
+
+      <template
+        v-if="hasLabelTooltip"
+        #tooltip
+      >
+        <slot name="label-tooltip" />
+      </template>
+    </KLabel>
+
     <KToggle v-slot="{ toggle, isToggled }">
       <KPop
         ref="popperElement"
@@ -32,9 +49,6 @@
             data-testid="select-input"
             :disabled="isDisabled"
             :error="error"
-            :help="help"
-            :label="label ? strippedLabel : undefined"
-            :label-attributes="labelAttributes"
             :model-value="filterQuery"
             :placeholder="selectedItem && !enableFiltering ? selectedItem.label : placeholderText"
             :readonly="isReadonly"
@@ -159,6 +173,13 @@
         </template>
       </KPop>
     </KToggle>
+    <p
+      v-if="help"
+      class="help-text"
+      :class="{ 'select-error': error }"
+    >
+      {{ help }}
+    </p>
   </div>
 </template>
 
@@ -167,6 +188,7 @@ import type { Ref, PropType } from 'vue'
 import { ref, computed, watch, nextTick, useAttrs, useSlots, onUnmounted, onMounted } from 'vue'
 import { v4 as uuidv4 } from 'uuid'
 import useUtilities from '@/composables/useUtilities'
+import KLabel from '@/components/KLabel/KLabel.vue'
 import KInput from '@/components/KInput/KInput.vue'
 import KPop from '@/components/KPop/KPop.vue'
 import KToggle from '@/components/KToggle'
@@ -327,6 +349,7 @@ const slots = useSlots()
 
 const resizeObserver = ref<ResizeObserverHelper>()
 
+const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.info || slots['label-tooltip']))
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const isDisabled = computed((): boolean => attrs.disabled !== undefined && String(attrs.disabled) !== 'false')
 const isReadonly = computed((): boolean => attrs.readonly !== undefined && String(attrs.readonly) !== 'false')
@@ -758,6 +781,18 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
 
     &-static {
       position: static;
+    }
+  }
+
+  .help-text {
+    @include inputHelpText;
+
+    // reset default margin from browser
+    margin: 0;
+    margin-top: var(--kui-space-40, $kui-space-40);
+
+    &.select-error {
+      color: var(--kui-color-text-danger, $kui-color-text-danger);
     }
   }
 }


### PR DESCRIPTION
# Summary

Use standalone KLabel and help text elements in KSelect to fix absolutely positioned element (custom item) taking up full height (screenshot)

![Screenshot 2024-01-09 at 6 04 48 PM](https://github.com/Kong/kongponents/assets/36751160/d16fb793-0818-4840-8403-bea29fcf1db8)
![Screenshot 2024-01-09 at 6 04 45 PM](https://github.com/Kong/kongponents/assets/36751160/882798a9-4ff1-4c29-ba70-1782fd975723)


## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
