### PR TITLE
fix(ktable): bulk actions checkboxes should be valign center

### DIFF
--- a/src/components/KCheckbox/KCheckbox.vue
+++ b/src/components/KCheckbox/KCheckbox.vue
@@ -192,7 +192,7 @@ export default {
     position: relative;
 
     &.has-label {
-      margin-top: 3px; // align with label
+      margin-top: 2px; // align with label
     }
   }
 
@@ -280,6 +280,7 @@ export default {
 
     .checkbox-label {
       cursor: pointer;
+      display: flex;
       margin: 0;
 
       &.required {

--- a/src/styles/mixins/_tables.scss
+++ b/src/styles/mixins/_tables.scss
@@ -95,7 +95,6 @@
             line-height: var(--kui-line-height-30, $kui-line-height-30);
             padding: $tableThPaddingY var(--kui-space-60, $kui-space-60);
             text-align: left;
-            vertical-align: bottom;
 
             &.resizable {
               // set min width so the column can't be collapsed to nothing - avoiding bad UX
@@ -376,6 +375,11 @@
           cursor: pointer;
         }
       }
+    }
+
+    .bulk-actions-checkbox,
+    .table-header-bulk-actions-checkbox {
+      display: flex;
     }
   }
 


### PR DESCRIPTION
# Summary

Before:

<img width="331" alt="image" src="https://github.com/user-attachments/assets/7eba949a-2b9a-4f2b-bf95-67bcc62ca5dc">

After:

<img width="331" alt="image" src="https://github.com/user-attachments/assets/b6487c74-8e7e-4df8-afc5-d346d7cb9365">

