### PR TITLE
fix(ktabs): remove panel tabindex, add padding top

### DIFF
--- a/sandbox/pages/SandboxInputSwitch.vue
+++ b/sandbox/pages/SandboxInputSwitch.vue
@@ -17,7 +17,7 @@
         </div>
 
         <div>
-          <KInputSwitch v-model="vModel" />
+          <KInputSwitch v-model="vModel0" />
         </div>
       </SandboxSectionComponent>
 
@@ -29,21 +29,21 @@
       <SandboxSectionComponent title="size">
         <div class="horizontal-spacing">
           <KInputSwitch
-            v-model="vModel"
+            v-model="vModel1"
             size="large"
           />
-          <KInputSwitch v-model="vModel" />
+          <KInputSwitch v-model="vModel1" />
         </div>
       </SandboxSectionComponent>
       <SandboxSectionComponent title="label">
         <KInputSwitch
-          v-model="vModel"
+          v-model="vModel1"
           label="Label"
         />
       </SandboxSectionComponent>
       <SandboxSectionComponent title="labelPosition">
         <KInputSwitch
-          v-model="vModel"
+          v-model="vModel1"
           label="Label"
           :label-attributes="{ info: 'I use the KLabel `info` prop' }"
           label-before
@@ -51,14 +51,14 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent title="disabled">
         <KInputSwitch
-          v-model="vModel"
+          v-model="vModel1"
           disabled
           label="Disabled"
         />
       </SandboxSectionComponent>
       <SandboxSectionComponent title="disabledTooltipText">
         <KInputSwitch
-          v-model="vModel"
+          v-model="vModel1"
           disabled
           disabled-tooltip-text="Disabled tooltip text"
           label="Disabled"
@@ -71,7 +71,7 @@
         title="Slots"
       />
       <SandboxSectionComponent title="label">
-        <KInputSwitch v-model="vModel">
+        <KInputSwitch v-model="vModel1">
           <template #label>
             Label
           </template>
@@ -79,7 +79,7 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent title="label-tooltip">
         <KInputSwitch
-          v-model="vModel"
+          v-model="vModel1"
           label="Label"
         >
           <template #label-tooltip>
@@ -96,7 +96,8 @@ import { ref, inject } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 
-const vModel = ref<boolean>(false)
+const vModel0 = ref<boolean>(false)
+const vModel1 = ref<boolean>(false)
 </script>
 
 <style scoped lang="scss">

--- a/sandbox/pages/SandboxTabs.vue
+++ b/sandbox/pages/SandboxTabs.vue
@@ -20,7 +20,13 @@
           :tabs="items"
         >
           <template #tab1>
-            Tab 1 content
+            <div>
+              Tab 1 content
+            </div>
+            <br>
+            <KButton size="small">
+              Dummy button
+            </KButton>
           </template>
           <template #tab2>
             Tab 2 content

--- a/src/components/KInputSwitch/KInputSwitch.vue
+++ b/src/components/KInputSwitch/KInputSwitch.vue
@@ -11,7 +11,6 @@
       :disabled="disabled"
       tabindex="-1"
       type="checkbox"
-      @change="handleChange"
       @input="handleChange"
     >
     <component

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -115,8 +115,6 @@ watch(() => props.modelValue, (newTabHash) => {
 
     .tab-item {
       cursor: pointer;
-      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
-      margin-bottom: calc(-1 * var(--kui-border-width-10, $kui-border-width-10)); // to make the active item border appear on top of the bottom border
       padding-bottom: var(--kui-space-40, $kui-space-40);
       position: relative;
       transition: border-bottom $kongponentsTransitionDurTimingFunc;

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -36,7 +36,6 @@
         :aria-labelledby="`${tab.hash.replace('#','')}-tab`"
         class="tab-container"
         role="tabpanel"
-        tabindex="0"
       >
         <slot
           v-if="activeTab === tab.hash"
@@ -112,6 +111,7 @@ watch(() => props.modelValue, (newTabHash) => {
     overflow-x: auto;
     overflow-y: hidden;
     padding: var(--kui-space-0, $kui-space-0) var(--kui-space-70, $kui-space-70);
+    padding-top: var(--kui-space-20, $kui-space-20);
 
     .tab-item {
       cursor: pointer;
@@ -119,7 +119,7 @@ watch(() => props.modelValue, (newTabHash) => {
       margin-bottom: calc(-1 * var(--kui-border-width-10, $kui-border-width-10)); // to make the active item border appear on top of the bottom border
       padding-bottom: var(--kui-space-40, $kui-space-40);
       position: relative;
-      transition: border-bottom $kongponentsKongIconSelector;
+      transition: border-bottom $kongponentsTransitionDurTimingFunc;
       white-space: nowrap;
 
       .tab-link {


### PR DESCRIPTION
# Summary

Fixes:
- removes `tabindex` attribute from KTabs panel container
- adds padding top to fix cutoff
- fixes `transition` property invalid value

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
