### PR TITLE
fix(ts): add danger property to dropdown item interface

### DIFF
--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -7,6 +7,7 @@ export interface DropdownItem {
   value?: string | number
   selected?: boolean
   hasDivider?: boolean
+  danger?: boolean
 }
 
 export type DropdownItemType = 'link' | 'button' | 'default'


### PR DESCRIPTION
# Summary

Add `danger?: boolean` property to `DropdownItem` interface

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
