### PR TITLE
fix(ktableview): disable column visibility dropdown [KHCP-13248]

### DIFF
--- a/sandbox/pages/SandboxTableView/SandboxTableView.vue
+++ b/sandbox/pages/SandboxTableView/SandboxTableView.vue
@@ -4,6 +4,57 @@
     title="KTableView"
   >
     <div class="k-table-view-sandbox">
+      <SandboxSectionComponent title="Toolbar default items">
+        <KComponent
+          v-slot="{ data }"
+          :data="{ tableLoadingState: false, tableEmptyState: false, tableHidableHeaders: true, tableBulkActions: false, tableToolbar: false }"
+        >
+          <div class="horizontal-container">
+            <KInputSwitch
+              v-model="data.tableLoadingState"
+              label="Loading state"
+            />
+            <KInputSwitch
+              v-model="data.tableEmptyState"
+              label="Empty state"
+            />
+            <KInputSwitch
+              v-model="data.tableHidableHeaders"
+              label="Hidable headers"
+            />
+            <KInputSwitch
+              v-model="data.tableBulkActions"
+              label="Bulk actions"
+            />
+            <KInputSwitch
+              v-model="data.tableToolbar"
+              label="Toolbar content"
+            />
+          </div>
+
+          <KTableView
+            :key="data.tableKey"
+            :data="data.tableEmptyState ? [] : tableData"
+            :headers="headers(data.tableHidableHeaders, false, data.tableBulkActions)"
+            :loading="data.tableLoadingState"
+            :pagination-attributes="{ totalCount: tableData.length }"
+          >
+            <template
+              v-if="data.tableToolbar"
+              #toolbar
+            >
+              foobar
+            </template>
+            <template #bulk-action-items>
+              <SandboxTableViewActions :count="selectedData.length" />
+            </template>
+            <template #action-items>
+              <SandboxTableViewActions />
+            </template>
+          </KTableView>
+        </KComponent>
+      </SandboxSectionComponent>
+
       <!-- Props -->
       <SandboxTitleComponent
         is-subtitle
@@ -12,7 +63,7 @@
       <SandboxSectionComponent title="rowHover & emptyStateIconVariant & emptyStateTitle & emptyStateMessage & emptyStateActionMessage & emptyStateActionRoute & emptyStateButtonAppearance & maxHeight">
         <KComponent
           v-slot="{ data }"
-          :data="{ tableKey: 0, tableRowHover: false, tableEmptyState: false }"
+          :data="{ tableRowHover: false, tableEmptyState: false }"
         >
           <div class="horizontal-container">
             <KInputSwitch
@@ -22,7 +73,6 @@
             <KInputSwitch
               v-model="data.tableEmptyState"
               label="Empty state"
-              @change="data.tableKey++"
             />
           </div>
 

--- a/sandbox/pages/SandboxTableView/SandboxTableView.vue
+++ b/sandbox/pages/SandboxTableView/SandboxTableView.vue
@@ -4,57 +4,6 @@
     title="KTableView"
   >
     <div class="k-table-view-sandbox">
-      <SandboxSectionComponent title="Toolbar default items">
-        <KComponent
-          v-slot="{ data }"
-          :data="{ tableLoadingState: false, tableEmptyState: false, tableHidableHeaders: true, tableBulkActions: false, tableToolbar: false }"
-        >
-          <div class="horizontal-container">
-            <KInputSwitch
-              v-model="data.tableLoadingState"
-              label="Loading state"
-            />
-            <KInputSwitch
-              v-model="data.tableEmptyState"
-              label="Empty state"
-            />
-            <KInputSwitch
-              v-model="data.tableHidableHeaders"
-              label="Hidable headers"
-            />
-            <KInputSwitch
-              v-model="data.tableBulkActions"
-              label="Bulk actions"
-            />
-            <KInputSwitch
-              v-model="data.tableToolbar"
-              label="Toolbar content"
-            />
-          </div>
-
-          <KTableView
-            :key="data.tableKey"
-            :data="data.tableEmptyState ? [] : tableData"
-            :headers="headers(data.tableHidableHeaders, false, data.tableBulkActions)"
-            :loading="data.tableLoadingState"
-            :pagination-attributes="{ totalCount: tableData.length }"
-          >
-            <template
-              v-if="data.tableToolbar"
-              #toolbar
-            >
-              foobar
-            </template>
-            <template #bulk-action-items>
-              <SandboxTableViewActions :count="selectedData.length" />
-            </template>
-            <template #action-items>
-              <SandboxTableViewActions />
-            </template>
-          </KTableView>
-        </KComponent>
-      </SandboxSectionComponent>
-
       <!-- Props -->
       <SandboxTitleComponent
         is-subtitle

--- a/src/components/KTable/ColumnVisibilityMenu.vue
+++ b/src/components/KTable/ColumnVisibilityMenu.vue
@@ -2,6 +2,7 @@
   <div class="table-column-visibility-menu">
     <KDropdown
       data-testid="table-column-visibility-menu"
+      :disabled="disabled"
       :kpop-attributes="{ placement: 'bottom-end' }"
       @toggle-dropdown="handleDropdownToggle"
     >
@@ -14,6 +15,7 @@
           aria-label="Show/Hide Columns"
           class="menu-button"
           data-testid="column-visibility-menu-button"
+          :disabled="disabled"
           icon
           size="large"
         >
@@ -90,6 +92,10 @@ const props = defineProps({
   visibilityPreferences: {
     type: Object as PropType<Record<string, boolean>>,
     default: () => ({}),
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
   },
 })
 

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -16,7 +16,6 @@
       >
         <ColumnVisibilityMenu
           :columns="visibilityColumns"
-          :disabled="columnVisibilityDisabled"
           :table-id="tableId"
           :visibility-preferences="visibilityPreferences"
           @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"
@@ -536,19 +535,10 @@ const resizerHoveredColumn = ref('')
 const currentHoveredColumn = ref('')
 const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0)
 const hasColumnVisibilityMenu = computed((): boolean => {
-  if (!hasHidableColumns.value || props.error) {
-    return false
-  }
-
-  if (slots.toolbar) {
-    // when toolbar slot is present, we want to disable column visibility menu rather than hide it in certain states
-    return true
-  }
-
-  // show when not loading and there is data
-  return !isTableLoading.value && !props.loading && !!data.value && !!data.value.length
+  // has hidable columns, no error/loading/empty state
+  return !!(hasHidableColumns.value &&
+    !props.error && !isTableLoading.value && !props.loading && (data.value && data.value.length))
 })
-const columnVisibilityDisabled = computed((): boolean => isTableLoading.value || props.loading || !(data.value && data.value.length))
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filter((header: TableHeader) => header.hidable))
 // visibility preferences from the host app (initialized by app)

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -545,7 +545,8 @@ const hasColumnVisibilityMenu = computed((): boolean => {
     return true
   }
 
-  return !isTableLoading.value && !props.loading && data.value && !!data.value.length
+  // show when not loading and there is data
+  return !isTableLoading.value && !props.loading && !!data.value && !!data.value.length
 })
 const columnVisibilityDisabled = computed((): boolean => isTableLoading.value || props.loading || !(data.value && data.value.length))
 // columns whose visibility can be toggled

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -9,9 +9,10 @@
         name="toolbar"
         :state="stateData"
       />
+
       <ColumnVisibilityMenu
-        v-if="hasColumnVisibilityMenu"
         :columns="visibilityColumns"
+        :disabled="columnVisibilityDisabled"
         :table-id="tableId"
         :visibility-preferences="visibilityPreferences"
         @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"
@@ -530,10 +531,18 @@ const resizerHoveredColumn = ref('')
 const currentHoveredColumn = ref('')
 const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((header: TableHeader) => header.hidable).length > 0)
 const hasColumnVisibilityMenu = computed((): boolean => {
-  // has hidable columns, no error/loading/empty state
-  return !!(hasHidableColumns.value &&
-    !props.error && !isTableLoading.value && !props.loading && (data.value && data.value.length))
+  if (!hasHidableColumns.value || props.error) {
+    return false
+  }
+
+  if (slots.toolbar) {
+    // when toolbar slot is present, we want to disable column visibility menu rather than hide it in certain states
+    return true
+  }
+
+  return !isTableLoading.value && !props.loading && data.value && !!data.value.length
 })
+const columnVisibilityDisabled = computed((): boolean => isTableLoading.value || props.loading || !(data.value && data.value.length))
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableHeader[] => tableHeaders.value.filter((header: TableHeader) => header.hidable))
 // visibility preferences from the host app (initialized by app)

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -625,6 +625,7 @@ const hasColumnVisibilityMenu = computed((): boolean => {
     return true
   }
 
+  // show when not loading and there is data
   return !props.loading && !!tableData.value && !!tableData.value.length
 })
 const columnVisibilityDisabled = computed((): boolean => props.loading || !(tableData.value && tableData.value.length))

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -11,11 +11,11 @@
       <slot name="toolbar" />
 
       <div
-        v-if="hasBulkActions || hasColumnVisibilityMenu"
+        v-if="showBulkActionsToolbar || hasColumnVisibilityMenu"
         class="toolbar-default-items-container"
       >
         <slot
-          v-if="hasBulkActions"
+          v-if="showBulkActionsToolbar"
           name="bulk-actions"
           :selected-rows="bulkActionsSelectedRows"
         >
@@ -23,7 +23,7 @@
             v-if="!$slots['bulk-actions']"
             :button-label="tableHeaders.find((header: TableViewHeader) => header.key === TableViewHeaderKeys.BULK_ACTIONS)!.label"
             :count="bulkActionsSelectedRowsCount"
-            :disabled="!bulkActionsSelectedRowsCount || loading"
+            :disabled="!bulkActionsSelectedRowsCount || loading || !tableData.length"
           >
             <template #items>
               <slot
@@ -37,6 +37,7 @@
         <ColumnVisibilityMenu
           v-if="hasColumnVisibilityMenu"
           :columns="visibilityColumns"
+          :disabled="columnVisibilityDisabled"
           :table-id="tableId"
           :visibility-preferences="visibilityPreferences"
           @update="(columnMap: Record<string, boolean>) => columnVisibility = columnMap"
@@ -615,10 +616,18 @@ const resizerHoveredColumn = ref('')
 const currentHoveredColumn = ref('')
 const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((header: TableViewHeader) => header.hidable).length > 0)
 const hasColumnVisibilityMenu = computed((): boolean => {
-  // has hidable columns, no error/loading/empty state
-  return !!(hasHidableColumns.value &&
-    !props.error && !props.loading && !props.loading && (tableData.value && tableData.value.length))
+  if (props.nested || !hasHidableColumns.value || props.error) {
+    return false
+  }
+
+  if (slots.toolbar) {
+    // when toolbar slot is present, we want to disable column visibility menu rather than hide it in certain states
+    return true
+  }
+
+  return !props.loading && !!tableData.value && !!tableData.value.length
 })
+const columnVisibilityDisabled = computed((): boolean => props.loading || !(tableData.value && tableData.value.length))
 // columns whose visibility can be toggled
 const visibilityColumns = computed((): TableViewHeader[] => tableHeaders.value.filter((header: TableViewHeader) => header.hidable && header.key !== TableViewHeaderKeys.EXPANDABLE && header.key !== TableViewHeaderKeys.BULK_ACTIONS))
 // visibility preferences from the host app (initialized by app)
@@ -630,7 +639,7 @@ const isScrolledHorizontally = ref<boolean>(false)
 const sortColumnKey = ref('')
 const sortColumnOrder = ref<SortColumnOrder>('desc')
 const isClickable = ref(false)
-const hasToolbarSlot = computed((): boolean => !props.nested && (!!slots.toolbar || hasColumnVisibilityMenu.value || hasBulkActions.value))
+const hasToolbarSlot = computed((): boolean => !props.nested && (!!slots.toolbar || hasColumnVisibilityMenu.value || showBulkActionsToolbar.value))
 const isActionsDropdownHovered = ref<boolean>(false)
 const tableWrapperStyles = computed((): Record<string, string> => ({
   maxHeight: getSizeFromString(props.maxHeight),
@@ -639,6 +648,19 @@ const tableWrapperStyles = computed((): Record<string, string> => ({
 const tableData = ref<TableViewData>([...props.data].map((row) => ({ ...row, selected: false })))
 const bulkActionsSelectedRows = ref<TableViewData>([])
 const hasBulkActions = computed((): boolean => !props.nested && !props.error && tableHeaders.value.some((header: TableViewHeader) => header.key === TableViewHeaderKeys.BULK_ACTIONS) && !!(slots['bulk-action-items'] || slots['bulk-actions']))
+const showBulkActionsToolbar = computed((): boolean => {
+  if (props.nested || !hasBulkActions.value || props.error) {
+    return false
+  }
+
+  if (slots.toolbar) {
+    // when toolbar slot is present, we want to disable bulk actions dropdown rather than hide it in certain states
+    return true
+  }
+
+  // show when not loading and there is data
+  return !props.loading && !!tableData.value && !!tableData.value.length
+})
 const bulkActionsSelectedRowsCount = computed((): string => {
   const selectedRowsCount = bulkActionsSelectedRows.value.length
 


### PR DESCRIPTION
# Summary

Jira: https://konghq.atlassian.net/browse/KHCP-13248

KTable and KTableView toolbar default items include bulk actions dropdown (only supported in KTableView) and column visibility menu (screenshot).

![Screenshot 2024-09-16 at 11 08 49 AM](https://github.com/user-attachments/assets/b3aa6d9c-bb1c-4b87-a4b3-e5ecce45ddcd)

Changes:
Instead of hiding toolbar default items in loading and empty states at all times, only hide them in those states when toolbar slot is NOT provided. Otherwise, display those toolbar default items in disabled state to avoid layout shifts when table switches states (e.g. loading -> empty -> loading -> success).

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
