### PR TITLE
fix(kcopy): expose copy method, tweak hover in kbutton

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,6 +1,6 @@
 # Button
 
-**KButton** is probably the most used Kongponent. It supports a number of variations
+KButton is probably the most used Kongponent. It supports a number of variations
 and configuration options.
 
 <KButton appearance="primary">I'm a button</KButton>

--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -230,7 +230,6 @@ const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 
 const onButtonClick = (): void => {
   kCopyElement.value?.copy()
-  alert(`Copied to clipboard: ${text}`)
 }
 </script>
 ```
@@ -244,6 +243,5 @@ const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 
 const onButtonClick = (): void => {
   kCopyElement.value?.copy()
-  alert(`Copied to clipboard: ${text}`)
 }
 </script>

--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -204,6 +204,46 @@ When `badge` is `true`, use this prop to control whether the copyable text has `
 <KCopy badge monospace :text="text" />
 ```
 
+## Usage
+
+### triggerCopy
+
+KCopy exposes `triggerCopy` method that can be used to trigger copy from outside the component. Here is an example of KCopy inside of KButton, clicking on which will trigger KCopy to copy the text.
+
+<KButton class="icon-button" @click="onButtonClick">
+  <KCopy format="hidden" ref="kCopyElement" :text="text" />
+</KButton>
+
+```vue
+<template>
+  <KButton @click="onButtonClick">
+    <KCopy format="hidden" ref="kCopyElement" :text="text" />
+  </KButton>
+</template>
+
 <script setup lang="ts">
+import { KCopy } from '@kong/kongponents'
+
 const text = '12345-6789-ABCD-EFGH-PQRSTUV-WXYZ'
+
+const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
+
+const onButtonClick = (): void => {
+  kCopyElement.value?.triggerCopy()
+  alert(`Copied to clipboard: ${text}`)
+}
+</script>
+```
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const text = '12345-6789-ABCD-EFGH-PQRSTUV-WXYZ'
+
+const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
+
+const onButtonClick = (): void => {
+  kCopyElement.value?.triggerCopy()
+  alert(`Copied to clipboard: ${text}`)
+}
 </script>

--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -206,9 +206,9 @@ When `badge` is `true`, use this prop to control whether the copyable text has `
 
 ## Usage
 
-### triggerCopy
+### copy
 
-KCopy exposes `triggerCopy` method that can be used to trigger copy from outside the component. Here is an example of KCopy inside of KButton, clicking on which will trigger KCopy to copy the text.
+KCopy exposes `copy` method that can be used to trigger copy from outside the component. Here is an example of KCopy inside of KButton, clicking on which will trigger KCopy to copy the text.
 
 <KButton class="icon-button" @click="onButtonClick">
   <KCopy format="hidden" ref="kCopyElement" :text="text" />
@@ -229,7 +229,7 @@ const text = '12345-6789-ABCD-EFGH-PQRSTUV-WXYZ'
 const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 
 const onButtonClick = (): void => {
-  kCopyElement.value?.triggerCopy()
+  kCopyElement.value?.copy()
   alert(`Copied to clipboard: ${text}`)
 }
 </script>
@@ -243,7 +243,7 @@ const text = '12345-6789-ABCD-EFGH-PQRSTUV-WXYZ'
 const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 
 const onButtonClick = (): void => {
-  kCopyElement.value?.triggerCopy()
+  kCopyElement.value?.copy()
   alert(`Copied to clipboard: ${text}`)
 }
 </script>

--- a/sandbox/pages/SandboxCopy.vue
+++ b/sandbox/pages/SandboxCopy.vue
@@ -143,7 +143,7 @@ const kButtonKCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 
 const onButtonClick = () => {
   // @ts-ignore
-  kButtonKCopyElement.value?.triggerCopy()
+  kButtonKCopyElement.value?.copy()
 }
 </script>
 

--- a/sandbox/pages/SandboxCopy.vue
+++ b/sandbox/pages/SandboxCopy.vue
@@ -93,14 +93,65 @@
           :text="uuid1"
         />
       </SandboxSectionComponent>
+
+      <!-- Usage -->
+      <SandboxTitleComponent
+        is-subtitle
+        title="Usage"
+      />
+      <SandboxSectionComponent title="KCopy inside of a KButton">
+        <div class="horizontal-container">
+          <KButton appearance="secondary">
+            <KCopy
+              format="hidden"
+              :text="uuid1"
+            />
+          </KButton>
+          <KButton appearance="tertiary">
+            <KCopy
+              format="hidden"
+              :text="uuid1"
+            />
+          </KButton>
+        </div>
+        <div>
+          <p>Clicking on KButton will trigger click on KCopy:</p>
+          <KButton
+            @click="onButtonClick"
+          >
+            <KCopy
+              ref="kButtonKCopyElement"
+              format="hidden"
+              :text="uuid1"
+            />
+          </KButton>
+        </div>
+      </SandboxSectionComponent>
     </div>
   </SandboxLayout>
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
+import { inject, ref } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
+import KCopy from '@/components/KCopy/KCopy.vue'
 
 const uuid1: string = '2cf64827-6c70-4116-906b-4c9aae83fc4a'
+
+const kButtonKCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
+
+const onButtonClick = () => {
+  // @ts-ignore
+  kButtonKCopyElement.value?.triggerCopy()
+}
 </script>
+
+<style lang="scss" scoped>
+.kcopy-sandbox {
+  .horizontal-container {
+    display: flex;
+    gap: $kui-space-50;
+  }
+}
+</style>

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -135,7 +135,7 @@ const props = defineProps({
   },
 })
 
-const copyButtonElementId = computed((): string => uuid4())
+const copyButtonElementId = uuid4()
 
 const tooltipText = ref<string>('')
 const nonSuccessText = computed((): string => {
@@ -201,8 +201,8 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
 }
 
 const triggerCopy = () => {
-  if (document.getElementById(copyButtonElementId.value)) {
-    document.getElementById(copyButtonElementId.value)?.click()
+  if (document.getElementById(copyButtonElementId)) {
+    document.getElementById(copyButtonElementId)?.click()
   }
 }
 

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -200,14 +200,14 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
   updateTooltipText()
 }
 
-const triggerCopy = () => {
+const copy = () => {
   if (document.getElementById(copyButtonElementId)) {
     document.getElementById(copyButtonElementId)?.click()
   }
 }
 
 defineExpose({
-  triggerCopy,
+  copy,
 })
 </script>
 

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -21,7 +21,9 @@
         <span
           class="copy-text"
           :class="{ 'monospace': monospace || !badge }"
-        >{{ textFormat }}</span>
+        >
+          {{ textFormat }}
+        </span>
       </KTooltip>
 
       <KTooltip
@@ -33,6 +35,7 @@
       >
         <KClipboardProvider v-slot="{ copyToClipboard }">
           <CopyIcon
+            :id="copyButtonElementId"
             class="text-icon"
             data-testid="copy-to-clipboard"
             :hide-title="!!copyTooltip || undefined"
@@ -54,6 +57,7 @@ import { CopyIcon } from '@kong/icons'
 import KClipboardProvider from '@/components/KClipboardProvider'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { v4 as uuid4 } from 'uuid'
 
 const props = defineProps({
   /**
@@ -131,6 +135,8 @@ const props = defineProps({
   },
 })
 
+const copyButtonElementId = computed((): string => uuid4())
+
 const tooltipText = ref<string>('')
 const nonSuccessText = computed((): string => {
   if (!props.badgeLabel || props.copyTooltip) {
@@ -193,6 +199,16 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
 
   updateTooltipText()
 }
+
+const triggerCopy = () => {
+  if (document.getElementById(copyButtonElementId.value)) {
+    document.getElementById(copyButtonElementId.value)?.click()
+  }
+}
+
+defineExpose({
+  triggerCopy,
+})
 </script>
 
 <style lang="scss" scoped>
@@ -241,7 +257,7 @@ const copyIdToClipboard = (executeCopy: (prop: string) => boolean) => {
     cursor: pointer;
     display: flex;
 
-    .text-icon {
+    .text-icon:not(.k-button .k-copy .text-icon-wrapper .text-icon) {
       &:hover,
       &:focus {
         // only applies to non-badge as for badge the mixin takes care hover styles


### PR DESCRIPTION
# Summary

KCopy:
* expose `triggerCopy` method to allow executing copy action from outside the component
* tweak styling to take hover color set by KButton when KCopy is a child of KButton

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
