### PR TITLE
fix(kradio): show-card-radio and card-orientation props [KHCP-13540]

### DIFF
--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -221,7 +221,7 @@ Accepted values are `vertical` (shown above) or `horizontal`. Defaults to `verti
 />
 ```
 
-### showCardRadio
+### cardRadioVisible
 
 Prop to show or hide radio button in card. Default value is `true`.
 
@@ -229,7 +229,7 @@ Prop to show or hide radio button in card. Default value is `true`.
   <KRadio
     v-model="showRadio"
     card
-    :card-show-radio="false"
+    :card-radio-visible="false"
     label="Vertical"
     description="Vertical radio card with hidden radio button."
     :selected-value="false"
@@ -238,7 +238,7 @@ Prop to show or hide radio button in card. Default value is `true`.
     v-model="showRadio"
     card
     card-orientation="horizontal"
-    :card-show-radio="false"
+    :card-radio-visible="false"
     label="Horizontal"
     description="Horizontal radio card with hidden radio button."
     :selected-value="true"
@@ -247,7 +247,7 @@ Prop to show or hide radio button in card. Default value is `true`.
 
 ```html
 <KRadio
-  :card-show-radio="false"
+  :card-radio-visible="false"
   v-model="radioCard"
   card
   label="Vertical"
@@ -255,7 +255,7 @@ Prop to show or hide radio button in card. Default value is `true`.
   :selected-value="false"
 />
 <KRadio
-  :card-show-radio="false"
+  :card-radio-visible="false"
   v-model="radioCard"
   card
   card-orientation="horizontal"

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -215,8 +215,8 @@ Accepted values are `vertical` (shown above) or `horizontal`. Defaults to `verti
   card-orientation="horizontal"
   v-model="cardRadio"
   description="Choose this option if you want your APIs to be publicly accessible by anyone on the internet."
-  card
   label="Public"
+  card
   selected-value="public"
 />
 ```
@@ -225,22 +225,44 @@ Accepted values are `vertical` (shown above) or `horizontal`. Defaults to `verti
 
 Prop to show or hide radio button in card. Default value is `true`.
 
-<div class="vertical-spacing">
+Vertical:
+<div class="cards-container">
   <KRadio
-    v-model="showRadio"
+    v-model="showRadioVertical"
     card
     :card-radio-visible="false"
-    label="Vertical"
-    description="Vertical radio card with hidden radio button."
+    description="Choose this option if you want your APIs to only be accessible from within your private network."
+    label="Private"
     :selected-value="false"
   />
   <KRadio
-    v-model="showRadio"
+    v-model="showRadioVertical"
+    card
+    :card-radio-visible="false"
+    description="Choose this option if you want your APIs to be publicly accessible by anyone on the internet."
+    label="Public"
+    :selected-value="true"
+  />
+</div>
+
+Horizontal:
+<div class="vertical-spacing">
+  <KRadio
+    v-model="showRadioHorizontal"
     card
     card-orientation="horizontal"
     :card-radio-visible="false"
-    label="Horizontal"
-    description="Horizontal radio card with hidden radio button."
+    description="Choose this option if you want your APIs to only be accessible from within your private network."
+    label="Private"
+    :selected-value="false"
+  />
+  <KRadio
+    v-model="showRadioHorizontal"
+    card
+    card-orientation="horizontal"
+    :card-radio-visible="false"
+    description="Choose this option if you want your APIs to be publicly accessible by anyone on the internet."
+    label="Public"
     :selected-value="true"
   />
 </div>
@@ -361,7 +383,8 @@ const cardRadio = ref<string>('')
 
 const horizontalCard = ref<string>('')
 
-const showRadio = ref<boolean | null>(null)
+const showRadioVertical = ref<boolean | null>(null)
+const showRadioHorizontal = ref<boolean | null>(null)
 
 const labelPropRadio = ref<boolean>(false)
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -171,6 +171,98 @@ const cardRadio = ref<string>('')
 </script>
 ```
 
+### cardOrientation
+
+Prop for changing card orientation. Default value is `vertical`, the alternative to which is `horizontal`.
+
+<KRadio
+  v-model="horizontalCard"
+  card
+  card-orientation="horizontal"
+  description="Choose this option if you want your APIs to only be accessible from within your private network."
+  label="Private"
+  selected-value="private"
+>
+  <KBadge appearance="success">
+    Recommended
+  </KBadge>
+</KRadio>
+<KRadio
+  v-model="horizontalCard"
+  card
+  card-orientation="horizontal"
+  description="Choose this option if you want your APIs to be publicly accessible by anyone on the internet."
+  label="Public"
+  selected-value="public"
+/>
+
+```html
+<KRadio
+  card-orientation="horizontal"
+  v-model="cardRadio"
+  description="Choose this option if you want your APIs to only be accessible from within your private network."
+  card
+  label="Private"
+  selected-value="private"
+>
+  <KBadge appearance="success">
+    Recommended
+  </KBadge>
+</KRadio>
+<KRadio
+  card-orientation="horizontal"
+  v-model="cardRadio"
+  description="Choose this option if you want your APIs to be publicly accessible by anyone on the internet."
+  card
+  label="Public"
+  selected-value="public"
+/>
+```
+
+### showCardRadio
+
+Prop to show or hide radio button in card. Default value is `true`.
+
+<div class="vertical-spacing">
+  <KRadio
+    v-model="showRadio"
+    card
+    :card-show-radio="false"
+    label="Vertical"
+    description="Vertical radio card with hidden radio button."
+    :selected-value="false"
+  />
+  <KRadio
+    v-model="showRadio"
+    card
+    card-orientation="horizontal"
+    :card-show-radio="false"
+    label="Horizontal"
+    description="Horizontal radio card with hidden radio button."
+    :selected-value="true"
+  />
+</div>
+
+```html
+<KRadio
+  :card-show-radio="false"
+  v-model="radioCard"
+  card
+  label="Vertical"
+  description="Vertical radio card with hidden radio button."
+  :selected-value="false"
+/>
+<KRadio
+  :card-show-radio="false"
+  v-model="radioCard"
+  card
+  card-orientation="horizontal"
+  label="Horizontal"
+  description="Horizontal radio card with hidden radio button."
+  :selected-value="true"
+/>
+```
+
 ## Slots
 
 ### default
@@ -190,12 +282,18 @@ Content passed in to the `default` slot will be shown as the label content. The 
   Label goes here. The radio is {{ checked ? "selected" : "not selected" }}
 </KRadio>
 ```
+
 :::warning NOTE
 To preserve a valid HTML structure, avoid slotting in block-level elements such as a `div` into the `default` slot as it will be rendered inside a `label` element. This also applies to card-style radio.
 :::
 
 :::tip TIP
-When `card` prop is true, the content passed to the `default` slot will render directly above the label. Should you want to customize the layout inside the card you can omit using the `label` and `description` props and style content passed through the `default` slot yourself.
+When `card` prop is true, the content passed to the `default` slot be will rendered:
+
+* directly above the label if [`cardOrientation` prop](#cardorientation) is `vertical`
+* to the right of label and description of `cardOrientation` prop is `horizontal`
+
+Should you want to customize the layout inside the card you can omit using the `label` and `description` props and style content passed through the `default` slot yourself.
 :::
 
 ### description
@@ -258,6 +356,10 @@ const radioValue = ref<boolean| string | object>('string')
 const defaultSlotModelValue = ref<boolean>(false)
 
 const cardRadio = ref<string>('')
+
+const horizontalCard = ref<string>('')
+
+const showRadio = ref<boolean | null>(null)
 
 const labelPropRadio = ref<boolean>(false)
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -173,7 +173,9 @@ const cardRadio = ref<string>('')
 
 ### cardOrientation
 
-Prop for changing card orientation. Default value is `vertical`, the alternative to which is `horizontal`.
+Used alongside the [`card` prop](/components/radio#card) to set the orientation of the card layout.
+
+Accepted values are `vertical` (shown above) or `horizontal`. Defaults to `vertical`.
 
 <KRadio
   v-model="horizontalCard"
@@ -293,7 +295,7 @@ When `card` prop is true, the content passed to the `default` slot be will rende
 * directly above the label if [`cardOrientation` prop](#cardorientation) is `vertical`
 * to the right of label and description of `cardOrientation` prop is `horizontal`
 
-Should you want to customize the layout inside the card you can omit using the `label` and `description` props and style content passed through the `default` slot yourself.
+Should you want to customize the layout inside the card you can omit the `label` and `description` props and style content passed through the `default` slot yourself.
 :::
 
 ### description

--- a/sandbox/pages/SandboxRadio.vue
+++ b/sandbox/pages/SandboxRadio.vue
@@ -185,6 +185,51 @@
           </KRadio>
         </div>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="cardOrientation">
+        <KRadio
+          v-model="modelValue4"
+          card
+          card-orientation="horizontal"
+          description="Lorem ipsum dolor sit amet."
+          label="Horizontal 1"
+          :selected-value="true"
+        >
+          <KBadge appearance="success">
+            Recommended
+          </KBadge>
+        </KRadio>
+        <KRadio
+          v-model="modelValue4"
+          card
+          card-orientation="horizontal"
+          description="Lorem ipsum dolor sit amet."
+          label="Horizontal 2"
+          :selected-value="false"
+        >
+          <KBadge appearance="info">
+            Default
+          </KBadge>
+        </KRadio>
+      </SandboxSectionComponent>
+      <SandboxSectionComponent title="cardShowRadio">
+        <KRadio
+          v-model="modelValue3"
+          card
+          :card-show-radio="false"
+          description="Lorem ipsum dolor sit amet."
+          label="Vertical"
+          :selected-value="false"
+        />
+        <KRadio
+          v-model="modelValue3"
+          card
+          card-orientation="horizontal"
+          :card-show-radio="false"
+          description="Lorem ipsum dolor sit amet."
+          label="Horizontal"
+          :selected-value="true"
+        />
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="labelAttributes">
         <div class="vertical-spacing">
           <KRadio
@@ -258,9 +303,11 @@ import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 import { KongIcon, LockIcon } from '@kong/icons'
 
-const modelValue0 = ref('foobar')
-const modelValue1 = ref('barfoo')
-const modelValue2 = ref('card0')
+const modelValue0 = ref<string>('foobar')
+const modelValue1 = ref<string>('barfoo')
+const modelValue2 = ref<string>('card0')
+const modelValue3 = ref<boolean>(false)
+const modelValue4 = ref<boolean>(true)
 </script>
 
 <style lang="scss" scoped>

--- a/sandbox/pages/SandboxRadio.vue
+++ b/sandbox/pages/SandboxRadio.vue
@@ -211,11 +211,11 @@
           </KBadge>
         </KRadio>
       </SandboxSectionComponent>
-      <SandboxSectionComponent title="cardShowRadio">
+      <SandboxSectionComponent title="cardRadioVisible">
         <KRadio
           v-model="modelValue3"
           card
-          :card-show-radio="false"
+          :card-radio-visible="false"
           description="Lorem ipsum dolor sit amet."
           label="Vertical"
           :selected-value="false"
@@ -224,7 +224,7 @@
           v-model="modelValue3"
           card
           card-orientation="horizontal"
-          :card-show-radio="false"
+          :card-radio-visible="false"
           description="Lorem ipsum dolor sit amet."
           label="Horizontal"
           :selected-value="true"

--- a/src/components/KRadio/KRadio.cy.ts
+++ b/src/components/KRadio/KRadio.cy.ts
@@ -72,13 +72,13 @@ describe('KRadio', () => {
     cy.get('input').should('be.visible')
   })
 
-  it('renders input element hidden when cardShowRadio prop is false', () => {
+  it('renders input element hidden when cardRadioVisible prop is false', () => {
     cy.mount(KRadio, {
       props: {
         modelValue: false,
         selectedValue: true,
         card: true,
-        cardShowRadio: false,
+        cardRadioVisible: false,
         label: 'Some label',
       },
     })

--- a/src/components/KRadio/KRadio.cy.ts
+++ b/src/components/KRadio/KRadio.cy.ts
@@ -55,10 +55,11 @@ describe('KRadio', () => {
       },
     })
 
+    cy.get('.radio-card').should('have.class', 'card-vertical')
     cy.get('.radio-card').should('contain.text', slotText)
   })
 
-  it('renders input element hidden when card prop is true', () => {
+  it('renders input element when card prop is true', () => {
     cy.mount(KRadio, {
       props: {
         modelValue: false,
@@ -68,7 +69,36 @@ describe('KRadio', () => {
       },
     })
 
+    cy.get('input').should('be.visible')
+  })
+
+  it('renders input element hidden when cardShowRadio prop is false', () => {
+    cy.mount(KRadio, {
+      props: {
+        modelValue: false,
+        selectedValue: true,
+        card: true,
+        cardShowRadio: false,
+        label: 'Some label',
+      },
+    })
+
     cy.get('input').should('not.be.visible')
+  })
+
+  it('renders card in horizontal orientation when cardOrientation prop is horizontal', () => {
+    cy.mount(KRadio, {
+      props: {
+        modelValue: false,
+        selectedValue: true,
+        card: true,
+        label: 'Some label',
+        cardOrientation: 'horizontal',
+      },
+    })
+
+    cy.get('.radio-card').should('not.have.class', 'card-vertical')
+    cy.get('.radio-card').should('have.class', 'card-horizontal')
   })
 
   it('emits checked value on click within entire label element when card prop is true', () => {

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -456,6 +456,10 @@ $kRadioDotSize: 6px;
         margin-left: var(--kui-space-70, $kui-space-70);
         margin-top: var(--kui-space-80, $kui-space-80);
       }
+
+      & + .k-radio.radio-card.card-horizontal {
+        margin-top: var(--kui-space-40, $kui-space-40);
+      }
     }
 
     &.checked.radio-card:not(.disabled) {

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -12,7 +12,7 @@
       :aria-checked="isChecked"
       :checked="isChecked"
       class="radio-input"
-      :class="{ 'hidden': !cardShowRadio }"
+      :class="{ 'hidden': card && !cardShowRadio }"
       :disabled="isDisabled"
       type="radio"
       @click="handleClick"

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -12,8 +12,9 @@
       :aria-checked="isChecked"
       :checked="isChecked"
       class="radio-input"
-      :class="{ 'hidden': card && !cardShowRadio }"
+      :class="{ 'hidden': card && !cardRadioVisible }"
       :disabled="isDisabled"
+      :tabindex="card || isDisabled || isChecked ? -1 : 0"
       type="radio"
       @click="handleClick"
     >
@@ -51,9 +52,9 @@
     <label
       v-else-if="label || $slots.default"
       class="radio-card-wrapper radio-label-wrapper"
-      :class="{ 'has-label': label, 'has-description': showCardDescription, 'show-radio': cardShowRadio }"
+      :class="{ 'has-label': label, 'has-description': showCardDescription, 'show-radio': cardRadioVisible }"
       :for="inputId"
-      :tabindex="isDisabled ? -1 : 0"
+      :tabindex="isDisabled || isChecked ? -1 : 0"
       @keydown.space.prevent
       @keyup.space="handleClick"
     >
@@ -148,7 +149,7 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  cardShowRadio: {
+  cardRadioVisible: {
     type: Boolean,
     default: true,
   },

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -213,7 +213,8 @@ const kRadioClasses = computed((): Record<string, boolean> => {
     checked: isChecked.value,
     'has-description': showDescription.value,
     'card-horizontal': props.card && props.cardOrientation === 'horizontal',
-    'card-vertical': props.card && props.cardOrientation === 'vertical',
+    // Add vertical class for `vertical` or an invalid prop value
+    'card-vertical': props.card && props.cardOrientation !== 'horizontal',
   }
 })
 </script>

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -12,6 +12,7 @@
       :aria-checked="isChecked"
       :checked="isChecked"
       class="radio-input"
+      :class="{ 'hidden': !cardShowRadio }"
       :disabled="isDisabled"
       type="radio"
       @click="handleClick"
@@ -50,7 +51,7 @@
     <label
       v-else-if="label || $slots.default"
       class="radio-card-wrapper radio-label-wrapper"
-      :class="{ 'has-label': label, 'has-description': showCardDescription }"
+      :class="{ 'has-label': label, 'has-description': showCardDescription, 'show-radio': cardShowRadio }"
       :for="inputId"
       :tabindex="isDisabled ? -1 : 0"
       @keydown.space.prevent
@@ -63,18 +64,23 @@
         <slot />
       </span>
       <span
-        v-if="label"
-        class="radio-label"
+        v-if="label || showCardDescription"
+        class="card-label-container"
       >
-        {{ label }}
-      </span>
-      <span
-        v-if="showCardDescription"
-        class="radio-description"
-      >
-        <slot name="description">
-          {{ description }}
-        </slot>
+        <span
+          v-if="label"
+          class="radio-label"
+        >
+          {{ label }}
+        </span>
+        <span
+          v-if="showCardDescription"
+          class="radio-description"
+        >
+          <slot name="description">
+            {{ description }}
+          </slot>
+        </span>
       </span>
     </label>
   </div>
@@ -142,6 +148,15 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  cardShowRadio: {
+    type: Boolean,
+    default: true,
+  },
+  cardOrientation: {
+    type: String as PropType<'horizontal' | 'vertical'>,
+    default: 'vertical',
+    validator: (value: 'horizontal' | 'vertical'): boolean => ['horizontal', 'vertical'].includes(value),
+  },
   /**
    * @deprecated in favor of `card`
    */
@@ -181,7 +196,6 @@ const handleClick = (): void => {
   emit('update:modelValue', props.selectedValue)
 }
 
-
 const modifiedAttrs = computed((): Record<string, any> => {
   const $attrs = { ...attrs }
 
@@ -198,6 +212,8 @@ const kRadioClasses = computed((): Record<string, boolean> => {
     'input-error': props.error,
     checked: isChecked.value,
     'has-description': showDescription.value,
+    'card-horizontal': props.card && props.cardOrientation === 'horizontal',
+    'card-vertical': props.card && props.cardOrientation === 'vertical',
   }
 })
 </script>
@@ -340,24 +356,17 @@ $kRadioDotSize: 6px;
 
   /* Card styles */
   &.radio-card {
+    position: relative;
     width: 100%;
 
-    .radio-input {
-      display: none;
-    }
-
     .radio-card-wrapper {
-      align-items: center;
       background-color: var(--kui-color-background, $kui-color-background);
       border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
       box-shadow: var(--kui-shadow-border, $kui-shadow-border);
       cursor: pointer;
-      display: flex;
-      flex-direction: column;
       height: 100%;
       outline: none;
       padding: var(--kui-space-70, $kui-space-70);
-      text-align: center;
       transition: box-shadow $kongponentsTransitionDurTimingFunc, background-color $kongponentsTransitionDurTimingFunc;
       width: 100%;
 
@@ -379,17 +388,73 @@ $kRadioDotSize: 6px;
         transition: color $kongponentsTransitionDurTimingFunc;
       }
 
-      &.has-label, &.has-description {
-        .card-content-wrapper {
-          height: auto;
-          margin-bottom: var(--kui-space-40, $kui-space-40);
+      .card-label-container {
+        display: flex;
+        flex-direction: column;
+
+        .radio-label {
+          @include labelDefaults;
+
+          transition: color $kongponentsTransitionDurTimingFunc;
+        }
+      }
+    }
+
+    .radio-input {
+      left: 0;
+      position: absolute;
+      top: 0;
+
+      &.hidden {
+        display: none;
+      }
+    }
+
+    &.card-vertical {
+      .radio-card-wrapper {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        text-align: center;
+
+        &.has-label, &.has-description {
+          .card-content-wrapper {
+            height: auto;
+            margin-bottom: var(--kui-space-40, $kui-space-40);
+          }
         }
       }
 
-      .radio-label {
-        @include labelDefaults;
+      .radio-input {
+        margin-left: var(--kui-space-50, $kui-space-50);
+        margin-top: var(--kui-space-50, $kui-space-50);
+      }
+    }
 
-        transition: color $kongponentsTransitionDurTimingFunc;
+    &.card-horizontal {
+      .radio-card-wrapper {
+        display: flex;
+
+        &.has-label, &.has-description {
+          &:has(.card-content-wrapper) {
+            flex-direction: row-reverse;
+            gap: var(--kui-space-50, $kui-space-50);
+            justify-content: space-between;
+          }
+
+          .card-content-wrapper {
+            align-self: center;
+          }
+        }
+
+        &.show-radio {
+          padding-left: var(--kui-space-110, $kui-space-110);
+        }
+      }
+
+      .radio-input {
+        margin-left: var(--kui-space-70, $kui-space-70);
+        margin-top: var(--kui-space-80, $kui-space-80);
       }
     }
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-13540

Adds `cardOrientation` and `showCardRadio` props

![Screenshot 2024-11-05 at 12 40 40 PM](https://github.com/user-attachments/assets/6071728d-a26c-4e17-8f89-65f4678c623c)
![Screenshot 2024-11-05 at 12 59 01 PM](https://github.com/user-attachments/assets/c24d2491-4617-4a7d-b217-9016b79cd41c)
![Screenshot 2024-11-05 at 12 41 02 PM](https://github.com/user-attachments/assets/545b1756-4ade-484c-957c-eac08b81f0e9)



<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
