### PR TITLE
fix(kcodeblock): icon button not to inherit attrs

### DIFF
--- a/src/components/KCodeBlock/KCodeBlockIconButton.vue
+++ b/src/components/KCodeBlock/KCodeBlockIconButton.vue
@@ -20,13 +20,19 @@
   </KTooltip>
 </template>
 
-<script setup lang="ts">
+<script lang="ts">
 import { ref, type PropType, useAttrs } from 'vue'
 import type { Theme } from '@/types'
 import { watch } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 
+export default {
+  inheritAttrs: false,
+}
+</script>
+
+<script setup lang="ts">
 const props = defineProps({
   theme: {
     type: String as PropType<Theme>,


### PR DESCRIPTION
# Summary

Adds `inheritAttrs: false` in `KCodeBlockIconButton.vue` so all attributes are bound to `KButton` (instead of `KTooltip` wrapper element)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
