### PR TITLE
fix(kcopy): truncated text should have max-width on tooltip

### DIFF
--- a/sandbox/pages/SandboxCopy.vue
+++ b/sandbox/pages/SandboxCopy.vue
@@ -35,6 +35,15 @@
           :text="uuid1"
           truncate
         />
+        <KCopy
+          :text="desc1"
+          truncate
+        />
+        <KCopy
+          badge
+          :text="desc1"
+          truncate
+        />
       </SandboxSectionComponent>
       <SandboxSectionComponent title="truncationLimit">
         <KCopy
@@ -138,6 +147,7 @@ import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 import KCopy from '@/components/KCopy/KCopy.vue'
 
 const uuid1: string = '2cf64827-6c70-4116-906b-4c9aae83fc4a'
+const desc1: string = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 
 const kButtonKCopyElement = ref<InstanceType<typeof KCopy> | null>(null)
 

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -14,6 +14,7 @@
         v-if="format !== 'hidden'"
         :class="[textTooltipClasses]"
         data-testid="copy-tooltip-wrapper"
+        max-width="500px"
         placement="bottom-start"
         :text="textTooltipLabel"
       >


### PR DESCRIPTION
# Summary

Added `max-width` for the tooltip for `<KCopy>`. I currently set it to `500px` , same as the copy button tooltip. Not sure if we have any design guideline here.

https://github.com/Kong/kongponents/blob/aa5192b3058c5cdd602689dfa3a2a1d54a2f68b5/src/components/KCopy/KCopy.vue#L29-L34

Before:

<img width="1718" alt="image" src="https://github.com/user-attachments/assets/0890e734-186b-4fe7-9af3-402daee22e86">

After:

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/802d4c5b-4819-4785-be34-ab39b97ecc7e">

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
