### PR TITLE
fix(ktoaster): icon, title and message styling

### DIFF
--- a/docs/components/toaster.md
+++ b/docs/components/toaster.md
@@ -83,7 +83,7 @@ Notification title.
 
 The message string that allows for displaying longer strings of text to the user. This prop is good for more detailed messages.
 
-Alternatively, if you provide a string as the only argument, it will be treated as message.
+Alternatively, if you provide a string as the only argument to the `open()` method, it will be treated as message.
 
 <div class="horizontal-container">
   <KButton @click="$toaster.open({ 

--- a/docs/components/toaster.md
+++ b/docs/components/toaster.md
@@ -62,7 +62,7 @@ KToaster is the underlying component rendered by the `ToastManager` instance, so
 ```ts
 interface Toast {
   key?: any
-  title: string
+  title?: string
   message?: string
   appearance?: ToasterAppearance
   timeoutMilliseconds?: number
@@ -71,38 +71,38 @@ interface Toast {
 
 ### title
 
-Notification title. When passing an object to `$toaster.open()` method, the `title` property is required. When passing only a string, the string will be rendered as the title.
+Notification title.
 
-<div class="horizontal-container">
-  <KButton @click="$toaster.open({ title: 'Long Title Gets Truncated With Ellipsis' })">Open Toaster</KButton>
-  <KButton @click="$toaster.open('String Will Become A Title')" appearance="secondary">Open Toaster</KButton>
-</div>
+<KButton @click="$toaster.open({ title: 'Notification Title' })">Open Toaster</KButton>
 
 ```html
-<KButton @click="$toaster.open({ title: 'Long Title Gets Truncated With Ellipsis' })">Open Toaster</KButton>
-<KButton @click="$toaster.open('String Will Become A Title')" appearance="secondary">Open Toaster</KButton>
+<KButton @click="$toaster.open({ title: 'Notification Title' })">Open Toaster</KButton>
 ```
 
 ### message
 
-The message prop allows for displaying longer strings of text to the user. This prop is good for more detailed messages, or displaying IDs, etc.
+The message string that allows for displaying longer strings of text to the user. This prop is good for more detailed messages.
 
-Because a long title gets truncated, it is only good for short notifications. When a longer notification needs to be shown to the user, the `message` property is ideal.
+Alternatively, if you provide a string as the only argument, it will be treated as message.
 
-<KButton @click="$toaster.open({ 
-  title: 'Long Title Gets Truncated With Ellipsis',
-  message: 'Detailed message. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.' })"
->
-  Open Toaster
-</KButton>
+<div class="horizontal-container">
+  <KButton @click="$toaster.open({ 
+    title: 'Title',
+    message: 'Detailed message. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.' })"
+  >
+    Open Toaster
+  </KButton>
+  <KButton @click="$toaster.open('String will become a message.')" appearance="secondary">Open Toaster</KButton>
+</div>
 
 ```html
 <KButton @click="$toaster.open({ 
-  title: 'Long Title Gets Truncated With Ellipsis',
+  title: 'Title',
   message: 'Detailed message. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.' })"
 >
   Open Toaster
 </KButton>
+<KButton @click="$toaster.open('String will become a message.')" appearance="secondary">Open Toaster</KButton>
 ```
 
 ### appearance

--- a/sandbox/pages/SandboxToaster.vue
+++ b/sandbox/pages/SandboxToaster.vue
@@ -102,7 +102,7 @@ const openToaster = (argument: string) => {
       break
     case 'title':
       options = {
-        title: 'Toast with truncated title and no message',
+        title: 'Toast with very long title and no message',
         appearance: 'system',
       }
       break

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -96,6 +96,7 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
 
   .toaster {
     align-items: flex-start;
+    align-items: center;
     background-color: var(--kui-color-background-inverse, $kui-color-background-inverse);
     border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
     box-shadow: var(--kui-shadow, $kui-shadow);
@@ -116,7 +117,6 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
     }
 
     .toaster-content {
-      align-self: center;
       display: flex;
       flex: 1;
       flex-direction: column;

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -39,7 +39,7 @@
         role="button"
         :size="KUI_ICON_SIZE_50"
         tabindex="0"
-        @click="() => $emit('close', toaster.key)"
+        @click="$emit('close', toaster.key)"
       />
     </div>
   </TransitionGroup>

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -11,33 +11,36 @@
       :class="`${toaster.appearance}`"
       role="alert"
     >
-      <div class="toaster-header">
-        <div class="toaster-icon-container">
-          <component
-            :is="getToastIcon(toaster.appearance)"
-            class="toaster-icon"
-            :color="KUI_COLOR_TEXT"
-          />
-        </div>
-        <span class="toaster-title">
-          {{ toaster.title }}
-        </span>
-        <CloseIcon
-          class="toaster-close-icon"
-          :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
-          data-testid="toaster-close-icon"
-          role="button"
-          :size="KUI_ICON_SIZE_50"
-          tabindex="0"
-          @click="() => $emit('close', toaster.key)"
+      <div class="toaster-icon-container">
+        <component
+          :is="getToastIcon(toaster.appearance)"
+          class="toaster-icon"
+          :color="KUI_COLOR_TEXT"
         />
       </div>
-      <p
-        v-if="toaster.message"
-        class="toaster-message"
-      >
-        {{ toaster.message }}
-      </p>
+      <div class="toaster-content">
+        <span
+          v-if="toaster.title"
+          class="toaster-title"
+        >
+          {{ toaster.title }}
+        </span>
+        <p
+          v-if="toaster.message"
+          class="toaster-message"
+        >
+          {{ toaster.message }}
+        </p>
+      </div>
+      <CloseIcon
+        class="toaster-close-icon"
+        :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
+        data-testid="toaster-close-icon"
+        role="button"
+        :size="KUI_ICON_SIZE_50"
+        tabindex="0"
+        @click="() => $emit('close', toaster.key)"
+      />
     </div>
   </TransitionGroup>
 </template>
@@ -92,35 +95,34 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
   z-index: 10000;
 
   .toaster {
+    align-items: flex-start;
     background-color: var(--kui-color-background-inverse, $kui-color-background-inverse);
     border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
     box-shadow: var(--kui-shadow, $kui-shadow);
     color: var(--kui-color-text-inverse, $kui-color-text-inverse);
     display: flex;
-    flex-direction: column;
-    gap: var(--kui-space-30, $kui-space-30);
+    gap: var(--kui-space-50, $kui-space-50);
     padding: var(--kui-space-50, $kui-space-50);
     width: 100%;
 
-    .toaster-header {
+    .toaster-icon-container {
       align-items: center;
+      background-color: var(--kui-color-background-primary-weak, $kui-color-background-primary-weak); // info appearance as default in case of invalid appearance
+      border-radius: var(--kui-border-radius-circle, $kui-border-radius-circle);
       display: flex;
-      gap: var(--kui-space-50, $kui-space-50);
+      height: 32px;
+      justify-content: center;
+      width: 32px;
+    }
 
-      .toaster-icon-container {
-        align-items: center;
-        background-color: var(--kui-color-background-primary-weak, $kui-color-background-primary-weak); // info appearance as default in case of invalid appearance
-        border-radius: var(--kui-border-radius-circle, $kui-border-radius-circle);
-        display: flex;
-        height: 32px;
-        justify-content: center;
-        width: 32px;
-      }
+    .toaster-content {
+      align-self: center;
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      gap: var(--kui-space-30, $kui-space-30);
 
       .toaster-title {
-        @include truncate;
-
-        flex: 1;
         font-family: var(--kui-font-family-text, $kui-font-family-text);
         font-size: var(--kui-font-size-50, $kui-font-size-50);
         font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
@@ -128,28 +130,28 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
         line-height: var(--kui-line-height-40, $kui-line-height-40);
       }
 
-      .toaster-close-icon {
-        border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
-        cursor: pointer;
-        margin-left: var(--kui-space-auto, $kui-space-auto);
-        outline: none;
-
-        &:hover, &:focus {
-          color: var(--kui-color-text-neutral-weaker, $kui-color-text-neutral-weaker) !important;
-        }
-
-        &:focus-visible {
-          box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
-        }
+      .toaster-message {
+        font-family: var(--kui-font-family-text, $kui-font-family-text);
+        font-size: var(--kui-font-size-30, $kui-font-size-30);
+        font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
+        line-height: var(--kui-line-height-30, $kui-line-height-30);
+        margin: var(--kui-space-0, $kui-space-0);
       }
     }
 
-    .toaster-message {
-      font-family: var(--kui-font-family-text, $kui-font-family-text);
-      font-size: var(--kui-font-size-30, $kui-font-size-30);
-      font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
-      line-height: var(--kui-line-height-30, $kui-line-height-30);
-      margin: var(--kui-space-0, $kui-space-0);
+    .toaster-close-icon {
+      border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
+      cursor: pointer;
+      margin-left: var(--kui-space-auto, $kui-space-auto);
+      outline: none;
+
+      &:hover, &:focus {
+        color: var(--kui-color-text-neutral-weaker, $kui-color-text-neutral-weaker) !important;
+      }
+
+      &:focus-visible {
+        box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+      }
     }
 
     // appearances

--- a/src/components/KToaster/ToastManager.ts
+++ b/src/components/KToaster/ToastManager.ts
@@ -57,14 +57,14 @@ export default class ToastManager {
     const _key: any = key || (this.toasters.value.length) + new Date().getTime()
     const _appearance: ToasterAppearance = (appearance && APPEARANCES.indexOf(appearance) !== -1) ? appearance : this.appearance
     const timer: number = this.setTimer(_key, timeoutMilliseconds || this.timeout)
-    const _title = typeof args === 'string' ? args : title
+    const _message = typeof args === 'string' ? args : message
 
     // Add toaster to state
     this.toasters.value.push({
       key: _key,
       appearance: _appearance,
-      title: _title,
-      message: message || '',
+      title,
+      message: _message,
       timer,
       timeoutMilliseconds: timeoutMilliseconds || this.timeout,
     })

--- a/src/types/toaster.ts
+++ b/src/types/toaster.ts
@@ -2,7 +2,7 @@ export type ToasterAppearance = 'info' | 'success' | 'danger' | 'warning' | 'sys
 
 export interface Toast {
   key?: any // unique identifier of toaster
-  title: string // Title of toaster
+  title?: string // Title of toaster
   message?: string // Text to display in toaster
   appearance?: ToasterAppearance
   timeoutMilliseconds?: number


### PR DESCRIPTION
# Summary

Changes:
* title becomes optional
* when only argument provided to `ToastManager.open()` is string - treat it like message
* styling tweaks displaying icon, title and message

![Screenshot 2024-02-20 at 6 01 36 PM](https://github.com/Kong/kongponents/assets/36751160/1d05110b-2762-4494-b162-90c12f84d0df)
![Screenshot 2024-02-20 at 6 02 06 PM](https://github.com/Kong/kongponents/assets/36751160/46cadeb5-e68b-4a75-b342-a2696cc9529e)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
