### PR TITLE
fix(kmultiselect): select jump glitch [KHCP-14366]

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -579,7 +579,7 @@ const modifiedAttrs = computed(() => {
   return $attrs
 })
 
-const createKPopAttributes = computed(() => {
+const createKPopAttributes = computed((): Record<string, any> => {
   return {
     ...defaultKPopAttributes,
     ...props.kpopAttributes,
@@ -1135,6 +1135,7 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
     gap: var(--kui-space-40, $kui-space-40);
     margin-bottom: $kMultiselectInputPaddingY;
     margin-top: $kMultiselectInputPaddingY;
+    min-height: 24px; // minimum height to prevent jumping when badges are removed or added
     padding-left: $kMultiselectInputPaddingX;
     padding-right: $kMultiselectSelectionsPaddingRight;
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-14366

Add `min-height: 24px;` on selected badges element to prevent it from jumping once the first item is selected

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
