### PR TITLE
fix(ktable): kemptystate props

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -110,11 +110,18 @@ The default slot allows you to provide the button text as well as to slot in oth
     Button Two
     <ChevronDownIcon />
   </KButton>
-  <!-- TODO: [beta] change this to icon prop -->
-  <KButton appearance="danger" size="small" class="icon-button">
-    <TrashIcon />
-  </KButton>
 </div>
+
+```html
+<KButton size="large">
+  <WorldIcon />
+  Button One
+</KButton>
+<KButton appearance="secondary">
+  Button Two
+  <ChevronDownIcon />
+</KButton>
+```
 
 :::tip TIP
 When utilizing icons inside KButton, some sizes work better than others. You can use the `kui-icon-size-*` tokens exported by the [@kong/design-tokens](https://github.com/Kong/design-tokens) package, or manually set the size.
@@ -131,12 +138,8 @@ We also recommend setting the icon style `color` property to a value of `current
 ### icon
 
 :::danger NOTE
-This slot is deprecated and will be removed in the `9.0.0-beta.0` release. Please use the [`default` slot](#default) instead whenever possible (unless the only content you are passing to KButton is icon).
+This slot is deprecated and will be removed in the `9.0.0-beta.0` release. Please use the [`default` slot](#default) instead whenever possible (unless the only content you are passing to KButton is icon and you need to make the button square (_left and right padding = top and bottom_)).
 :::
-
-KButton supports using an icon either before the text or without text. If you are using the KIcon component you must maintain the icon color yourself when the button is enabled or disabled.
-
-Using only this slot without the default slot will make button square (left and right padding = top and bottom).
 
 <div class="spacing-container">
   <KButton appearance="secondary">

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -335,6 +335,16 @@ Should you decide to use your own custom icons, you can use design tokens export
 We also recommend setting the icon style `color` property to a value of `currentColor` to utilize default KDropdownItem styling for slotted content.
 :::
 
+## Events
+
+### toggleDropdown
+
+Fires when dropdown is opened/closed. Returns state of the dropdown (boolean).
+
+### change
+
+Fires when item is selected. Returns the selected menu item object.
+
 ## KDropdownItem
 
 KDropdown generates a KDropdownItem for each object in the `items` prop array. At the most basic level, KDropdownItem is a wrapper around each item to display it correctly inside KDropdown. You can use the `items` slot of the KDropdown to manually create your own menu items.

--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -140,6 +140,7 @@ Accepted values:
 * `default` (default)
 * `error`
 * `search`
+* `kong`
 
 <KEmptyState
   icon-variant="error"

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -843,7 +843,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
 
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <div v-if="eventType">
         {{eventType}} on: {{row}}
       </div>
@@ -1231,7 +1231,7 @@ the section below or completely slot in your own content.
 - `error-state` - Slot content to be displayed when in an error state
 
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable :fetcher="emptyFetcher" :headers="headers">
       <template v-slot:empty-state>
         <div style="text-align: center;">
@@ -1280,7 +1280,7 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 
 <br/>
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable :fetcher="() => { return { data: [] } }" />
   </template>
 </KCard>
@@ -1288,7 +1288,7 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 ```html
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <KTable :fetcher="fetcher" :headers="headers" />
     </template>
   </KCard>
@@ -1299,7 +1299,7 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 
 <br/>
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable
       :fetcher="() => { return { data: [] } }"
       emptyStateTitle="No Workspaces exist"
@@ -1317,7 +1317,7 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 <!-- Using a route string -->
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <KTable
         :fetcher="fetcher"
         :headers="headers"
@@ -1336,7 +1336,7 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
 <!-- Using a route object -->
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <KTable
         :fetcher="fetcher"
         :headers="headers"
@@ -1377,7 +1377,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 <br/>
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable :fetcher="() => { return { data: [] } }" :hasError="true" />
   </template>
 </KCard>
@@ -1385,7 +1385,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 ```html
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <KTable :fetcher="fetcher" :headers="headers" :hasError="true" />
     </template>
   </KCard>
@@ -1396,7 +1396,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 
 <br/>
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable
       :fetcher="() => { return { data: [] } }"
       :hasError="true"
@@ -1414,7 +1414,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 <!-- Using a route string -->
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <KTable
         :fetcher="fetcher"
         :headers="headers"
@@ -1433,7 +1433,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 <!-- Using a route object -->
 <template>
   <KCard>
-    <template v-slot:body>
+    <template #default>
       <KTable
         :fetcher="fetcher"
         :headers="headers"
@@ -1460,7 +1460,7 @@ If using a CTA button, a `ktable-error-cta-clicked` event is fired when clicked.
 Set the `isLoading` prop to `true` to enable the loading state.
 
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable
       :fetcher="() => { return { data: [] } }"
       :isLoading="true"
@@ -1471,7 +1471,7 @@ Set the `isLoading` prop to `true` to enable the loading state.
 ```html
 <template>
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KTable
       :fetcher="fetcher"
       :headers="headers"
@@ -1501,7 +1501,7 @@ https://kongponents.dev/api/components?_page=1&_limit=10&_sort=name&_order=desc
 <!-- Example Component Usage -->
 
 <KCard>
-  <template v-slot:body>
+  <template #default>
     <KInput placeholder="Search" v-model="search" type="search" />
     <KTable
       cache-identifier="server-side-functions-table"

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1348,13 +1348,17 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
         emptyStateTitle="No Workspaces exist"
         emptyStateMessage="Adding a new Workspace will populate this table."
         emptyStateActionMessage="Create a Workspace"
-        emptyStateActionButtonIcon="plus"
         emptyStateActionRoute="{
           name: 'create-workspace',
           params: {
             organizationId: 'd27e40e0-c9ac-43e2-8be8-54862fab45ea'
           }
-        }" />
+        }"
+        empty-state-icon-variant="kong">
+        <template #empty-state-action-icon>
+          <AddIcon />
+        </template>
+      </KTable>
     </template>
   </KCard>
 </template>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1229,6 +1229,7 @@ the section below or completely slot in your own content.
 
 - `empty-state` - Slot content to be displayed when empty
 - `error-state` - Slot content to be displayed when in an error state
+- `empty-state-action-icon` - Slot for slotting an icon to be rendered to the left of button text in empty state action button
 
 <KCard>
   <template #default>
@@ -1307,9 +1308,11 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
       emptyStateActionMessage="Create a Workspace"
       emptyStateActionButtonIcon="plus"
       emptyStateActionRoute="#empty-state-full-example"
-      emptyStateIcon="workspaces"
-      emptyStateIconColor="#5996ff"
-      emptyStateIconSize="35" />
+      empty-state-icon-variant="kong">
+      <template #empty-state-action-icon>
+        <AddIcon />
+      </template>
+    </KTable>
   </template>
 </KCard>
 
@@ -1326,9 +1329,11 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
         emptyStateActionMessage="Create a Workspace"
         emptyStateActionButtonIcon="plus"
         emptyStateActionRoute="create-workspace"
-        emptyStateIcon="workspaces"
-        emptyStateIconColor="#5996ff"
-        emptyStateIconSize="35" />
+        empty-state-icon-variant="kong">
+        <template #empty-state-action-icon>
+          <AddIcon />
+        </template>
+      </KTable>
     </template>
   </KCard>
 </template>
@@ -1349,10 +1354,7 @@ If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when c
           params: {
             organizationId: 'd27e40e0-c9ac-43e2-8be8-54862fab45ea'
           }
-        }"
-        emptyStateIcon="workspaces"
-        emptyStateIconColor="#5996ff"
-        emptyStateIconSize="35" />
+        }" />
     </template>
   </KCard>
 </template>
@@ -1566,8 +1568,12 @@ fetcher(payload) {
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { AddIcon } from '@kong/icons'
 
 export default defineComponent({
+  components: {
+    AddIcon
+  },
   data() {
     return {
       row: null,

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1272,8 +1272,7 @@ Set the following properties to handle empty state:
 - `emptyStateMessage` - Message for empty state
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
-- `emptyStateActionButtonShowPlusIcon` - Boolean prop to show/hide plus icon in empty state action button
-- `emptyStateIconVariant` - Prop set empty state icon variant. See [KEmptyState component docs](/components/empty-state#iconvariant) for details. Alternatively, you can use `empty-state-icon` slot.
+- `emptyStateIconVariant` - Prop set empty state icon variant. See [KEmptyState component docs](/components/empty-state#iconvariant) for details
 
 If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when clicked.
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1270,12 +1270,10 @@ Set the following properties to handle empty state:
 
 - `emptyStateTitle` - Title text for empty state
 - `emptyStateMessage` - Message for empty state
-- `emptyStateIcon` - Icon for empty state
-- `emptyStateIconColor` - Color for empty state icon
-- `emptyStateIconSize` - Size for empty state icon
 - `emptyStateActionRoute` - Route for empty state action
 - `emptyStateActionMessage` - Button text for empty state action
-- `emptyStateActionButtonIcon` - Icon for the empty state action button
+- `emptyStateActionButtonShowPlusIcon` - Boolean prop to show/hide plus icon in empty state action button
+- `emptyStateIconVariant` - Prop set empty state icon variant. See [KEmptyState component docs](/components/empty-state#iconvariant) for details. Alternatively, you can use `empty-state-icon` slot.
 
 If using a CTA button, a `@ktable-empty-state-cta-clicked` event is fired when clicked.
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -644,6 +644,12 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 
 ### KTable
 
+#### Props
+
+* `emptyStateIcon` prop has been removed. You can use the new `emptyStateIconVariant` prop or `empty-state-icon` slot instead
+* `emptyStateIconColor` prop has been removed
+* `emptyStateIconSize` prop has been removed
+* `emptyStateActionButtonIcon` prop has been removed. You can use the new `emptyStateActionButtonShowPlusIcon` prop instead
 
 ### KTabs
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -646,10 +646,10 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 
 #### Props
 
-* `emptyStateIcon` prop has been removed. You can use the new `emptyStateIconVariant` prop or `empty-state-icon` slot instead
+* `emptyStateIcon` prop has been removed. You can use the new `emptyStateIconVariant` prop instead
 * `emptyStateIconColor` prop has been removed
 * `emptyStateIconSize` prop has been removed
-* `emptyStateActionButtonIcon` prop has been removed. You can use the new `emptyStateActionButtonShowPlusIcon` prop instead
+* `emptyStateActionButtonIcon` prop has been removed
 
 ### KTabs
 

--- a/docs/guide/migrating-to-version-9.md
+++ b/docs/guide/migrating-to-version-9.md
@@ -649,7 +649,7 @@ Removed as of `v9`. Use `KBreadcumbs` instead.
 * `emptyStateIcon` prop has been removed. You can use the new `emptyStateIconVariant` prop instead
 * `emptyStateIconColor` prop has been removed
 * `emptyStateIconSize` prop has been removed
-* `emptyStateActionButtonIcon` prop has been removed
+* `emptyStateActionButtonIcon` prop has been removed. You can use the new `empty-state-action-icon` slot instead
 
 ### KTabs
 

--- a/sandbox/pages/SandboxEmptyState.vue
+++ b/sandbox/pages/SandboxEmptyState.vue
@@ -82,6 +82,12 @@
           message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec purus feugiat, molestie ipsum et, consequat nibh."
           title="Search Icon Variant"
         />
+        <KEmptyState
+          action-button-text="Action"
+          icon-variant="kong"
+          message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec purus feugiat, molestie ipsum et, consequat nibh."
+          title="Kong Icon Variant"
+        />
       </SandboxSectionComponent>
 
       <!-- Slots -->

--- a/sandbox/pages/SandboxTable.vue
+++ b/sandbox/pages/SandboxTable.vue
@@ -3,48 +3,73 @@
     :links="inject('app-links', [])"
     title="KTable"
   >
-    <KTable
-      :fetcher="fetcher"
-      :headers="[
-        { key: 'name', label: 'Name' },
-        { key: 'username', label: 'Username' },
-        { key: 'email', label: 'Email' },
-        { key: 'actions', hideLabel: true }
-      ]"
-      :initial-fetcher-params="{
-        pageSize: 30
-      }"
-    >
-      <template #actions>
-        <KDropdown>
-          <template #default>
-            <KButton
-              appearance="tertiary"
-              size="small"
-            >
-              <MoreIcon />
-            </KButton>
-          </template>
-          <template #items>
-            <KDropdownItem>
-              Edit
-            </KDropdownItem>
-            <KDropdownItem
-              danger
-              has-divider
-            >
-              Delete
-            </KDropdownItem>
-          </template>
-        </KDropdown>
-      </template>
-    </KTable>
+    <SandboxSectionComponent>
+      <div class="horizontal-container">
+        <KInputSwitch
+          v-model="tableEmptyState"
+          label="Show empty state"
+        />
+        <KInputSwitch
+          v-model="tableErrorState"
+          label="Show error state"
+        />
+      </div>
+
+      <KTable
+        :key="tableKey"
+        empty-state-action-message="Add new item"
+        :fetcher="fetcher"
+        :has-error="tableErrorState"
+        :headers="[
+          { key: 'name', label: 'Name' },
+          { key: 'username', label: 'Username' },
+          { key: 'email', label: 'Email' },
+          { key: 'actions', hideLabel: true }
+        ]"
+        :initial-fetcher-params="{
+          pageSize: 30
+        }"
+      >
+        <template #actions>
+          <KDropdown>
+            <template #default>
+              <KButton
+                appearance="tertiary"
+                size="small"
+              >
+                <MoreIcon />
+              </KButton>
+            </template>
+            <template #items>
+              <KDropdownItem>
+                Edit
+              </KDropdownItem>
+              <KDropdownItem
+                danger
+                has-divider
+              >
+                Delete
+              </KDropdownItem>
+            </template>
+          </KDropdown>
+        </template>
+        <template #empty-state-action-icon>
+          <AddIcon />
+        </template>
+      </KTable>
+    </SandboxSectionComponent>
   </SandboxLayout>
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
-import { MoreIcon } from '@kong/icons'
+import { inject, ref, watch } from 'vue'
+import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
+import { MoreIcon, AddIcon } from '@kong/icons'
+
+const tableKey = ref<number>(0)
+
+const tableEmptyState = ref<boolean>(false)
+const tableErrorState = ref<boolean>(false)
 
 const fetcher = async (): Promise<any> => {
   // Fake delay
@@ -54,8 +79,19 @@ const fetcher = async (): Promise<any> => {
   const responseData = await response.json()
 
   return {
-    data: responseData,
+    data: tableEmptyState.value ? [] : responseData,
     total: responseData.length,
   }
 }
+
+watch([tableEmptyState, tableErrorState], () => {
+  tableKey.value++
+})
 </script>
+
+<style lang="scss" scoped>
+.horizontal-container {
+  display: flex;
+  gap: $kui-space-50;
+}
+</style>

--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -11,6 +11,7 @@
         <component
           :is="getAlertIcon"
           class="alert-icon"
+          decorative
           :size="KUI_ICON_SIZE_40"
         />
       </slot>

--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -52,7 +52,7 @@
 
 <script lang="ts" setup>
 import { computed, type PropType } from 'vue'
-import { AnalyticsIcon, WarningIcon, SearchIcon } from '@kong/icons'
+import { AnalyticsIcon, WarningIcon, SearchIcon, KongIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_COLOR_TEXT_WARNING, KUI_ICON_SIZE_60 } from '@kong/design-tokens'
 import KButton from '@/components/KButton/KButton.vue'
 import { EmptyStateIconVariants } from '@/types'
@@ -97,6 +97,8 @@ const getEmptyStateIcon = computed((): EmptyStateIcon => {
       return WarningIcon
     case EmptyStateIconVariants.Search:
       return SearchIcon
+    case EmptyStateIconVariants.Kong:
+      return KongIcon
     default:
       return AnalyticsIcon // default variant in case of invalid value
   }

--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -9,6 +9,7 @@
           <component
             :is="getEmptyStateIcon"
             :color="getIconColor"
+            decorative
             :size="KUI_ICON_SIZE_60"
           />
         </slot>

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -222,7 +222,6 @@ import {
   TablePaginationTypeArray,
   TableSortOrderArray,
   TableTestModeArray,
-  EmptyStateIconVariants,
 } from '@/types'
 import { KUI_COLOR_TEXT, KUI_ICON_SIZE_20 } from '@kong/design-tokens'
 import { AddIcon } from '@kong/icons/dist/types'
@@ -340,7 +339,7 @@ const props = defineProps({
   },
   emptyStateIconVariant: {
     type: String as PropType<EmptyStateIconVariant>,
-    default: EmptyStateIconVariants.Default,
+    default: 'default',
   },
   /**
    * A prop that enables the error state

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -24,12 +24,14 @@
     >
       <slot name="error-state">
         <KEmptyState
-          :action-button-visible="!!errorStateActionMessage && !!errorStateActionRoute"
           icon-variant="error"
           :message="errorStateMessage"
           :title="errorStateTitle"
         >
-          <template #action>
+          <template
+            v-if="!!errorStateActionMessage && !!errorStateActionRoute"
+            #action
+          >
             <KButton
               :data-testid="getTestIdString(errorStateActionMessage)"
               :to="errorStateActionRoute ? errorStateActionRoute : undefined"
@@ -49,11 +51,13 @@
     >
       <slot name="empty-state">
         <KEmptyState
-          :action-button-visible="!!emptyStateActionMessage && !!emptyStateActionRoute"
           :message="emptyStateMessage"
           :title="emptyStateTitle"
         >
-          <template #action>
+          <template
+            v-if="!!emptyStateActionMessage && !!emptyStateActionRoute"
+            #action
+          >
             <KButton
               :appearance="searchInput ? 'tertiary' : 'primary'"
               :data-testid="getTestIdString(emptyStateActionMessage)"

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -51,9 +51,17 @@
     >
       <slot name="empty-state">
         <KEmptyState
+          :icon-variant="emptyStateIconVariant"
           :message="emptyStateMessage"
           :title="emptyStateTitle"
         >
+          <template
+            v-if="$slots['empty-state-icon']"
+            #icon
+          >
+            <slot name="empty-state-icon" />
+          </template>
+
           <template
             v-if="!!emptyStateActionMessage && !!emptyStateActionRoute"
             #action
@@ -61,10 +69,13 @@
             <KButton
               :appearance="searchInput ? 'tertiary' : 'primary'"
               :data-testid="getTestIdString(emptyStateActionMessage)"
-              :icon="emptyStateActionButtonIcon"
               :to="emptyStateActionRoute ? emptyStateActionRoute : undefined"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
+              <AddIcon
+                v-if="emptyStateActionButtonShowPlusIcon"
+                decorative
+              />
               {{ emptyStateActionMessage }}
             </KButton>
           </template>
@@ -205,13 +216,16 @@ import type {
   TableSortPayload,
   TableStatePayload,
   TableTestMode,
+  EmptyStateIconVariant,
 } from '@/types'
 import {
   TablePaginationTypeArray,
   TableSortOrderArray,
   TableTestModeArray,
+  EmptyStateIconVariants,
 } from '@/types'
 import { KUI_COLOR_TEXT, KUI_ICON_SIZE_20 } from '@kong/design-tokens'
+import { AddIcon } from '@kong/icons/dist/types'
 
 const { useDebounce, useRequest, useSwrvState } = useUtilities()
 
@@ -320,33 +334,13 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  /**
-   * A prop to pass in a custom empty state action message
-   */
-  emptyStateActionButtonIcon: {
-    type: String,
-    default: '',
+  emptyStateActionButtonShowPlusIcon: {
+    type: Boolean,
+    default: false,
   },
-  /**
-   * A prop to pass in a custom empty state icon
-   */
-  emptyStateIcon: {
-    type: String,
-    default: '',
-  },
-  /**
-   * A prop to pass in a color for the empty state icon
-   */
-  emptyStateIconColor: {
-    type: String,
-    default: '',
-  },
-  /**
-   * A prop to pass in a size for the empty state icon
-   */
-  emptyStateIconSize: {
-    type: String,
-    default: '50',
+  emptyStateIconVariant: {
+    type: String as PropType<EmptyStateIconVariant>,
+    default: EmptyStateIconVariants.Default,
   },
   /**
    * A prop that enables the error state

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -222,9 +222,10 @@ import {
   TablePaginationTypeArray,
   TableSortOrderArray,
   TableTestModeArray,
+  EmptyStateIconVariants,
 } from '@/types'
 import { KUI_COLOR_TEXT, KUI_ICON_SIZE_20 } from '@kong/design-tokens'
-import { AddIcon } from '@kong/icons/dist/types'
+import { AddIcon } from '@kong/icons'
 
 const { useDebounce, useRequest, useSwrvState } = useUtilities()
 
@@ -339,7 +340,7 @@ const props = defineProps({
   },
   emptyStateIconVariant: {
     type: String as PropType<EmptyStateIconVariant>,
-    default: 'default',
+    default: EmptyStateIconVariants.Default,
   },
   /**
    * A prop that enables the error state

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -56,13 +56,6 @@
           :title="emptyStateTitle"
         >
           <template
-            v-if="$slots['empty-state-icon']"
-            #icon
-          >
-            <slot name="empty-state-icon" />
-          </template>
-
-          <template
             v-if="!!emptyStateActionMessage"
             #action
           >
@@ -72,10 +65,6 @@
               :to="emptyStateActionRoute ? emptyStateActionRoute : undefined"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
-              <AddIcon
-                v-if="emptyStateActionButtonShowPlusIcon"
-                decorative
-              />
               {{ emptyStateActionMessage }}
             </KButton>
           </template>
@@ -225,7 +214,6 @@ import {
   EmptyStateIconVariants,
 } from '@/types'
 import { KUI_COLOR_TEXT, KUI_ICON_SIZE_20 } from '@kong/design-tokens'
-import { AddIcon } from '@kong/icons'
 
 const { useDebounce, useRequest, useSwrvState } = useUtilities()
 
@@ -333,10 +321,6 @@ const props = defineProps({
   emptyStateActionMessage: {
     type: String,
     default: '',
-  },
-  emptyStateActionButtonShowPlusIcon: {
-    type: Boolean,
-    default: false,
   },
   emptyStateIconVariant: {
     type: String as PropType<EmptyStateIconVariant>,

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -29,7 +29,7 @@
           :title="errorStateTitle"
         >
           <template
-            v-if="!!errorStateActionMessage && !!errorStateActionRoute"
+            v-if="!!errorStateActionMessage"
             #action
           >
             <KButton
@@ -63,7 +63,7 @@
           </template>
 
           <template
-            v-if="!!emptyStateActionMessage && !!emptyStateActionRoute"
+            v-if="!!emptyStateActionMessage"
             #action
           >
             <KButton

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -65,6 +65,7 @@
               :to="emptyStateActionRoute ? emptyStateActionRoute : undefined"
               @click="$emit('ktable-empty-state-cta-clicked')"
             >
+              <slot name="empty-state-action-icon" />
               {{ emptyStateActionMessage }}
             </KButton>
           </template>

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -16,6 +16,7 @@
           :is="getToastIcon(toaster.appearance)"
           class="toaster-icon"
           :color="KUI_COLOR_TEXT"
+          decorative
         />
       </div>
       <div class="toaster-content">

--- a/src/types/empty-state.ts
+++ b/src/types/empty-state.ts
@@ -2,6 +2,7 @@ export enum EmptyStateIconVariants {
   Default = 'default',
   Error = 'error',
   Search = 'search',
+  Kong = 'kong',
 }
 
 export type EmptyStateIconVariant = `${EmptyStateIconVariants}`


### PR DESCRIPTION
# Summary

Changes:

`KTable.vue`:

- remove `empty-state-action-button-icon` prop because it was utilizing KIcon - we no longer want to be doing that
- remove `empty-state-icon` - same reason as above
- remove `empty-state-icon-color` - no longer supported, KEmptyState sets the default color for the icon
- remove `empty-state-icon-size` - not supported, icon comes in default size
- add `emptyStateIconVariant` prop
- add `empty-state-action-icon` slot
- all of the above documented in migration guide and reflected in KTable docs

`KEmptyState.vue`:

- add kong icon variant

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
