### PR TITLE
fix(kcodeblock): fix maxHeight and getSizeFromString util

### DIFF
--- a/src/composables/useUtilities.cy.ts
+++ b/src/composables/useUtilities.cy.ts
@@ -183,46 +183,60 @@ describe('Client-side sorting (deprecated in favor of server-side sorting)', () 
 })
 
 describe('getSizeFromString(): ', () => {
-  it('handles numbers', () => {
+  it('handles integers', () => {
     const sizeStr = '500'
     const result = getSizeFromString(sizeStr)
 
     expect(result).equal(`${sizeStr}px`)
   })
 
+  it('handles floats', () => {
+    const sizeStr = '500.500'
+    const result = getSizeFromString(sizeStr)
+
+    expect(result).equal('500.5px')
+  })
+
   it('handles auto', () => {
     const sizeStr = 'auto'
     const result = getSizeFromString(sizeStr)
 
-    expect(result).equal(`${sizeStr}`)
+    expect(result).equal(sizeStr)
   })
 
   it('handles percentages', () => {
     const sizeStr = '500%'
     const result = getSizeFromString(sizeStr)
 
-    expect(result).equal(`${sizeStr}`)
+    expect(result).equal(sizeStr)
   })
 
   it('handles vh', () => {
     const sizeStr = '500vh'
     const result = getSizeFromString(sizeStr)
 
-    expect(result).equal(`${sizeStr}`)
+    expect(result).equal(sizeStr)
   })
 
   it('handles vw', () => {
     const sizeStr = '500vw'
     const result = getSizeFromString(sizeStr)
 
-    expect(result).equal(`${sizeStr}`)
+    expect(result).equal(sizeStr)
   })
 
   it('handles px', () => {
     const sizeStr = '500px'
     const result = getSizeFromString(sizeStr)
 
-    expect(result).equal(`${sizeStr}`)
+    expect(result).equal(sizeStr)
+  })
+
+  it('handles invalid values', () => {
+    const sizeStr = 'foo'
+    const result = getSizeFromString(sizeStr)
+
+    expect(result).equal(sizeStr)
   })
 })
 

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -226,19 +226,13 @@ export default function useUtilities() {
   }
 
   /**
-   * Convert a given string to a height with units. If no units are provided, append `px`.
+   * Convert a given string to a height with units. If pure number, append `px`.
    * @param sizeStr A string that can be used for the height of an element.
    * @returns A string to be used for the height of an element.
    */
   const getSizeFromString = (sizeStr: string): string => {
-    return sizeStr === 'auto' ||
-      sizeStr.endsWith('%') ||
-      sizeStr.endsWith('vw') ||
-      sizeStr.endsWith('vh') ||
-      sizeStr.endsWith('px') ||
-      sizeStr.includes('calc(')
-      ? sizeStr
-      : sizeStr + 'px'
+    const numeric = Number(sizeStr)
+    return !Number.isNaN(numeric) ? `${numeric}px` : sizeStr
   }
 
   /**


### PR DESCRIPTION
# Summary

[KM-843](https://konghq.atlassian.net/browse/KM-843)

Fixed the implementation of `getSizeFromString` which was producing `nonepx` in `<KCodeBlock>`.

Before:

![image](https://github.com/user-attachments/assets/d537d9f4-9368-47e0-a09b-f953902168bb)

After:

![image](https://github.com/user-attachments/assets/49df91de-7373-4759-bd89-4e1438d29ab1)

[KM-843]: https://konghq.atlassian.net/browse/KM-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ