### PR TITLE
feat(kcopy): support truncationLimit auto [khcp-11256]

### DIFF
--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -153,7 +153,7 @@ Number of characters to truncate at. Defaults to `8`.
 
 If you specify `'auto'` for the `truncationLimit` the text will only truncate if there is not enough space for it to be fully displayed.
 
-<div class="copy-flexed">
+<KCard class="copy-flexed">
   <KCopy
     badge
     badge-label="Truncated(auto):"
@@ -168,7 +168,7 @@ If you specify `'auto'` for the `truncationLimit` the text will only truncate if
     :text="longUrl"
     :truncation-limit="20"
   />
-</div>
+</KCard>
 
 ```html
 <KCopy
@@ -286,15 +286,13 @@ const onButtonClick = (): void => {
 
 <style lang="scss" scoped>
 .copy-flexed {
-  border: 1px solid $kui-color-border;
   display: flex;
   flex-wrap: wrap;
   gap: $kui-space-70;
-  padding: $kui-space-30;
 
   /** Resizable */
   max-width: 90%;
-  min-width: 100px;
+  min-width: 250px;
   overflow-x: auto;
   resize: horizontal;
 }

--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -153,24 +153,22 @@ Number of characters to truncate at. Defaults to `8`.
 
 If you specify `'auto'` for the `truncationLimit` the text will only truncate if there is not enough space for it to be fully displayed.
 
-<KCard>
-  <div class="copy-flexed">
-    <KCopy
-      badge
-      badge-label="Truncated(auto):"
-      truncate
-      :text="longUrl"
-      truncation-limit="auto"
-    />
-    <KCopy
-      badge
-      badge-label="Truncated(20ch):"
-      truncate
-      :text="longUrl"
-      :truncation-limit="20"
-    />
-  </div>
-</KCard>
+<div class="copy-flexed">
+  <KCopy
+    badge
+    badge-label="Truncated(auto):"
+    truncate
+    :text="longUrl"
+    truncation-limit="auto"
+  />
+  <KCopy
+    badge
+    badge-label="Truncated(20ch):"
+    truncate
+    :text="longUrl"
+    :truncation-limit="20"
+  />
+</div>
 
 ```html
 <KCopy
@@ -288,9 +286,16 @@ const onButtonClick = (): void => {
 
 <style lang="scss" scoped>
 .copy-flexed {
+  border: 1px solid $kui-color-border;
   display: flex;
   flex-wrap: wrap;
   gap: $kui-space-70;
-  max-width: 100%;
+  padding: $kui-space-30;
+
+  /** Resizable */
+  max-width: 90%;
+  min-width: 100px;
+  overflow-x: auto;
+  resize: horizontal;
 }
 </style>

--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -151,14 +151,53 @@ Number of characters to truncate at. Defaults to `8`.
 />
 ```
 
+If you specify `'auto'` for the `truncationLimit` the text will only truncate if there is not enough space for it to be fully displayed.
+
+<KCard>
+  <div class="copy-flexed">
+    <KCopy
+      badge
+      badge-label="Truncated(auto):"
+      truncate
+      :text="longUrl"
+      truncation-limit="auto"
+    />
+    <KCopy
+      badge
+      badge-label="Truncated(20ch):"
+      truncate
+      :text="longUrl"
+      :truncation-limit="20"
+    />
+  </div>
+</KCard>
+
+```html
+<KCopy
+  badge
+  badge-label="Truncated(auto):"
+  truncate
+  :text="longUrl"
+  truncation-limit="auto"
+/>
+
+<KCopy
+  badge
+  badge-label="Truncated(20ch):"
+  truncate
+  :text="longUrl"
+  :truncation-limit="20"
+/>
+```
+
 ### copyTooltip
 
-Tooltip text displayed on hover copy button. 
+Tooltip text displayed on hover copy button.
 If the `badgeLabel` prop has a value, then the copy tooltip text is `Copy {badgeLabel}` and the trailing colon from label if one exists will be stripped; otherwise the copy tooltip text is `Copy`.
 
 <KCopy
   :text="text"
-  badge 
+  badge
   badge-label="Service ID:"
   copy-tooltip="Copy to clipboard"
 />
@@ -166,7 +205,7 @@ If the `badgeLabel` prop has a value, then the copy tooltip text is `Copy {badge
 ```html
 <KCopy
   :text="text"
-  badge 
+  badge
   badge-label="Service ID:"
   copy-tooltip="Copy to clipboard"
 />
@@ -238,6 +277,7 @@ const onButtonClick = (): void => {
 import { ref } from 'vue'
 
 const text = '12345-6789-ABCD-EFGH-PQRSTUV-WXYZ'
+const longUrl = 'http://i.can.haz.cookies/chocolate/chocolate-chip?best=true&ref=a24Sfsdjh382-3hhdsu3-dsda'
 
 const kCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 
@@ -245,3 +285,12 @@ const onButtonClick = (): void => {
   kCopyElement.value?.copy()
 }
 </script>
+
+<style lang="scss" scoped>
+.copy-flexed {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  max-width: 100%;
+}
+</style>

--- a/docs/components/copy.md
+++ b/docs/components/copy.md
@@ -290,7 +290,7 @@ const onButtonClick = (): void => {
 .copy-flexed {
   display: flex;
   flex-wrap: wrap;
-  gap: 20px;
+  gap: $kui-space-70;
   max-width: 100%;
 }
 </style>


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Update `KCopy` to support truncation while expanding to fill the space if it's available by specifying `'auto'` for the `truncationLimit`.
Part of [KHCP-11256](https://konghq.atlassian.net/browse/KHCP-11256).

![image](https://github.com/Kong/kongponents/assets/67973710/2b95a7f1-ed21-4db2-a366-fa0ca7a73369)


## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README


[KHCP-11256]: https://konghq.atlassian.net/browse/KHCP-11256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ