### PR TITLE
fix: duplicate ids

### DIFF
--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="k-file-upload">
+  <div
+    class="k-file-upload"
+    v-bind="modifiedAttrs"
+  >
     <KLabel
       v-if="label"
       v-bind-once="{ for: inputId }"
@@ -26,9 +29,9 @@
       </span>
 
       <KInput
+        :id="inputId"
         :key="fileInputKey"
         ref="fileInputElement"
-        v-bind-once="{ id: inputId }"
         :accept="accept"
         class="upload-input"
         :disabled="disabled"
@@ -72,6 +75,10 @@ import KInput from '@/components/KInput/KInput.vue'
 import KButton from '@/components/KButton/KButton.vue'
 import useUtilities from '@/composables/useUtilities'
 import useUniqueId from '@/composables/useUniqueId'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const props = defineProps({
   labelAttributes: {
@@ -132,6 +139,14 @@ const fileInputElement = ref<InstanceType<typeof KInput> | null>(null)
 const hasLabelTooltip = computed((): boolean => !!(props.labelAttributes?.info || slots['label-tooltip']))
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
+const modifiedAttrs = computed(() => {
+  const $attrs = { ...attrs }
+
+  // delete id because we bind id to the input element
+  delete $attrs.id
+
+  return $attrs
+})
 
 const hasFileSizeError = ref<boolean>(false)
 const fileSizeErrorMessage = computed((): string => {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -39,7 +39,6 @@
           @click="onSelectWrapperClick"
         >
           <KInput
-            v-bind-once="{ id: selectId }"
             autocapitalize="off"
             autocomplete="off"
             class="select-input"

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -39,6 +39,7 @@
           @click="onSelectWrapperClick"
         >
           <KInput
+            :id="selectId"
             autocapitalize="off"
             autocomplete="off"
             class="select-input"


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes a bug where assigning `id` to `KFileUpload` and `KSelect` results in duplicate `id`s on the page.

## KFileUpload
| Before | After |
| - | - |
| <img width="1727" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/2e21a119-7413-4936-854c-313de7ecb296"> | <img width="1727" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/722df7f9-501d-43ad-bab4-842e561fa462"> |

1. Use `inheritAttrs: false` to avoid directly binding attributes to the root element. Instead, strip `id` from attributes and explicitly assign them.
2. Remove `v-bind-once="{ id: inputId }"` because according to the [Vue doc](https://vuejs.org/guide/reusability/custom-directives.html#usage-on-components) and `v-bind-once`'s [implementation](https://github.com/danielroe/vue-bind-once/blob/919c4d7cd85625ce4b8aedce86b643ec9a58e3a9/src/index.ts#L5-L12), adding `v-bind-once="{ id: inputId }"` on a custom component binds `id` to the root element of the custom component, regardless of its `inheritAttrs` configuration. Instead, use `:id="inputId"` so that [`KInput` can bind the `id` to the `<input>` element](https://github.com/Kong/kongponents/blob/5f9232c61bd72d7519c4c653d346e9372c926195/src/components/KInput/KInput.vue#L35).

## KSelect
| Before | After |
| - | - |
| <img width="1727" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/47da1cb7-4ad4-464f-bf44-373737fd17b4"> | <img width="1727" alt="image" src="https://github.com/Kong/kongponents/assets/10095631/61330024-4303-4571-a608-f953b95b713c"> |
1. Remove `v-bind-once="{ id: selectId }"` for the same reason as the second bullet point above. [`KSelect` already binds attributes to `KInput`](https://github.com/Kong/kongponents/blob/5f9232c61bd72d7519c4c653d346e9372c926195/src/components/KSelect/KSelect.vue#L55).

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
