### PR TITLE
fix(ktable): disable column visibility menu while loading

### DIFF
--- a/src/components/KTable/ColumnVisibilityMenu.vue
+++ b/src/components/KTable/ColumnVisibilityMenu.vue
@@ -2,6 +2,7 @@
   <div class="table-column-visibility-menu">
     <KDropdown
       data-testid="table-column-visibility-menu"
+      :disabled="disabled"
       :kpop-attributes="{ placement: 'bottom-end' }"
       @toggle-dropdown="handleDropdownToggle"
     >
@@ -14,6 +15,7 @@
           aria-label="Show/Hide Columns"
           class="menu-button"
           data-testid="column-visibility-menu-button"
+          :disabled="disabled"
           icon
           size="large"
         >
@@ -79,6 +81,10 @@ const emit = defineEmits<{
 }>()
 
 const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
   columns: {
     type: Array as PropType<TableHeader[]>,
     required: true,

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -12,6 +12,7 @@
       <ColumnVisibilityMenu
         v-if="hasColumnVisibilityMenu"
         :columns="visibilityColumns"
+        :disabled="isTableLoading || loading"
         :table-id="tableId"
         :visibility-preferences="visibilityPreferences"
         @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"
@@ -532,7 +533,7 @@ const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((hea
 const hasColumnVisibilityMenu = computed((): boolean => {
   // has hidable columns, no error/loading/empty state
   return !!(hasHidableColumns.value &&
-    !props.error && !isTableLoading.value && !props.loading && (data.value && data.value.length))
+    !props.error && (data.value && data.value.length))
 })
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filter((header: TableHeader) => header.hidable))

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -12,7 +12,7 @@
       <ColumnVisibilityMenu
         v-if="hasColumnVisibilityMenu"
         :columns="visibilityColumns"
-        :disabled="isTableLoading || loading"
+        :disabled="isTableLoading || loading || !data || !data.length"
         :table-id="tableId"
         :visibility-preferences="visibilityPreferences"
         @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"
@@ -530,11 +530,7 @@ const resizerHoveredColumn = ref('')
 // lowest priority - currently hovered resizable column (mouse is somewhere in the <th>)
 const currentHoveredColumn = ref('')
 const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0)
-const hasColumnVisibilityMenu = computed((): boolean => {
-  // has hidable columns, no error/loading/empty state
-  return !!(hasHidableColumns.value &&
-    !props.error && (data.value && data.value.length))
-})
+const hasColumnVisibilityMenu = computed((): boolean => !!(!props.error && hasHidableColumns.value))
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filter((header: TableHeader) => header.hidable))
 // visibility preferences from the host app (initialized by app)
@@ -1123,7 +1119,7 @@ watch([query, page, pageSize], async (newData, oldData) => {
   }
 }, { deep: true, immediate: true })
 
-// because hasColumnVisibilityMenu also accounts for error/loading/empty state, we need to watch it
+// because hasColumnVisibilityMenu also accounts for error state, we need to watch it
 watch(hasColumnVisibilityMenu, (newVal) => {
   if (newVal) {
     columnVisibility.value = props.tablePreferences.columnVisibility || {}

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -9,6 +9,7 @@
       <ColumnVisibilityMenu
         v-if="hasColumnVisibilityMenu"
         :columns="visibilityColumns"
+        :disabled="loading"
         :table-id="tableId"
         :visibility-preferences="visibilityPreferences"
         @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"
@@ -477,7 +478,7 @@ const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((hea
 const hasColumnVisibilityMenu = computed((): boolean => {
   // has hidable columns, no error/loading/empty state
   return !!(hasHidableColumns.value &&
-    !props.error && !props.loading && !props.loading && (props.data && props.data.length))
+    !props.error && (props.data && props.data.length))
 })
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableViewHeader[] => tableHeaders.value.filter((header: TableViewHeader) => header.hidable))

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -31,6 +31,7 @@
         <ColumnVisibilityMenu
           v-if="hasColumnVisibilityMenu"
           :columns="visibilityColumns"
+          :disabled="loading"
           :table-id="tableId"
           :visibility-preferences="visibilityPreferences"
           @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"


### PR DESCRIPTION
# Summary

Instead of hiding column visibility menu while KTable is in loading state, disable it

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
