### PR TITLE
docs(ktextarea): to clarify maximum characters of ktextarea for readers

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -1,6 +1,9 @@
 # TextArea
 
 KTextArea provides a wrapper around textarea element, as well as contextual styling and states (error, focus, etc).
+:::tip NOTE
+The default maximum character limit is `2048 characters`.
+:::
 
 <KTextArea />
 


### PR DESCRIPTION
it gives hint of maximum characters for textarea by default.

# Summary
This PR enhances the docs of KTextArea by adding a note of default maximum 2048 characters limit.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
