### PR TITLE
fix(ktreelist): label alignment

### DIFF
--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -98,6 +98,10 @@ const handleClick = () => {
     width: var(--kui-icon-size-40, $kui-icon-size-40) !important;
   }
 
+  .tree-item-label {
+    text-align: left;
+  }
+
   &.selected {
     background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
     border-color: var(--kui-color-border-neutral-weaker, $kui-color-border-neutral-weaker);


### PR DESCRIPTION
# Summary

On smaller screens, the text ends up being center-aligned. This PR aligns left.

## Before

![image](https://github.com/Kong/kongponents/assets/2229946/6a28538c-e72b-4bb6-92a4-28287292a5f4)


## After

![image](https://github.com/Kong/kongponents/assets/2229946/60e6043d-fc49-49d6-8ec4-dc92a5d58aaf)
