### PR TITLE
docs(kinput): fix typo

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -236,7 +236,7 @@ Use the `before` and `after` slots for inserting icons before and/or after the i
 ```
 
 :::tip TIP
-If you want to make an icon clickable, you **must** assign `role="button"` and `tabindex="0"` attributes to that element and bind an event handler. KBadge will take care of state styling (hover, focus, disabled).
+If you want to make an icon clickable, you **must** assign `role="button"` and `tabindex="0"` attributes to that element and bind an event handler. KInput will take care of state styling (hover, focus, disabled).
 
 <KInput model-value="b0490b53-4f47-410d-92b0-e76a3141c04d">
   <template #after>


### PR DESCRIPTION
# Summary

<img width="665" alt="image" src="https://github.com/user-attachments/assets/c46b9055-1227-4d34-983f-21c18a8aa178">