### PR TITLE
fix(kbutton): remove deprecated icon slot

### DIFF
--- a/sandbox/pages/SandboxButton.vue
+++ b/sandbox/pages/SandboxButton.vue
@@ -411,87 +411,84 @@
       />
       <SandboxSectionComponent>
         <div class="horizontal-spacing">
-          <KButton size="large">
-            <template #icon>
-              <AddCircleIcon />
-            </template>
+          <KButton
+            icon
+            size="large"
+          >
+            <AddCircleIcon />
           </KButton>
           <KButton
             appearance="secondary"
+            icon
             size="large"
           >
-            <template #icon>
-              <ProfileIcon />
-            </template>
+            <ProfileIcon />
           </KButton>
           <KButton
             appearance="tertiary"
+            icon
             size="large"
           >
-            <template #icon>
-              <BookIcon />
-            </template>
+            <BookIcon />
           </KButton>
           <KButton
             appearance="danger"
+            icon
             size="large"
           >
-            <template #icon>
-              <DisabledIcon />
-            </template>
+            <DisabledIcon />
           </KButton>
         </div>
         <div class="horizontal-spacing">
-          <KButton>
-            <template #icon>
-              <AddCircleIcon />
-            </template>
-          </KButton>
-          <KButton appearance="secondary">
-            <template #icon>
-              <ProfileIcon />
-            </template>
-          </KButton>
-          <KButton appearance="tertiary">
-            <template #icon>
-              <BookIcon />
-            </template>
-          </KButton>
-          <KButton appearance="danger">
-            <template #icon>
-              <DisabledIcon />
-            </template>
-          </KButton>
-        </div>
-        <div class="horizontal-spacing">
-          <KButton size="small">
-            <template #icon>
-              <AddCircleIcon />
-            </template>
+          <KButton icon>
+            <AddCircleIcon />
           </KButton>
           <KButton
             appearance="secondary"
-            size="small"
+            icon
           >
-            <template #icon>
-              <ProfileIcon />
-            </template>
+            <ProfileIcon />
           </KButton>
           <KButton
             appearance="tertiary"
-            size="small"
+            icon
           >
-            <template #icon>
-              <BookIcon />
-            </template>
+            <BookIcon />
           </KButton>
           <KButton
             appearance="danger"
+            icon
+          >
+            <DisabledIcon />
+          </KButton>
+        </div>
+        <div class="horizontal-spacing">
+          <KButton
+            icon
             size="small"
           >
-            <template #icon>
-              <DisabledIcon />
-            </template>
+            <AddCircleIcon />
+          </KButton>
+          <KButton
+            appearance="secondary"
+            icon
+            size="small"
+          >
+            <ProfileIcon />
+          </KButton>
+          <KButton
+            appearance="tertiary"
+            icon
+            size="small"
+          >
+            <BookIcon />
+          </KButton>
+          <KButton
+            appearance="danger"
+            icon
+            size="small"
+          >
+            <DisabledIcon />
           </KButton>
         </div>
       </SandboxSectionComponent>

--- a/sandbox/pages/SandboxCatalog.vue
+++ b/sandbox/pages/SandboxCatalog.vue
@@ -105,10 +105,11 @@
             Card title
           </template>
           <template #card-actions>
-            <KButton size="small">
-              <template #icon>
-                <KongIcon />
-              </template>
+            <KButton
+              icon
+              size="small"
+            >
+              <KongIcon />
             </KButton>
           </template>
           <template #card-body>

--- a/sandbox/pages/SandboxTable/SandboxTableActions.vue
+++ b/sandbox/pages/SandboxTable/SandboxTableActions.vue
@@ -3,11 +3,10 @@
     <template #default>
       <KButton
         appearance="tertiary"
+        icon
         size="small"
       >
-        <template #icon>
-          <MoreIcon />
-        </template>
+        <MoreIcon />
       </KButton>
     </template>
     <template #items>

--- a/src/components/KTable/ColumnVisibilityMenu.vue
+++ b/src/components/KTable/ColumnVisibilityMenu.vue
@@ -14,11 +14,10 @@
           aria-label="Show/Hide Columns"
           class="menu-button"
           data-testid="column-visibility-menu-button"
+          icon
           size="large"
         >
-          <template #icon>
-            <TableColumnsIcon decorative />
-          </template>
+          <TableColumnsIcon decorative />
         </KButton>
       </KTooltip>
 


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR removes the deprecated `icon` slot usage in `<TableColumnsIcon>` and all components sandboxes.

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
