### PR TITLE
fix(ktabs): slotted anchor link

### DIFF
--- a/docs/components/table-view.md
+++ b/docs/components/table-view.md
@@ -518,11 +518,28 @@ The `rowKey` prop accepts either a unique string or a function that returns a un
 If a string is provided which corresponds to a property of the `row`, the unique identifier will utilize the `row[rowKey]` as the unique identifier.
 
 ```html
-<KTableView
-  row-key="id"
-  :data="tableData"
-  :headers="headers"
-/>
+<template>
+  <KTableView
+    row-key="id"
+    :data="tableData"
+    :headers="headers"
+  />
+</template>
+
+<script setup lang="ts">
+import type { TableViewData } from '@kong/kongponents'
+
+const tableData: TableViewData = [
+  {
+    id: 'a70642b3-20f2-4658-b459-fe1cbcf9e315',
+    ...
+  },
+  {
+    id: '58c599a9-f453-41f3-9e64-0a7fc6caedad',
+    ...
+  }
+]
+</script>
 ```
 
 Alternatively, if a function is passed, it allows for the creation of a custom identifier based on the row data passed to the function.

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -178,7 +178,7 @@ const tabChange = (hash: string): void => {
 
 ### anchorTabindex
 
-This prop allows setting a custom `tabindex` for the tab anchor element. It’s useful when passing a custom interactive element, like a link, through the [`anchor` slot](#anchor-panel), ensuring that only the slotted element is focusable by resetting the default anchor `tabindex`. Default value is `0`.
+This prop allows setting a custom `tabindex` for the tab anchor element. It’s useful when passing a custom interactive element, like a link, through the [`anchor` slot](#anchor-panel), ensuring that only the slotted element is focusable by resetting the default anchor `tabindex`. Default value is `0`. Accepted values are `0` and `-1`.
 
 #### Dynamic RouterView
 

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -178,7 +178,7 @@ const tabChange = (hash: string): void => {
 
 ### anchorTabindex
 
-This prop allows setting a custom `tabindex` for the tab anchor element. It’s useful when passing a custom interactive element, like a link, through the [`anchor` slot](#anchor-panel), ensuring that only the slotted element is focusable by resetting the default anchor `tabindex`. Default value is `0`. Accepted values are `0` and `-1`.
+This prop allows setting a custom `tabindex` for the tab anchor element. It’s useful when passing a custom interactive element, like a link, through the [`anchor` slot](#anchor-panel), ensuring that only the slotted element is focusable by resetting the default anchor `tabindex`. Default value is `0`.
 
 #### Dynamic RouterView
 

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -176,6 +176,10 @@ const tabChange = (hash: string): void => {
 </script>
 ```
 
+### anchorTabindex
+
+This prop allows setting a custom `tabindex` for the tab anchor element. It’s useful when passing a custom interactive element, like a link, through the [`anchor` slot](#anchor-panel), ensuring that only the slotted element is focusable by resetting the default anchor `tabindex`. Default value is `0`.
+
 #### Dynamic RouterView
 
 Here's an example (code only) of utilizing a dynamic `router-view` component within the host app:

--- a/sandbox/pages/SandboxTabs.vue
+++ b/sandbox/pages/SandboxTabs.vue
@@ -111,6 +111,7 @@
       />
       <SandboxSectionComponent title="Dynamic router view without panels">
         <KTabs
+          anchor-tabindex="-1"
           hide-panels
           :tabs="dynamicRouterViewItems"
           @change="(hash: string) => $router.replace({ hash })"

--- a/sandbox/pages/SandboxTabs.vue
+++ b/sandbox/pages/SandboxTabs.vue
@@ -111,7 +111,7 @@
       />
       <SandboxSectionComponent title="Dynamic router view without panels">
         <KTabs
-          anchor-tabindex="-1"
+          :anchor-tabindex="-1"
           hide-panels
           :tabs="dynamicRouterViewItems"
           @change="(hash: string) => $router.replace({ hash })"

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -17,7 +17,7 @@
           class="tab-link"
           :class="{ 'has-panels': !hidePanels, disabled: tab.disabled }"
           role="tab"
-          :tabindex="tab.disabled ? '-1' : anchorTabindex"
+          :tabindex="getAnchorTabindex(tab)"
           @click.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
           @keydown.enter.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
           @keydown.space.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
@@ -76,9 +76,9 @@ const props = defineProps({
     default: false,
   },
   anchorTabindex: {
-    type: String,
+    type: String as PropType<'0' | '-1'>,
     default: '0',
-    validator: (val: string): boolean => val === '0' || val === '-1',
+    validator: (val: string): boolean => ['0', '-1'].includes(val),
   },
 })
 
@@ -96,6 +96,14 @@ const handleTabChange = (tab: string): void => {
 }
 
 const getTabSlotName = (tabHash: string): string => tabHash.replace('#', '')
+
+const getAnchorTabindex = (tab: Tab): string => {
+  if (tab.disabled) {
+    return '-1'
+  }
+
+  return ['0', '-1'].includes(props.anchorTabindex) ? props.anchorTabindex : '0'
+}
 
 watch(() => props.modelValue, (newTabHash) => {
   activeTab.value = newTabHash

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -102,7 +102,7 @@ const getAnchorTabindex = (tab: Tab): string => {
     return '-1'
   }
 
-  return props.anchorTabindex >= -1 && props.anchorTabindex <= 32767 ? String(props.anchorTabindex) : '0'
+  return typeof props.anchorTabindex === 'number' && props.anchorTabindex >= -1 && props.anchorTabindex <= 32767 ? String(props.anchorTabindex) : '0'
 }
 
 watch(() => props.modelValue, (newTabHash) => {

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -141,7 +141,7 @@ watch(() => props.modelValue, (newTabHash) => {
         }
 
         a, :deep(a) {
-          // color: var(--kui-color-text, $kui-color-text);
+          color: var(--kui-color-text-neutral, $kui-color-text-neutral);
           text-decoration: none;
         }
 

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -76,9 +76,9 @@ const props = defineProps({
     default: false,
   },
   anchorTabindex: {
-    type: String as PropType<'0' | '-1'>,
-    default: '0',
-    validator: (val: string): boolean => ['0', '-1'].includes(val),
+    type: Number,
+    default: 0,
+    validator: (val: number): boolean => val >= -1 && val <= 32767,
   },
 })
 
@@ -102,7 +102,7 @@ const getAnchorTabindex = (tab: Tab): string => {
     return '-1'
   }
 
-  return ['0', '-1'].includes(props.anchorTabindex) ? props.anchorTabindex : '0'
+  return props.anchorTabindex >= -1 && props.anchorTabindex <= 32767 ? String(props.anchorTabindex) : '0'
 }
 
 watch(() => props.modelValue, (newTabHash) => {

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -167,6 +167,10 @@ watch(() => props.modelValue, (newTabHash) => {
 
         .tab-link {
           color: var(--kui-color-text, $kui-color-text);
+
+          a, :deep(a) {
+            color: var(--kui-color-text, $kui-color-text);
+          }
         }
       }
     }

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -141,7 +141,7 @@ watch(() => props.modelValue, (newTabHash) => {
         }
 
         a, :deep(a) {
-          color: var(--kui-color-text, $kui-color-text);
+          // color: var(--kui-color-text, $kui-color-text);
           text-decoration: none;
         }
 

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -17,12 +17,12 @@
           class="tab-link"
           :class="{ 'has-panels': !hidePanels, disabled: tab.disabled }"
           role="tab"
-          :tabindex="tab.disabled ? '-1' : '0'"
+          :tabindex="tab.disabled ? '-1' : anchorTabindex"
           @click.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
           @keydown.enter.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
           @keydown.space.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
         >
-          <slot :name="`${tab.hash.replace('#','')}-anchor`">
+          <slot :name="`${getTabSlotName(tab.hash)}-anchor`">
             <span>{{ tab.title }}</span>
           </slot>
         </div>
@@ -34,13 +34,13 @@
         v-for="(tab, i) in tabs"
         :id="`panel-${i}`"
         :key="tab.hash"
-        :aria-labelledby="`${tab.hash.replace('#','')}-tab`"
+        :aria-labelledby="`${getTabSlotName(tab.hash)}-tab`"
         class="tab-container"
         role="tabpanel"
       >
         <slot
           v-if="activeTab === tab.hash"
-          :name="tab.hash.replace('#','')"
+          :name="getTabSlotName(tab.hash)"
         />
       </div>
     </template>
@@ -75,6 +75,11 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  anchorTabindex: {
+    type: String,
+    default: '0',
+    validator: (val: string): boolean => val === '0' || val === '-1',
+  },
 })
 
 const emit = defineEmits<{
@@ -90,6 +95,8 @@ const handleTabChange = (tab: string): void => {
   emit('update:modelValue', tab)
 }
 
+const getTabSlotName = (tabHash: string): string => tabHash.replace('#', '')
+
 watch(() => props.modelValue, (newTabHash) => {
   activeTab.value = newTabHash
   emit('change', newTabHash)
@@ -98,6 +105,14 @@ watch(() => props.modelValue, (newTabHash) => {
 </script>
 
 <style lang="scss" scoped>
+@mixin kTabsFocus {
+  background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
+  border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+  box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+  color: var(--kui-color-text, $kui-color-text);
+  outline: none;
+}
+
 .k-tabs {
   ul {
     border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
@@ -143,6 +158,10 @@ watch(() => props.modelValue, (newTabHash) => {
         a, :deep(a) {
           color: var(--kui-color-text-neutral, $kui-color-text-neutral);
           text-decoration: none;
+
+          &:focus-visible {
+            @include kTabsFocus;
+          }
         }
 
         &:hover:not(.disabled) {
@@ -150,10 +169,7 @@ watch(() => props.modelValue, (newTabHash) => {
         }
 
         &:focus-visible {
-          background-color: var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker);
-          box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
-          color: var(--kui-color-text, $kui-color-text);
-          outline: none;
+          @include kTabsFocus;
         }
 
         &.disabled {


### PR DESCRIPTION
# Summary

The issue:
When a link is slotted into anchor slot of a tab, when using keyboard nav, the user needs to press tab twice to navigate to next element (first time the wrapper element `div.tab-link` has focus, then the slotted link element).

Solution:
Add `anchorTabindex` prop that allows set tabindex for `div.tab-link` element. This allows to make only one element in tab focusable.

https://github.com/user-attachments/assets/8d37cb5a-548b-42fd-8652-465be6546780

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
