### PR TITLE
fix(kpop): duplicate popover elements when transitioning

### DIFF
--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -18,10 +18,12 @@
       </slot>
     </div>
 
-    <Transition name="kongponents-fade-transition">
+    <Transition
+      :key="popoverKey"
+      name="kongponents-fade-transition"
+    >
       <div
         v-show="isVisible"
-        :key="popoverKey"
         ref="popoverElement"
         v-bind-once="{ id: popoverId }"
         :aria-labelledby="$slots.title || title ? titleId : undefined"
@@ -84,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue'
 import type { PropType } from 'vue'
 import { useFloating, autoUpdate, autoPlacement, flip, shift, size } from '@floating-ui/vue'
 import type { PopPlacements, PopTrigger } from '@/types'
@@ -183,13 +185,16 @@ const togglePopover = () => {
   }
 }
 
-const showPopover = () => {
+const showPopover = async () => {
   if (!props.disabled) {
     if (timer.value) {
       clearTimeout(timer.value)
     }
 
-    popoverKey.value++
+    if (props.placement !== 'auto') {
+      popoverKey.value++
+      await nextTick() // wait for the Transition to update to ensure the animation works as expected
+    }
     isVisible.value = true
   }
 }


### PR DESCRIPTION
# Summary

<!-- Insert a description of the changes in the PR, along with a JIRA ticket reference, if applicable. -->

This PR fixes an issue where two popover elements are present until the transition animation ends.

![image](https://github.com/Kong/kongponents/assets/10095631/ee1ca36c-7dc9-4c47-ae13-2977d6a4d094)

## PR Checklist

* [ ] **Conventional Commits** all commits follow the conventional commit standards [outlined in the main README](https://github.com/Kong/kongponents#committing-changes).
* [ ] **Tests coverage:** test coverage was added for new features and bug fixes
* [ ] **Docs:** includes a technically accurate README
