### PR TITLE
fix(kpagination): ensure currentPage is highlighted

### DIFF
--- a/sandbox/pages/SandboxPagination.vue
+++ b/sandbox/pages/SandboxPagination.vue
@@ -15,9 +15,17 @@
           @page-size-change="handlePageSizeChange"
         />
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="currentPage">
+        <KPagination
+          :current-page="currentPage"
+          :items="currentPageItems"
+          :page-sizes="[10, 20, 30, 40]"
+          :total-count="currentPageItems.length"
+          @page-change="handleCurrentPage"
+        />
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="pageSizes">
         <KPagination
-          :current-page="7"
           :page-sizes="[10, 20, 30, 40]"
           :total-count="100"
           @page-size-change="handlePageSizeChange"
@@ -88,13 +96,22 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
+import { inject, ref, computed } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
+import type { PageChangeData, PageSizeChangeData } from '@/types'
 
-const handlePageSizeChange = (obj: any) => {
+const handlePageSizeChange = (obj: PageSizeChangeData) => {
   console.log(obj)
 }
+
+const currentPage = ref<number>(7)
+const currentPageItems = computed(() => Array.from({ length: 200 }, (_, index) => index + 1))
+const handleCurrentPage = ({ page }: PageChangeData) => {
+  currentPage.value = page
+}
+
+
 </script>
 
 <style lang="scss" scoped>

--- a/sandbox/pages/SandboxPagination.vue
+++ b/sandbox/pages/SandboxPagination.vue
@@ -44,15 +44,6 @@
           @page-size-change="handlePageSizeChange"
         />
       </SandboxSectionComponent>
-      <SandboxSectionComponent title="initialPage">
-        <KPagination
-          :current-page="7"
-          :initial-page-size="10"
-          :page-sizes="[10, 20, 30, 40]"
-          :total-count="100"
-          @page-size-change="handlePageSizeChange"
-        />
-      </SandboxSectionComponent>
       <SandboxSectionComponent
         description="Setting a way too high number of visible neighbors here (20) but KPagination detects overflow and reduces the number of visible neighbors down to acceptable number (minimum of 1)."
         title="neighbors"

--- a/sandbox/pages/SandboxPagination.vue
+++ b/sandbox/pages/SandboxPagination.vue
@@ -17,6 +17,7 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent title="pageSizes">
         <KPagination
+          :current-page="7"
           :page-sizes="[10, 20, 30, 40]"
           :total-count="100"
           @page-size-change="handlePageSizeChange"
@@ -30,6 +31,15 @@
       <SandboxSectionComponent title="initialPageSize">
         <KPagination
           :initial-page-size="20"
+          :page-sizes="[10, 20, 30, 40]"
+          :total-count="100"
+          @page-size-change="handlePageSizeChange"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent title="initialPage">
+        <KPagination
+          :current-page="7"
+          :initial-page-size="10"
           :page-sizes="[10, 20, 30, 40]"
           :total-count="100"
           @page-size-change="handlePageSizeChange"

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -288,8 +288,6 @@ const getVisiblePages = (currPage: number, pageCount: number, firstDetached: boo
   if (pages.length <= visiblePages) {
     return pages
   }
-
-
   if (!firstDetached) {
     // First pages
     pages = pages.filter((n) => n <= (fittingNeighbors.value * 2) + sequentialItemsVisible.value)
@@ -304,12 +302,12 @@ const getVisiblePages = (currPage: number, pageCount: number, firstDetached: boo
     // Last pages
     pages = pages.filter((n) => n > pageCount - (fittingNeighbors.value * 2) - sequentialItemsVisible.value)
   }
-
   return pages
 }
 
 const backDisabled = ref<boolean>(currPage.value === 1)
 const forwardDisabled = ref<boolean>(currPage.value === pageCount.value)
+
 
 const startCount = computed((): number => (currPage.value - 1) * currentPageSize.value + 1)
 const endCount = computed((): number => {
@@ -321,12 +319,12 @@ const endCount = computed((): number => {
 const pagesString = computed((): string => `${startCount.value} to ${endCount.value}`)
 const pageCountString = computed((): string => ` of ${props.totalCount}`)
 const currentlySelectedPage = computed((): number => props.currentPage ? props.currentPage : currPage.value)
-const firstDetached = ref<boolean>(false)
+const firstDetached = ref<boolean>(currentlySelectedPage.value >= fittingNeighbors.value + (sequentialItemsVisible.value + 1))
 const lastDetached = ref<boolean>(pageCount.value > (sequentialItemsVisible.value + 2) + (2 * fittingNeighbors.value))
 const pagesVisible = ref<Array<number>>(getVisiblePages(
   currentlySelectedPage.value,
   pageCount.value,
-  false,
+  firstDetached.value,
   lastDetached.value,
 ))
 


### PR DESCRIPTION
If your current page is not in the set of page buttons that KPagination defaults to (e.g. [1] [2] [3] [...] [20] with a current page of `7`). This fix ensures that the correct set of page buttons is displayed plus highlights the button that corresponds to the current page.

Honestly, I've kinda no idea what this is doing (I've no idea what `firstDetached` means for example), but I fiddled with things a little and noticed the hardcoded `false` in related code. Following this I copy/pasta'd some code in from somewhere else that seemed to be doing something important 🤷 and things began to work 😅 

I also added an example to the sandbox which I used to figure this out.

---

FYI: Our use case is that we always pass bookmarkable `?page=7` parameters to our pages, previous to this fix a '7 page button' would not be shown or highlighted, also see https://github.com/kumahq/kuma-gui/issues/2769

---

(precursor PR for reference https://github.com/Kong/kongponents/pull/2303)