### PR TITLE
fix(ktable, ktableview): `resizeColumns` should ignore right clicks

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -753,6 +753,11 @@ const headerHeight = computed((): string => {
 })
 
 const startResize = (evt: MouseEvent, colKey: string) => {
+  // right clicks should be ignored
+  if (evt.button !== 0) {
+    return
+  }
+
   let x = 0
   let width = 0
 

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -705,6 +705,11 @@ const headerHeight = computed((): string => {
 })
 
 const startResize = (evt: MouseEvent, colKey: string) => {
+  // right clicks should be ignored
+  if (evt.button !== 0) {
+    return
+  }
+
   let x = 0
   let width = 0
 


### PR DESCRIPTION
# Summary

The column resizer should ignore right clicks.

Before:

![Sep-06-2024 17-46-49](https://github.com/user-attachments/assets/913ad1b4-42b6-4611-b399-5b528d119d8c)

After:

![Sep-06-2024 17-48-23](https://github.com/user-attachments/assets/33af0b0a-87a8-4c46-b223-f81df27514a1)

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
