### PR TITLE
fix(kalert): use proper danger icon

### DIFF
--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -50,7 +50,7 @@ import { computed } from 'vue'
 import type { PropType } from 'vue'
 import type { AlertAppearance } from '@/types'
 import { AlertAppearances } from '@/types'
-import { InfoIcon, CheckCircleIcon, WarningIcon, ClearIcon, CloseIcon } from '@kong/icons'
+import { InfoIcon, CheckCircleIcon, WarningIcon, DangerIcon, CloseIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 type AlertIcon = typeof InfoIcon // all icons are the same type so we can use any of them
@@ -92,7 +92,7 @@ const getAlertIcon = computed((): AlertIcon => {
     case AlertAppearances.warning:
       return WarningIcon
     case AlertAppearances.danger:
-      return ClearIcon
+      return DangerIcon
     default:
       return InfoIcon // info as default in case of invalid appearance
   }


### PR DESCRIPTION
# Summary

Update the KAlert `danger` appearance icon to match our design system.

![image](https://github.com/user-attachments/assets/1d68bbea-20ac-4154-b0af-7e8707daf63c)
