### PR TITLE
fix(kselect): don't emit query-change on select [KHCP-13895]

### DIFF
--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -226,7 +226,6 @@ describe('KSelect', () => {
     })
 
     cy.get('input').type('a').then(() => {
-      cy.get('@onQueryChange').should('have.been.calledWith', '')
       cy.get('@onQueryChange').should('have.been.calledWith', 'a')
     }).then(() => {
       cy.wrap(Cypress.vueWrapper.setProps({ loading: true })).getTestId('select-loading').should('exist')
@@ -245,7 +244,7 @@ describe('KSelect', () => {
 
   it('handles query change correctly', () => {
     const itemLabel = 'Label 1'
-    let emitCount = 1 // 1 for initial query change
+    let emitCount = 0
 
     mount(KSelect, {
       props: {

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -212,8 +212,10 @@ describe('KSelect', () => {
     cy.getTestId('item-slot-content').should('be.visible').should('contain.text', itemSlotContent)
   })
 
-  it('handles all states correctly when `enableFiltering` is `true`', () => {
+  it('handles all states correctly when enableFiltering is true', () => {
     const onQueryChange = cy.spy().as('onQueryChange')
+    const itemLabel = 'Label 1'
+
     mount(KSelect, {
       props: {
         enableFiltering: true,
@@ -231,13 +233,43 @@ describe('KSelect', () => {
     }).then(() => {
       cy.wrap(Cypress.vueWrapper.setProps({ loading: false })).getTestId('select-loading').should('not.exist')
     }).then(() => {
-      cy.wrap(Cypress.vueWrapper.setProps({ items: [{ label: 'Label 1', value: 'label1' }] })).getTestId('select-item-label1').should('contain.text', 'Label 1')
+      cy.wrap(Cypress.vueWrapper.setProps({ items: [{ label: itemLabel, value: 'label1' }] })).getTestId('select-item-label1').should('contain.text', itemLabel)
     }).then(() => {
       cy.getTestId('select-item-label1').trigger('click')
-      cy.get('input').should('have.value', 'Label 1')
+      cy.get('input').should('have.value', itemLabel)
       cy.getTestId('select-input').trigger('click')
       cy.get('[data-testid="select-item-label1"] button').should('have.class', 'selected')
       cy.get('@onQueryChange').should('have.been.calledWith', '')
+    })
+  })
+
+  it('handles query change correctly', () => {
+    const itemLabel = 'Label 1'
+    let emitCount = 1 // 1 for initial query change
+
+    mount(KSelect, {
+      props: {
+        enableFiltering: true,
+        loading: false,
+        items: [{ label: itemLabel, value: 'label1' }],
+      },
+    })
+
+    cy.get('input').type(itemLabel).then(() => {
+      emitCount += itemLabel.length // 1 emit for each character typed
+      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'query-change')
+      cy.wrap(Cypress.vueWrapper.emitted()['query-change']).should('have.length', emitCount)
+      cy.getTestId('select-item-label1').trigger('click')
+      // selecting an item should not emit query change
+      cy.wrap(Cypress.vueWrapper.emitted()['query-change']).should('have.length', emitCount)
+      cy.getTestId('select-input').trigger('click').then(() => {
+        emitCount += 1 // 1 for resetting query when opening dropdown
+        // simulate pasting a value
+        cy.get('input').invoke('val', itemLabel).trigger('input').then(() => {
+          emitCount += 1 // 1 for pasting the value
+          cy.wrap(Cypress.vueWrapper.emitted()['query-change']).should('have.length', emitCount)
+        })
+      })
     })
   })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -717,7 +717,9 @@ watch(() => props.items, (newValue, oldValue) => {
 }, { deep: true, immediate: true })
 
 watch(filterQuery, (query: string) => {
-  if (!skipQueryChangeEmit.value || !query || uniqueFilterQuery.value) {
+  const isUnique = selectItems.value?.filter((item: SelectItem) => item.label === query)?.length
+
+  if (!skipQueryChangeEmit.value || !query || isUnique) {
     emit('query-change', query)
   }
   skipQueryChangeEmit.value = false

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -717,11 +717,11 @@ watch(() => props.items, (newValue, oldValue) => {
 }, { deep: true, immediate: true })
 
 watch(filterQuery, (query: string) => {
-  if (!skipQueryChangeEmit.value) {
+  if (!skipQueryChangeEmit.value || !query || uniqueFilterQuery.value) {
     emit('query-change', query)
   }
   skipQueryChangeEmit.value = false
-}, { immediate: true })
+})
 
 watch(selectedItem, (newVal, oldVal) => {
   if (newVal && newVal !== oldVal) {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -379,6 +379,7 @@ const labelElement = ref<InstanceType<typeof KLabel> | null>(null)
 
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 
+const skipQueryChangeEmit = ref<boolean>(false)
 const filterQuery = ref<string>('')
 
 // whether or not filter string matches an existing item's label
@@ -529,6 +530,7 @@ const handleItemSelect = (item: SelectItem, isNew?: boolean) => {
     }
   })
 
+  skipQueryChangeEmit.value = true
   filterQuery.value = item.label
 }
 
@@ -576,8 +578,6 @@ const onQueryChange = (query: string) => {
 
 const onInputFocus = (): void => {
   inputFocused.value = true
-
-  emit('query-change', filterQuery.value)
 }
 
 const onInputBlur = (): void => {
@@ -613,6 +613,7 @@ const onClose = (toggle: () => void, isToggled: boolean) => {
   isDropdownOpen.value = false
 
   if (selectedItem.value) {
+    skipQueryChangeEmit.value = true
     filterQuery.value = selectedItem.value.label
   } else {
     filterQuery.value = ''
@@ -691,6 +692,7 @@ watch(() => props.items, (newValue, oldValue) => {
       selectItems.value[i].key += '-selected'
 
       if (!inputFocused.value) {
+        skipQueryChangeEmit.value = true
         filterQuery.value = selectedItem.value.label
       }
     }
@@ -713,8 +715,11 @@ watch(() => props.items, (newValue, oldValue) => {
   }
 }, { deep: true, immediate: true })
 
-watch(filterQuery, (q: string) => {
-  emit('query-change', q)
+watch(filterQuery, (query: string) => {
+  if (!skipQueryChangeEmit.value || !query) {
+    emit('query-change', query)
+  }
+  skipQueryChangeEmit.value = false
 })
 
 watch(selectedItem, (newVal, oldVal) => {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -379,6 +379,7 @@ const labelElement = ref<InstanceType<typeof KLabel> | null>(null)
 
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
 
+// sometimes (e.g. when selecting an item) we don't want to emit the query change event
 const skipQueryChangeEmit = ref<boolean>(false)
 const filterQuery = ref<string>('')
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -717,9 +717,7 @@ watch(() => props.items, (newValue, oldValue) => {
 }, { deep: true, immediate: true })
 
 watch(filterQuery, (query: string) => {
-  const isUnique = selectItems.value?.filter((item: SelectItem) => item.label === query)?.length
-
-  if (!skipQueryChangeEmit.value || !query || isUnique) {
+  if (!skipQueryChangeEmit.value || !query) {
     emit('query-change', query)
   }
   skipQueryChangeEmit.value = false

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -717,9 +717,12 @@ watch(() => props.items, (newValue, oldValue) => {
 }, { deep: true, immediate: true })
 
 watch(filterQuery, (query: string) => {
-  if (!skipQueryChangeEmit.value || !query) {
-    emit('query-change', query)
+  // skip emitting query change when the query is the selected item's label
+  if (skipQueryChangeEmit.value && query) {
+    return
   }
+
+  emit('query-change', query)
   skipQueryChangeEmit.value = false
 })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -720,7 +720,7 @@ watch(filterQuery, (query: string) => {
     emit('query-change', query)
   }
   skipQueryChangeEmit.value = false
-})
+}, { immediate: true })
 
 watch(selectedItem, (newVal, oldVal) => {
   if (newVal && newVal !== oldVal) {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -717,7 +717,7 @@ watch(() => props.items, (newValue, oldValue) => {
 }, { deep: true, immediate: true })
 
 watch(filterQuery, (query: string) => {
-  if (!skipQueryChangeEmit.value || !query) {
+  if (!skipQueryChangeEmit.value) {
     emit('query-change', query)
   }
   skipQueryChangeEmit.value = false


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-13895

Selecting a value in KSelect should not trigger `@query-change` event

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
