### PR TITLE
fix(skeleton): layout shifting due to delayed rendering

### DIFF
--- a/src/components/KSkeleton/KSkeleton.vue
+++ b/src/components/KSkeleton/KSkeleton.vue
@@ -115,9 +115,12 @@ const props = defineProps({
   },
 })
 
-const isVisible = ref(false)
+const isVisible = ref(props.delayMilliseconds === 0)
 
 onMounted(() => {
+  if (isVisible.value) {
+    return
+  }
   setTimeout(() => {
     isVisible.value = true
   }, props.delayMilliseconds)


### PR DESCRIPTION
# Summary
There is a brief layout shift during the query update in the `KTable`. You can observe this between 0:05 and 0:06 in the video, specifically after typing the second ‘d’ and before the Skeleton appears.

https://github.com/user-attachments/assets/903cf59a-e6be-4aa6-90f9-fc3aaa0bdd86

The issue arises because the Skeleton component is always rendered after a `setTimeout`. This PR addresses the issue by ensuring that when `delayMilliseconds === 0`, the Skeleton is rendered immediately.

https://github.com/user-attachments/assets/b4deee86-ea3c-4e57-a67b-43c5ba14125f

