### PR TITLE
fix(kcopy): not using actual button

### DIFF
--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -35,18 +35,18 @@
         :text="tooltipText"
       >
         <KClipboardProvider v-slot="{ copyToClipboard }">
-          <CopyIcon
+          <button
             :id="copyButtonElementId"
-            class="text-icon"
             data-testid="copy-to-clipboard"
-            :hide-title="!!copyTooltip || undefined"
-            role="button"
-            :size="KUI_ICON_SIZE_30"
-            tabindex="0"
+            type="button"
             @click.stop="copyIdToClipboard(copyToClipboard)"
-            @keydown.enter="copyIdToClipboard(copyToClipboard)"
-            @keydown.space.prevent="copyIdToClipboard(copyToClipboard)"
-          />
+          >
+            <CopyIcon
+              class="text-icon"
+              :hide-title="!!copyTooltip || undefined"
+              :size="KUI_ICON_SIZE_30"
+            />
+          </button>
         </KClipboardProvider>
       </KTooltip>
     </div>


### PR DESCRIPTION
# Summary

Fix KCopy not using an actual button for its click interaction. This is strictly better because you don’t have to worry about re-implementing button functionality and it’s default accessibility properties.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- There is a pre-existing "Extraneous non-props attributes (class, data-testid) were passed to component but could not be automatically inherited because component renders fragment or text root nodes." warning in this component.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README
