### PR TITLE
fix(kselect): allow arrow keys navigation [khcp-12967]

### DIFF
--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -1,20 +1,19 @@
 <template>
   <div
     :key="item.key"
+    :aria-selected="item.selected"
     class="select-item"
     :data-testid="`select-item-${item.value}`"
+    role="option"
     tabindex="0"
-    @click="handleClick"
   >
-    <div
-      class="select-item-container"
-      role="option"
-    >
+    <div class="select-item-container">
       <button
         :class="{ selected: item.selected }"
         :disabled="item.disabled === true ? true : undefined"
         type="button"
         :value="item.value"
+        @click="handleClick"
       >
         <span class="select-item-label">
           <slot name="content">{{ item.label }}</slot>

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -1,18 +1,20 @@
 <template>
   <div
     :key="item.key"
-    :aria-selected="item.selected"
     class="select-item"
     :data-testid="`select-item-${item.value}`"
-    role="option"
+    tabindex="0"
+    @click="handleClick"
   >
-    <div class="select-item-container">
+    <div
+      class="select-item-container"
+      role="option"
+    >
       <button
         :class="{ selected: item.selected }"
         :disabled="item.disabled === true ? true : undefined"
         type="button"
         :value="item.value"
-        @click="handleClick"
       >
         <span class="select-item-label">
           <slot name="content">{{ item.label }}</slot>

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -2,7 +2,9 @@
   <KSelectItem
     v-for="item in nonGroupedItems"
     :key="item.key"
+    ref="focusableItems"
     :item="item"
+    @keydown="($event: KeyboardEvent) => handleKeyDown($event, item)"
     @selected="handleItemSelect"
   >
     <template #content>
@@ -26,7 +28,9 @@
     <KSelectItem
       v-for="item in getGroupItems(group)"
       :key="item.key"
+      ref="focusableItems"
       :item="item"
+      @keydown="($event: KeyboardEvent) => handleKeyDown($event, item)"
       @selected="handleItemSelect"
     >
       <template #content>
@@ -41,7 +45,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { SelectItem, SelectItemWithGroup } from '@/types'
 import KSelectItem from '@/components/KSelect/KSelectItem.vue'
 
@@ -59,7 +63,87 @@ const emit = defineEmits<{
   (e: 'selected', item: SelectItem): void
 }>()
 
-const handleItemSelect = (item: SelectItem) => emit('selected', item)
+const handleItemSelect = (item: SelectItem) => {
+  return emit('selected', item)
+}
+
+// Ref to store focusable items
+const focusableItems = ref<HTMLElement[]>([])
+
+// Function to handle the keydown event
+const handleKeyDown = (event: KeyboardEvent, item: SelectItem) => {
+
+  const activeElement = document.activeElement as HTMLElement
+
+  const elements = focusableItems.value
+    .map((el: any) => el.$el || el)
+    .filter((el: HTMLElement) => {
+    // Check if the element has a disabled button among its children
+      const hasDisabledButton = Array.from(el.querySelectorAll('button')).some(button => button.disabled)
+      // Exclude the element if it contains a disabled button
+      return !hasDisabledButton
+    })
+
+  const currentIndex = elements.indexOf(activeElement)
+
+  if (['ArrowUp', 'ArrowDown', 'Tab', ' ', 'Enter'].includes(event.key)) {
+    event.preventDefault()
+
+    let nextIndex: number | undefined
+
+    if (event.key === 'ArrowUp') {
+      nextIndex = findPreviousFocusableIndex(currentIndex, elements)
+    } else if (event.key === 'ArrowDown' || (event.key === 'Tab')) {
+      nextIndex = findNextFocusableIndex(currentIndex, elements)
+    } else if (event.key === ' ' || event.key === 'Enter') {
+      emit('selected', item)
+      const popOverElement = document.querySelector('.select-popover') as HTMLElement
+      const inputElement = document.querySelector('.select-input') as HTMLElement
+
+      if (popOverElement) {
+        // Close the popover
+        popOverElement.style.display = 'none'
+      }
+
+      if (inputElement) {
+        // Remove the input element focus class
+        inputElement.classList.remove('input-has-focus')
+      }
+    }
+
+    // Focus the next element
+    if (nextIndex !== undefined && elements[nextIndex]) {
+      elements[nextIndex].focus()
+    }
+  }
+}
+
+// Helper function to find the previous focusable element
+const findPreviousFocusableIndex = (currentIndex: number, elements: HTMLElement[]): number | undefined => {
+  // Search backwards from the currentIndex
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    if (isFocusable(elements[i])) {
+      return i
+    }
+  }
+  return undefined // No previous focusable element
+}
+
+// Helper function to find the next focusable element
+const findNextFocusableIndex = (currentIndex: number, elements: HTMLElement[]): number | undefined => {
+  // Search forwards from the currentIndex
+  for (let i = currentIndex + 1; i < elements.length; i++) {
+    if (isFocusable(elements[i])) {
+      return i
+    }
+  }
+  return undefined // No next focusable element
+}
+
+// Check if an element is focusable
+const isFocusable = (element: HTMLElement) => {
+  return element && typeof element.focus === 'function' && (element.tabIndex >= 0 || element.getAttribute('tabindex') !== null)
+}
 
 const nonGroupedItems = computed((): SelectItem[] => props.items?.filter(item => !item.group))
 const groups = computed((): string[] =>


### PR DESCRIPTION
# Summary
Addresses:
[https://konghq.atlassian.net/browse/KHCP-12967](https://konghq.atlassian.net/browse/KHCP-12967)

This PR introduces the ability to navigate through the select options using the arrow keys. Users can now:

- Use the up and down arrow keys to move through the list of options.
- Press Enter or Space to select the highlighted option.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
