### PR TITLE
fix(ktabs): tab click target being too small when using hide panels

### DIFF
--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -115,9 +115,13 @@ watch(() => props.modelValue, (newTabHash) => {
     padding-top: var(--kui-space-20, $kui-space-20);
 
     .tab-item {
+      border-bottom-color: var(--kui-color-border-transparent, $kui-color-border-transparent);
+      border-bottom-style: solid;
+      border-bottom-width: var(--kui-border-width-20, $kui-border-width-20);
       cursor: pointer;
       padding-bottom: var(--kui-space-40, $kui-space-40);
       position: relative;
+      transition: border-color $kongponentsTransitionDurTimingFunc;
       white-space: nowrap;
 
       .tab-link {
@@ -155,7 +159,7 @@ watch(() => props.modelValue, (newTabHash) => {
       }
 
       &.active {
-        border-bottom: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-decorative-purple, $kui-color-border-decorative-purple);
+        border-color: var(--kui-color-border-decorative-purple, $kui-color-border-decorative-purple);
 
         .tab-link {
           color: var(--kui-color-text, $kui-color-text);

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -118,7 +118,6 @@ watch(() => props.modelValue, (newTabHash) => {
       cursor: pointer;
       padding-bottom: var(--kui-space-40, $kui-space-40);
       position: relative;
-      transition: border-bottom $kongponentsTransitionDurTimingFunc;
       white-space: nowrap;
 
       .tab-link {

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -121,7 +121,7 @@ watch(() => props.modelValue, (newTabHash) => {
       cursor: pointer;
       padding-bottom: var(--kui-space-40, $kui-space-40);
       position: relative;
-      transition: border-color $kongponentsTransitionDurTimingFunc;
+      transition: border-bottom-color $kongponentsTransitionDurTimingFunc;
       white-space: nowrap;
 
       .tab-link {
@@ -159,7 +159,7 @@ watch(() => props.modelValue, (newTabHash) => {
       }
 
       &.active {
-        border-color: var(--kui-color-border-decorative-purple, $kui-color-border-decorative-purple);
+        border-bottom-color: var(--kui-color-border-decorative-purple, $kui-color-border-decorative-purple);
 
         .tab-link {
           color: var(--kui-color-text, $kui-color-text);

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -15,6 +15,7 @@
           :aria-controls="hidePanels ? undefined : `panel-${tab.hash}`"
           :aria-selected="hidePanels ? undefined : (activeTab === tab.hash ? 'true' : 'false')"
           class="tab-link"
+          :class="{ 'has-panels': !hidePanels }"
           role="tab"
           :tabindex="tab.disabled ? '-1' : '0'"
           @click.prevent="handleTabChange(tab.hash)"
@@ -125,10 +126,15 @@ watch(() => props.modelValue, (newTabHash) => {
         color: var(--kui-color-text-neutral, $kui-color-text-neutral);
         display: inline-flex;
         gap: var(--kui-space-40, $kui-space-40);
-        padding: var(--kui-space-30, $kui-space-30) var(--kui-space-50, $kui-space-50);
         text-decoration: none;
         transition: color $kongponentsTransitionDurTimingFunc, background-color $kongponentsTransitionDurTimingFunc, box-shadow $kongponentsTransitionDurTimingFunc;
         user-select: none;
+
+        // Applies the padding to the tab’s content when not showing panels which is typically used for placing links inside KTabs for navigational tabs. Otherwise, clicking the tab outside of the link’s box will mark it as active but won’t actually navigate.
+        &.has-panels,
+        &:not(.has-panels) :deep(> *) {
+          padding: var(--kui-space-30, $kui-space-30) var(--kui-space-50, $kui-space-50);
+        }
 
         a, :deep(a) {
           color: var(--kui-color-text, $kui-color-text);


### PR DESCRIPTION
# Summary

fix(ktabs): padding not assigned to tab content when using hidePanels

Restores the padding being assigned to a tab’s content instead of the tab itself when using `props.hidePanels`.

fix(ktabs): layout shift when clicking tabs

Fixes a layout shift when clicking tabs that was caused by transitioning between `border-bottom: none` and `border-bottom: 2px ...`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
