### PR TITLE
ci: reuse build artifacts

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,10 @@ on:
       - alpha
       - beta
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-changed-files:
     name: Get Changed Files
@@ -17,11 +21,6 @@ jobs:
     needs:
       - get-changed-files
     uses: ./.github/workflows/test.yaml
-    # Must pass in secrets here so that the calling workflow can pass in the NPM_TOKEN needed to install private packages.
-    secrets:
-      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-      # We MUST run Percy tests on publish to update our baseline images
-      PREVENT_PERCY_TESTS: 'false'
 
   publish:
       name: Build and Publish Kongponents
@@ -52,8 +51,13 @@ jobs:
         - name: Setup PNPM with Dependencies
           uses: ./.github/actions/setup-pnpm-with-dependencies/
 
-        - name: Build
-          run: pnpm build:kongponents
+        - name: Download Build Artifacts
+          uses: actions/download-artifact@v4
+          with:
+            name: kongponents-ci-build-output-artifact
+            path: |
+              dist
+              docs/.vitepress/dist
 
         - name: Semantic Release
           uses: cycjimmy/semantic-release-action@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,15 +17,6 @@ on:
 
   # Allow workflow to be called by another workflow
   workflow_call:
-    # Must define secrets here so that the calling workflow can pass in the NPM_TOKEN needed to install private packages.
-    secrets:
-      # Normally, this should not be passed as Percy should only run on PR
-      PERCY_TOKEN:
-        description: 'The PERCY_TOKEN passed from the caller workflow as it is not available within workflow_call.'
-        required: true
-      PREVENT_PERCY_TESTS:
-        description: 'Pass false to prevent the Percy visual regression tests from running.'
-        required: true
 
 jobs:
   test:
@@ -60,6 +51,16 @@ jobs:
 
       - name: Build components and docs
         run: pnpm build:ci
+
+      # Upload artifact for `publish` workflow if this is a push event
+      - name: Upload build artifacts
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: kongponents-ci-build-output-artifact
+          path: |
+            dist
+            docs/.vitepress/dist
 
       - name: Publish Package Preview
         id: package-preview


### PR DESCRIPTION
# Summary

Reuse the build artifacts from the `test.yaml` workflow when publishing.
