### PR TITLE
fix(kslideout): remove user-select: none from title of KSlideout

### DIFF
--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -180,7 +180,6 @@ onUnmounted(() => {
         gap: var(--kui-space-40, $kui-space-40);
         letter-spacing: var(--kui-letter-spacing-minus-40, $kui-letter-spacing-minus-40);
         line-height: var(--kui-line-height-50, $kui-line-height-50);
-        user-select: none;
       }
 
       .slideout-close-icon {


### PR DESCRIPTION
# Summary

Remove `user-select: none` from title of KSlideout to allow user to select the title

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
