### PR TITLE
fix(kfileupload): force transparent color for the input element

### DIFF
--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -255,7 +255,7 @@ $kFileUploadInputPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to
 
   :deep(.k-input-wrapper) input[type="file"],
   :deep(.k-input-wrapper) input[type="file"][disabled] {
-    color: transparent;
+    color: transparent !important;
   }
 
   :deep(.k-input) {


### PR DESCRIPTION
this prevents the native "No file selected" placeholder from being rendered and causing the placeholder text overlapped

before:
<img width="306" alt="image" src="https://github.com/Kong/kongponents/assets/1770466/68100784-0604-4d1d-a2ff-c59be3bd307a">

after:
<img width="274" alt="image" src="https://github.com/Kong/kongponents/assets/1770466/09ba5e15-5499-4b8d-b92c-b811afce25f9">

