### PR TITLE
fix(kdropdown): fix leaking styles

### DIFF
--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -223,7 +223,7 @@ onMounted(() => {
     width: 100%;
   }
 
-  :deep(.popover.k-dropdown-popover .popover-container) {
+  :deep(.popover.k-dropdown-popover > .popover-container) {
     border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
     border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
     margin-top: var(--kui-space-30, $kui-space-30);


### PR DESCRIPTION
# Summary

Fixes leaking from KDropdown to other components using KPop styles (scrrenshots)

Before
![Screenshot 2024-06-12 at 10 17 45 AM](https://github.com/Kong/kongponents/assets/36751160/a2bf4666-a118-4274-a35c-cf2449b7d67a)

After
![Screenshot 2024-06-12 at 10 16 58 AM](https://github.com/Kong/kongponents/assets/36751160/0fa511a9-b043-40bf-87db-855b6a9714f4)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
