### PR TITLE
feat(kbutton): add appearance="none" to button

### DIFF
--- a/.stylelintrc.mjs
+++ b/.stylelintrc.mjs
@@ -12,7 +12,10 @@ export default {
   rules: {
     // Disallow relative font units since we don't know the base font size in other apps
     'unit-disallowed-list': ['rem', 'em'],
-    'order/properties-alphabetical-order': true,
+    'order/properties-order': [
+      ['all'],
+      { 'unspecified': 'bottomAlphabetical' },
+	  ],
     '@kong/design-tokens/use-proper-token': true,
     '@stylistic/indentation': [2, { baseIndentLevel: 0 }],
     // Only allow @kong/design-tokens or `--kong-ui-*` CSS custom properties

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -21,6 +21,10 @@ The Button component can take 1 of 5 appearance values:
 - `danger`
 - `none`
 
+:::tip NOTE
+`appearance="none"` is used in scenarios where custom styles are needed while retaining the basic behavior of `KButton`. When enabled, the size and icon props will not be supported and do not need to be supported.
+:::
+
 <div class="spacing-container">
   <KButton appearance="primary">Primary</KButton>
   <KButton appearance="secondary">Secondary</KButton>

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -13,18 +13,20 @@ and configuration options.
 
 ### appearance
 
-The Button component can take 1 of 4 appearance values:
+The Button component can take 1 of 5 appearance values:
 
 - `primary`
 - `secondary`
 - `tertiary`
 - `danger`
+- `none`
 
 <div class="spacing-container">
   <KButton appearance="primary">Primary</KButton>
   <KButton appearance="secondary">Secondary</KButton>
   <KButton appearance="tertiary">Tertiary</KButton>
   <KButton appearance="danger">Danger</KButton>
+  <KButton appearance="none">None</KButton>
 </div>
 
 ```html
@@ -32,6 +34,7 @@ The Button component can take 1 of 4 appearance values:
 <KButton appearance="secondary">Secondary</KButton>
 <KButton appearance="tertiary">Tertiary</KButton>
 <KButton appearance="danger">Danger</KButton>
+<KButton appearance="none">None</KButton>
 ```
 
 ### size

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -22,7 +22,7 @@ The Button component can take 1 of 5 appearance values:
 - `none`
 
 :::tip NOTE
-`appearance="none"` is used in scenarios where custom styles are needed while retaining the basic behavior of `KButton`. When enabled, the size and icon props will not be supported and do not need to be supported.
+`appearance="none"` is used in scenarios where custom styles are needed while retaining the basic behavior of `KButton`. When enabled, the `size` and `icon` props will not be supported (and there's no need to support them).
 :::
 
 <div class="spacing-container">

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -22,7 +22,9 @@ The Button component can take 1 of 5 appearance values:
 - `none`
 
 :::tip NOTE
-Use `appearance="none"` to apply custom styles while keeping KButton's basic functionality. When this is enabled, the `size` prop won’t work unless `icon` is set to `true`.
+Use `appearance="none"` to get an unstyled button, making it easier to customize from scratch. This removes the built-in styling but retains the button's functionality.
+
+When `appearance="none"` is set, the `size` prop only works if `icon` is `true`; otherwise, `size` has no effect.
 :::
 
 <div class="spacing-container">

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -22,7 +22,7 @@ The Button component can take 1 of 5 appearance values:
 - `none`
 
 :::tip NOTE
-`appearance="none"` is used in scenarios where custom styles are needed while retaining the basic behavior of `KButton`. When enabled, the `size` and `icon` props will not be supported (and there's no need to support them).
+Use `appearance="none"` to apply custom styles while keeping KButton's basic functionality. When this is enabled, the `size` prop won’t work unless `icon` is set to `true`.
 :::
 
 <div class="spacing-container">

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
+        api: 'modern',
         // Inject the @kong/design-tokens SCSS variables, kongponents variables and mixins to make them available for all components.
         // This is not needed in host applications.
         additionalData: `

--- a/sandbox/pages/SandboxButton.vue
+++ b/sandbox/pages/SandboxButton.vue
@@ -13,7 +13,7 @@
         title="appearance"
       >
         <template #description>
-          KButton component takes 1 of 4 appearance values:
+          KButton component takes 1 of 5 appearance values:
           <ul>
             <li>
               <em>primary</em> - default value
@@ -26,6 +26,9 @@
             </li>
             <li>
               <em>danger</em>
+            </li>
+            <li>
+              <em>none</em>
             </li>
           </ul>
         </template>
@@ -51,6 +54,12 @@
           >
             Danger
           </KButton>
+          <KButton
+            appearance="none"
+            @click="test"
+          >
+            None
+          </KButton>
         </div>
         <div class="horizontal-spacing">
           <KButton
@@ -75,6 +84,13 @@
           </KButton>
           <KButton
             appearance="danger"
+            disabled
+            @click="test"
+          >
+            Disabled
+          </KButton>
+          <KButton
+            appearance="none"
             disabled
             @click="test"
           >
@@ -189,6 +205,13 @@
             Danger
           </KButton>
           <KButton
+            appearance="none"
+            target="_blank"
+            to="https://kongponents.konghq.com/"
+          >
+            None
+          </KButton>
+          <KButton
             disabled
             target="_blank"
             to="https://kongponents.konghq.com/"
@@ -228,6 +251,13 @@
             :to="{ name: 'home' }"
           >
             Danger
+          </KButton>
+          <KButton
+            appearance="none"
+            target="_blank"
+            :to="{ name: 'home' }"
+          >
+            None
           </KButton>
           <KButton
             disabled
@@ -274,6 +304,13 @@
             <AddCircleIcon />
             Danger
           </KButton>
+          <KButton
+            appearance="none"
+            size="large"
+          >
+            <AddCircleIcon />
+            None
+          </KButton>
         </div>
         <div class="horizontal-spacing">
           <KButton>
@@ -291,6 +328,10 @@
           <KButton appearance="danger">
             <AddCircleIcon />
             Danger
+          </KButton>
+          <KButton appearance="none">
+            <AddCircleIcon />
+            None
           </KButton>
         </div>
         <div class="horizontal-spacing">
@@ -318,6 +359,13 @@
           >
             <AddCircleIcon />
             Danger
+          </KButton>
+          <KButton
+            appearance="none"
+            size="small"
+          >
+            <AddCircleIcon />
+            None
           </KButton>
         </div>
         <!-- icon after -->
@@ -347,6 +395,13 @@
             Danger
             <ChevronDownIcon />
           </KButton>
+          <KButton
+            appearance="none"
+            size="large"
+          >
+            None
+            <ChevronDownIcon />
+          </KButton>
         </div>
         <div class="horizontal-spacing">
           <KButton>
@@ -363,6 +418,10 @@
           </KButton>
           <KButton appearance="danger">
             Danger
+            <ChevronDownIcon />
+          </KButton>
+          <KButton appearance="none">
+            None
             <ChevronDownIcon />
           </KButton>
         </div>
@@ -390,6 +449,13 @@
             size="small"
           >
             Danger
+            <ChevronDownIcon />
+          </KButton>
+          <KButton
+            appearance="none"
+            size="small"
+          >
+            None
             <ChevronDownIcon />
           </KButton>
         </div>
@@ -429,6 +495,13 @@
           >
             <DisabledIcon />
           </KButton>
+          <KButton
+            appearance="none"
+            icon
+            size="large"
+          >
+            <AddCircleIcon />
+          </KButton>
         </div>
         <div class="horizontal-spacing">
           <KButton icon>
@@ -452,6 +525,12 @@
           >
             <DisabledIcon />
           </KButton>
+          <KButton
+            appearance="none"
+            icon
+          >
+            <AddCircleIcon />
+          </KButton>
         </div>
         <div class="horizontal-spacing">
           <KButton
@@ -480,6 +559,36 @@
             size="small"
           >
             <DisabledIcon />
+          </KButton>
+          <KButton
+            appearance="none"
+            icon
+            size="small"
+          >
+            <AddCircleIcon />
+          </KButton>
+        </div>
+      </SandboxSectionComponent>
+      <SandboxTitleComponent
+        is-subtitle
+        title="Custom button"
+      />
+      <SandboxSectionComponent>
+        <div class="horizontal-spacing">
+          <KButton
+            appearance="none"
+            class="custom-button"
+            @click="test"
+          >
+            Custom
+          </KButton>
+          <KButton
+            appearance="none"
+            class="custom-button"
+            disabled
+            @click="test"
+          >
+            Custom
           </KButton>
         </div>
       </SandboxSectionComponent>
@@ -505,6 +614,25 @@ const test = () => {
     display: flex;
     flex-wrap: wrap;
     gap: $kui-space-50;
+  }
+}
+
+/* Low-specificity styles should be able to override */
+.custom-button {
+  background-color: #42b883;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 8px 16px;
+
+  &:hover:not(:disabled) {
+    background-color: #33a06f;
+    transition-duration: .2s;
+  }
+
+  &:disabled {
+    opacity: 0.3;
   }
 }
 </style>

--- a/sandbox/pages/SandboxButton.vue
+++ b/sandbox/pages/SandboxButton.vue
@@ -102,6 +102,7 @@
         description="Here we pass an invalid value to the appearance prop (see the error in the console) which the KButton handles by falling back to primary appearance."
         title="invalid value"
       >
+        <!-- @vue-expect-error -->
         <KButton appearance="outline">
           Still Primary
         </KButton>
@@ -304,13 +305,6 @@
             <AddCircleIcon />
             Danger
           </KButton>
-          <KButton
-            appearance="none"
-            size="large"
-          >
-            <AddCircleIcon />
-            None
-          </KButton>
         </div>
         <div class="horizontal-spacing">
           <KButton>
@@ -328,10 +322,6 @@
           <KButton appearance="danger">
             <AddCircleIcon />
             Danger
-          </KButton>
-          <KButton appearance="none">
-            <AddCircleIcon />
-            None
           </KButton>
         </div>
         <div class="horizontal-spacing">
@@ -359,13 +349,6 @@
           >
             <AddCircleIcon />
             Danger
-          </KButton>
-          <KButton
-            appearance="none"
-            size="small"
-          >
-            <AddCircleIcon />
-            None
           </KButton>
         </div>
         <!-- icon after -->

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -2,7 +2,14 @@
   <component
     :is="buttonType"
     class="k-button"
-    :class="[buttonSize, buttonAppearance, { 'icon-button': icon === true || (!$slots.default && $slots.icon /* TODO: remove this once we remove icon slot */) }]"
+    :class="[
+      buttonSize,
+      buttonAppearance,
+      {
+        'icon-button': appearance !== 'none' &&
+          (icon === true || (!$slots.default && $slots.icon /* TODO: remove this once we remove icon slot */))
+      }
+    ]"
     :disabled="disabled ? disabled : undefined"
     :tabindex="disabled && buttonType !== 'button' ? '-1' : undefined"
     :type="type"
@@ -115,10 +122,14 @@ const buttonSize = computed((): ButtonSize | null => {
 const strippedAttrs = computed((): typeof attrs => {
   const modifiedAttrs = Object.assign({}, attrs)
 
-  if (props.to && typeof props.to === 'string') {
-    modifiedAttrs.href = props.to
-  } else if (props.to) {
-    modifiedAttrs.to = props.to
+  if (props.disabled) {
+    modifiedAttrs.href = null
+  } else {
+    if (props.to && typeof props.to === 'string') {
+      modifiedAttrs.href = props.to
+    } else if (props.to) {
+      modifiedAttrs.to = props.to
+    }
   }
 
   if (props.disabled !== undefined && props.disabled !== false) {
@@ -313,6 +324,7 @@ export default {
   &:where(.none) {
     all: unset;
     align-items: center;
+    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
     box-sizing: border-box;
     cursor: pointer;
     display: inline-flex;
@@ -320,6 +332,10 @@ export default {
     transition: background-color $kongponentsTransitionDurTimingFunc, color $kongponentsTransitionDurTimingFunc, border-color $kongponentsTransitionDurTimingFunc;
     user-select: none;
     white-space: nowrap;
+
+    &:where(.disabled, [disabled]) {
+      color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+    }
   }
 
   /* Sizes */

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -2,14 +2,7 @@
   <component
     :is="buttonType"
     class="k-button"
-    :class="[
-      buttonSize,
-      buttonAppearance,
-      {
-        'icon-button': appearance !== 'none' &&
-          (icon === true || (!$slots.default && $slots.icon /* TODO: remove this once we remove icon slot */))
-      }
-    ]"
+    :class="[buttonSize, buttonAppearance, { 'icon-button': icon === true || (!$slots.default && $slots.icon /* TODO: remove this once we remove icon slot */) }]"
     :disabled="disabled ? disabled : undefined"
     :tabindex="disabled && buttonType !== 'button' ? '-1' : undefined"
     :type="type"
@@ -106,7 +99,7 @@ const buttonAppearance = computed((): ButtonAppearance | [ButtonAppearance, stri
 })
 
 const buttonSize = computed((): ButtonSize | null => {
-  if (props.appearance === 'none') {
+  if (props.appearance === 'none' && !props.icon) {
     return null
   }
 
@@ -335,6 +328,11 @@ export default {
 
     &:where(.disabled, [disabled]) {
       color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+    }
+
+    &:where(.icon-button) {
+      border-color: transparent;
+      border-style: solid;
     }
   }
 

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,6 +1,6 @@
 import type { Replace } from '@/types/utils'
 
-export type ButtonAppearance = 'primary' | 'secondary' | 'tertiary' | 'danger'
+export type ButtonAppearance = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'none'
 export type ButtonAppearanceRecord = Record<Replace<ButtonAppearance, '-', ''>, ButtonAppearance>
 
 export type ButtonSize = 'large' | 'medium' | 'small'
@@ -11,6 +11,7 @@ export const ButtonAppearances: ButtonAppearanceRecord = {
   secondary: 'secondary',
   tertiary: 'tertiary',
   danger: 'danger',
+  none: 'none',
 }
 
 export const ButtonSizes: ButtonSizeRecord = {


### PR DESCRIPTION
# Summary

This PR adds a `none` value to the `<KButton>` `appearance` prop, enabling buttons to render with minimal styling similar to a `<div>`. This allows for fully custom styles while retaining `<KButton>` features like link rendering to links, cursor styles, and disabled states.

## Changes

- New Appearance: `none`
  - Renders `<KButton>` with minimal styles (`border-box`, `cursor`) for custom styling.

- Style Refactoring
  - `.k-button` no longer applies primary styles unless the `primary` class is present to make overriding easier.
  - Output `primary outline` classes to maintain backward compatibility when `appearance="outline"` (or any other invalid values).

- Disabled Link Behavior
  - Disabled links are now unfocusable and cannot be activated with the <kbd>enter</kbd> key.
  - Removed `pointer-events: none` to ensure `cursor: not-allowed` displays correctly for consistency.
  - Used JavaScript to prevent navigation and click events on disabled links, emulating native button behavior.
