### PR TITLE
fix(kcodeblock): spacing and max height prop fixes

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -190,7 +190,7 @@ The `max-height` of the code block.
     id="code-block-max-height"
     :code="code"
     language="json"
-    max-height="200px"
+    max-height="200"
   />
 </ClientOnly>
 
@@ -199,7 +199,7 @@ The `max-height` of the code block.
   id="code-block-max-height"
   :code="code"
   language="json"
-  max-height="200px"
+  max-height="200"
 />
 ```
 

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -288,6 +288,9 @@ import type { Command } from '@/utilities/ShortcutManager'
 import { ShortcutManager } from '@/utilities/ShortcutManager'
 import type { CodeBlockEventData, CommandKeywords, Theme } from '@/types/code-block'
 import { KUI_ICON_SIZE_30, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import useUtilities from '@/composables/useUtilities'
+
+const { getSizeFromString } = useUtilities()
 
 const IS_MAYBE_MAC = window?.navigator?.platform?.toLowerCase().includes('mac')
 const ALT_SHORTCUT_LABEL = IS_MAYBE_MAC ? 'Options' : 'Alt'
@@ -485,6 +488,8 @@ const escapeUnsafeCharacters = (unescapedCodeString: string): string => {
 }
 
 const finalCode = computed(() => props.isSingleLine ? escapeUnsafeCharacters(props.code).replaceAll('\n', '') : escapeUnsafeCharacters(props.code))
+
+const maxHeightValue = computed(() => getSizeFromString(props.maxHeight))
 
 watch(() => props.code, async function() {
   // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.
@@ -829,7 +834,7 @@ $dark-focusColor: $tmp-color-green-500;
   grid-template-columns: v-bind('maxLineNumberWidth') 1fr;
   margin-bottom: var(--kui-space-0, $kui-space-0);
   margin-top: var(--kui-space-0, $kui-space-0);
-  max-height: v-bind('$props.maxHeight');
+  max-height: v-bind('maxHeightValue');
   min-height: 56px;
   overflow: auto;
   padding: var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0) var(--kui-space-0, $kui-space-0) var(--kui-space-50, $kui-space-50);
@@ -1104,7 +1109,7 @@ $dark-focusColor: $tmp-color-green-500;
   display: flex;
   gap: var(--kui-space-40, $kui-space-40);
   position: absolute;
-  right: 16px;
+  right: 22px;
   top: 8px;
   z-index: 1;
 }


### PR DESCRIPTION
# Summary

Changes:
* add a bit more spacing to code block actions container so it doesn't overlap with the scrollbar (screenshot)
* `maxHeight` prop to add `px` to value automatically

![image](https://github.com/Kong/kongponents/assets/36751160/17bdf675-aeb1-423e-ad08-1f6f2a5c6846)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
