### PR TITLE
feat: autosubmit timeframe button clicks [MA-3223]

### DIFF
--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -73,6 +73,7 @@ describe('KDateTimePicker', () => {
 
     cy.getTestId(timepickerInput).should('exist')
     cy.getTestId(timepickerInput).find('.calendar-icon').should('not.exist')
+    cy.getTestId(submitButton).should('exist')
     cy.getTestId(clearButton).should('not.exist')
   })
 
@@ -113,6 +114,7 @@ describe('KDateTimePicker', () => {
     // Open the date time picker, click "Clear" and make sure default placeholder is shown
     cy.getTestId(timepickerInput).click()
     cy.get('.popover-content').should('be.visible')
+    cy.getTestId(submitButton).should('exist')
     cy.getTestId(clearButton).should('exist')
     cy.getTestId(clearButton).eq(0).click()
     cy.getTestId(timepickerDisplay).should('contain.text', placeholderText)
@@ -129,6 +131,7 @@ describe('KDateTimePicker', () => {
     cy.getTestId(timepickerInput).should('exist')
     cy.getTestId(timepickerInput).click()
     cy.get('.vc-pane-container').should('exist')
+    cy.getTestId(submitButton).should('exist')
     cy.get('.vc-pane-container').find('.vc-time-picker').should('not.exist')
   })
 
@@ -140,6 +143,8 @@ describe('KDateTimePicker', () => {
         range: false,
       },
     })
+
+    cy.getTestId(submitButton).should('exist')
     cy.getTestId(timepickerInput).should('exist')
     cy.getTestId(timepickerInput).click()
     cy.get('.vc-pane-container').should('exist')
@@ -159,6 +164,8 @@ describe('KDateTimePicker', () => {
     })
 
     cy.get('.k-datetime-picker').should('exist')
+    cy.getTestId(submitButton).should('exist')
+
     cy.get('.k-datetime-picker').getTestId(timepickerInput).should('exist')
     cy.get('.k-datetime-picker').getTestId(timepickerInput).click()
     cy.get('.k-datetime-picker').get('.vc-pane-container .vc-time-picker').should('exist')
@@ -229,6 +236,8 @@ describe('KDateTimePicker', () => {
       },
     })
 
+    cy.getTestId(submitButton).should('not.exist')
+
     cy.getTestId(timepickerInput).click()
     cy.get('.timeframe-section').should('exist')
     cy.get('.timeframe-buttons').should('exist')
@@ -250,14 +259,17 @@ describe('KDateTimePicker', () => {
       },
     })
     cy.getTestId(timepickerInput).click()
+    cy.getTestId(submitButton).should('exist')
 
     // Check that time frames render
     cy.getTestId(segmentedToggle).find('button[data-testid="relative-option"]').eq(0).click()
+    cy.getTestId(submitButton).should('not.exist')
     cy.get('.timeframe-section').should('exist')
     cy.get('.timeframe-buttons').should('exist')
 
     // Check that calendar month and 2 x time selection inputs show up
     cy.getTestId(segmentedToggle).find('button[data-testid="custom-option"]').eq(0).click()
+    cy.getTestId(submitButton).should('exist')
     cy.get('.k-datetime-picker .vc-pane-container .vc-weeks').should('exist')
   })
 

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -329,7 +329,6 @@ describe('KDateTimePicker', () => {
     // If a timeframe is selected, "Apply" should be re-enabled
     cy.getTestId(segmentedToggle).find('button[data-testid="relative-option"]').eq(0).click()
     cy.getTestId('select-timeframe-86400000').click()
-    cy.getTestId(submitButton).eq(0).click()
     cy.getTestId(timepickerDisplay).should('contain.text', 'Last 24 hours')
   })
 })

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -403,7 +403,6 @@ const changeCalendarRange = (vCalValue: TimeRange | null): void => {
 const changeRelativeTimeframe = (timeframe: TimePeriod, autoSubmit: boolean = false): void => {
   state.selectedTimeframe = state.previouslySelectedTimeframe = timeframe
 
-  console.warn('>>>> changeRelativeTimeframe called. <<<')
   // Format the start/end values as human readable date
   const start: Date = state.selectedTimeframe.start()
   const end: Date = state.selectedTimeframe.end()

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -98,7 +98,7 @@
                 :appearance="getTimeframeButtonAppearance(timeFrame)"
                 class="timeframe-button"
                 :data-testid="`select-timeframe-${timeFrame.timeframeLength()}`"
-                @click="changeRelativeTimeframe(timeFrame)"
+                @click="changeRelativeTimeframe(timeFrame, true)"
               >
                 {{ ucWord(timeFrame.timeframeText) }}
               </KButton>
@@ -400,9 +400,10 @@ const changeCalendarRange = (vCalValue: TimeRange | null): void => {
  * when a relative time frame button is clicked
  * @param {*} timeframe
  */
-const changeRelativeTimeframe = (timeframe: TimePeriod): void => {
+const changeRelativeTimeframe = (timeframe: TimePeriod, autoSubmit: boolean = false): void => {
   state.selectedTimeframe = state.previouslySelectedTimeframe = timeframe
 
+  console.warn('>>>> changeRelativeTimeframe called. <<<')
   // Format the start/end values as human readable date
   const start: Date = state.selectedTimeframe.start()
   const end: Date = state.selectedTimeframe.end()
@@ -416,6 +417,10 @@ const changeRelativeTimeframe = (timeframe: TimePeriod): void => {
 
   state.fullRangeDisplay = formatDisplayDate(state.selectedRange, false)
   submitDisabled.value = false
+
+  if (autoSubmit) {
+    submitTimeFrame()
+  }
 }
 
 /**

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -119,6 +119,7 @@
             Clear
           </KButton>
           <KButton
+            v-if="showCalendar"
             appearance="tertiary"
             class="action-button"
             data-testid="datetime-picker-submit"


### PR DESCRIPTION
# Summary

We now auto-submit relative timeframe button clicks. Custom (calendar) ranges still require the extra click on "Apply".

https://konghq.atlassian.net/browse/MA-3223


### Deploy Preview:
https://deploy-preview-2404--kongponents.netlify.app/components/datetime-picker.html#custom-date-time-and-relative-time-frames

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
