### PR TITLE
fix(kdatetimepicker): fix wrapping in timepicker display

### DIFF
--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -173,8 +173,8 @@ Kongponents styles are no longer designed to be utilized standalone, separately 
 
 #### Structure
 
-* `timepicker-input` class has been changed to `datetime-picker-input`
-* `k-datetime-picker-input` `data-testid` attribute has been changed to `datetime-picker-input`
+* `timepicker-input` class has been changed to `datetime-picker-trigger`
+* `k-datetime-picker-input` `data-testid` attribute has been changed to `datetime-picker-trigger`
 * `timepicker-display` class has been changed to `datetime-picker-display`
 * `k-datetime-picker-display` `data-testid` attribute has been changed to `datetime-picker-display`
 * `k-datetime-picker-toggle` `data-testid` attribute has been changed to `datetime-picker-toggle`

--- a/sandbox/pages/SandboxDateTimePicker.vue
+++ b/sandbox/pages/SandboxDateTimePicker.vue
@@ -128,7 +128,10 @@
         is-subtitle
         title="Usage"
       />
-      <SandboxSectionComponent title="popoverPlacement">
+      <SandboxSectionComponent
+        description="When range is selected, in narrow spaces KDateTimePicker should wrap to next line."
+        title="Wrapping to next line"
+      >
         <div class="between-container">
           <div class="full-width-sibling">
             <p>Full-width sibling</p>

--- a/sandbox/pages/SandboxDateTimePicker.vue
+++ b/sandbox/pages/SandboxDateTimePicker.vue
@@ -112,6 +112,7 @@
         <KDateTimePicker
           mode="dateTime"
           placeholder="Select a date and time"
+          range
           width="300"
         />
       </SandboxSectionComponent>
@@ -120,6 +121,26 @@
           disabled
           mode="dateTime"
         />
+      </SandboxSectionComponent>
+
+      <!-- Usage -->
+      <SandboxTitleComponent
+        is-subtitle
+        title="Usage"
+      />
+      <SandboxSectionComponent title="popoverPlacement">
+        <div class="between-container">
+          <div class="full-width-sibling">
+            <p>Full-width sibling</p>
+          </div>
+          <div>
+            <KDateTimePicker
+              mode="dateTime"
+              popover-placement="bottomEnd"
+              range
+            />
+          </div>
+        </div>
       </SandboxSectionComponent>
     </div>
   </SandboxLayout>
@@ -133,3 +154,28 @@ import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 const maxDate = new Date()
 maxDate.setMonth(new Date().getMonth() + 3)
 </script>
+
+<style lang="scss" scoped>
+.kdatetimepicker-sandbox {
+  .between-container {
+    display: flex;
+    gap: $kui-space-50;
+    justify-content: space-between;
+
+    .full-width-sibling {
+      align-items: center;
+      background-color: $kui-color-background-danger-weaker;
+      border-radius: $kui-border-radius-20;
+      display: flex;
+      overflow: auto;
+      padding: $kui-space-40;
+      resize: horizontal;
+      width: 100%;
+
+      p {
+        margin: 0;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -54,7 +54,7 @@ const emptyTimeRange = {
   timePeriodKey: null,
 }
 
-const timepickerInput = 'datetime-picker-input'
+const timepickerInput = 'datetime-picker-trigger'
 const timepickerDisplay = 'datetime-picker-display'
 const submitButton = 'datetime-picker-submit'
 const clearButton = 'datetime-picker-clear'

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -6,6 +6,7 @@
     :style="widthStyle"
   >
     <KPop
+      :disabled="disabled"
       hide-caret
       :hide-popover="state.hidePopover"
       :placement="popoverPlacement"
@@ -13,31 +14,32 @@
       width="auto"
       @opened="state.hidePopover = false"
     >
-      <div class="datetime-picker-input-wrapper">
-        <span
-          class="datetime-picker-display"
-          :class="{ 'has-icon': icon, 'disabled': disabled }"
-          data-testid="datetime-picker-display"
-          v-html="state.abbreviatedDisplay"
-        />
-
-        <KInput
-          class="datetime-picker-input"
-          data-testid="datetime-picker-input"
-          :disabled="disabled"
-          readonly
+      <div
+        class="datetime-picker-trigger-wrapper"
+        :class="{ 'disabled': disabled }"
+      >
+        <div
+          class="datetime-picker-trigger"
+          :class="{ 'disabled': disabled }"
+          data-testid="datetime-picker-trigger"
+          role="button"
           :style="widthStyle"
+          :tabindex="disabled ? -1 : 0"
         >
-          <template
-            v-if="icon"
-            #before
-          >
-            <CalIcon
-              class="calendar-icon"
-              decorative
-            />
-          </template>
-        </KInput>
+          <span
+            class="datetime-picker-display"
+            :class="{ 'has-icon': icon, 'disabled': disabled }"
+            data-testid="datetime-picker-display"
+            v-html="state.abbreviatedDisplay"
+          />
+        </div>
+        <CalIcon
+          v-if="icon"
+          class="calendar-icon"
+          :color="KUI_COLOR_TEXT_NEUTRAL"
+          decorative
+          :size="KUI_ICON_SIZE_40"
+        />
       </div>
 
       <template
@@ -142,7 +144,6 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { format } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import { DatePicker } from 'v-calendar'
-import KInput from '@/components/KInput/KInput.vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KPop from '@/components/KPop/KPop.vue'
 import KSegmentedControl from '@/components/KSegmentedControl/KSegmentedControl.vue'
@@ -151,6 +152,7 @@ import { ModeArray, ModeArrayCustom, ModeArrayRelative, ModeDateOnly, Timepicker
 import type { DateTimePickerState, TimeFrameSection, TimePeriod, TimeRange, Mode, CSSProperties, DatePickerModel, ButtonAppearance, PopPlacements } from '@/types'
 import { CalIcon } from '@kong/icons'
 import useUtilities from '@/composables/useUtilities'
+import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 const { getSizeFromString } = useUtilities()
 
@@ -584,51 +586,58 @@ $kDateTimePickerInputPaddingY: var(--kui-space-40, $kui-space-40); // correspond
     }
   }
 
-  .datetime-picker-input-wrapper {
+  .datetime-picker-trigger-wrapper {
     position: relative;
 
-    .datetime-picker-input {
-      :deep(.k-input:read-only) {
-        @include inputDefaults;
-        cursor: pointer;
+    .datetime-picker-trigger {
+      @include inputDefaults;
 
-        &:hover {
-          @include inputHover;
+      cursor: pointer;
+      display: inline-flex;
+
+      &:hover {
+        @include inputHover;
+      }
+
+      &:focus {
+        @include inputFocus;
+      }
+
+      &.disabled {
+        @include inputDisabled;
+        pointer-events: none;
+
+        .datetime-picker-display {
+          color: var(--kui-color-text-disabled, $kui-color-text-disabled) !important;
         }
+      }
 
-        &:focus {
-          @include inputFocus;
-        }
+      .datetime-picker-display {
+        @include inputText;
 
-        &:disabled {
-          @include inputDisabled;
+        display: flex;
+        flex-wrap: wrap;
+        pointer-events: none;
+        white-space: nowrap;
+
+        &.has-icon {
+          // icon size + icon spacing
+          /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+          margin-left: calc(var(--kui-icon-size-40, $kui-icon-size-40) + var(--kui-space-40, $kui-space-40));
         }
       }
     }
 
-    .datetime-picker-display {
-      @include inputText;
-
-      display: inline-flex;
-      left: 0;
-      margin-left: $kDateTimePickerInputPaddingX;
-      margin-top: $kDateTimePickerInputPaddingY;
-      max-width: 90%;
+    .calendar-icon {
+      left: $kDateTimePickerInputPaddingX;
+      margin-top: 2px; // align icon vertically with input text
       pointer-events: none;
       position: absolute;
-      top: 0;
-      z-index: 1;
+      top: $kDateTimePickerInputPaddingY;
+    }
 
-      &.has-icon {
-        // default spacing + icon size + icon spacing
-        /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
-        margin-left: calc($kDateTimePickerInputPaddingX + var(--kui-icon-size-40, $kui-icon-size-40) + var(--kui-space-40, $kui-space-40));
-        max-width: 80%;
-      }
-
-      &.disabled {
-        color: var(--kui-color-text-disabled, $kui-color-text-disabled) !important;
-      }
+    &.disabled {
+      cursor: not-allowed;
     }
   }
 

--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -21,7 +21,7 @@
   font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
   line-height: var(--kui-line-height-40, $kui-line-height-40); // $kTextAreaLineHeight
 
-  @media (max-width: $kui-breakpoint-mobile) {
+  @media (min-width: $kui-breakpoint-mobile) {
     font-size: var(--kui-font-size-30, $kui-font-size-30);
   }
 }

--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -21,7 +21,7 @@
   font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
   line-height: var(--kui-line-height-40, $kui-line-height-40); // $kTextAreaLineHeight
 
-  @media (min-width: $kui-breakpoint-mobile) {
+  @media (max-width: $kui-breakpoint-mobile) {
     font-size: var(--kui-font-size-30, $kui-font-size-30);
   }
 }


### PR DESCRIPTION
# Summary

Issue: we want KDateTimePicker to wrap to next line when a range is selected and the space is either too narrow (like on smaller screens). Because KInput which the component utilizes under the hood won't allow wrapping, we need to use a `div role="button"` styled like KInput.

Before
![Screenshot 2024-02-13 at 8 41 29 AM](https://github.com/Kong/kongponents/assets/36751160/3d928fbd-e311-46f5-becf-c193594fd25c)

After
![Screenshot 2024-02-13 at 8 54 17 AM](https://github.com/Kong/kongponents/assets/36751160/191efaf4-caea-4ed3-9789-42b5839ff56e)
![Screenshot 2024-02-13 at 9 00 36 AM](https://github.com/Kong/kongponents/assets/36751160/f94c642f-84cd-461d-9cd5-cc6f11065473)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
