### PR TITLE
fix(kpagination): detect and fix overflow [KHCP-10930]

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -73,10 +73,18 @@ const visibleLetters = ref<string>(['a', 'b', 'c'])
 
 A number that sets the neighboring pages visible to the left and right of the center page when ellipsis are visible on both sides. By default, 1 neighbor is shown. For bigger sets of data we want user to see more pages to go through the pagination faster.
 
-<KPagination :total-count="1000" :neighbors="2" />
+<KPagination :neighbors="2" :total-count="1000" />
 
 ```html
-<KPagination :total-count="1000" :neighbors="2" />
+<KPagination :neighbors="2" :total-count="1000" />
+```
+
+If KPagination detects horizontal overflow it will automatically reduce number of displayed neighbors down to a number at which it fits into the parent container without overflowing, ignoring the value provided through `neighbors` prop. It will always display at least 1 neighbor. See the example below where value passed through the `neighbors` prop is unreasonably high but KPagination only displays as many items as it can without overflowing.
+
+<KPagination :neighbors="20" :total-count="1000" />
+
+```html
+<KPagination :neighbors="20" :total-count="1000" />
 ```
 
 ### disablePageJump

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -427,7 +427,7 @@ Set this to `true` to hide pagination when using a fetcher.
 
 ### hidePaginationWhenOptional
 
-Set this to `true` to hide pagination when the table record count is less than or equal to the `pageSize`.
+Set this to `true` to hide pagination when the table record count is less than or equal to the `paginationPageSizes`.
 
 ## States
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@cypress/vite-dev-server": "^5.1.1",
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.6.18",
-    "@kong-ui-public/sandbox-layout": "^2.1.13",
+    "@kong-ui-public/sandbox-layout": "^2.1.14",
     "@kong/design-tokens": "^1.15.1",
     "@kong/eslint-config-kong-ui": "^1.1.1",
     "@semantic-release/changelog": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^1.6.18
         version: 1.6.18
       '@kong-ui-public/sandbox-layout':
-        specifier: ^2.1.13
-        version: 2.1.13(@kong/kongponents@9.0.0-pr.2229.901d3f4d.0(axios@1.7.2)(vue-router@4.3.3(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5))
+        specifier: ^2.1.14
+        version: 2.1.14(@kong/kongponents@9.0.0-pr.2229.901d3f4d.0(axios@1.7.2)(vue-router@4.3.3(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5))
       '@kong/design-tokens':
         specifier: ^1.15.1
         version: 1.15.1
@@ -785,7 +785,6 @@ packages:
 
   '@evilmartians/lefthook@1.6.18':
     resolution: {integrity: sha512-nvJ1uYgz/F1DbykTMIiI2nUZctVmijUYkqdGqmGkrL0ImEKFjWxk1jZg6pULJ5vWxsArfUFJiFuOhUnUhyMbig==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -835,8 +834,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@kong-ui-public/sandbox-layout@2.1.13':
-    resolution: {integrity: sha512-HTENcSSNPWKi95u59v2p758V/ilNUxFJ/iG665U04+Yb52qI2EBatjIsmfKTdMyOdZ9YjFsKFJnKai59xMceTA==}
+  '@kong-ui-public/sandbox-layout@2.1.14':
+    resolution: {integrity: sha512-Jw9FcSfJObdydmiLqwZkx9w71NHBRlI+Dhdewy9MP36D0UMU6lkQbR0e6/6MDYL/Wo3EFd2L5Fl5xbGH/+IJRg==}
     peerDependencies:
       '@kong/kongponents': ^9.0.8
       vue: '>= 3.3.13 < 4'
@@ -5325,7 +5324,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@kong-ui-public/sandbox-layout@2.1.13(@kong/kongponents@9.0.0-pr.2229.901d3f4d.0(axios@1.7.2)(vue-router@4.3.3(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5))':
+  '@kong-ui-public/sandbox-layout@2.1.14(@kong/kongponents@9.0.0-pr.2229.901d3f4d.0(axios@1.7.2)(vue-router@4.3.3(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5))':
     dependencies:
       '@kong/icons': 1.14.2(vue@3.4.31(typescript@5.4.5))
       '@kong/kongponents': 9.0.0-pr.2229.901d3f4d.0(axios@1.7.2)(vue-router@4.3.3(vue@3.4.31(typescript@5.4.5)))(vue@3.4.31(typescript@5.4.5))

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -18,6 +18,7 @@
       font-family: 'Inter', sans-serif;
       margin: 0;
       padding: 0;
+      overflow-x: hidden;
     }
   </style>
 </head>

--- a/sandbox/pages/SandboxPagination.vue
+++ b/sandbox/pages/SandboxPagination.vue
@@ -35,12 +35,17 @@
           @page-size-change="handlePageSizeChange"
         />
       </SandboxSectionComponent>
-      <SandboxSectionComponent title="neighbors">
-        <KPagination
-          :neighbors="3"
-          :page-size="15"
-          :total-count="1000"
-        />
+      <SandboxSectionComponent
+        description="Setting a way too high number of visible neighbors here (20) but KPagination detects overflow and reduces the number of visible neighbors down to acceptable number (minimum of 1)."
+        title="neighbors"
+      >
+        <div class="neighbors-wrapper">
+          <KPagination
+            :neighbors="20"
+            :page-size="15"
+            :total-count="1000"
+          />
+        </div>
       </SandboxSectionComponent>
       <SandboxSectionComponent title="disablePageJump">
         <KPagination
@@ -81,3 +86,18 @@ const handlePageSizeChange = (obj: any) => {
   console.log(obj)
 }
 </script>
+
+<style lang="scss" scoped>
+.kpagination-sandbox {
+  .neighbors-wrapper {
+    border: $kui-border-width-10 solid $kui-color-border;
+    display: flex;
+    flex-direction: column;
+    gap: $kui-space-40;
+    max-width: 100%;
+    overflow-x: auto;
+    padding: $kui-space-70;
+    resize: horizontal;
+  }
+}
+</style>

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -2,6 +2,7 @@
   <nav
     ref="kPaginationElement"
     class="k-pagination"
+    :class="{ 'full': !disablePageJump && !offset }"
     data-testid="k-pagination"
   >
     <template v-if="!offset">
@@ -105,6 +106,15 @@
       @get-previous-offset="getPreviousOffset"
     />
     <div class="page-size-select">
+      <span
+        v-if="!disablePageJump && !offset"
+        class="pagination-text-mobile"
+        data-testid="visible-items"
+      >
+        <span class="pagination-text-pages">{{ pagesString }}</span>
+        {{ pageCountString }}
+      </span>
+
       <KDropdown
         class="page-size-dropdown"
         data-testid="page-size-dropdown"
@@ -120,7 +130,9 @@
           :disabled="pageSizeOptions.length <= 1"
           type="button"
         >
-          {{ pageSizeText }}<ChevronDownIcon
+          {{ pageSizeText }}
+
+          <ChevronDownIcon
             v-if="pageSizeOptions.length > 1"
             decorative
           />
@@ -421,7 +433,69 @@ onUnmounted(() => {
   padding: var(--kui-space-20, $kui-space-20);
   width: 100%;
 
-  .pagination-text {
+  &.full {
+    flex-direction: column;
+    gap: var(--kui-space-50, $kui-space-50);
+
+    @media (min-width: $kui-breakpoint-mobile) {
+      flex-direction: row;
+    }
+
+    .pagination-text {
+      display: none;
+
+      @media (min-width: $kui-breakpoint-mobile) {
+        display: block;
+      }
+    }
+
+    .pagination-text-mobile {
+      @media (min-width: $kui-breakpoint-mobile) {
+        display: none;
+      }
+    }
+
+    .pagination-button-container {
+      width: 100%;
+
+      @media (min-width: $kui-breakpoint-mobile) {
+        width: auto;
+      }
+
+      li {
+        &:first-child {
+          margin-right: var(--kui-space-auto, $kui-space-auto);
+
+          @media (min-width: $kui-breakpoint-mobile) {
+            margin-right: var(--kui-space-0, $kui-space-0);
+          }
+        }
+
+        &:last-child {
+          margin-left: var(--kui-space-auto, $kui-space-auto);
+
+          @media (min-width: $kui-breakpoint-mobile) {
+            margin-right: var(--kui-space-0, $kui-space-0);
+          }
+        }
+      }
+    }
+
+    .page-size-select {
+      align-items: center;
+      display: flex;
+      gap: var(--kui-space-20, $kui-space-20);
+      justify-content: space-between;
+      width: 100%;
+
+      @media (min-width: $kui-breakpoint-mobile) {
+        width: auto;
+      }
+    }
+  }
+
+  .pagination-text,
+  .pagination-text-mobile {
     color: var(--kui-color-text-neutral, $kui-color-text-neutral);
     font-size: var(--kui-font-size-30, $kui-font-size-30);
     font-weight: var(--kui-font-weight-medium, $kui-font-weight-medium);


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-10930

Changes:
* KPaginatiion to automatically detect horizontal overflow and adjust number of displayed pagination items until overflow is fixed
* Styling to stack on mobile (screenshot)

![Screenshot 2024-07-12 at 11 52 09 AM](https://github.com/user-attachments/assets/d7c6ecb0-f12f-4ede-a58c-69cdc6c638d6)

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
