### PR TITLE
fix(kinput): update readonly styles [KHCP-10785]

### DIFF
--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -58,21 +58,17 @@
   box-shadow: var(--kui-shadow-border-primary, $kui-shadow-border-primary), var(--kui-shadow-focus, $kui-shadow-focus);
 }
 
-// shared styles between disabled and readonly states
-@mixin inputDisabledReadOnly {
-  background-color: var(--kui-color-background-disabled, $kui-color-background-disabled);
-  box-shadow: var(--kui-shadow-border-disabled, $kui-shadow-border-disabled);
-  color: var(--kui-color-text-disabled, $kui-color-text-disabled);
-}
-
 @mixin inputDisabled {
-  @include inputDisabledReadOnly;
-
+  background-color: var(--kui-color-background-disabled, $kui-color-background-disabled) !important;
+  box-shadow: var(--kui-shadow-border-disabled, $kui-shadow-border-disabled) !important;
+  color: var(--kui-color-text-disabled, $kui-color-text-disabled) !important;
   cursor: not-allowed;
 }
 
 @mixin inputReadOnly {
-  @include inputDisabledReadOnly;
+  background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
+  box-shadow: var(--kui-shadow-border, $kui-shadow-border);
+  color: var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong);
 }
 
 // error state styles


### PR DESCRIPTION
# Summary

Updates readonly KInput styles to make them more accessible

![Screenshot 2024-02-20 at 2 19 33 PM](https://github.com/Kong/kongponents/assets/36751160/d4b3f5fd-d265-404e-b22d-40c41bbaf733)


## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
