### PR TITLE
fix(klabel, kselect, kmultiselect): a11y attributes [KHCP-111026]

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -101,6 +101,30 @@ You can set the maximum width of the tooltip container with the `maxWidth` prope
 </KTooltip>
 ```
 
+### tooltipId
+
+A string to be used as `id` attribute on underlying `role="tooltip"` element. Useful for setting accessible attributes (such as `aria-describedby`) on other elements.
+
+<label aria-describedby="full-name-field-tooltip" for="full-name-field" class="example-label">
+  Full Name
+
+  <KTooltip tooltip-id="full-name-field-tooltip" text="Please enter your full name as it appears in government documents.">
+    <InfoIcon tabindex="0"/>
+  </KTooltip>
+</label>
+<KInput id="full-name-field" />
+
+```html
+<label aria-describedby="full-name-field-tooltip" for="full-name-field">
+  Full Name
+
+  <KTooltip tooltip-id="full-name-field-tooltip" text="Please enter your full name as it appears in government documents.">
+    <InfoIcon tabindex="0"/>
+  </KTooltip>
+</label>
+<KInput id="full-name-field" />
+```
+
 ## Slots
 
 ### default
@@ -143,5 +167,11 @@ import { InfoIcon } from '@kong/icons'
 .tooltip-container {
   display: flex;
   justify-content: space-around;
+}
+
+.example-label {
+  display: flex;
+  gap: $kui-space-40;
+  margin-bottom: $kui-space-40;
 }
 </style>

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    :id="labelId"
+    :aria-describedby="tooltipId"
     class="k-label"
     :class="{ 'required': required }"
   >
@@ -8,10 +8,10 @@
 
     <KTooltip
       v-if="hasTooltip"
-      :aria-labelledby="labelId"
       v-bind="tooltipAttributes"
       class="label-tooltip"
       position-fixed
+      :tooltip-id="tooltipId"
     >
       <InfoIcon
         class="tooltip-trigger-icon"
@@ -27,7 +27,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, useAttrs, useSlots } from 'vue'
+import { computed, useSlots } from 'vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import type { TooltipAttributes } from '@/types'
 import { InfoIcon } from '@kong/icons'
@@ -64,11 +64,10 @@ const props = defineProps({
 })
 
 const slots = useSlots()
-const attrs = useAttrs()
 
 const hasTooltip = computed((): boolean => !!(props.help || props.info || slots.tooltip))
 
-const labelId = attrs.id ? String(attrs.id) : uuidv4()
+const tooltipId = uuidv4()
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -1,11 +1,14 @@
 <template>
   <label
+    :id="labelId"
     class="k-label"
     :class="{ 'required': required }"
   >
     <slot />
+
     <KTooltip
       v-if="hasTooltip"
+      :aria-labelledby="labelId"
       v-bind="tooltipAttributes"
       class="label-tooltip"
       position-fixed
@@ -24,11 +27,12 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, useSlots } from 'vue'
+import { computed, useAttrs, useSlots } from 'vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import type { TooltipAttributes } from '@/types'
 import { InfoIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
+import { v4 as uuidv4 } from 'uuid'
 
 const props = defineProps({
   info: {
@@ -60,8 +64,11 @@ const props = defineProps({
 })
 
 const slots = useSlots()
+const attrs = useAttrs()
 
 const hasTooltip = computed((): boolean => !!(props.help || props.info || slots.tooltip))
+
+const labelId = attrs.id ? String(attrs.id) : uuidv4()
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -173,47 +173,49 @@
                   @update:model-value="onQueryChange"
                 />
               </div>
-              <KMultiselectItems
-                :items="sortedItems"
-                @selected="handleItemSelect"
+              <div aria-live="polite">
+                <KMultiselectItems
+                  :items="sortedItems"
+                  @selected="handleItemSelect"
+                >
+                  <template #content="{ item }">
+                    <slot
+                      class="multiselect-item"
+                      :item="item"
+                      name="item-template"
+                    />
+                  </template>
+                </KMultiselectItems>
+                <KMultiselectItem
+                  v-if="enableItemCreation && uniqueFilterStr && !$slots.empty"
+                  key="multiselect-add-item"
+                  class="multiselect-add-item"
+                  data-testid="multiselect-add-item"
+                  :item="{ label: `${filterString} (Add new value)`, value: 'add_item' }"
+                  @selected="handleAddItem"
+                >
+                  <template #content>
+                    <div class="select-item-description">
+                      {{ filterString }}
+                      <span class="select-item-new-indicator">(Add new value)</span>
+                    </div>
+                  </template>
+                </KMultiselectItem>
+                <KMultiselectItem
+                  v-if="!sortedItems.length && !$slots.empty && !enableItemCreation"
+                  key="multiselect-empty-item"
+                  class="multiselect-empty-item"
+                  data-testid="multiselect-empty-item"
+                  :item="{ label: 'No results', value: 'no_results', disabled: true }"
+                />
+              </div>
+              <div
+                v-if="$slots.empty && !loading && !sortedItems.length"
+                class="multiselect-empty"
+                data-propagate-clicks="false"
               >
-                <template #content="{ item }">
-                  <slot
-                    class="multiselect-item"
-                    :item="item"
-                    name="item-template"
-                  />
-                </template>
-              </KMultiselectItems>
-              <KMultiselectItem
-                v-if="enableItemCreation && uniqueFilterStr && !$slots.empty"
-                key="multiselect-add-item"
-                class="multiselect-add-item"
-                data-testid="multiselect-add-item"
-                :item="{ label: `${filterString} (Add new value)`, value: 'add_item' }"
-                @selected="handleAddItem"
-              >
-                <template #content>
-                  <div class="select-item-description">
-                    {{ filterString }}
-                    <span class="select-item-new-indicator">(Add new value)</span>
-                  </div>
-                </template>
-              </KMultiselectItem>
-              <KMultiselectItem
-                v-if="!sortedItems.length && !$slots.empty && !enableItemCreation"
-                key="multiselect-empty-item"
-                class="multiselect-empty-item"
-                data-testid="multiselect-empty-item"
-                :item="{ label: 'No results', value: 'no_results', disabled: true }"
-              />
-            </div>
-            <div
-              v-if="$slots.empty && !loading && !sortedItems.length"
-              class="multiselect-empty"
-              data-propagate-clicks="false"
-            >
-              <slot name="empty" />
+                <slot name="empty" />
+              </div>
             </div>
             <div
               v-if="hasDropdownFooter"

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -8,7 +8,7 @@
       v-if="label"
       v-bind="labelAttributes"
       :data-testid="labelAttributes['data-testid'] ? labelAttributes['data-testid'] : 'multiselect-label'"
-      :for="multiselectId"
+      :for="multiselectWrapperId"
       :required="isRequired"
     >
       {{ strippedLabel }}
@@ -37,6 +37,7 @@
             :id="multiselectWrapperId"
             ref="multiselectElement"
             class="multiselect-trigger"
+            v-bind="modifiedAttrs"
             :class="{ focused: isFocused, hovered: isHovered, disabled: isDisabled, readonly: isReadonly }"
             data-testid="multiselect-trigger"
             role="listbox"
@@ -46,7 +47,6 @@
             <div v-if="collapsedContext">
               <KInput
                 :id="multiselectId"
-                v-bind="modifiedAttrs"
                 ref="multiselectInputElement"
                 autocapitalize="off"
                 autocomplete="off"

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -101,67 +101,69 @@
           </Transition>
         </div>
         <template #content>
-          <div
-            v-if="enableFiltering && loading"
-            class="select-loading"
-            data-propagate-clicks="false"
-            data-testid="select-loading"
-          >
-            <slot name="loading">
-              <ProgressIcon class="loading-icon" />
-            </slot>
-          </div>
-          <div
-            v-else
-            class="select-items-container"
-            data-propagate-clicks="false"
-          >
-            <KSelectItems
-              :items="filteredItems"
-              @selected="handleItemSelect"
-            >
-              <template #content="{ item }">
-                <slot
-                  class="select-item-label select-item-desc"
-                  :item="item"
-                  name="item-template"
-                />
-              </template>
-            </KSelectItems>
-            <KSelectItem
-              v-if="!filteredItems.length && !$slots.empty && !enableItemCreation"
-              :item="{ label: 'No results', value: 'no_results', disabled: true }"
-            />
-            <KSelectItem
-              v-if="!filteredItems.length && uniqueFilterQuery && !$slots.empty && enableItemCreation"
-              key="select-add-item"
-              class="select-add-item"
-              data-testid="select-add-item"
-              :item="{ label: `${filterQuery} (Add new value)`, value: 'add_item' }"
-              @selected="handleAddItem"
-            >
-              <template #content>
-                <div class="select-item-description">
-                  {{ filterQuery }}
-                  <span class="select-item-new-indicator">(Add new value)</span>
-                </div>
-              </template>
-            </KSelectItem>
+          <div :aria-live="enableFiltering ? 'polite' : 'off'">
             <div
-              v-if="hasDropdownFooter && dropdownFooterTextPosition === 'static'"
-              class="dropdown-footer dropdown-footer-static"
+              v-if="enableFiltering && loading"
+              class="select-loading"
+              data-propagate-clicks="false"
+              data-testid="select-loading"
             >
-              <slot name="dropdown-footer-text">
-                {{ dropdownFooterText }}
+              <slot name="loading">
+                <ProgressIcon class="loading-icon" />
               </slot>
             </div>
-          </div>
-          <div
-            v-if="!loading && !filteredItems.length && $slots.empty"
-            class="select-empty"
-            data-propagate-clicks="false"
-          >
-            <slot name="empty" />
+            <div
+              v-else
+              class="select-items-container"
+              data-propagate-clicks="false"
+            >
+              <KSelectItems
+                :items="filteredItems"
+                @selected="handleItemSelect"
+              >
+                <template #content="{ item }">
+                  <slot
+                    class="select-item-label select-item-desc"
+                    :item="item"
+                    name="item-template"
+                  />
+                </template>
+              </KSelectItems>
+              <KSelectItem
+                v-if="!filteredItems.length && !$slots.empty && !enableItemCreation"
+                :item="{ label: 'No results', value: 'no_results', disabled: true }"
+              />
+              <KSelectItem
+                v-if="!filteredItems.length && uniqueFilterQuery && !$slots.empty && enableItemCreation"
+                key="select-add-item"
+                class="select-add-item"
+                data-testid="select-add-item"
+                :item="{ label: `${filterQuery} (Add new value)`, value: 'add_item' }"
+                @selected="handleAddItem"
+              >
+                <template #content>
+                  <div class="select-item-description">
+                    {{ filterQuery }}
+                    <span class="select-item-new-indicator">(Add new value)</span>
+                  </div>
+                </template>
+              </KSelectItem>
+              <div
+                v-if="hasDropdownFooter && dropdownFooterTextPosition === 'static'"
+                class="dropdown-footer dropdown-footer-static"
+              >
+                <slot name="dropdown-footer-text">
+                  {{ dropdownFooterText }}
+                </slot>
+              </div>
+            </div>
+            <div
+              v-if="!loading && !filteredItems.length && $slots.empty"
+              class="select-empty"
+              data-propagate-clicks="false"
+            >
+              <slot name="empty" />
+            </div>
           </div>
           <div
             v-if="hasDropdownFooter && dropdownFooterTextPosition === 'sticky'"

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -14,7 +14,10 @@
     <slot />
 
     <template #content>
-      <div role="tooltip">
+      <div
+        :id="tooltipId"
+        role="tooltip"
+      >
         <slot
           :label="text || label"
           name="content"
@@ -36,6 +39,7 @@ import type { PropType } from 'vue'
 import KPop from '@/components/KPop/KPop.vue'
 import type { PopPlacements } from '@/types'
 import { PopPlacementsArray } from '@/types'
+import { v4 as uuidv4 } from 'uuid'
 
 const props = defineProps({
   /**
@@ -78,6 +82,10 @@ const props = defineProps({
   label: {
     type: String,
     default: '',
+  },
+  tooltipId: {
+    type: String,
+    default: `tooltip-${uuidv4()}`,
   },
 })
 

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -85,7 +85,7 @@ const props = defineProps({
   },
   tooltipId: {
     type: String,
-    default: `tooltip-${uuidv4()}`,
+    default: uuidv4(),
   },
 })
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-11026

Changes:
* add `aria-labelledby` on KLabel's tooltip
* add `aria-live` attribute in KSelect and KMultiselect
* change element to bind attributes to in KMultiselect

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
