### PR TITLE
fix(ktooltip): suppress vue attr passthrough warning

### DIFF
--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -41,6 +41,10 @@ import type { PopPlacements } from '@/types'
 import { PopPlacementsArray } from '@/types'
 import { v4 as uuidv4 } from 'uuid'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps({
   /**
   * Text to show in tooltip


### PR DESCRIPTION
it's safe to set `inheritAttrs` to `false` because we have set `v-bind="$attrs"` on `<KPop />` manually

# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
