### PR TITLE
fix(kpagination): ensure firstDetached consistency [KM-580]

### DIFF
--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -319,7 +319,10 @@ const endCount = computed((): number => {
 const pagesString = computed((): string => `${startCount.value} to ${endCount.value}`)
 const pageCountString = computed((): string => ` of ${props.totalCount}`)
 const currentlySelectedPage = computed((): number => props.currentPage ? props.currentPage : currPage.value)
-const firstDetached = ref<boolean>(currentlySelectedPage.value >= fittingNeighbors.value + (sequentialItemsVisible.value + 1))
+
+// Selected page, first page, last page, 2 placeholders and 2 * neighbors
+const visiblePages = computed((): number => 5 + 2 * fittingNeighbors.value)
+const firstDetached = ref<boolean>(currentlySelectedPage.value >= fittingNeighbors.value + (sequentialItemsVisible.value + 1) && pageCount.value > visiblePages.value)
 const lastDetached = ref<boolean>(pageCount.value > (sequentialItemsVisible.value + 2) + (2 * fittingNeighbors.value))
 const pagesVisible = ref<Array<number>>(getVisiblePages(
   currentlySelectedPage.value,
@@ -348,9 +351,7 @@ const updatePage = (): void => {
   forwardDisabled.value = lastEntry >= props.totalCount
   backDisabled.value = currPage.value === 1
   // The view will hold
-  // Selected page, first page, last page, 2 placeholders and 2 * neighbors
-  const visiblePages = 5 + 2 * fittingNeighbors.value
-  if (pageCount.value <= visiblePages) {
+  if (pageCount.value <= visiblePages.value) {
     // All pages will fit in screen
     firstDetached.value = false
     lastDetached.value = false


### PR DESCRIPTION
# Summary

[KM-580]
When the currentPage is controlled for kpagination, it may behave differently from when there is no currentPage passed in and add unneeded ellipsis

Before:
![image](https://github.com/user-attachments/assets/69823bec-f227-440d-8666-4307ce95025d)
After:
<img width="1901" alt="截屏2024-10-12 下午4 50 38" src="https://github.com/user-attachments/assets/6dead5dd-b289-4478-b3f7-026c647d7f2a">


[KM-580]: https://konghq.atlassian.net/browse/KM-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ