### PR TITLE
fix(kmodal): allow input-autofocus in content slot

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -252,7 +252,10 @@ const toggleEventListeners = (isActive: boolean): void => {
 }
 
 const setInputAutofocus = (): void => {
-  const allInputs = focusTrapElement.value?.$el?.querySelector('.modal-content')?.querySelectorAll('input')
+  const allInputs = [
+    ...(focusTrapElement.value?.$el?.querySelector('.modal-content')?.querySelectorAll('input') || []),
+    ...(focusTrapElement.value?.$el?.querySelector('.modal-container.custom-content')?.querySelectorAll('input') || []),
+  ]
   if (allInputs?.length) {
     // loop through all inputs and focus on the first one that is not disabled or read-only
     Array.from(allInputs).every((input: any) => {


### PR DESCRIPTION
# Summary

Allow `input-autofocus` prop functionality within the `content` slot
