### PR TITLE
feat(kselect): add `before` slot

### DIFF
--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -597,7 +597,7 @@ A slot alternative for [`dropdownFooterText` prop](#dropdownfootertext).
 
 ### loading
 
-Content to be displayed when [`loading` prop](#loading-1) is `true`. Note that this prop only applies when `enableFiltering` is `true`.
+Content to be displayed when [`loading` prop](#loading-1) is `true`. Note that this slot only applies when `enableFiltering` is `true`.
 
 <ClientOnly>
   <KToggle toggled v-slot="{ isToggled, toggle }">
@@ -642,7 +642,7 @@ Slot to display custom content when items is empty or no items match filter quer
 
 ### label-tooltip
 
-Use this prop to pass any custom content to label tooltip.
+Use this slot to pass any custom content to label tooltip.
 
 <ClientOnly>
   <KSelect label="Label" :items="selectItems">
@@ -655,6 +655,18 @@ Use this prop to pass any custom content to label tooltip.
   <template #label-tooltip>Id: <code>8576925e-d7e0-4ecd-8f14-15db1765e69a</code></template>
 </KSelect>
 ```
+
+### before
+
+Use this slot for inserting icons before the input field.
+
+<ClientOnly>
+  <KSelect :items="selectItems">
+    <template #before>
+      <SearchIcon />
+    </template>
+  </KSelect>
+</ClientOnly>
 
 ## Events
 
@@ -684,7 +696,7 @@ Event payload is removed [item](#items).
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { KongIcon } from '@kong/icons'
+import { KongIcon, SearchIcon } from '@kong/icons'
 
 const selectItems: SelectItem[] = [{
   label: 'Service A',

--- a/sandbox/pages/SandboxSelect.vue
+++ b/sandbox/pages/SandboxSelect.vue
@@ -183,6 +183,15 @@
           </template>
         </KSelect>
       </SandboxSectionComponent>
+      <SandboxSectionComponent
+        title="before"
+      >
+        <KSelect :items="selectItems">
+          <template #before>
+            <KongIcon />
+          </template>
+        </KSelect>
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="itemTemplate">
         <KSelect
           :items="selectItems"

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -61,6 +61,12 @@
             @keyup.enter.stop
             @update:model-value="onQueryChange"
           >
+            <template
+              v-if="slots.before"
+              #before
+            >
+              <slot name="before" />
+            </template>
             <template #after>
               <button
                 v-if="isClearVisible"


### PR DESCRIPTION
# Summary

[KM-637](https://konghq.atlassian.net/browse/KM-637)

Added support for the `before` slot of `<KSelect>`.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/1250cb80-8995-4162-9668-2528a9eda630">


[KM-637]: https://konghq.atlassian.net/browse/KM-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ