### PR TITLE
fix(kselect): do not clear selected item when items empty

### DIFF
--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -610,7 +610,13 @@ watch(() => props.items, (newValue, oldValue) => {
   }
 
   selectItems.value = JSON.parse(JSON.stringify(props.items))
-  selectedItem.value = null
+
+  // drop selected item value to find the selected item in the new list
+  // unless items is empty
+  if (selectItems.value?.length) {
+    selectedItem.value = null
+  }
+
   for (let i = 0; i < selectItems.value?.length; i++) {
     // Ensure each item has a `selected` property
     if (selectItems.value[i].selected === undefined) {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -44,7 +44,7 @@
             autocomplete="off"
             class="select-input"
             :class="{ 'filtering-disabled': !enableFiltering,
-                      'hide-model-value': hasCustomSelectedItem
+                      'hide-model-value': hasCustomSelectedItem,
             }"
             data-testid="select-input"
             :disabled="isDisabled"
@@ -707,6 +707,10 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
     &.hide-model-value {
       :deep(input) {
         color: transparent;
+
+        &::placeholder {
+          color: transparent;
+        }
       }
     }
   }

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -44,7 +44,7 @@
             autocomplete="off"
             class="select-input"
             :class="{ 'filtering-disabled': !enableFiltering,
-                      'hide-model-value': hasCustomSelectedItem,
+                      'hide-model-value': hasCustomSelectedItem
             }"
             data-testid="select-input"
             :disabled="isDisabled"


### PR DESCRIPTION
# Summary

Fixes:
1. We clear selected items to then find it again in the items array, however if items is empty we still want to have the selected item that’s set through `v-model`
2. Hide input placeholder when custom selected item is visible

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
