### PR TITLE
fix(ktabs): add margin top 0

### DIFF
--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -109,6 +109,7 @@ watch(() => props.modelValue, (newTabHash) => {
     line-height: var(--kui-line-height-40, $kui-line-height-40);
     list-style: none;
     margin-bottom: var(--kui-space-70, $kui-space-70);
+    margin-top: var(--kui-space-0, $kui-space-0);
     overflow-x: auto;
     overflow-y: hidden;
     padding: var(--kui-space-0, $kui-space-0) var(--kui-space-70, $kui-space-70);


### PR DESCRIPTION
# Summary

Adds `margin-top: 0;` to KTabs `ul role=tablist` element

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
