### PR TITLE
fix(kmultiselect): duplicate placeholder [KHCP-12560]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -544,11 +544,11 @@ const debouncedHandler = debounce(function (val) {
 You can pass any input attribute and it will get properly bound to the element.
 
 <ClientOnly>
-  <KMultiselect disabled placeholder="I am disabled" :items="[{ label: 'test', value: 'test' }]" />
+  <KMultiselect disabled :items="[{ label: 'test', value: 'test' }]" />
 </ClientOnly>
 
 ```html
-<KMultiselect disabled placeholder="I am disabled" :items="[{ label: 'test', value: 'test' }]" />
+<KMultiselect disabled :items="[{ label: 'test', value: 'test' }]" />
 ```
 
 ### required

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -49,7 +49,7 @@
                 :class="{ 'is-readonly': isReadonly }"
                 data-testid="multiselect-input"
                 :model-value="filterString"
-                :placeholder="getPlaceholderText"
+                :placeholder="placeholderText"
                 :readonly="isReadonly ? true : undefined"
                 type="text"
                 @blur="() => isFocused = false"
@@ -69,7 +69,7 @@
               v-else-if="!selectedItems.length"
               class="expanded-selection-empty"
             >
-              {{ getPlaceholderText }}
+              {{ selectedItemsText }}
             </div>
             <div
               v-else
@@ -593,11 +593,11 @@ const numericWidthStyle = computed(() => {
   }
 })
 
-const getPlaceholderText = computed((): string => {
-  if (selectedItems.value.length === 0) {
-    return props.placeholder ? props.placeholder : '0 items selected'
-  }
+const placeholderText = computed(() => {
+  return selectedItems.value.length ? selectedItemsText.value : props.placeholder || 'Filter...'
+})
 
+const selectedItemsText = computed((): string => {
   if (selectedItems.value.length === 1) {
     return `${selectedItems.value.length} item selected`
   }

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -48,6 +48,7 @@
                 class="multiselect-input"
                 :class="{ 'is-readonly': isReadonly }"
                 data-testid="multiselect-input"
+                :disabled="isDisabled"
                 :model-value="filterString"
                 :placeholder="placeholderText"
                 :readonly="isReadonly ? true : undefined"


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-12560

When a placeholder is provided, display it in dropdown input. In selections container, only display _0 items selected_ when no selections have been made

![Screenshot 2024-07-10 at 10 13 18 AM](https://github.com/Kong/kongponents/assets/36751160/8346359a-02ea-47d5-9e56-dd3a5c292bce)


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
