### PR TITLE
fix: export components object

### DIFF
--- a/sandbox/index.ts
+++ b/sandbox/index.ts
@@ -3,7 +3,6 @@ import App from './App.vue'
 import router from './router'
 import '../src/styles/styles.scss'
 import Kongponents from '../src'
-
 // Sandbox layout
 import { SandboxLayout } from '@kong-ui-public/sandbox-layout'
 import type { SandboxNavigationItem } from '@kong-ui-public/sandbox-layout'

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ export default {
   },
 }
 
+// Export a named object exporting all available components. This is utilized to loop through all available components in this package.
+export { components }
+
 // All other named exports
 export * from './components'
 export * from './global-components'


### PR DESCRIPTION
# Summary

Export a `components` object in order to loop through available components in a host app.