### PR TITLE
fix(KInput): add aria label to associate helper text with input [KHCP-11030]

### DIFF
--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -35,6 +35,7 @@
       <!-- TODO: [beta] change input class to text-input -->
       <input
         v-bind="modifiedAttrs"
+        :aria-describedby="helpTextId"
         :aria-invalid="error || hasError || charLimitExceeded ? 'true' : undefined"
         class="k-input"
         :value="getValue()"
@@ -56,6 +57,7 @@
     >
       <p
         v-if="helpText"
+        :id="helpTextId"
         :key="String(helpTextKey)"
         class="help-text"
       >
@@ -215,6 +217,8 @@ const helpText = computed((): string => {
   // if error prop is true it danger styles will be applied
   return props.help
 })
+
+const helpTextId = helpText.value ? uuidv4() : ''
 
 watch(charLimitExceeded, (newVal, oldVal) => {
   if (newVal !== oldVal) {

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -35,7 +35,7 @@
       <!-- TODO: [beta] change input class to text-input -->
       <input
         v-bind="modifiedAttrs"
-        :aria-describedby="helpTextId"
+        :aria-describedby="helpText ? helpTextId : undefined"
         :aria-invalid="error || hasError || charLimitExceeded ? 'true' : undefined"
         class="k-input"
         :value="getValue()"
@@ -146,6 +146,7 @@ const attrs = useAttrs()
 
 const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
 const inputId = computed((): string => attrs.id ? String(attrs.id) : uuidv4())
+const helpTextId = uuidv4()
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.info || slots['label-tooltip']))
 
@@ -217,8 +218,6 @@ const helpText = computed((): string => {
   // if error prop is true it danger styles will be applied
   return props.help
 })
-
-const helpTextId = helpText.value ? uuidv4() : ''
 
 watch(charLimitExceeded, (newVal, oldVal) => {
   if (newVal !== oldVal) {


### PR DESCRIPTION
# Summary

Added the helper text as a constraint/error description for the input tag via aria attribute

<img width="853" alt="image" src="https://github.com/Kong/kongponents/assets/47082523/06acbb00-4489-429c-97e1-7f115e5c348c">

[LevelAccess ticket](https://kong.hub.essentia11y.com/manual-evaluations/65a99b2c7e398d9f95af2af7/results/AMP449/view?linkedPropertyData=64b6a2897bb1382840bc4998%7C64b6a2897bb13892bcbc4992)

[KHCP-11030](https://konghq.atlassian.net/browse/KHCP-11030)

## PR Checklist

* [X] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
~[ ] **Tests coverage:** test coverage was added for new features and bug fixes~
~[ ] **Docs:** includes a technically accurate README~


[KHCP-11030]: https://konghq.atlassian.net/browse/KHCP-11030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ