### PR TITLE
fix(ktableview, ktabledata): cell-attrs and row-attrs prop type

### DIFF
--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -153,7 +153,7 @@ interface TablePropsShared {
   /**
    * A function that conditionally specifies cell attributes
    */
-  cellAttrs?: (param: CellAttrsParam) => Record<string, string>
+  cellAttrs?: (param: CellAttrsParam) => Record<string, any>
   /**
    * A prop that enables a loading skeleton
    */

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -137,7 +137,7 @@ interface TablePropsShared {
   /**
    * A function that conditionally specifies row attributes on each row
    */
-  rowAttrs?: (row: Record<string, any>) => Record<string, string>
+  rowAttrs?: (row: Record<string, any>) => Record<string, any>
   /**
    * A function that conditionally turns a row into a link
    */


### PR DESCRIPTION
# Summary

Accept `Record<string, any>` instead of `Record<string, string>` in `cellAttrs` & `rowAttrs` props in KTableView & KTableData.

Explanation:
```
// this isn't valid because style is object, not a string
:cell-attrs="() => ({ style: { width: '100%' }, class: 'foobar' })"
```

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
