### PR TITLE
fix(kprompt): proceed on enter

### DIFF
--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -356,7 +356,7 @@ interface ModalAttributes {
 
 ### errorMessage
 
-Error message text that will be displayed once user attempts to proceed after having typed in the wrong confirmation prompt. Default value is "Confirmation text does not match.".
+Error message text that will be displayed once user attempts to proceed after having typed in the wrong confirmation prompt. Default value is "Please enter the text as indicated above.".
 
 <KButton @click="prompt14Visible = true">Prompt</KButton>
 <KPrompt

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -354,16 +354,41 @@ interface ModalAttributes {
 />
 ```
 
+### errorMessage
+
+Error message text that will be displayed once user attempts to proceed after having typed in the wrong confirmation prompt. Default value is "Confirmation text does not match.".
+
+<KButton @click="prompt14Visible = true">Prompt</KButton>
+<KPrompt
+  confirmation-text="confirm"
+  error-message="Wrong confirmation text entered."
+  confirmation-prompt="Type in something other than {confirmationText} and press Enter."
+  :visible="prompt14Visible"
+  @cancel="closeAllPrompts"
+  @proceed="closeAllPrompts"
+/>
+
+```html
+<KPrompt
+  error-message="Wrong confirmation text entered."
+  confirmation-text="confirm"
+  confirmation-prompt="Type in something other than {confirmationText} and press Enter."
+  :visible="promptVisible"
+  @cancel="handlePromptClose"
+  @proceed="handlePromptProceed"
+/>
+```
+
 ## Slots
 
 ### default
 
 Slot for prompt content.
 
-<KButton @click="prompt14Visible = true">Prompt</KButton>
+<KButton @click="prompt15Visible = true">Prompt</KButton>
 <KPrompt
   title="Prompt"
-  :visible="prompt14Visible"
+  :visible="prompt15Visible"
   @cancel="closeAllPrompts"
   @proceed="closeAllPrompts"
 >
@@ -389,10 +414,10 @@ Slot for prompt content.
 
 Slot for title string.
 
-<KButton @click="prompt15Visible = true">Prompt</KButton>
+<KButton @click="prompt16Visible = true">Prompt</KButton>
 <KPrompt
   title="Title"
-  :visible="prompt15Visible"
+  :visible="prompt16Visible"
   @cancel="closeAllPrompts"
   @proceed="closeAllPrompts"
 >
@@ -444,6 +469,7 @@ const closeAllPrompts = () => {
   prompt13Visible.value = false
   prompt14Visible.value = false
   prompt15Visible.value = false
+  prompt16Visible.value = false
 }
 
 const prompt1Visible = ref<boolean>(false)
@@ -461,6 +487,7 @@ const prompt12Visible = ref<boolean>(false)
 const prompt13Visible = ref<boolean>(false)
 const prompt14Visible = ref<boolean>(false)
 const prompt15Visible = ref<boolean>(false)
+const prompt16Visible = ref<boolean>(false)
 </script>
 
 <style lang="scss" scoped>

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -86,7 +86,7 @@ A string to be displayed as the prompt dialog title. Can also be [slotted](#titl
 
 ### confirmationText
 
-A string the user must type before the action button becomes enabled. Pressing _Enter_ after typing in the confirmation text will trigger proceed action too.
+A string the user must type before the action button becomes enabled. Pressing `Enter` in the confirmation text input will trigger the `proceed` action.
 
 <KButton @click="prompt4Visible = true">Prompt</KButton>
 <KPrompt

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -356,7 +356,7 @@ interface ModalAttributes {
 
 ### errorMessage
 
-Error message text that will be displayed once user attempts to proceed after having typed in the wrong confirmation prompt. Default value is "Please enter the text as indicated above.".
+Error message text that will be displayed once user attempts to proceed after having typed in the wrong confirmation prompt. Default value is "You must enter the text as indicated above to confirm.".
 
 <KButton @click="prompt14Visible = true">Prompt</KButton>
 <KPrompt

--- a/docs/components/prompt.md
+++ b/docs/components/prompt.md
@@ -86,7 +86,7 @@ A string to be displayed as the prompt dialog title. Can also be [slotted](#titl
 
 ### confirmationText
 
-A string the user must type before the action button becomes enabled.
+A string the user must type before the action button becomes enabled. Pressing _Enter_ after typing in the confirmation text will trigger proceed action too.
 
 <KButton @click="prompt4Visible = true">Prompt</KButton>
 <KPrompt

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -46,6 +46,7 @@
           autocapitalize="off"
           autocomplete="off"
           data-testid="confirmation-input"
+          @keydown.enter.prevent="onEnter"
         />
       </div>
     </template>
@@ -116,7 +117,7 @@ const props = defineProps({
 
 const attrs = useAttrs()
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'proceed'): void
 }>()
@@ -151,6 +152,12 @@ const actionButtonDisabledValue = computed(() => {
 const confirmationPromptText = computed((): string[] => {
   return props.confirmationPrompt.split('{confirmationText}')
 })
+
+const onEnter = () => {
+  if (!actionButtonDisabledValue.value) {
+    emit('proceed')
+  }
+}
 
 watch(() => props.visible, async (visible: boolean) => {
   if (visible) {

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -12,7 +12,7 @@
     :title="title || 'Confirm your action'"
     :visible="visible"
     @cancel="$emit('cancel')"
-    @proceed="$emit('proceed')"
+    @proceed="handleProceed"
   >
     <template
       v-if="$slots.title"
@@ -46,6 +46,8 @@
           autocapitalize="off"
           autocomplete="off"
           data-testid="confirmation-input"
+          :error="displayErrorState"
+          :error-message="errorMessage"
           @keydown.enter.prevent="onEnter"
         />
       </div>
@@ -113,6 +115,10 @@ const props = defineProps({
     type: Object as PropType<ModalAttributes>,
     default: () => ({}),
   },
+  errorMessage: {
+    type: String,
+    default: 'Confirmation text does not match.',
+  },
 })
 
 const attrs = useAttrs()
@@ -140,6 +146,7 @@ const sanitizedAttrs = computed(() => {
 })
 
 const confirmationInput = ref<string>('')
+const displayErrorState = ref<boolean>(false)
 
 const actionButtonDisabledValue = computed(() => {
   if (props.actionButtonDisabled) {
@@ -153,9 +160,16 @@ const confirmationPromptText = computed((): string[] => {
   return props.confirmationPrompt.split('{confirmationText}')
 })
 
+const handleProceed = () => {
+  displayErrorState.value = false
+  emit('proceed')
+}
+
 const onEnter = () => {
   if (!actionButtonDisabledValue.value) {
-    emit('proceed')
+    handleProceed()
+  } else {
+    displayErrorState.value = true
   }
 }
 

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -117,7 +117,7 @@ const props = defineProps({
   },
   errorMessage: {
     type: String,
-    default: 'Please enter the text as indicated above.',
+    default: 'You must enter the text as indicated above to confirm.',
   },
 })
 

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -117,7 +117,7 @@ const props = defineProps({
   },
   errorMessage: {
     type: String,
-    default: 'Confirmation text does not match.',
+    default: 'Please enter the text as indicated above.',
   },
 })
 

--- a/src/components/KPrompt/KPrompt.vue
+++ b/src/components/KPrompt/KPrompt.vue
@@ -57,7 +57,7 @@
 
 <script lang="ts" setup>
 import type { PropType } from 'vue'
-import { computed, ref, useAttrs, watch, nextTick } from 'vue'
+import { computed, ref, useAttrs, watch } from 'vue'
 import KModal from '@/components/KModal/KModal.vue'
 import KInput from '@/components/KInput/KInput.vue'
 import type { ButtonAppearance, ModalAttributes } from '@/types'
@@ -173,10 +173,10 @@ const onEnter = () => {
   }
 }
 
-watch(() => props.visible, async (visible: boolean) => {
-  if (visible) {
-    await nextTick()
+watch(() => props.visible, (visible: boolean) => {
+  if (!visible) {
     confirmationInput.value = ''
+    displayErrorState.value = false
   }
 })
 </script>


### PR DESCRIPTION
# Summary

Allow trigger proceed action on _Enter_ upon typing in confirmation text in KPrompt

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
