### PR TITLE
feat(kcatalogitem): add card-footer slot

### DIFF
--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -251,7 +251,7 @@ The footer content for the card.
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
   </template>
   <template #card-footer>
-    Card Footer
+    <KBadge appearance="neutral">Card footer</KBadge>
   </template>
 </KCatalogItem>
 

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -239,12 +239,19 @@ The title content for the card.
 
 The body content for the card.
 
+#### card-footer
+
+The footer content for the card.
+
 <KCatalogItem>
   <template #card-title>
     Card Title
   </template>
   <template #card-body>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
+  </template>
+  <template #card-footer>
+    Card Footer
   </template>
 </KCatalogItem>
 
@@ -255,6 +262,9 @@ The body content for the card.
   </template>
   <template #card-body>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
+  </template>
+  <template #card-footer>
+    Card Footer
   </template>
 </KCatalogItem>
 ```

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -264,7 +264,7 @@ The footer content for the card.
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
   </template>
   <template #card-footer>
-        <KBadge appearance="neutral">Card footer</KBadge>
+      <KBadge appearance="neutral">Card footer</KBadge>
   </template>
 </KCatalogItem>
 ```

--- a/docs/components/catalog.md
+++ b/docs/components/catalog.md
@@ -264,7 +264,7 @@ The footer content for the card.
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nec justo libero. Nullam accumsan quis ipsum vitae tempus. Integer non pharetra orci. Suspendisse potenti.
   </template>
   <template #card-footer>
-    Card Footer
+        <KBadge appearance="neutral">Card footer</KBadge>
   </template>
 </KCatalogItem>
 ```

--- a/src/components/KCatalog/KCatalogItem.vue
+++ b/src/components/KCatalog/KCatalogItem.vue
@@ -21,6 +21,10 @@
         {{ item ? item.description : '' }}
       </slot>
     </div>
+
+    <template #footer>
+      <slot name="card-footer" />
+    </template>
   </KCard>
 </template>
 


### PR DESCRIPTION
# Summary

Adds a `card-footer` slot to the `KCatalogItem` component so that items in a `KCatalog` can leverage a card footer.

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
