### PR TITLE
fix(kinput): prevent focus loss on icon/button click

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -236,7 +236,7 @@ Use the `before` and `after` slots for inserting icons before and/or after the i
 ```
 
 :::tip TIP
-If you want to make an icon clickable, you **must** assign `role="button"` and `tabindex="0"` attributes to that element and bind an event handler. KBadge will take care of state styling (hover, focus, disabled).
+If you want to make an icon clickable, you **must** assign `role="button"` and `tabindex="0"` attributes to that element and bind an event handler. KInput will take care of state styling (hover, focus, disabled).
 
 <KInput model-value="b0490b53-4f47-410d-92b0-e76a3141c04d">
   <template #after>

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -188,11 +188,11 @@ describe('KInput', () => {
 
     cy.get('.k-input .mask-value-toggle-button').should('be.visible')
     cy.get('.k-input input').should('have.attr', 'type', 'password')
+    cy.get('.k-input input').focus()
     cy.get('.k-input .mask-value-toggle-button').click()
     cy.get('.k-input input').should('have.attr', 'type', 'text')
     cy.get('.k-input .mask-value-toggle-button').click()
-    cy.get('.k-input input').should('have.attr', 'type', 'password')
-
+    cy.get('.k-input input').should('have.attr', 'type', 'password').should('be.focused')
     // user-provided after slot should be rendered
     cy.get('.k-input').find(`[data-testid="${afterSlot}"]`).should('not.exist')
   })

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -51,6 +51,8 @@
           :aria-label="`${maskValue ? 'Hide' : 'Show'} value`"
           class="mask-value-toggle-button"
           @click.stop="maskValue = !maskValue"
+          @mousedown.prevent
+          @mouseup.prevent
         >
           <VisibilityOffIcon
             v-if="maskValue"
@@ -382,6 +384,12 @@ $kInputSlotSpacing: var(--kui-space-40, $kui-space-40); // $kSelectInputSlotSpac
       :deep(#{$kongponentsKongIconSelector}) {
         height: $kInputIconSize !important;
         width: $kInputIconSize !important;
+      }
+
+      // enhance the experience for most common cases that icon only slots should not
+      // prevent the input from being focused by click on the icon
+      &:has(> #{$kongponentsKongIconSelector}:not(button):not([role="button"]):only-child) {
+        pointer-events: none;
       }
 
       :deep([role="button"]:not(.k-button)), :deep(button:not(.k-button)),


### PR DESCRIPTION
# Summary

Fixed issue where clicking icons/buttons inside an input caused focus loss. This PR ensures the input remains focused.

Before:

![Oct-13-2024 01-04-21](https://github.com/user-attachments/assets/dd78bc79-30b8-4155-89c9-a78169a6232d)
![Oct-13-2024 01-04-36](https://github.com/user-attachments/assets/2a5518fb-361f-4a8b-be85-9f55f9fb0070)

After:

![Oct-13-2024 01-04-27](https://github.com/user-attachments/assets/ab9e242f-10e5-474c-b71c-71dbd500a4fa)
![Oct-13-2024 01-04-31](https://github.com/user-attachments/assets/6e3c38b0-db81-4d11-85a9-3f75cb8862b6)

