### PR TITLE
fix(ktooltip, klabel): slotted code background color

### DIFF
--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -115,7 +115,7 @@ $kLabelRequiredDotSize: 6px;
       font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
 
       code {
-        background-color: var(--kui-color-background-neutral, $kui-color-background-neutral);
+        background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
         color: var(--kui-color-text-inverse, $kui-color-text-inverse);
       }
     }

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -114,6 +114,7 @@ const randomTooltipId = useUniqueId()
       line-height: var(--kui-line-height-20, $kui-line-height-20);
 
       code {
+        background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
         color: var(--kui-color-text-decorative-aqua, $kui-color-text-decorative-aqua);
       }
 


### PR DESCRIPTION
# Summary

Fixes background color for slotted `code` element in KTooltip

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
