### PR TITLE
fix(kdropdown): selection menu item selected state style

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -156,7 +156,7 @@ By default the dropdown has no notion of "selection". When `selectionMenu` is `t
     selection-menu
     :items="selectionMenuItems"
     trigger-text="Select region"
-    @change="handleSelectionMenuUpdate"
+    @change="handleSelectionMenuUpdate1"
     show-caret
   />
 </ClientOnly>
@@ -188,7 +188,7 @@ If using the [`items` slot](#items-1), you will have access to the `handleSelect
   <KDropdown
     selection-menu
     trigger-text="Select region (with items slot)"
-    @change="handleSelectionMenuUpdate"
+    @change="handleSelectionMenuUpdate2"
     show-caret
   >
     <template #items="{ handleSelection }">
@@ -196,7 +196,7 @@ If using the [`items` slot](#items-1), you will have access to the `handleSelect
         v-for="item in selectionMenuItems"
         :key="item.value"
         :item="item"
-        :selected="item.value === selectionMenuSelectedItem?.value"
+        :selected="item.value === selectionMenu2SelectedItem?.value"
         @click="handleSelection(item)"
       />
     </template>
@@ -528,7 +528,8 @@ const defaultItems = [
   { label: 'Top', to: { path: '/components/dropdown' } },
 ]
 
-const selectionMenuSelectedItem = ref<DropdownItem>()
+const selectionMenu1SelectedItem = ref<DropdownItem>()
+const selectionMenu2SelectedItem = ref<DropdownItem>()
 
 const selectionMenuItems = ref<Array<DropdownItem>>([{
   label: 'US (United States)',
@@ -539,8 +540,12 @@ const selectionMenuItems = ref<Array<DropdownItem>>([{
   value: 'fr',
 }])
 
-const handleSelectionMenuUpdate = (item: DropdownItem): void => {
-  selectedItem.value = item
+const handleSelectionMenuUpdate1 = (item: DropdownItem): void => {
+  selectionMenu1SelectedItem.value = item
+}
+
+const handleSelectionMenuUpdate2 = (item: DropdownItem): void => {
+  selectionMenu2SelectedItem.value = item
 }
 
 const clickHandler = (): void => {

--- a/src/components/KDropdown/KDropdown.cy.ts
+++ b/src/components/KDropdown/KDropdown.cy.ts
@@ -93,6 +93,7 @@ describe('KDropdown', () => {
     mount(KDropdown, {
       props: {
         triggerText: 'Click me',
+        selectionMenu: true,
         items: [
           { label: selectedLabel, value: 'label1', selected: true },
           ...selectionMenuItems,

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -56,6 +56,7 @@
                 v-bind="item"
                 :key="`${item.label}-${idx}`"
                 :item="item"
+                :selected="selectionMenu && selectedItem?.value === item.value"
                 :selection-menu-child="selectionMenu"
                 @change="handleSelection"
               />

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -229,6 +229,23 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
     cursor: not-allowed;
   }
 
+  &.dropdown-selected-option {
+    .dropdown-item-trigger {
+      background-color: var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest);
+      color: var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger);
+
+      &:hover:not(:disabled):not(.disabled):not(:focus):not(:active),
+      &:focus:not(:disabled):not(.disabled),
+      &:active:not(:disabled):not(.disabled) {
+        background-color: var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest);
+      }
+
+      &:disabled, &[disabled], &.disabled {
+        background-color: var(--kui-color-background-disabled, $kui-color-background-disabled);
+      }
+    }
+  }
+
   .dropdown-item-trigger {
     background-color: var(--kui-color-background, $kui-color-background);
     border: 0;

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, useSlots, useAttrs, onMounted } from 'vue'
+import { computed, ref, watch, useSlots, useAttrs, onMounted, nextTick } from 'vue'
 import type { PropType } from 'vue'
 import type { LabelAttributes, LimitExceededData } from '@/types'
 import { v4 as uuidv4 } from 'uuid'
@@ -269,12 +269,14 @@ const afterSlotElement = ref<HTMLElement | null>(null)
 const beforeSlotElementWidth = ref<string>(KUI_ICON_SIZE_40) // default to slot icon size
 const afterSlotElementWidth = ref<string>(KUI_ICON_SIZE_40) // default to slot icon size
 
-onMounted(() => {
+onMounted(async () => {
   if (beforeSlotElement.value) {
+    await nextTick() // wait for the slot content to render
     beforeSlotElementWidth.value = beforeSlotElement.value.offsetWidth + 'px'
   }
 
   if (afterSlotElement.value) {
+    await nextTick() // wait for the slot content to render
     afterSlotElementWidth.value = afterSlotElement.value.offsetWidth + 'px'
   }
 })

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -270,13 +270,13 @@ const beforeSlotElementWidth = ref<string>(KUI_ICON_SIZE_40) // default to slot 
 const afterSlotElementWidth = ref<string>(KUI_ICON_SIZE_40) // default to slot icon size
 
 onMounted(async () => {
-  if (beforeSlotElement.value) {
-    await nextTick() // wait for the slot content to render
+  await nextTick() // wait for the slots content to render
+
+  if (beforeSlotElement.value?.offsetWidth) {
     beforeSlotElementWidth.value = beforeSlotElement.value.offsetWidth + 'px'
   }
 
-  if (afterSlotElement.value) {
-    await nextTick() // wait for the slot content to render
+  if (afterSlotElement.value?.offsetWidth) {
     afterSlotElementWidth.value = afterSlotElement.value.offsetWidth + 'px'
   }
 })

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -220,6 +220,7 @@ const pageSizeOptions = props.pageSizes.map((size, i) => ({
   label: `${size}`,
   key: `size-${i}`,
   value: size,
+  selected: size === currentPageSize.value,
 }))
 const pageSizeText = computed((): string => currentPageSize.value + ' items per page')
 

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -318,15 +318,17 @@ const updatePage = (): void => {
 }
 
 const updatePageSize = (item: DropdownItem): void => {
-  currentPageSize.value = item.value as number
+  if (currentPageSize.value !== item.value) {
+    currentPageSize.value = item.value as number
 
-  emit('pageSizeChanged', {
-    pageSize: currentPageSize.value,
-    pageCount: pageCount.value,
-  })
+    emit('pageSizeChanged', {
+      pageSize: currentPageSize.value,
+      pageCount: pageCount.value,
+    })
 
-  if (props.currentPage !== 1) {
-    changePage(1)
+    if (props.currentPage !== 1) {
+      changePage(1)
+    }
   }
 }
 

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -118,7 +118,6 @@ watch(() => props.modelValue, (newTabHash) => {
       border-bottom-color: var(--kui-color-border-transparent, $kui-color-border-transparent);
       border-bottom-style: solid;
       border-bottom-width: var(--kui-border-width-20, $kui-border-width-20);
-      cursor: pointer;
       padding-bottom: var(--kui-space-40, $kui-space-40);
       position: relative;
       transition: border-bottom-color $kongponentsTransitionDurTimingFunc;
@@ -127,6 +126,7 @@ watch(() => props.modelValue, (newTabHash) => {
       .tab-link {
         border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
         color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+        cursor: pointer;
         display: inline-flex;
         gap: var(--kui-space-40, $kui-space-40);
         text-decoration: none;
@@ -144,17 +144,15 @@ watch(() => props.modelValue, (newTabHash) => {
           text-decoration: none;
         }
 
+        &:hover:not(.disabled) {
+          background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
+        }
+
         &:focus-visible {
           background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
           box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
           color: var(--kui-color-text, $kui-color-text);
           outline: none;
-        }
-      }
-
-      &:hover:not(.disabled) {
-        .tab-link {
-          background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
         }
       }
 


### PR DESCRIPTION
# Summary

Adds selected item styling to KDropdown selectionMenu selected item

Before (selected item in not distinct from other items in the dropdown)
![Screenshot 2024-01-18 at 4 36 10 PM](https://github.com/Kong/kongponents/assets/36751160/0f437812-ab36-4f0e-a12e-a762ad618505)

After (selected item has different background and text color, following the pattern established in KSelect and KMultiselect)
![Screenshot 2024-01-18 at 4 37 55 PM](https://github.com/Kong/kongponents/assets/36751160/3a4c7880-9618-4815-8aa2-3c88c6ae3ee3)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
