### PR TITLE
fix(types): allow legend header tag

### DIFF
--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -82,6 +82,7 @@ Accepted values are:
 * `div`
 * `span`
 * `a`
+* `legend`
 * `h1`
 * `h2`
 * `h3`

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,3 +1,3 @@
-export type HeaderTag = 'div' | 'span' | 'a' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+export type HeaderTag = 'div' | 'span' | 'a' | 'legend' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
-export const HeaderTags: HeaderTag[] = ['div', 'span', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+export const HeaderTags: HeaderTag[] = ['div', 'span', 'a', 'legend', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']


### PR DESCRIPTION
# Summary

Allow `legend` value in `HeaderTag` type

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
