### PR TITLE
fix(ktooltip): content id

### DIFF
--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -15,7 +15,7 @@
 
     <template #content>
       <div
-        :id="tooltipId"
+        :id="tooltipId || uuidv4()"
         role="tooltip"
       >
         <slot
@@ -85,7 +85,7 @@ const props = defineProps({
   },
   tooltipId: {
     type: String,
-    default: uuidv4(),
+    default: '',
   },
 })
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

The way the default value of `tooltipId` is generated has caused unit tests in host app to fail.

<img width="725" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/4ee44c0c-b0fc-4b62-91ec-9072ea7bde37">

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
