### PR TITLE
feat(kcodeblock): add highlighted line numbers prop

### DIFF
--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -98,7 +98,9 @@ Boolean to control whether to show or hide the search bar and related action but
 
 ### highlightedLineNumbers
 
-An array of the line numbers to highlight by default in the codeblock. If search is enabled, search results will override the default highlighted lines and be cleared once the search query is cleared
+An array of line numbers to initially highlight in the code block. 
+
+If search is enabled, matching results will be highlighted in place of the provided line numbers, and all highlighted lines will be cleared once the search query is cleared.
 
 <ClientOnly>
   <KCodeBlock

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -96,6 +96,28 @@ Boolean to control whether to show or hide the search bar and related action but
 />
 ```
 
+### highlightedLineNumbers
+
+An array of the line numbers to highlight by default in the codeblock.
+
+<ClientOnly>
+  <KCodeBlock
+    id="code-block-highlight"
+    :code="code"
+    language="json"
+    :highlighted-line-numbers="[2,4,6]"
+  />
+</ClientOnly>
+
+```html
+<KCodeBlock
+  id="code-block-highlight"
+  :code="code"
+  language="json"
+  :highlighted-line-numbers="[2,4,6]"
+/>
+```
+
 ### singleLine
 
 Whether the code passed into the component should be displayed on a single line. Defaults to `false`.

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -98,7 +98,7 @@ Boolean to control whether to show or hide the search bar and related action but
 
 ### highlightedLineNumbers
 
-An array of the line numbers to highlight by default in the codeblock.
+An array of the line numbers to highlight by default in the codeblock. If search is enabled, search results will override the default highlighted lines and be cleared once the search query is cleared
 
 <ClientOnly>
   <KCodeBlock

--- a/sandbox/pages/SandboxCodeBlock.vue
+++ b/sandbox/pages/SandboxCodeBlock.vue
@@ -33,6 +33,29 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent
         class="limited-width"
+        title="highlightedLineNumbers"
+      >
+        <KCodeBlock
+          id="highlighted-codeblock"
+          :code="code"
+          :highlighted-line-numbers="[2,4,6]"
+          language="json"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
+        class="limited-width"
+        title="highlightedLineNumbers & searchable"
+      >
+        <KCodeBlock
+          id="highlighted-and-searchable"
+          :code="code"
+          :highlighted-line-numbers="[2,4,6]"
+          language="json"
+          searchable
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
+        class="limited-width"
         title="singleLine"
       >
         <KCodeBlock

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -138,14 +138,14 @@ describe('KCodeBlock', () => {
   })
 
   it('shows matching results when initializing with query', () => {
-    renderComponent({ id: 'code-block', searchable: true, query: 'key', highlightedLineNumbers: [1] })
+    renderComponent({ id: 'code-block', searchable: true, query: 'key' })
 
     // should highlight 2, 3, 4
     cy.get('.line-is-match').should('have.length', 3)
   })
 
-  it('matching results when initializing with query override highlightedNumberLines', () => {
-    renderComponent({ id: 'code-block', searchable: true, query: 'key' })
+  it('matching results when initializing with query overrides highlightedNumberLines', () => {
+    renderComponent({ id: 'code-block', searchable: true, query: 'key', highlightedLineNumbers: [1] })
 
     cy.get('.line-is-match').should('have.length', 3)
   })

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -140,13 +140,13 @@ describe('KCodeBlock', () => {
   it('shows matching results when initializing with query', () => {
     renderComponent({ id: 'code-block', searchable: true, query: 'key' })
 
-    // should highlight 2, 3, 4
     cy.get('.line-is-match').should('have.length', 3)
   })
 
   it('matching results when initializing with query overrides highlightedNumberLines', () => {
     renderComponent({ id: 'code-block', searchable: true, query: 'key', highlightedLineNumbers: [1] })
 
+    // should highlight 2, 3, 4
     cy.get('.line-is-match').should('have.length', 3)
   })
 

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -76,6 +76,24 @@ describe('KCodeBlock', () => {
     }
   })
 
+  it('can highlight matching lines when initialized with highlightedLineNumbers', () => {
+    const id = 'code-block'
+    const expectedLineNumbers = [3, 4, 5]
+    renderComponent({
+      id,
+      highlightedLineNumbers: expectedLineNumbers,
+    })
+
+    cy.get('[data-testid="code-block-processing-icon"]').should('not.exist')
+
+    // Jumps to the next (i.e. first) match using F3 and checks that the highlighted line numbers are jumped to in order.
+    cy.get('.line-is-highlighted-match').should('not.exist')
+    for (const lineNumber of expectedLineNumbers) {
+      cy.get('[data-testid="k-code-block"]').trigger('keydown', { code: 'F3', bubbles: true })
+      cy.get(`.line-is-highlighted-match .line-anchor#${id}-L${lineNumber}`).should('be.visible')
+    }
+  })
+
   it('can be filtered to show only matching lines (like grep)', () => {
     renderComponent({ id: 'code-block', searchable: true })
 
@@ -120,6 +138,13 @@ describe('KCodeBlock', () => {
   })
 
   it('shows matching results when initializing with query', () => {
+    renderComponent({ id: 'code-block', searchable: true, query: 'key', highlightedLineNumbers: [1] })
+
+    // should highlight 2, 3, 4
+    cy.get('.line-is-match').should('have.length', 3)
+  })
+
+  it('matching results when initializing with query override highlightedNumberLines', () => {
     renderComponent({ id: 'code-block', searchable: true, query: 'key' })
 
     cy.get('.line-is-match').should('have.length', 3)

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -291,6 +291,15 @@ const props = defineProps({
   },
 
   /**
+   * The line numbers for the lines to highlight by default. **Default: `[]`**.
+   */
+  highlightedLineNumbers: {
+    type: Array as PropType<number[]>,
+    required: false,
+    default: () => [],
+  },
+
+  /**
    * Allows controlling the processing state from outside the component. This allows a parent component to show the processing icon when it’s, for example, currently syntax highlighting the code. **Default: `false`**.
    */
   processing: {
@@ -445,6 +454,10 @@ watch(() => isRegExpMode.value, function() {
   updateMatchingLineNumbers()
 })
 
+watch(() => props.highlightedLineNumbers, function() {
+  setDefaultMatchingLineNumbers()
+})
+
 watch(() => isShowingFilteredCode.value, async function() {
   // Moves the focus to the code block so that code block-scoped shortcuts still work. That’s necessary because toggling filter mode changes which pre element is rendered. In doing so, the currently focused element is removed from the DOM and in response, the browser moves the focus to document.body.
   if (document?.activeElement?.tagName === 'PRE') {
@@ -528,7 +541,12 @@ onMounted(function() {
   shortcutManager.registerListener()
 
   emitCodeBlockRenderEvent()
-  updateMatchingLineNumbers()
+
+  if (props.highlightedLineNumbers.length > 0) {
+    setDefaultMatchingLineNumbers()
+  } else {
+    updateMatchingLineNumbers()
+  }
 })
 
 onBeforeUnmount(function() {
@@ -575,6 +593,18 @@ function handleSearch(): void {
 function handleSearchInputValue(): void {
   emit('query-change', searchQuery.value)
   updateMatchingLineNumbers()
+}
+
+function setDefaultMatchingLineNumbers(): void {
+  isProcessingInternally.value = true
+  regExpError.value = null
+
+  matchingLineNumbers.value = Array.from(new Set(props.highlightedLineNumbers))
+  numberOfMatches.value = matchingLineNumbers.value.length
+
+  emitMatchingLinesChangeEvent()
+
+  isProcessingInternally.value = false
 }
 
 function updateMatchingLineNumbers(): void {

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -456,7 +456,7 @@ watch(() => isRegExpMode.value, function() {
 
 watch(() => props.highlightedLineNumbers, function() {
   setDefaultMatchingLineNumbers()
-})
+}, { deep: true })
 
 watch(() => isShowingFilteredCode.value, async function() {
   // Moves the focus to the code block so that code block-scoped shortcuts still work. That’s necessary because toggling filter mode changes which pre element is rendered. In doing so, the currently focused element is removed from the DOM and in response, the browser moves the focus to document.body.

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -542,7 +542,7 @@ onMounted(function() {
 
   emitCodeBlockRenderEvent()
 
-  if (props.highlightedLineNumbers.length > 0) {
+  if (!props.query && props.highlightedLineNumbers.length) {
     setDefaultMatchingLineNumbers()
   } else {
     updateMatchingLineNumbers()


### PR DESCRIPTION
# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
Add new `highlightedLineNumbers` prop to manually set highlighting without requiring search.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/c5257b55-a36b-4c8e-866e-c2b0f8b9fcbf" />

