### PR TITLE
feat(kcodeblock): support line highlight syntax

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,9 @@
   "[vue]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
   "markdownlint.ignore": [
     "docs/**/*.md"
   ],

--- a/docs/components/codeblock.md
+++ b/docs/components/codeblock.md
@@ -98,7 +98,10 @@ Boolean to control whether to show or hide the search bar and related action but
 
 ### highlightedLineNumbers
 
-An array of line numbers to initially highlight in the code block. 
+An string or array specifying the line numbers to initially highlight in the code block.
+
+- String: Use a comma-separated list of line numbers or ranges, e.g., `"2,4,6"` or `"2,4,6-12"`. This syntax is commonly supported in Markdown code block extensions.
+- Array: Provide an array of line numbers or ranges, e.g., `[2, 4, 6]` or `[2, 4, [6, 12]]`.
 
 If search is enabled, matching results will be highlighted in place of the provided line numbers, and all highlighted lines will be cleared once the search query is cleared.
 
@@ -107,7 +110,7 @@ If search is enabled, matching results will be highlighted in place of the provi
     id="code-block-highlight"
     :code="code"
     language="json"
-    :highlighted-line-numbers="[2,4,6]"
+    highlighted-line-numbers="2,4,6-12"
   />
 </ClientOnly>
 
@@ -116,7 +119,7 @@ If search is enabled, matching results will be highlighted in place of the provi
   id="code-block-highlight"
   :code="code"
   language="json"
-  :highlighted-line-numbers="[2,4,6]"
+  highlighted-line-numbers="2,4,6-12"
 />
 ```
 

--- a/sandbox/pages/SandboxCodeBlock.vue
+++ b/sandbox/pages/SandboxCodeBlock.vue
@@ -56,6 +56,17 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent
         class="limited-width"
+        title="highlightedLineNumbers expression"
+      >
+        <KCodeBlock
+          id="highlighted-expression"
+          :code="code"
+          highlighted-line-numbers="2,4,6-12,17-19"
+          language="json"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
+        class="limited-width"
         title="singleLine"
       >
         <KCodeBlock

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -7,6 +7,39 @@ const code = `{
   "key3": [1, 2, 3]
 }`
 
+const longCode = `{
+  "key1": "string value",
+  "key2": 5681,
+  "key3": [1, 2, 3],
+  "key4": "string value",
+  "key5": 5681,
+  "key6": [1, 2, 3],
+  "key7": "string value",
+  "key8": 5681,
+  "key9": [1, 2, 3],
+  "key10": "string value",
+  "key11": 5681,
+  "key12": [1, 2, 3],
+  "key13": "string value",
+  "key14": 5681,
+  "key15": [1, 2, 3],
+  "key16": "string value",
+  "key17": 5681,
+  "key18": [1, 2, 3],
+  "key19": "string value",
+  "key20": 5681,
+  "key21": [1, 2, 3],
+  "key22": "string value",
+  "key23": 5681,
+  "key24": [1, 2, 3],
+  "key25": "string value",
+  "key26": 5681,
+  "key27": [1, 2, 3],
+  "key28": "string value",
+  "key29": 5681,
+  "key30": [1, 2, 3]
+}`
+
 function renderComponent(props = {}) {
   return cy.mount(KCodeBlock, {
     props: {
@@ -91,6 +124,35 @@ describe('KCodeBlock', () => {
     for (const lineNumber of expectedLineNumbers) {
       cy.get('[data-testid="k-code-block"]').trigger('keydown', { code: 'F3', bubbles: true })
       cy.get(`.line-is-highlighted-match .line-anchor#${id}-L${lineNumber}`).should('be.visible')
+    }
+  })
+
+  it('can highlight matching lines when initialized with highlightedLineNumbers in range expressions', () => {
+    const id = 'code-block'
+    const expectedLineNumbers = [1, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 30, 31, 32]
+    renderComponent({
+      id,
+      code: longCode,
+      highlightedLineNumbers: '10-3,4,6,12,1,13-13,30-34',
+    })
+
+    for (const lineNumber of expectedLineNumbers) {
+      console.log(lineNumber)
+      cy.get('.line').eq(lineNumber - 1).should('have.class', 'line-is-match')
+    }
+  })
+
+  it('can highlight matching lines when initialized with highlightedLineNumbers in range expressions', () => {
+    const id = 'code-block'
+    const expectedLineNumbers = [1, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 30, 31, 32]
+    renderComponent({
+      id,
+      code: longCode,
+      highlightedLineNumbers: [[10, 3], 4, 6, 12, 1, [13, 13], [30, 34]],
+    })
+
+    for (const lineNumber of expectedLineNumbers) {
+      cy.get('.line').eq(lineNumber - 1).should('have.class', 'line-is-match')
     }
   })
 

--- a/src/components/KCodeBlock/KCodeBlock.cy.ts
+++ b/src/components/KCodeBlock/KCodeBlock.cy.ts
@@ -137,7 +137,6 @@ describe('KCodeBlock', () => {
     })
 
     for (const lineNumber of expectedLineNumbers) {
-      console.log(lineNumber)
       cy.get('.line').eq(lineNumber - 1).should('have.class', 'line-is-match')
     }
   })

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -179,7 +179,7 @@
             :key="line"
             class="line"
             :class="{
-              'line-is-match': matchingLineNumbers.includes(line),
+              'line-is-match': matchingLineSet.has(line),
               'line-is-highlighted-match': currentLineIndex !== null && line === matchingLineNumbers[currentLineIndex],
             }"
           >
@@ -425,6 +425,7 @@ const numberOfMatches = ref<number>(0)
 const matchingLineNumbers = ref<number[]>([])
 const currentLineIndex = ref<null | number>(null)
 
+const matchingLineSet = computed(() => new Set(matchingLineNumbers.value))
 const totalLines = computed((): number[] => Array.from({ length: props.code?.split('\n').length }, (_, index) => index + 1))
 const maxLineNumberWidth = computed((): string => totalLines.value[totalLines.value?.length - 1]?.toString().length + 'ch')
 const linePrefix = computed((): string => props.id.toLowerCase().replace(/\s+/g, '-'))
@@ -436,7 +437,7 @@ const filteredCode = computed((): string => {
   }
 
   return props.code?.split('\n')
-    .filter((_line, index) => matchingLineNumbers.value.includes(index + 1))
+    .filter((_line, index) => matchingLineSet.value.has(index + 1))
     .map((line) => {
       try {
         const regExp = new RegExp(searchQuery.value, 'gi')

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -232,12 +232,12 @@ import { CopyIcon, SearchIcon, ProgressIcon, CloseIcon, RegexIcon, FilterIcon, A
 import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_NEUTRAL_STRONG, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import KCodeBlockIconButton from './KCodeBlockIconButton.vue'
 
+const { getSizeFromString } = useUtilities()
+
 const IS_MAYBE_MAC = typeof navigator !== 'undefined' &&
   ('userAgentData' in navigator && navigator.userAgentData === 'macOS' ||
     navigator.platform.toLowerCase().includes('mac'))
 const ALT_SHORTCUT_LABEL = IS_MAYBE_MAC ? 'Option' : 'Alt'
-
-const { getSizeFromString } = useUtilities()
 
 // Debounces the search handler which ensures that we don’t trigger several searches while the user is still typing.
 const debouncedHandleSearchInputValue = debounce(handleSearchInputValue, 150)

--- a/src/utilities/lineHighlighting.cy.ts
+++ b/src/utilities/lineHighlighting.cy.ts
@@ -1,0 +1,25 @@
+import { normalizeHighlightedLines } from './lineHighlighting'
+
+describe('normalizeHighlightedLines', () => {
+  it('converts string expression to lines', () => {
+    expect(normalizeHighlightedLines('1,2,4-6', 10)).eql([1, 2, 4, 5, 6])
+    expect(normalizeHighlightedLines('15', 10)).eql([])
+    expect(normalizeHighlightedLines('7,5-9,10-9,12,0,3,1', 11)).eql([1, 3, 5, 6, 7, 8, 9, 10])
+    expect(normalizeHighlightedLines('1,2,3', 0)).eql([])
+    expect(normalizeHighlightedLines('1,1,3-3,5-6,5-6', 10)).eql([1, 3, 5, 6])
+  })
+
+  it('normalizes ranges to lines', () => {
+    expect(normalizeHighlightedLines([1, 2, [4, 6]], 10)).eql([1, 2, 4, 5, 6])
+    expect(normalizeHighlightedLines([15], 10)).eql([])
+    expect(normalizeHighlightedLines([7, [5, 9], [10, 9], 12, 0, 3, 1], 11)).eql([1, 3, 5, 6, 7, 8, 9, 10])
+    expect(normalizeHighlightedLines([1, 2, 3], 0)).eql([])
+    expect(normalizeHighlightedLines([1, 1, [3, 3], [5, 6], [5, 6]], 10)).eql([1, 3, 5, 6])
+  })
+
+  it('throws error for invalid expression', () => {
+    expect(() => normalizeHighlightedLines('', 10)).to.throw('Invalid line number expression.')
+    expect(() => normalizeHighlightedLines('foo', 10)).to.throw('Invalid line number expression.')
+    expect(() => normalizeHighlightedLines('1,2,4-6,-5', 10)).to.throw('Invalid line number expression.')
+  })
+})

--- a/src/utilities/lineHighlighting.ts
+++ b/src/utilities/lineHighlighting.ts
@@ -1,0 +1,43 @@
+export const LINE_NUMBER_EXPRESSION_REGEX = /^\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$/
+
+// '1,2,4-6' -> [1, 2, 4, 5, 6]
+function expressionToLines(expression: string, maxLines: number): number[] {
+  if (!LINE_NUMBER_EXPRESSION_REGEX.test(expression)) {
+    throw new Error('Invalid line number expression.')
+  }
+
+  const ranges = expression.split(',').map((part) => {
+    const [start, end] = part.split('-').map(Number)
+    // If there's no end, it's a single line, otherwise it's a range
+    return end == null ? start : [start, end] as [number, number]
+  })
+
+  return rangesToLines(ranges, maxLines)
+}
+
+// [1, 2, [4, 6]] -> [1, 2, 4, 5, 6]
+function rangesToLines(ranges: (number | [number, number])[], maxLines: number): number[] {
+  const lines = ranges.flatMap((range) => {
+    if (typeof range === 'number') {
+      return range < 1 || range > maxLines ? [] : range
+    }
+
+    // Ensure start is less than end
+    let [start, end] = range[0] < range[1] ? range : [range[1], range[0]]
+
+    // Ensure start and end are within bounds
+    start = Math.max(1, start)
+    end = Math.min(maxLines, end)
+
+    return Array.from({ length: end - start + 1 }, (_, i) => i + start)
+  }).sort((a, b) => a - b)
+
+  // Ensure no duplicates
+  return Array.from(new Set(lines))
+}
+
+export function normalizeHighlightedLines(lines: string | (number | [number, number])[], maxLines: number): number[] {
+  return typeof lines === 'string'
+    ? expressionToLines(lines, maxLines)
+    : rangesToLines(lines, maxLines)
+}


### PR DESCRIPTION
# Summary

[KM-886](https://konghq.atlassian.net/browse/KM-886)
[KHCP-14552](https://konghq.atlassian.net/browse/KHCP-14552)

This PR:

1. Introduces support for line highlighting syntax (e.g., `"2,4,6-12"`) for the `<KCodeBlock>` component’s `highlighted-line-numbers` prop. I recommend using this approach over arrays, as primitive values are less likely to trigger unnecessary re-renders. This is particularly advantageous compared to binding array literals like `:highlighted-line-numbers="[2, 4, 6]"`.

2. Improves the line navigation behavior to prevent scrolling each time the “Next match” or “Previous match” button is clicked, which reduce the pain for consecutive clicks.

3. Enhances line matching performance, particularly when dealing with multiple matches for a lengthy section of code.

[KM-886]: https://konghq.atlassian.net/browse/KM-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KHCP-14552]: https://konghq.atlassian.net/browse/KHCP-14552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ