### PR TITLE
fix(ktable): emit preferences only in success state [KHCP-11890]

### DIFF
--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -207,6 +207,10 @@ Boolean to control whether the component should display the error state. Default
 
 Allow table column width to be resizable (defaults to `false`). Adjusting a column's width will trigger an [`update:table-preferences` event](#updatetable-preferences).
 
+:::warning WARNING
+`update:table-preferences` event only fires when KTable is in `success` state (see [`state` event](#state) for details).
+:::
+
 <KTable
   resize-columns
   :fetcher="basicFetcher"

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -207,10 +207,6 @@ Boolean to control whether the component should display the error state. Default
 
 Allow table column width to be resizable (defaults to `false`). Adjusting a column's width will trigger an [`update:table-preferences` event](#updatetable-preferences).
 
-:::warning WARNING
-`update:table-preferences` event only fires when KTable is in `success` state (see [`state` event](#state) for details).
-:::
-
 <KTable
   resize-columns
   :fetcher="basicFetcher"
@@ -873,6 +869,10 @@ Emitted when error state action button is clicked.
 ### update:table-preferences
 
 Fired when the user changes the table's page size, performs sorting, resizes columns or toggles column visibility. Event payload is object of type `TablePreferences` interface (see [`tablePreferences` prop](#tablepreferences) for details).
+
+:::warning WARNING
+`update:table-preferences` event only fires when KTable is in `success` state (see [`state` event](#state) for details).
+:::
 
 <script setup lang="ts">
 import { AddIcon, SearchIcon, MoreIcon } from '@kong/icons'

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -988,7 +988,9 @@ const tablePreferences = computed((): TablePreferences => ({
 }))
 
 const emitTablePreferences = (): void => {
-  emit('update:table-preferences', tablePreferences.value)
+  if (tableState.value === 'success') {
+    emit('update:table-preferences', tablePreferences.value)
+  }
 }
 
 const getNextOffsetHandler = (): void => {


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-11890

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
