### PR TITLE
fix(klabel): fix aria attributes on tooltip icon

### DIFF
--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -1,6 +1,5 @@
 <template>
   <label
-    v-bind-once="{ ...(hasTooltip && { 'aria-describedby': tooltipId }) }"
     class="k-label"
     :class="{ 'required': required }"
   >
@@ -13,9 +12,9 @@
       :tooltip-id="tooltipId"
     >
       <InfoIcon
+        v-bind-once="{ 'aria-describedby': tooltipId }"
         class="tooltip-trigger-icon"
         :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
-        decorative
         tabindex="0"
       />
       <template #content>


### PR DESCRIPTION
# Summary

We are now getting a console error when we focused on a tooltip icon:

> Blocked aria-hidden on a <span> element because the element that just received focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden. 

So I made some changes according to the [spec](https://www.w3.org/TR/html-aria/):

* Removed `decorative` for the icon
* Moved `aria-describedby` on label to the icon as `<label>` is [Naming prohibited](https://www.w3.org/TR/html-aria/#dfn-naming-prohibited).