### PR TITLE
fix(kbutton): pass to as long as it's a router-link [KM-644]

### DIFF
--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,5 +1,5 @@
 import { mount } from 'cypress/vue'
-//  vue-router only throws uncaught errors in production mode
+// vue-router only throws uncaught errors in production mode
 import { createMemoryHistory, createRouter } from 'vue-router/dist/vue-router.prod.cjs'
 import type { RouteRecordRaw } from 'vue-router'
 import type { App, ComputedOptions } from 'vue'

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -1,9 +1,22 @@
 import { mount } from 'cypress/vue'
+//  vue-router only throws uncaught errors in production mode
+import { createMemoryHistory, createRouter } from 'vue-router/dist/vue-router.prod.cjs'
+import type { RouteRecordRaw } from 'vue-router'
 import type { App, ComputedOptions } from 'vue'
 import Chainable = Cypress.Chainable
 import 'cypress-fail-fast'
 // Import Kongponent styles
 import '@/styles/styles.scss'
+
+const testRoutes: RouteRecordRaw[] = [
+  {
+    path: '/',
+    name: 'home',
+    alias: '/:pathMatch(.*)*',
+    meta: { title: 'Kongponents Sandbox' },
+    component: () => import('../../sandbox/pages/HomePage.vue'),
+  },
+]
 
 Cypress.Commands.add('getTestId', (dataTestId: string): Chainable => {
   return cy.get(`[data-testid="${dataTestId}"]`)
@@ -23,6 +36,29 @@ Cypress.Commands.add('mount', (component: ComputedOptions, options = {}): Chaina
       if (options.router) {
         app.use(options.router)
       }
+    },
+  })
+
+  return mount(component, options)
+})
+
+Cypress.Commands.add('mountWithProdRouter', (component: ComputedOptions, options = {}) => {
+  // Setup options object
+  options.global = options.global || {}
+  options.global.plugins = options.global.plugins || []
+
+  // create router if one is not provided
+  if (!options.router) {
+    options.router = createRouter({
+      routes: testRoutes,
+      history: createMemoryHistory(),
+    })
+  }
+
+  // Add router plugin
+  options.global.plugins.push({
+    install(app) {
+      app.use(options.router)
     },
   })
 

--- a/src/components/KButton/KButton.cy.ts
+++ b/src/components/KButton/KButton.cy.ts
@@ -96,4 +96,19 @@ describe('KButton', () => {
 
     cy.get('.k-button').should('not.have.attr', 'disabled')
   })
+
+  it('should not throw error when `to` prop is an object and disabled is true', () => {
+    expect(() => cy.mountWithProdRouter(
+      KButton,
+      {
+        props: {
+          to: { name: 'home' },
+          disabled: true,
+        },
+        slots: {
+          default: () => 'Click me',
+        },
+      },
+    )).to.not.throw()
+  })
 })

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -115,13 +115,16 @@ const buttonSize = computed((): ButtonSize | null => {
 const strippedAttrs = computed((): typeof attrs => {
   const modifiedAttrs = Object.assign({}, attrs)
 
-  if (props.disabled) {
-    modifiedAttrs.href = null
-  } else {
-    if (props.to && typeof props.to === 'string') {
+  if (props.to) {
+    if (typeof props.to === 'string') {
       modifiedAttrs.href = props.to
-    } else if (props.to) {
+    } else {
+      // `to` prop is nessessary for router-link to successfully render
       modifiedAttrs.to = props.to
+    }
+    if (props.disabled) {
+      // Set href to null so that user cannot bypass by right clicking it and opening in new tab
+      modifiedAttrs.href = null
     }
   }
 


### PR DESCRIPTION
# Summary

KM-644

`to` prop needs to be passed to `<router-link>`. So when `disabled` is passed, we still pass `to` prop to it and delete `href` attribute so that users cannot bypass this grey state by right clicking and open it in a new tab.
