### PR TITLE
fix(ktable): dont clear visibility prefs on load

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -584,7 +584,7 @@ const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filte
 // visibility preferences from the host app (initialized by app)
 const visibilityPreferences = computed((): Record<string, boolean> => props.tablePreferences.columnVisibility || {})
 // current column visibility state
-const columnVisibility = ref<Record<string, boolean>>({})
+const columnVisibility = ref<Record<string, boolean>>(props.tablePreferences.columnVisibility || {})
 const total = ref(0)
 const isScrolled = ref(false)
 const page = ref(1)


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Fix a bug where visibility preferences were getting overridden by default value.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
