### PR TITLE
fix(kmodal): input autofocus with content slot

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -252,7 +252,7 @@ const toggleEventListeners = (isActive: boolean): void => {
 }
 
 const setInputAutofocus = (): void => {
-  const allInputs = focusTrapElement.value?.$el?.querySelector('.modal-content')?.querySelectorAll('input')
+  const allInputs = focusTrapElement.value?.$el?.querySelector('.modal-container')?.querySelectorAll('input')
   if (allInputs?.length) {
     // loop through all inputs and focus on the first one that is not disabled or read-only
     Array.from(allInputs).every((input: any) => {


### PR DESCRIPTION
# Summary

Allow `inputAutofocus` prop functionality within the `content` slot

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
