### PR TITLE
fix(ktable): column visibility menu button

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -711,7 +711,7 @@ const tdlisteners = computed((): any => {
   }
 })
 
-const columnWidths = ref<Record<string, number>>({})
+const columnWidths = ref<Record<string, number>>(props.tablePreferences.columnWidths || {})
 const columnStyles = computed(() => {
   const styles: Record<string, any> = {}
   for (const colKey in columnWidths.value) {

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -580,8 +580,8 @@ const resizerHoveredColumn = ref('')
 const currentHoveredColumn = ref('')
 const hasColumnVisibilityMenu = computed((): boolean => {
   // has hidable columns, no error/loading/empty state
-  return tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0 &&
-    !props.hasError && !isTableLoading.value && !props.isLoading && (data.value && data.value.length)
+  return !!(tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0 &&
+    !props.hasError && !isTableLoading.value && !props.isLoading && (data.value && data.value.length))
 })
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filter((header: TableHeader) => header.hidable))

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -578,7 +578,11 @@ const resizingColumn = ref('')
 const resizerHoveredColumn = ref('')
 // lowest priority - currently hovered resizable column (mouse is somewhere in the <th>)
 const currentHoveredColumn = ref('')
-const hasColumnVisibilityMenu = computed((): boolean => tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0)
+const hasColumnVisibilityMenu = computed((): boolean => {
+  // has hidable columns, no error/loading/empty state
+  return tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0 &&
+    !props.hasError && !isTableLoading.value && !props.isLoading && (data.value && data.value.length)
+})
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filter((header: TableHeader) => header.hidable))
 // visibility preferences from the host app (initialized by app)


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->
Hide column visibility menu when loading/error/empty state and persist initial column widths from table preferences.

## PR Checklist

* [x] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
