### PR TITLE
docs: use shorthand for named slots usage in docs [KHCP-11488]

### DIFF
--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -429,12 +429,12 @@ Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specif
 ```html
 <KCatalog :fetcher="fetcher" title="Customized cards">
   <template #cardTitle="{ item }">
-    <div>
+    <div class="custom-title">
       {{ item.title }}
     </div>
   </template>
   <template #cardBody="{ item }">
-    <span>
+    <span class="custom-description">
     {{ item.description }}
     </span>
   </template>

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -229,14 +229,14 @@ a wrapper around `KCard` to display correctly inside `KCatalog`. You can use the
 
 ```html
 <KCatalogItem>
-  <template #cardTitle>
+  <template v-slot:cardTitle>
     <KIcon
       icon="profile"
       color="#7F01FE"
       size="44" />
     Look Mah!
   </template>
-  <template #cardBody>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.</template>
+  <template v-slot:cardBody>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.</template>
 </KCatalogItem>
 ```
 
@@ -392,7 +392,7 @@ Both the `title` & `description` of the card items as well as the entire catalog
 If used in conjuction with a `fetcher` you have the option of using the returned `data` in the `body` slot.
 
 <KCatalog :fetcher="fetcherSm" title="Customized body">
-  <template #body="{ data }">
+  <template v-slot:body="{ data }">
     <div v-for="item in data">
       <h4>{{ item.title }}</h4>
       <p>{{ item.description }}</p>
@@ -402,7 +402,7 @@ If used in conjuction with a `fetcher` you have the option of using the returned
 
 ```html
 <KCatalog :fetcher="fetcher" title="Customized body">
-  <template #body="{ data }">
+  <template v-slot:body="{ data }">
     <div v-for="item in data">
       <h4>{{ item.title }}</h4>
       <p>{{ item.description }}</p>
@@ -414,12 +414,12 @@ If used in conjuction with a `fetcher` you have the option of using the returned
 Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specific data.
 
 <KCatalog :fetcher="fetcherSm" title="Customized cards">
-  <template #cardTitle="{ item }">
+  <template v-slot:cardTitle="{ item }">
     <div class="custom-title">
       {{ item.title }}
     </div>
   </template>
-  <template #cardBody="{ item }">
+  <template v-slot:cardBody="{ item }">
     <span class="custom-description">
     {{ item.description }}
     </span>
@@ -428,13 +428,13 @@ Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specif
 
 ```html
 <KCatalog :fetcher="fetcher" title="Customized cards">
-  <template #cardTitle="{ item }">
-    <div class="custom-title">
+  <template v-slot:cardTitle="{ item }">
+    <div>
       {{ item.title }}
     </div>
   </template>
-  <template #cardBody="{ item }">
-    <span class="custom-description">
+  <template v-slot:cardBody="{ item }">
+    <span>
     {{ item.description }}
     </span>
   </template>
@@ -502,15 +502,15 @@ the section above or completely slot in your own content.
 - `error-state` - Slot content to be displayed when in an error state
 
 <KCard>
-  <template #body>
+  <template v-slot:body>
     <KCatalog :fetcher="emptyFetcher">
-      <template #empty-state>
+      <template v-slot:empty-state>
         <div style="text-align: center;">
           <KIcon icon="warning" />
           <div>No Content!!!</div>
         </div>
       </template>
-      <template #error-state>
+      <template v-slot:error-state>
         <KIcon icon="error" />
         Something went wrong
       </template>
@@ -521,11 +521,11 @@ the section above or completely slot in your own content.
 ```html
 <template>
   <KCatalog :fetcher="() => { return { data: [] } }">
-    <template #empty-state>
+    <template v-slot:empty-state>
       <KIcon icon="warning" />
       No Content!!!
     </template>
-    <template #error-state>
+    <template v-slot:error-state>
       <KIcon icon="error" />
       Something went wrong
     </template>
@@ -565,7 +565,7 @@ https://kongponents.dev/api/components?_page=1&_limit=10
 <!-- Example Component Usage -->
 
 <KCard>
-  <template #body>
+  <template v-slot:body>
     <KInput placeholder="Search" v-model="search" type="search" />
     <KCatalog
       cache-identifier="server-side-functions-catalog"

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -229,14 +229,14 @@ a wrapper around `KCard` to display correctly inside `KCatalog`. You can use the
 
 ```html
 <KCatalogItem>
-  <template v-slot:cardTitle>
+  <template #cardTitle>
     <KIcon
       icon="profile"
       color="#7F01FE"
       size="44" />
     Look Mah!
   </template>
-  <template v-slot:cardBody>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.</template>
+  <template #cardBody>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.</template>
 </KCatalogItem>
 ```
 
@@ -392,7 +392,7 @@ Both the `title` & `description` of the card items as well as the entire catalog
 If used in conjuction with a `fetcher` you have the option of using the returned `data` in the `body` slot.
 
 <KCatalog :fetcher="fetcherSm" title="Customized body">
-  <template v-slot:body="{ data }">
+  <template #body="{ data }">
     <div v-for="item in data">
       <h4>{{ item.title }}</h4>
       <p>{{ item.description }}</p>
@@ -402,7 +402,7 @@ If used in conjuction with a `fetcher` you have the option of using the returned
 
 ```html
 <KCatalog :fetcher="fetcher" title="Customized body">
-  <template v-slot:body="{ data }">
+  <template #body="{ data }">
     <div v-for="item in data">
       <h4>{{ item.title }}</h4>
       <p>{{ item.description }}</p>
@@ -414,12 +414,12 @@ If used in conjuction with a `fetcher` you have the option of using the returned
 Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specific data.
 
 <KCatalog :fetcher="fetcherSm" title="Customized cards">
-  <template v-slot:cardTitle="{ item }">
+  <template #cardTitle="{ item }">
     <div class="custom-title">
       {{ item.title }}
     </div>
   </template>
-  <template v-slot:cardBody="{ item }">
+  <template #cardBody="{ item }">
     <span class="custom-description">
     {{ item.description }}
     </span>
@@ -428,12 +428,12 @@ Use the `cardTitle`, `cardActions`, and `cardBody` slots to access `item` specif
 
 ```html
 <KCatalog :fetcher="fetcher" title="Customized cards">
-  <template v-slot:cardTitle="{ item }">
+  <template #cardTitle="{ item }">
     <div>
       {{ item.title }}
     </div>
   </template>
-  <template v-slot:cardBody="{ item }">
+  <template #cardBody="{ item }">
     <span>
     {{ item.description }}
     </span>
@@ -502,15 +502,15 @@ the section above or completely slot in your own content.
 - `error-state` - Slot content to be displayed when in an error state
 
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KCatalog :fetcher="emptyFetcher">
-      <template v-slot:empty-state>
+      <template #empty-state>
         <div style="text-align: center;">
           <KIcon icon="warning" />
           <div>No Content!!!</div>
         </div>
       </template>
-      <template v-slot:error-state>
+      <template #error-state>
         <KIcon icon="error" />
         Something went wrong
       </template>
@@ -521,11 +521,11 @@ the section above or completely slot in your own content.
 ```html
 <template>
   <KCatalog :fetcher="() => { return { data: [] } }">
-    <template v-slot:empty-state>
+    <template #empty-state>
       <KIcon icon="warning" />
       No Content!!!
     </template>
-    <template v-slot:error-state>
+    <template #error-state>
       <KIcon icon="error" />
       Something went wrong
     </template>
@@ -565,7 +565,7 @@ https://kongponents.dev/api/components?_page=1&_limit=10
 <!-- Example Component Usage -->
 
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KInput placeholder="Search" v-model="search" type="search" />
     <KCatalog
       cache-identifier="server-side-functions-catalog"

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -172,7 +172,7 @@ You can read more about the viewBox attribute
 
 <div class="spacing-container">
   <KIcon icon="check" size="48px" color="url('#linear-gradient')">
-    <template v-slot:svgElements>
+    <template #svgElements>
       <defs>
         <linearGradient id="linear-gradient" x1="0" x2="1">
           <stop offset="0%" stop-color="#16BDCC" />
@@ -184,7 +184,7 @@ You can read more about the viewBox attribute
   </KIcon>
 
   <KIcon icon="search" size="48px" color="url('#linear-gradient2')">
-    <template v-slot:svgElements>
+    <template #svgElements>
       <defs>
         <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
           <stop offset="10%"  stop-color="gold" />
@@ -195,7 +195,7 @@ You can read more about the viewBox attribute
   </KIcon>
 
   <KIcon icon="cogwheel" size="48px" color="dark-grey">
-    <template v-slot:svgElements>
+    <template #svgElements>
       <animateTransform
         attributeName="transform"
         type="rotate"
@@ -210,7 +210,7 @@ You can read more about the viewBox attribute
 
 ```html
 <KIcon icon="check" size="48px" color="url('#linear-gradient')">
-  <template v-slot:svgElements>
+  <template #svgElements>
     <defs>
       <linearGradient id="linear-gradient" x1="0" x2="1">
         <stop offset="0%" stop-color="#16BDCC" />
@@ -222,7 +222,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="search" size="48px" color="url('#linear-gradient2')">
-  <template v-slot:svgElements>
+  <template #svgElements>
     <defs>
       <linearGradient id="linear-gradient2" gradientTransform="rotate(90)">
         <stop offset="10%"  stop-color="gold" />
@@ -233,7 +233,7 @@ You can read more about the viewBox attribute
 </KIcon>
 
 <KIcon icon="cogwheel" size="48px" color="dark-grey">
-  <template v-slot:svgElements>
+  <template #svgElements>
     <animateTransform
       attributeName="transform"
       type="rotate"

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -6,7 +6,7 @@ For example a button:
 
 <KPop title="Cool header">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am some sample text!
   </template>
 </KPop>
@@ -14,7 +14,7 @@ For example a button:
 ```html
 <KPop title="Cool header">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am some sample text!
   </template>
 </KPop>
@@ -28,14 +28,14 @@ This is the text that will be displayed on the button that triggers the popover 
 the default slot.
 
 <KPop title="Cool header" buttonText="Click Me!">
-  <template v-slot:content>
+  <template #content>
     You clicked me!
   </template>
 </KPop>
 
 ```html
 <KPop title="Cool header" buttonText="Click Me!">
-  <template v-slot:content>
+  <template #content>
     You clicked me!
   </template>
 </KPop>
@@ -47,7 +47,7 @@ This is the target `element` that the <code>popover</code> is appended to. By de
 
 <KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am a popover, inside the <code>.theme-default-content</code> selector so
     I can get some of the stylings inside the theme!
   </template>
@@ -56,7 +56,7 @@ This is the target `element` that the <code>popover</code> is appended to. By de
 ```html
 <KPop title="Cool header" target=".theme-default-content">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am a popover, inside the <code>.theme-default-content</code> selector so
     I can get some of the stylings inside the theme!
   </template>
@@ -70,13 +70,13 @@ This is the tag that the popover is wrapped around. By default its the div tag.
 ```html
 <KPop title="Cool header" tag="details">
   <KButton>button</KButton>
-  <template v-slot:content>I am inside a &lt;details/&gt; block!</template>
+  <template #content>I am inside a &lt;details/&gt; block!</template>
 </KPop>
 ```
 
 <KPop title="Cool header" tag="details">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am inside a &lt;details/&gt; block!
   </template>
 </KPop>
@@ -87,7 +87,7 @@ This is the Title of the popover. Either this or the title slot needs to be fill
 
 <KPop title="I am a new sample header">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am some sample text!
   </template>
 </KPop>
@@ -95,7 +95,7 @@ This is the Title of the popover. Either this or the title slot needs to be fill
 ```html
 <KPop title="I am a new sample header">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am some sample text!
   </template>
 </KPop>
@@ -104,11 +104,11 @@ This is the Title of the popover. Either this or the title slot needs to be fill
 or alternatively, via the slot:
 
 <KPop>
-  <template v-slot:default>
+  <template #default>
     <KButton>button</KButton>
   </template>
-  <template v-slot:title>I am a new sample header</template>
-  <template v-slot:content>I am some sample text!</template>
+  <template #title>I am a new sample header</template>
+  <template #content>I am some sample text!</template>
 </KPop>
 
 ```html
@@ -116,8 +116,8 @@ or alternatively, via the slot:
   <template>
     <KButton>button</KButton>
   </template>
-  <template v-slot:title>I am a new sample header</template>
-  <template v-slot:content>I am some sample text!</template>
+  <template #title>I am a new sample header</template>
+  <template #content>I am some sample text!</template>
 </KPop>
 ```
 
@@ -132,7 +132,7 @@ Here are the different options:
 
 <KPop title="Cool header" trigger="hover">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am triggered on hover!
   </template>
 </KPop>
@@ -140,7 +140,7 @@ Here are the different options:
 ```html
 <KPop title="Cool header" trigger="hover">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am triggered on hover!
   </template>
 </KPop>
@@ -170,7 +170,7 @@ Here are the different options:
 
 <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am placed on the {{ selectedPosition }}!
   </template>
 </KPop>
@@ -186,7 +186,7 @@ Here are the different options:
 
   <KPop title="Cool header" trigger="hover" :placement="selectedPosition">
     <KButton>button</KButton>
-    <template v-slot:content>
+    <template #content>
       I am placed on the {{ selectedPosition }}!
     </template>
   </KPop>
@@ -231,7 +231,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
     placement="right"
   >
     <KButton>Click</KButton>
-    <template v-slot:content>
+    <template #content>
       My parent is too small 😭
     </template>
   </KPop>
@@ -245,7 +245,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
     placement="right"
   >
     <KButton>Click</KButton>
-    <template v-slot:content>
+    <template #content>
       My parent is too small 😭
     </template>
   </KPop>
@@ -260,7 +260,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
     :position-fixed="true"
   >
     <KButton>Click</KButton>
-    <template v-slot:content>
+    <template #content>
       My parent is too small, but I don't care 😎
     </template>
   </KPop>
@@ -275,7 +275,7 @@ Use fixed positioning of the popover to avoid content being clipped by parental 
     :position-fixed="true"
   >
     <KButton>Click</KButton>
-    <template v-slot:content>
+    <template #content>
       My parent is too small, but I don't care 😎
     </template>
   </KPop>
@@ -288,7 +288,7 @@ The width of the popover body - by default it is `200px`. Currently we support n
 
 <KPop title="Cool header" width="300">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am 300 pixels wide!
   </template>
 </KPop>
@@ -296,7 +296,7 @@ The width of the popover body - by default it is `200px`. Currently we support n
 ```html
 <KPop title="Cool header" width="300">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am 300 pixels wide!
   </template>
 </KPop>
@@ -308,7 +308,7 @@ The max width of the popover body - by default it is `auto`.
 
 <KPop title="Cool header" width="auto" max-width="500">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide!
   </template>
 </KPop>
@@ -316,7 +316,7 @@ The max width of the popover body - by default it is `auto`.
 ```html
 <KPop title="Cool header" max-width="500">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide! I am 500 pixels wide!
   </template>
 </KPop>
@@ -329,7 +329,7 @@ Custom classes that you want to append to the popover - by default it has a `k-p
 ```html
 <KPop title="Cool header" popoverClasses="my-class">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I have a custom my-class class on me!
   </template>
 </KPop>
@@ -342,7 +342,7 @@ Custom transitions that you want the popover to have - by default it uses a `fad
 ```html
 <KPop title="Cool header" popoverTransitions="slide">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I use a slide transition!
   </template>
 </KPop>
@@ -354,7 +354,7 @@ Custom timeout setting that you want the popover to have - by default it is set 
 
 <KPop title="Cool header" :popover-timeout="1000" trigger="hover">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I have a 1 second timeout!
   </template>
 </KPop>
@@ -362,7 +362,7 @@ Custom timeout setting that you want the popover to have - by default it is set 
 ```html
 <KPop title="Cool header" :popover-timeout="1000">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I have a 1 second timeout!
   </template>
 </KPop>
@@ -375,7 +375,7 @@ You can pass in an optional flag to trigger the popover to hide - useful for ext
 ```html
 <KPop title="Cool header" hidePopover="zoom()">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
   I am hidden depending on the outcome of the zoom function!
   </template>
 </KPop>
@@ -388,7 +388,7 @@ You can pass in an optional flag to disable the popover - by default it is set t
 ```html
 <KPop title="Cool header" disabled="true">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     I do not trigger because I am disabled!
   </template>
 </KPop>
@@ -400,7 +400,7 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 
 <KPop title="Cool header" hide-caret placement="right">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     Look ma, no caret!
   </template>
 </KPop>
@@ -408,7 +408,7 @@ You can pass in an optional flag to not show the caret on the edge of the popove
 ```html
 <KPop title="Cool header" hide-caret placement="right">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     Look ma, no caret!
   </template>
 </KPop>
@@ -422,7 +422,7 @@ The callback function can optionally return a boolean, which will show or hide t
 
 <KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     The first time you click the button, I will close when you click here once.
     The second time you click the button, I will close when you click here twice.
   </template>
@@ -431,7 +431,7 @@ The callback function can optionally return a boolean, which will show or hide t
 ```html
 <KPop title="Cool header" :on-popover-click="toggle">
   <KButton>button</KButton>
-  <template v-slot:content>
+  <template #content>
     The first time you click the button, I will close when you click here once.
     The second time you click the button, I will close when you click here twice.
   </template>
@@ -460,7 +460,7 @@ To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` pro
 
 <svg style="cursor: pointer; height: 20px; width: 20px; margin-right: 16px;" v-for="light in [{ color: 'red', value: 'red'}, { color: 'yellow', value: 'gold'}, { color: 'green', value: 'lime'}]">
   <KPop trigger="hover" :title="light.color" :is-svg="true" tag="svg" :popover-timeout="10">
-    <template v-slot:content>
+    <template #content>
       <p>{{ light.color }} means {{ light.color == 'green' ? 'GO!' : (light.color == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
     </template>
     <rect :fill="`${light.value}`" width="20" height="20" rx="20" ry="20"></rect>
@@ -470,7 +470,7 @@ To support `<KPop>` being able to be used inside an svg tag, use the `isSvg` pro
 ```html
 <svg v-for="light in ['red', 'gold', 'lime']">
   <KPop trigger="hover" title="Light" :is-svg="true" tag="g" :popover-timeout="10">
-    <template v-slot:content>
+    <template #content>
       <p>{{ light }} means {{ light == 'green' ? 'GO!' : (light == 'red' ? 'STOP!' : 'SLOW DOWN!') }}</p>
     </template>
     <rect :fill="`${light}`" width="20" height="20" rx="20" ry="20"></rect>
@@ -498,7 +498,7 @@ There is an optional title slot that can take in an element for the title. The t
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your title goes here -->
-  <template v-slot:title>
+  <template #title>
     My Title
   </template>
 </KPop>
@@ -513,7 +513,7 @@ An optional slot for an actions button in the upper right corner of the popover.
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your content goes here -->
-  <template v-slot:actions>
+  <template #actions>
     View All
   </template>
 </KPop>
@@ -528,7 +528,7 @@ This is the slot that takes in the content of the popover.
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your content goes here -->
-  <template v-slot:content>
+  <template #content>
     I am some cool content
   </template>
 </KPop>
@@ -544,7 +544,7 @@ a button or link.
   <!-- Your element goes here -->
   <KButton>button</KButton>
   <!-- Your footer content goes here -->
-  <template v-slot:footer>
+  <template #footer>
     View All
   </template>
 </KPop>
@@ -554,16 +554,16 @@ Example:
 
 <KPop title="Notifications" :on-popover-click="toggle" width="500">
   <KButton>Fire!</KButton>
-  <template v-slot:title>
+  <template #title>
     <div>Notifications</div>
   </template>
-  <template v-slot:actions>
+  <template #actions>
     <KButton appearance="tertiary" size="small">Mark all as read</KButton>
   </template>
-  <template v-slot:content>
+  <template #content>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eleifend lorem ut ex tempus, a tincidunt elit hendrerit. Nunc eu ex vestibulum, consequat tellus sed, pharetra magna.
   </template>
-  <template v-slot:footer>
+  <template #footer>
     <KButton size="small">View all notifications</KButton>
   </template>
 </KPop>
@@ -571,16 +571,16 @@ Example:
 ```html
 <KPop title="Notifications" :on-popover-click="toggle" width="500">
   <KButton>Fire!</KButton>
-  <template v-slot:title>
+  <template #title>
     <div>Notifications</div>
   </template>
-  <template v-slot:actions>
+  <template #actions>
     <KButton appearance="tertiary" size="small">Mark all as read</KButton>
   </template>
-  <template v-slot:content>
+  <template #content>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eleifend lorem ut ex tempus, a tincidunt elit hendrerit. Nunc eu ex vestibulum, consequat tellus sed, pharetra magna.
   </template>
-  <template v-slot:footer>
+  <template #footer>
     <KButton size="small">View all notifications</KButton>
   </template>
 </KPop>
@@ -595,7 +595,7 @@ Example:
 
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
-  <template v-slot:content>
+  <template #content>
     <div style="justify-content: center;" class="loading-container">
       <KIcon v-if="currentState == 'pending'" icon="spinner" color="purple" />
       <div>{{ message }}</div>
@@ -677,7 +677,7 @@ export default defineComponent({
 ```html
 <KPop @opened="loadSomething" @closed="onClose">
   <KButton :disabled="currentState == 'pending'">{{ buttonText }}</KButton>
-  <template v-slot:content>
+  <template #content>
     <div style="justify-content: center;">
       <KIcon v-if="currentState == 'pending'" icon="spinner" color="purple" />
       <div>{{ message }}</div>

--- a/docs/components/renderless/k-component.md
+++ b/docs/components/renderless/k-component.md
@@ -60,7 +60,7 @@ them and placing them inside `KComponent`'s default slot.
 
 <br/>
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KComponent :data="{ selected: '' }" v-slot="{ data }">
       <div>
         <label for="apes">What's your favorite great ape? </label>
@@ -79,7 +79,7 @@ them and placing them inside `KComponent`'s default slot.
 
 ```html
 <KCard style="min-height: 100px;">
-  <template v-slot:body>
+  <template #body>
     <KComponent :data="{ selected: '' }" v-slot="{ data }">
       <div>
         <label for="apes">What's your favorite great ape?</label>

--- a/docs/components/renderless/toggle.md
+++ b/docs/components/renderless/toggle.md
@@ -50,7 +50,7 @@ For instance, here we are toggling the state on `mouseover` and toggling back on
 `mouseout`.
 
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KToggle :toggled="true" v-slot="{isToggled, toggle}">
       <div
         :style="{color: isToggled.value ? 'green' : 'red'}"
@@ -77,7 +77,7 @@ For instance, here we are toggling the state on `mouseover` and toggling back on
 | `toggled` | `isToggled` Boolean |
 
 <KCard>
-  <template v-slot:body>
+  <template #body>
     <KToggle v-slot="{ toggle }" @toggled="sayHello">
       <KButton @click="toggle">Keep clicking me</KButton>
     </KToggle>
@@ -139,7 +139,7 @@ them and placing them inside `KToggle`'s default slot.
 
 <br/>
 <KCard style="min-height: 100px;">
-  <template v-slot:body>
+  <template #body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
         <KButton @click="toggle" class="vertical-spacing">
@@ -168,7 +168,7 @@ them and placing them inside `KToggle`'s default slot.
 
 <br/>
 <KCard style="min-height: 100px;">
-  <template v-slot:body>
+  <template #body>
     <KToggle v-slot="{isToggled, toggle}">
       <div>
         <KButton @click="toggle" class="vertical-spacing">

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -250,7 +250,7 @@ Accepted values: `1` (default), `2`.
 For example, here is a card skeleton with different arrangement of placeholders:
 
 <KSkeleton class="k-skeleton-modified" type="card" :card-count="2">
-  <template v-slot:card-header>
+  <template #card-header>
     <div class="skeleton-header-container">
       <div>
         <KSkeletonBox width="5" />
@@ -258,10 +258,10 @@ For example, here is a card skeleton with different arrangement of placeholders:
       <hr>
     </div>
   </template>
-  <template v-slot:card-content>
+  <template #card-content>
     <KSkeletonBox width="100"/>
   </template>
-  <template v-slot:card-footer>
+  <template #card-footer>
     <div class="skeleton-header-container">
       <div>
         <KSkeletonBox width="5" />
@@ -272,7 +272,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 
 ```html
 <KSkeleton type="card" :card-count="2">
-  <template v-slot:card-header>
+  <template #card-header>
     <div>
       <div>
         <KSkeletonBox width="5" />
@@ -280,7 +280,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
       <hr>
     </div>
   </template>
-  <template v-slot:card-footer>
+  <template #card-footer>
     <div>
       <div>
         <KSkeletonBox width="5" />
@@ -293,7 +293,7 @@ For example, here is a card skeleton with different arrangement of placeholders:
 And another example:
 
 <KSkeleton type="card">
-  <template v-slot:card-header>
+  <template #card-header>
     <div>
       <div>
         <KSkeletonBox width="5" />
@@ -301,7 +301,7 @@ And another example:
       <hr>
     </div>
   </template>
-  <template v-slot:card-content>
+  <template #card-content>
     <div>
       <template v-for="i in 8">
         <KSkeletonBox width="5" />
@@ -311,7 +311,7 @@ And another example:
       </template>
     </div>
   </template>
-  <template v-slot:card-footer>
+  <template #card-footer>
     <KSkeletonBox width="100" />
   </template>
 </KSkeleton>
@@ -319,7 +319,7 @@ And another example:
 ```html
 <template>
   <KSkeleton type="card">
-    <template v-slot:card-header>
+    <template #card-header>
       <div>
         <div>
           <KSkeletonBox width="5" />
@@ -327,7 +327,7 @@ And another example:
         <hr>
       </div>
     </template>
-    <template v-slot:card-content>
+    <template #card-content>
       <div>
         <template v-for="i in 8">
           <KSkeletonBox width="5" />
@@ -337,7 +337,7 @@ And another example:
         </template>
       </div>
     </template>
-    <template v-slot:card-footer>
+    <template #card-footer>
       <KSkeletonBox width="100" />
     </template>
   </KSkeleton>

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -707,17 +707,17 @@ To avoid firing row clicks by accident, the row click handler ignores events com
 <KInputSwitch v-model="enableRowClick" :label="enableRowClick ? 'Row clicks enabled' : 'Row clicks disabled'" />
 
 <KTable :headers="tableOptionsLinkHeaders" :fetcher="tableOptionsLinkFetcher" @row:click="enableRowClick ? handleRowClick : undefined">
-  <template v-slot:company="{ rowValue }">
+  <template #company="{ rowValue }">
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
-  <template v-slot:actions>
+  <template #actions>
     <div>
       <KButton appearance="secondary" @click="buttonHandler">
         Fire Button Handler!
       </KButton>
     </div>
   </template>
-  <template v-slot:input>
+  <template #input>
     <KInput type="text" placeholder="Need help?" />
     <KInput type="text" placeholder="Row click me" disabled />
   </template>
@@ -730,11 +730,11 @@ To avoid firing row clicks by accident, the row click handler ignores events com
   :fetcher="fetcher"
   :headers="headers"
   @row:click="enableRowClick ? handleRowClick : undefined">
-  <template v-slot:company="{rowValue}">
+  <template #company="{rowValue}">
     <!-- .stop not needed on @click because we ignore clicks from anchors -->
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
-  <template v-slot:actions>
+  <template #actions>
     <div>
       <!-- .stop not needed on @click because we ignore clicks from buttons -->
       <KButton
@@ -744,7 +744,7 @@ To avoid firing row clicks by accident, the row click handler ignores events com
       </KButton>
     </div>
   </template>
-  <template v-slot:input>
+  <template #input>
     <!-- no special handling needed because click events on input elements are ignored -->
     <KInput type="text" placeholder="Need help?" />
     <!-- row click is triggered when clicking disabled elements -->
@@ -786,13 +786,13 @@ Click events tied to non-ignored elements (not `a`, `button`, `input`, `select`)
 Using a `KPop` inside of a clickable row requires some special handling. Non-clickable content must be wrapped in a `div` with the `@click.stop` attribute to prevent the row click handler from firing if a user clicks content inside of the popover. Any handlers on non-ignored elements will need to have `.stop`.
 
 <KTable :headers="tableOptionsLinkHeaders2" :fetcher="tableOptionsLinkFetcher" @row:click="handleRowClick">
-  <template v-slot:company="{rowValue}">
+  <template #company="{rowValue}">
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
-  <template v-slot:wrapped>
+  <template #wrapped>
     <div>Row click event <div class="eventful-row" @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
   </template>
-  <template v-slot:other>
+  <template #other>
     <div>
       <KPop title="Cool header">
         <KButton appearance="tertiary">
@@ -804,7 +804,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
             />
           </template>
         </KButton>
-        <template v-slot:content>
+        <template #content>
           <div @click.stop>Clicking me does nothing!</div>
           <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div>
         </template>
@@ -818,14 +818,14 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
   :fetcher="fetcher"
   :headers="headers"
   @row:click="handleRowClick">
-  <template v-slot:company="{rowValue}">
+  <template #company="{rowValue}">
     <a @click="linkHander">{{rowValue.label}}</a>
   </template>
-  <template v-slot:wrapped>
+  <template #wrapped>
     <!-- We have a click event on a div, div clicks are not ignored so we need .stop -->
     <div>Row click event <div @click.stop="buttonHandler"><KBadge appearance="success">Button click</KBadge></div></div>
   </template>
-  <template v-slot:other>
+  <template #other>
     <div>
       <KPop title="Cool header">
         <KButton appearance="tertiary">
@@ -837,7 +837,7 @@ Using a `KPop` inside of a clickable row requires some special handling. Non-cli
             />
           </template>
         </KButton>
-        <template v-slot:content>
+        <template #content>
           <!-- non-clickable content in a KPop MUST be wrapped in a div with @click.stop to prevent row click firing on content click -->
           <div @click.stop>Clicking me does nothing!</div>
           <!-- an example where we want a click event to fire from the popover, requires .stop on the @click -->
@@ -1026,7 +1026,7 @@ Both column cells & header cells are slottable in KTable. Use slots to gain acce
 #### Column Header
 
 <KTable :headers="tableOptionsHeaders" :fetcher="tableOptionsFetcher">
-  <template v-slot:column-name="{ column }">
+  <template #column-name="{ column }">
     {{ column.label.toUpperCase() }}
   </template>
 </KTable>
@@ -1035,7 +1035,7 @@ Both column cells & header cells are slottable in KTable. Use slots to gain acce
 <template>
   <KTable :fetcher="fetcher" :headers="headers">
     <!-- Slot column header "name" -->
-    <template v-slot:column-name="{ column }">
+    <template #column-name="{ column }">
       {{ column.label.toUpperCase() }}
     </template>
   </KTable>
@@ -1064,11 +1064,11 @@ This example uses the [`KDropdown`](/components/dropdown) component as the slot 
   <KTable
     :headers="tableOptionsHeaders"
     :fetcher="tableOptionsFetcher">
-    <template v-slot:enabled="{rowValue}">
+    <template #enabled="{rowValue}">
       <span v-if="rowValue" style="color: green">&#10003;</span>
       <span v-else style="color: red">&#10007;</span>
     </template>
-    <template v-slot:actions>
+    <template #actions>
       <KDropdown>
         <template #default>
           <KButton
@@ -1108,12 +1108,12 @@ This example uses the [`KDropdown`](/components/dropdown) component as the slot 
     :headers="headers"
   >
     <!-- Slot each "enabled" cell in each row & add icon if matching value -->
-    <template v-slot:enabled="{rowValue}">
+    <template #enabled="{rowValue}">
       <span v-if="rowValue" style="color: green">&#10003;</span>
       <span v-else style="color: red">&#10007;</span>
     </template>
     <!-- Slot each "actions" cell in each row & link -->
-    <template v-slot:actions>
+    <template #actions>
       <KDropdown>
         <template #default>
           <KButton
@@ -1177,7 +1177,7 @@ You can choose utilize the `.k-table-cell-title` and `.k-table-cell-description`
     :enableClientSort="true"
     hidePaginationWhenOptional
     >
-    <template v-slot:name="{row}">
+    <template #name="{row}">
       <img class="horizontal-spacing" src="/img/kong-logomark.png" :alt="row.img.alt">
       <div>
         <div class="k-table-cell-title">{{row.name}}</div>
@@ -1284,13 +1284,13 @@ the section below or completely slot in your own content.
 <KCard>
   <template #default>
     <KTable :fetcher="emptyFetcher" :headers="headers">
-      <template v-slot:empty-state>
+      <template #empty-state>
         <div style="text-align: center;">
           <KIcon icon="warning" />
           <div>No Content!!!</div>
         </div>
       </template>
-      <template v-slot:error-state>
+      <template #error-state>
         <KIcon icon="error" />
         Something went wrong
       </template>
@@ -1301,11 +1301,11 @@ the section below or completely slot in your own content.
 ```html
 <template>
   <KTable :fetcher="() => { return { data: [] } }" :headers="headers">
-    <template v-slot:empty-state>
+    <template #empty-state>
       <KIcon icon="warning" />
       No Content!!!
     </template>
-    <template v-slot:error-state>
+    <template #error-state>
       <KIcon icon="error" />
       Something went wrong
     </template>

--- a/src/components/KToggle/index.ts
+++ b/src/components/KToggle/index.ts
@@ -33,7 +33,7 @@ export default defineComponent({
   Example usage:
 
     <KToggle>
-      <button v-slot:default="{isToggled, toggle}" @click="toggle">
+      <button #default="{isToggled, toggle}" @click="toggle">
         {{ isToggled ? 'hello' : 'goodbye' }}
       </button>
       ^^------add slotted content


### PR DESCRIPTION
# Summary

Named slots have a `#` shorthand which can be used instead of `v-slot:`. [Ref](https://vuejs.org/guide/components/slots.html#named-slots:~:text=v%2Dslot%20has%20a%20dedicated%20shorthand%20%23%2C%20so%20%3Ctemplate%20v%2Dslot%3Aheader%3E%20can%20be%20shortened%20to%20just%20%3Ctemplate%20%23header%3E.%20Think%20of%20it%20as%20%22render%20this%20template%20fragment%20in%20the%20child%20component%27s%20%27header%27%20slot%22.)

[KHCP-11488](https://konghq.atlassian.net/browse/KHCP-11488)

## PR Checklist

* [X] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
N/A * ~[ ] **Tests coverage:** test coverage was added for new features and bug fixes~
* [X] **Docs:** includes a technically accurate README


[KHCP-11488]: https://konghq.atlassian.net/browse/KHCP-11488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ