### PR TITLE
feat: add zIndex prop to overlaying components [KHCP-10747]

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -352,6 +352,20 @@ Maximum height of the content area. When content overflows, content area becomes
 </KModal>
 ```
 
+### zIndex
+
+`z-index` value for the modal. Defaults to `1100`.
+
+```html
+<KModal
+  z-index="9999"
+  title="Modal"
+  :visible="modalVisible"
+  @cancel="handleModalClose"
+  @proceed="handleModalProceed"
+/>
+```
+
 ### fullScreen
 
 Use this prop to make modal window take up almost the whole screen. When set to `true`, `maxWidth` and `maxHeight` props will have no effect.

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -322,6 +322,19 @@ The max width of the popover body - by default it is `auto`.
 </KPop>
 ```
 
+### zIndex
+
+The `z-index` of the popover - by default it is `1000`.
+
+```html
+<KPop title="Cool header" z-index="9999">
+  <KButton>button</KButton>
+  <template v-slot:content>
+    I have a z-index of 9999! I have a z-index of 9999!
+  </template>
+</KPop>
+```
+
 ### popoverClasses
 
 Custom classes that you want to append to the popover - by default it has a `k-popover` class on it.

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -140,6 +140,10 @@ Used for controlling the progress indicator.
 
 Defaults to `false`, you can use this prop to hide the progress indicator.
 
+### zIndex
+
+Defaults to `10500`, you can use this prop to control the `z-index` value of the full-screen skeleton container
+
 <div class="horizontal-spacing-container">
   <KButton @click="onClickNoProgress">Click for no progress indicator</KButton>
   <KButton @click="onClick">Click for default progress behavior</KButton>

--- a/docs/components/slideout.md
+++ b/docs/components/slideout.md
@@ -256,6 +256,19 @@ Controls width of the slideout content area. Default value is `500px`.
 />
 ```
 
+### zIndex
+
+Controls `z-index` of the slideout content area. Default value is `9999`.
+
+```html
+<KSlideout
+  z-index="92929"
+  title="Very high z-index"
+  :visible="slideoutVisible"
+  @close="hideSlideout"
+/>
+```
+
 ## Slots
 
 ### default

--- a/docs/components/toaster.md
+++ b/docs/components/toaster.md
@@ -13,7 +13,13 @@ import { ToastManager } from '@kong/kongponents'
 const app = createApp()
 
 // Available inside any component template in the application, and also on 'this' of any component instance
-app.config.globalProperties.$toaster = new ToastManager()
+app.config.globalProperties.$toaster = new ToastManager({
+  // you can also override the default value of following properties while initializing ToastManager
+  id: 'custom-id', // default: 'toaster-container'
+  timeout: 500, // default: 5000
+  appearance: 'success', // default: 'info'
+  zIndex: 92929, // default: 10000
+})
 ```
 
 For TypeScript, you should also augment the global property in your vue declaration file

--- a/src/components/KModal/KModal.cy.ts
+++ b/src/components/KModal/KModal.cy.ts
@@ -223,6 +223,31 @@ describe('KModal', () => {
     cy.get('.k-modal .modal-backdrop.modal-full-screen').should('be.visible')
   })
 
+  it('renders modal with correct zIndex when prop is passed', () => {
+
+    mount(KModal, {
+      props: {
+        visible: true,
+        zIndex: 1200,
+      },
+    })
+
+    // cypress only allows assertion with strings in CSS assertions
+    // https://github.com/cypress-io/cypress/blob/0e1a49dc461a670a3a1dd9a6e139eeb2f00c7c46/cli/types/cypress.d.ts#L5632
+    cy.get('.k-modal .modal-backdrop').should('have.css', 'z-index', '1200')
+  })
+
+  it('renders modal with correct default zIndex when prop is not passed', () => {
+
+    mount(KModal, {
+      props: {
+        visible: true,
+      },
+    })
+
+    cy.get('.k-modal .modal-backdrop').should('have.css', 'z-index', '1100') // default z-index
+  })
+
   it('emits proceed event when action button is clicked', () => {
     mount(KModal, {
       props: {

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -170,6 +170,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  zIndex: {
+    type: Number,
+    default: 1100,
+  },
 })
 
 const emit = defineEmits<{
@@ -299,7 +303,7 @@ onBeforeUnmount(async () => {
     justify-content: center;
     padding: var(--kui-space-70, $kui-space-70) var(--kui-space-50, $kui-space-50) var(--kui-space-0, $kui-space-0) var(--kui-space-50, $kui-space-50);
     position: fixed;
-    z-index: 1100;
+    z-index: v-bind(zIndex);
 
     @media (min-width: $kui-breakpoint-phablet) {
       padding-top: var(--kui-space-110, $kui-space-110);

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -303,7 +303,7 @@ onBeforeUnmount(async () => {
     justify-content: center;
     padding: var(--kui-space-70, $kui-space-70) var(--kui-space-50, $kui-space-50) var(--kui-space-0, $kui-space-0) var(--kui-space-50, $kui-space-50);
     position: fixed;
-    z-index: v-bind(zIndex);
+    z-index: v-bind('zIndex');
 
     @media (min-width: $kui-breakpoint-phablet) {
       padding-top: var(--kui-space-110, $kui-space-110);

--- a/src/components/KPop/KPop.cy.ts
+++ b/src/components/KPop/KPop.cy.ts
@@ -118,4 +118,20 @@ describe('KPop', () => {
     cy.get('.slottedEl').trigger('mouseenter')
     cy.get('.k-popover').should('be.visible')
   })
+
+  it('renders with correct default zIndex', () => {
+    mount(KPop)
+
+    cy.get('.k-popover').should('have.css', 'z-index', '1000')
+  })
+
+  it('renders with custom zIndex', () => {
+    mount(KPop, {
+      props: {
+        zIndex: 2200,
+      },
+    })
+
+    cy.get('.k-popover').should('have.css', 'z-index', '2200')
+  })
 })

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -268,6 +268,13 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    /**
+     * z-index - to control z-index value of the popover
+     */
+    zIndex: {
+      type: Number,
+      default: 1000,
+    },
   },
   emits: ['opened', 'closed'],
   data() {
@@ -459,7 +466,7 @@ export default defineComponent({
   padding: var(--kui-space-80, $kui-space-80) var(--kui-space-60, $kui-space-60);
   text-align: left;
   white-space: normal;
-  z-index: 1000;
+  z-index: v-bind(zIndex);
 
   // Prevent Vue animation classes from impacting the positioning of the popover
   &.fade-enter-active,

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -466,7 +466,7 @@ export default defineComponent({
   padding: var(--kui-space-80, $kui-space-80) var(--kui-space-60, $kui-space-60);
   text-align: left;
   white-space: normal;
-  z-index: v-bind(zIndex);
+  z-index: v-bind('zIndex');
 
   // Prevent Vue animation classes from impacting the positioning of the popover
   &.fade-enter-active,

--- a/src/components/KSkeleton/FullScreenGenericSpinner.vue
+++ b/src/components/KSkeleton/FullScreenGenericSpinner.vue
@@ -34,6 +34,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  zIndex: {
+    type: Number,
+    default: 10500,
+  },
 })
 
 const timer = ref(0)
@@ -61,7 +65,7 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 .fullscreen-loading-container {
-  @include fullScreenLoadingContainer;
+  @include fullScreenLoadingContainer(v-bind(zIndex));
 
   .progress {
     @include fullScreenLoadingProgressBar;

--- a/src/components/KSkeleton/FullScreenGenericSpinner.vue
+++ b/src/components/KSkeleton/FullScreenGenericSpinner.vue
@@ -65,7 +65,7 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 .fullscreen-loading-container {
-  @include fullScreenLoadingContainer(v-bind(zIndex));
+  @include fullScreenLoadingContainer(v-bind('zIndex'));
 
   .progress {
     @include fullScreenLoadingProgressBar;

--- a/src/components/KSkeleton/FullScreenKongSkeleton.vue
+++ b/src/components/KSkeleton/FullScreenKongSkeleton.vue
@@ -68,7 +68,7 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 .fullscreen-loading-container {
-  @include fullScreenLoadingContainer(v-bind(zIndex));
+  @include fullScreenLoadingContainer(v-bind('zIndex'));
 
   .progress {
     @include fullScreenLoadingProgressBar;

--- a/src/components/KSkeleton/FullScreenKongSkeleton.vue
+++ b/src/components/KSkeleton/FullScreenKongSkeleton.vue
@@ -36,6 +36,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  zIndex: {
+    type: Number,
+    default: 10500,
+  },
 })
 
 const timer = ref(0)
@@ -64,7 +68,7 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 .fullscreen-loading-container {
-  @include fullScreenLoadingContainer;
+  @include fullScreenLoadingContainer(v-bind(zIndex));
 
   .progress {
     @include fullScreenLoadingProgressBar;

--- a/src/components/KSkeleton/KSkeleton.cy.ts
+++ b/src/components/KSkeleton/KSkeleton.cy.ts
@@ -65,6 +65,19 @@ describe('KSkeleton', () => {
       cy.get('[role="progressbar"]').should('be.visible')
     })
 
+    it('renders full screen loader with custom zIndex', () => {
+      mount(KSkeleton, {
+        props: {
+          type: 'fullscreen-kong',
+          zIndex: 12000,
+        },
+      })
+
+      cy.getTestId('full-screen-loader').should('be.visible')
+
+      cy.get('.k-skeleton .fullscreen-loading-container').should('have.css', 'z-index', '12000')
+    })
+
     it('renders full screen generic loader with progress bar', () => {
       mount(KSkeleton, {
         props: {
@@ -75,6 +88,20 @@ describe('KSkeleton', () => {
       cy.getTestId('full-screen-spinner-loader').should('be.visible')
 
       cy.get('[role="progressbar"]').should('be.visible')
+    })
+
+    it('renders full screen generic loader with custom zIndex', () => {
+      mount(KSkeleton, {
+        props: {
+          type: 'fullscreen-generic',
+          zIndex: 12000,
+        },
+      })
+
+      cy.getTestId('full-screen-spinner-loader').should('be.visible')
+
+      cy.get('.k-skeleton .fullscreen-loading-container').should('have.css', 'z-index', '12000')
+
     })
   })
 })

--- a/src/components/KSkeleton/KSkeleton.vue
+++ b/src/components/KSkeleton/KSkeleton.vue
@@ -36,12 +36,14 @@
       v-else-if="type === 'fullscreen-kong'"
       :hide-progress="hideProgress"
       :progress="progress"
+      :z-index="zIndex"
     />
 
     <FullScreenGenericSpinner
       v-else-if="type === 'fullscreen-generic'"
       :hide-progress="hideProgress"
       :progress="progress"
+      :z-index="zIndex"
     />
 
     <ProgressIcon
@@ -105,6 +107,10 @@ const props = defineProps({
     type: Number,
     required: false,
     default: 6,
+  },
+  zIndex: {
+    type: Number,
+    default: 10500,
   },
 })
 

--- a/src/components/KSlideout/KSlideout.cy.ts
+++ b/src/components/KSlideout/KSlideout.cy.ts
@@ -36,6 +36,31 @@ describe('KSlideout', () => {
     cy.getTestId('slideout-title').should('be.visible').should('have.text', titleProp)
   })
 
+  it('renders with correct default z-index', () => {
+
+    mount(KSlideout, {
+      props: {
+        visible: true,
+      },
+    })
+
+    cy.get('.k-slideout .slideout-container').should('have.css', 'z-index', '9999')
+    cy.get('.k-slideout .slideout-backdrop').should('have.css', 'z-index', '9999')
+  })
+
+  it('renders with custom z-index', () => {
+
+    mount(KSlideout, {
+      props: {
+        visible: true,
+        zIndex: 92929,
+      },
+    })
+
+    cy.get('.k-slideout .slideout-container').should('have.css', 'z-index', '92929')
+    cy.get('.k-slideout .slideout-backdrop').should('have.css', 'z-index', '92929')
+  })
+
   it('renders close icon on right', () => {
     mount(KSlideout, {
       props: {

--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -166,7 +166,7 @@ onUnmounted(() => {
     right: 0;
     top: v-bind('offsetTopValue');
     width: 100%;
-    z-index: v-bind(zIndex);
+    z-index: v-bind('zIndex');
 
     .slideout-header {
       display: flex;
@@ -228,7 +228,7 @@ onUnmounted(() => {
     position: fixed;
     right: 0;
     top: v-bind('offsetTopValue');
-    z-index: v-bind(zIndex); // same value as z-index of slideout-container
+    z-index: v-bind('zIndex'); // same value as z-index of slideout-container
 
     &.backdrop-transparent {
       background: var(--kui-color-background-transparent, $kui-color-background-transparent);

--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -88,6 +88,10 @@ const props = defineProps({
     required: false,
     default: '500px',
   },
+  zIndex: {
+    type: Number,
+    default: 9999,
+  },
 })
 
 const emit = defineEmits<{
@@ -162,7 +166,7 @@ onUnmounted(() => {
     right: 0;
     top: v-bind('offsetTopValue');
     width: 100%;
-    z-index: 9999;
+    z-index: v-bind(zIndex);
 
     .slideout-header {
       display: flex;
@@ -224,7 +228,7 @@ onUnmounted(() => {
     position: fixed;
     right: 0;
     top: v-bind('offsetTopValue');
-    z-index: 9999;
+    z-index: v-bind(zIndex); // same value as z-index of slideout-container
 
     &.backdrop-transparent {
       background: var(--kui-color-background-transparent, $kui-color-background-transparent);

--- a/src/components/KToaster/KToaster.cy.ts
+++ b/src/components/KToaster/KToaster.cy.ts
@@ -61,6 +61,29 @@ describe('KToaster', () => {
       cy.get('.toaster .toaster-message').should('not.exist')
       cy.get('.toaster .toaster-close-icon').should('be.visible')
     })
+
+    it('renders toast with correct default z-index', () => {
+
+      mount(KToaster, {
+        props: {
+          toasterState: [{ title: 'I have a toast' }],
+        },
+      })
+
+      cy.get('.k-toaster').should('have.css', 'z-index', '10000')
+    })
+
+    it('renders toast with custom z-index', () => {
+
+      mount(KToaster, {
+        props: {
+          toasterState: [{ title: 'I have a toast' }],
+          zIndex: 9999,
+        },
+      })
+
+      cy.get('.k-toaster').should('have.css', 'z-index', '9999')
+    })
   })
 
   describe('ToastManager', () => {

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -63,6 +63,10 @@ defineProps({
     default: [] as Toast[],
     required: true,
   },
+  zIndex: {
+    type: Number,
+    default: 10000,
+  },
 })
 
 defineEmits<{
@@ -97,7 +101,7 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
   right: 50%;
   transform: translateX(50%);
   width: 90%;
-  z-index: 10000;
+  z-index: v-bind(zIndex);
 
   @media (min-width: $kui-breakpoint-mobile) {
     right: 16px;

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -101,7 +101,7 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
   right: 50%;
   transform: translateX(50%);
   width: 90%;
-  z-index: v-bind(zIndex);
+  z-index: v-bind('zIndex');
 
   @media (min-width: $kui-breakpoint-mobile) {
     right: 16px;

--- a/src/components/KToaster/ToastManager.ts
+++ b/src/components/KToaster/ToastManager.ts
@@ -10,6 +10,7 @@ const DEFAULTS = {
   id: 'toaster-container',
   timeout: 5000,
   appearance: ToasterAppearances.info,
+  zIndex: 10000,
 }
 
 export default class ToastManager {
@@ -17,13 +18,15 @@ export default class ToastManager {
   public timeout: number
   public appearance: string
   public id: string
+  public zIndex: number
 
-  constructor(id = DEFAULTS.id, timeout = DEFAULTS.timeout, appearance = DEFAULTS.appearance) {
+  constructor(id = DEFAULTS.id, timeout = DEFAULTS.timeout, appearance = DEFAULTS.appearance, zIndex = DEFAULTS.zIndex) {
     this.toasters = ref<Toast[]>([])
 
     this.timeout = timeout
     this.appearance = appearance
     this.id = id
+    this.zIndex = zIndex
 
     this.mount()
   }
@@ -39,6 +42,7 @@ export default class ToastManager {
 
     const Toast = h(KToaster, {
       toasterState: this.toasters.value,
+      zIndex: this.zIndex,
       onClose: (key: any) => this.close(key),
     })
 

--- a/src/components/KToaster/ToastManager.ts
+++ b/src/components/KToaster/ToastManager.ts
@@ -20,7 +20,7 @@ export default class ToastManager {
   public id: string
   public zIndex: number
 
-  constructor(id = DEFAULTS.id, timeout = DEFAULTS.timeout, appearance = DEFAULTS.appearance, zIndex = DEFAULTS.zIndex) {
+  constructor({ id, timeout, appearance, zIndex } = DEFAULTS) {
     this.toasters = ref<Toast[]>([])
 
     this.timeout = timeout

--- a/src/components/KTooltip/KTooltip.cy.ts
+++ b/src/components/KTooltip/KTooltip.cy.ts
@@ -45,4 +45,25 @@ describe('KTooltip', () => {
 
     cy.get('.k-tooltip').should('not.exist')
   })
+
+  it('renders with correct default zIndex', () => {
+    mount(KTooltip, {
+      props: {
+        text: 'sample text',
+      },
+    })
+
+    cy.get('.k-tooltip.k-popover').should('have.css', 'z-index', '9999')
+  })
+
+  it('renders with custom zIndex', () => {
+    mount(KTooltip, {
+      props: {
+        text: 'sample text',
+        zIndex: 92929,
+      },
+    })
+
+    cy.get('.k-tooltip.k-popover').should('have.css', 'z-index', '92929')
+  })
 })

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -87,6 +87,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  zIndex: {
+    type: Number,
+    default: 9999,
+  },
 })
 
 const slots = useSlots()
@@ -124,7 +128,7 @@ const computedClass = computed((): string => {
   font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   line-height: var(--kui-line-height-20, $kui-line-height-20);
   padding: var(--kui-space-30, $kui-space-30);
-  z-index: 9999;
+  z-index: v-bind(zIndex);
 
   &.tooltip-top {
     margin-bottom: var(--kui-space-20, $kui-space-20);

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -128,7 +128,7 @@ const computedClass = computed((): string => {
   font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);
   line-height: var(--kui-line-height-20, $kui-line-height-20);
   padding: var(--kui-space-30, $kui-space-30);
-  z-index: v-bind(zIndex);
+  z-index: v-bind('zIndex');
 
   &.tooltip-top {
     margin-bottom: var(--kui-space-20, $kui-space-20);

--- a/src/styles/mixins/_loaders.scss
+++ b/src/styles/mixins/_loaders.scss
@@ -1,6 +1,6 @@
 /* Loaders styles */
 
-@mixin fullScreenLoadingContainer {
+@mixin fullScreenLoadingContainer($zIndex: 10500) {
   align-items: center;
   background: var(--kui-color-background, $kui-color-background);
   bottom: 0;
@@ -12,7 +12,7 @@
   position: fixed;
   right: 0;
   top: 0;
-  z-index: 10500;
+  z-index: $zIndex;
 }
 
 @mixin fullScreenLoadingProgressBar {


### PR DESCRIPTION
# Summary

Adds a `zIndex` prop to all overlaying components (that need to be shown above the default layer) so that they can be assigned custom `z-index` values.

Components updated:
- `KModal`
- `KPop`
- `KSlideout`
- `KToaster`
- `KTooltip`
- `KSkeleton`
  - `FullScreenKongSkeleton`
  - `FullScreenGenericSpinner`

[KHCP-10747](https://konghq.atlassian.net/browse/KHCP-10747)

## PR Checklist

* [X] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [x] **Tests coverage:** test coverage was added for new features and bug fixes
* [x] **Docs:** includes a technically accurate README


[KHCP-10747]: https://konghq.atlassian.net/browse/KHCP-10747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ