### PR TITLE
fix(kcodeblock): correct the line height for single line code block

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -841,6 +841,10 @@ $kCodeBlockDarkLineMatchBackgroundColor: rgba(255, 255, 255, 0.12); // we don't 
       &.single-line {
         grid-template-columns: auto;
         padding-right: var(--kui-space-100, $kui-space-100);
+
+        code {
+          line-height: var(--kui-line-height-60, $kui-line-height-60);
+        }
       }
     }
 


### PR DESCRIPTION
Adjusts the line height to center the text in single-line code blocks

Before & After:
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/296e316d-d43a-4c79-adbc-beb1cb42f26d">

JIRA: KM-347