### PR TITLE
fix(ShortcutManager): return empty string for invalid keycode during normalization [KHCP-11186]

### DIFF
--- a/src/utilities/ShortcutManager.ts
+++ b/src/utilities/ShortcutManager.ts
@@ -118,8 +118,8 @@ function triggerShortcuts<CommandKeyword extends string>(event: KeyboardEvent, k
 }
 
 function normalizeKeyCode(code: string): string {
-  // If keycode is a relevant modifier key () or an invalid string, return empty string.
-  if (MODIFIER_KEY_CODES.includes(code) || !code) {
+  // If keycode is a relevant modifier key or an invalid string, return empty string.
+  if (!code || MODIFIER_KEY_CODES.includes(code)) {
     return ''
   }
 

--- a/src/utilities/ShortcutManager.ts
+++ b/src/utilities/ShortcutManager.ts
@@ -118,8 +118,8 @@ function triggerShortcuts<CommandKeyword extends string>(event: KeyboardEvent, k
 }
 
 function normalizeKeyCode(code: string): string {
-  // Returns relevant modifier keys as the empty string which is going to be filtered out.
-  if (MODIFIER_KEY_CODES.includes(code)) {
+  // If keycode is a relevant modifier key () or an invalid string, return empty string.
+  if (MODIFIER_KEY_CODES.includes(code) || !code) {
     return ''
   }
 


### PR DESCRIPTION
# Summary

Datadog reported that in `normalizeKeyCode` method, `.replace` was being accessed on `undefined`. So added a check to early return with an empty string in case the parameter passed to the method is `undefined`, or an invalid string.

Extended explanation [here](https://konghq.atlassian.net/browse/KHCP-11186?focusedCommentId=129798)

[Ref Datadog error](https://app.datadoghq.com/rum/error-tracking/issue/4fc5bfdc-e857-11ee-b032-da7ad0900002?query=env%3Aprod%20-%40browser.name%3AHeadlessChrome%20%40issue.age%3A%3C%3D300000&refresh_mode=sliding&view=spans&from_ts=1707996277000&to_ts=1713180277000&live=true)

[KHCP-11186](https://konghq.atlassian.net/browse/KHCP-11186)

## PR Checklist

* [X] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
~[ ] **Tests coverage:** test coverage was added for new features and bug fixes~
~[ ] **Docs:** includes a technically accurate README~
