### PR TITLE
fix(kradio): remove horizontal card vertical spacing

### DIFF
--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -458,10 +458,6 @@ $kRadioDotSize: 6px;
         margin-left: var(--kui-space-70, $kui-space-70);
         margin-top: var(--kui-space-80, $kui-space-80);
       }
-
-      & + .k-radio.radio-card.card-horizontal {
-        margin-top: var(--kui-space-40, $kui-space-40);
-      }
     }
 
     &.checked.radio-card:not(.disabled) {


### PR DESCRIPTION
# Summary

Remove automatic vertical spacing for horizontal KRadio card so that they can be used in both vertical and horizontal layouts

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
