### PR TITLE
fix(kselect, kmultiselect): filtered arrow navigation [KHCP-13956]

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -177,10 +177,12 @@
                   @update:model-value="onQueryChange"
                 />
               </div>
-              <div aria-live="polite">
+              <div
+                ref="kMultiselectItemsContainer"
+                aria-live="polite"
+                class="multiselect-items-container"
+              >
                 <KMultiselectItems
-                  :key="kMultiselectItemsKey"
-                  ref="kMultiselectItems"
                   :items="sortedItems"
                   @selected="handleItemSelect"
                 >
@@ -467,8 +469,7 @@ const emit = defineEmits<{
   (e: 'item-removed', value: MultiselectItem): void
 }>()
 
-const kMultiselectItems = ref<InstanceType<typeof KMultiselectItems> | null>(null)
-const kMultiselectItemsKey = ref<number>(0)
+const kMultiselectItemsContainer = ref<HTMLDivElement | null>(null)
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
@@ -911,7 +912,7 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp')) {
-    kMultiselectItems.value?.setFocus()
+    setArrowNavigationFocus()
   }
 }
 
@@ -921,7 +922,14 @@ const onTriggerKeypress = () => {
 
 const onDropdownInputKeyup = (event: any) => {
   if ((event.code === 'ArrowDown' || event.code === 'ArrowUp')) {
-    kMultiselectItems.value?.setFocus()
+    setArrowNavigationFocus()
+  }
+}
+
+const setArrowNavigationFocus = (): void => {
+  const firstSelectableItemButtonElement = kMultiselectItemsContainer.value?.querySelectorAll('.multiselect-item button:not([disabled])')[0] as HTMLButtonElement
+  if (firstSelectableItemButtonElement) {
+    firstSelectableItemButtonElement.focus()
   }
 }
 
@@ -987,10 +995,6 @@ watch(key, async () => {
 watch(filteredItems, () => {
   sortItems()
 })
-
-watch(sortedItems, () => {
-  kMultiselectItemsKey.value++
-}, { deep: true })
 
 // watch for programmatic changes to model
 watch(value, (newVal, oldVal) => {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -179,6 +179,7 @@
               </div>
               <div aria-live="polite">
                 <KMultiselectItems
+                  :key="kMultiselectItemsKey"
                   ref="kMultiselectItems"
                   :items="sortedItems"
                   @selected="handleItemSelect"
@@ -467,6 +468,7 @@ const emit = defineEmits<{
 }>()
 
 const kMultiselectItems = ref<InstanceType<typeof KMultiselectItems> | null>(null)
+const kMultiselectItemsKey = ref<number>(0)
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
@@ -985,6 +987,10 @@ watch(key, async () => {
 watch(filteredItems, () => {
   sortItems()
 })
+
+watch(sortedItems, () => {
+  kMultiselectItemsKey.value++
+}, { deep: true })
 
 // watch for programmatic changes to model
 watch(value, (newVal, oldVal) => {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -177,46 +177,30 @@
                   @update:model-value="onQueryChange"
                 />
               </div>
-              <div
-                ref="kMultiselectItemsContainer"
-                aria-live="polite"
-                class="multiselect-items-container"
+              <KMultiselectItems
+                ref="kMultiselectItems"
+                :filter-string="filterString"
+                :item-creation-enabled="enableItemCreation && uniqueFilterStr"
+                :item-creation-valid="itemCreationValidator(filterString)"
+                :items="sortedItems"
+                @add-item="handleAddItem"
+                @selected="handleItemSelect"
               >
-                <KMultiselectItems
-                  :items="sortedItems"
-                  @selected="handleItemSelect"
-                >
-                  <template #content="{ item }">
-                    <slot
-                      class="multiselect-item"
-                      :item="item"
-                      name="item-template"
-                    />
-                  </template>
-                </KMultiselectItems>
-                <KMultiselectItem
-                  v-if="enableItemCreation && uniqueFilterStr && !$slots.empty"
-                  key="multiselect-add-item"
-                  class="multiselect-add-item"
-                  data-testid="multiselect-add-item"
-                  :item="{ label: `${filterString} (Add new value)`, value: 'add_item', disabled: !itemCreationValidator(filterString) }"
-                  @selected="handleAddItem"
-                >
-                  <template #content>
-                    <div class="select-item-description">
-                      {{ filterString }}
-                      <span class="select-item-new-indicator">(Add new value)</span>
-                    </div>
-                  </template>
-                </KMultiselectItem>
-                <KMultiselectItem
-                  v-if="!sortedItems.length && !$slots.empty && !enableItemCreation"
-                  key="multiselect-empty-item"
-                  class="multiselect-empty-item"
-                  data-testid="multiselect-empty-item"
-                  :item="{ label: 'No results', value: 'no_results', disabled: true }"
-                />
-              </div>
+                <template #content="{ item }">
+                  <slot
+                    class="multiselect-item"
+                    :item="item"
+                    name="item-template"
+                  />
+                </template>
+              </KMultiselectItems>
+              <KMultiselectItem
+                v-if="!sortedItems.length && !$slots.empty && !enableItemCreation"
+                key="multiselect-empty-item"
+                class="multiselect-empty-item"
+                data-testid="multiselect-empty-item"
+                :item="{ label: 'No results', value: 'no_results', disabled: true }"
+              />
               <div
                 v-if="$slots.empty && !loading && !sortedItems.length"
                 class="multiselect-empty"
@@ -469,7 +453,7 @@ const emit = defineEmits<{
   (e: 'item-removed', value: MultiselectItem): void
 }>()
 
-const kMultiselectItemsContainer = ref<HTMLDivElement | null>(null)
+const kMultiselectItems = ref<InstanceType<typeof KMultiselectItems> | null>(null)
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
@@ -912,7 +896,7 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp')) {
-    setArrowNavigationFocus()
+    kMultiselectItems.value?.setFocus()
   }
 }
 
@@ -922,14 +906,7 @@ const onTriggerKeypress = () => {
 
 const onDropdownInputKeyup = (event: any) => {
   if ((event.code === 'ArrowDown' || event.code === 'ArrowUp')) {
-    setArrowNavigationFocus()
-  }
-}
-
-const setArrowNavigationFocus = (): void => {
-  const firstSelectableItemButtonElement = kMultiselectItemsContainer.value?.querySelectorAll('.multiselect-item button:not([disabled])')[0] as HTMLButtonElement
-  if (firstSelectableItemButtonElement) {
-    firstSelectableItemButtonElement.focus()
+    kMultiselectItems.value?.setFocus()
   }
 }
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -44,7 +44,6 @@
           >
             <div v-if="collapsedContext">
               <KInput
-                ref="multiselectInputElement"
                 autocapitalize="off"
                 autocomplete="off"
                 class="multiselect-input"
@@ -272,7 +271,7 @@
 
 <script lang="ts">
 import type { Ref, PropType } from 'vue'
-import { ref, computed, watch, nextTick, onMounted, onUnmounted, useAttrs, useSlots, useId } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onUnmounted, useAttrs, useSlots, useId, useTemplateRef } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import KBadge from '@/components/KBadge/KBadge.vue'
 import KInput from '@/components/KInput/KInput.vue'
@@ -453,7 +452,7 @@ const emit = defineEmits<{
   (e: 'item-removed', value: MultiselectItem): void
 }>()
 
-const kMultiselectItems = ref<InstanceType<typeof KMultiselectItems> | null>(null)
+const multiselectItemsRef = useTemplateRef('kMultiselectItems')
 
 const isRequired = computed((): boolean => attrs.required !== undefined && String(attrs.required) !== 'false')
 const strippedLabel = computed((): string => stripRequiredLabel(props.label, isRequired.value))
@@ -486,10 +485,9 @@ const defaultId = useId()
 const multiselectWrapperId = computed((): string => attrs.id ? String(attrs.id) : defaultId) // unique id for the KLabel `for` attribute
 const multiselectKey = useId()
 
-const multiselectElement = ref<HTMLDivElement | null>(null)
-const multiselectInputElement = ref<InstanceType<typeof KInput> | null>(null)
-const multiselectDropdownInputElement = ref<InstanceType<typeof KInput> | null>(null)
-const multiselectSelectionsStagingElement = ref<HTMLDivElement>()
+const multiselectElementRef = useTemplateRef('multiselectElement')
+const multiselectDropdownInputElementRef = useTemplateRef('multiselectDropdownInputElement')
+const multiselectSelectionsStagingElementRef = useTemplateRef('multiselectSelectionsStagingElement')
 
 // filter and selection
 const selectionsMaxHeight = computed((): number => {
@@ -644,7 +642,7 @@ const handleToggle = async (open: boolean, isToggled: Ref<boolean>, toggle: () =
 
       await nextTick() // wait for the dropdown to open
 
-      const input = multiselectDropdownInputElement.value?.$el?.querySelector('input') as HTMLInputElement
+      const input = multiselectDropdownInputElementRef.value?.$el?.querySelector('input') as HTMLInputElement
       input?.focus({ preventScroll: true })
     }
   } else {
@@ -660,7 +658,7 @@ const handleToggle = async (open: boolean, isToggled: Ref<boolean>, toggle: () =
 const stageSelections = () => {
   // set timeout required to push the calculation to the end of the update lifecycle event queue
   setTimeout(() => {
-    const elem = multiselectSelectionsStagingElement.value
+    const elem = multiselectSelectionsStagingElementRef.value
 
     if (props.collapsedContext) {
       // if it's collapsed don't do calculations, because we don't display badges
@@ -896,7 +894,7 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp')) {
-    kMultiselectItems.value?.setFocus()
+    multiselectItemsRef.value?.setFocus()
   }
 }
 
@@ -906,7 +904,7 @@ const onTriggerKeypress = () => {
 
 const onDropdownInputKeyup = (event: any) => {
   if ((event.code === 'ArrowDown' || event.code === 'ArrowUp')) {
-    kMultiselectItems.value?.setFocus()
+    multiselectItemsRef.value?.setFocus()
   }
 }
 
@@ -927,7 +925,7 @@ const triggerInitialFocus = (): void => {
 watch(stagingKey, () => {
   // set timeout required to push the calculation to the end of the update lifecycle event queue
   setTimeout(() => {
-    const elem = multiselectSelectionsStagingElement.value
+    const elem = multiselectSelectionsStagingElementRef.value
 
     if (props.collapsedContext) {
       // if collapsed, don't do all the calculations because we are not displaying badges
@@ -1049,7 +1047,7 @@ const numericWidth = ref<number>(300)
 const setNumericWidth = async (): Promise<void> => {
   numericWidth.value = 300
   await nextTick()
-  numericWidth.value = multiselectElement.value?.clientWidth || 300
+  numericWidth.value = multiselectElementRef.value?.clientWidth || 300
   stageSelections()
 }
 
@@ -1059,12 +1057,12 @@ onMounted(() => {
   useEventListener('resize', setNumericWidth) // automatically removes listener on unmount so no need to clean up
   resizeObserver.value = ResizeObserverHelper.create(setNumericWidth)
 
-  resizeObserver.value.observe(multiselectElement.value as HTMLDivElement)
+  resizeObserver.value.observe(multiselectElementRef.value as HTMLDivElement)
 })
 
 onUnmounted(() => {
-  if (resizeObserver.value && multiselectElement.value) {
-    resizeObserver.value.unobserve(multiselectElement.value)
+  if (resizeObserver.value && multiselectElementRef.value) {
+    resizeObserver.value.unobserve(multiselectElementRef.value)
   }
 })
 </script>

--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -64,7 +64,7 @@
 
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { computed, ref } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import KMultiselectItem from '@/components/KMultiselect/KMultiselectItem.vue'
 import type { MultiselectItem } from '@/types'
 
@@ -101,17 +101,17 @@ const groups = computed((): string[] => [...new Set((props.items?.filter(item =>
 
 const getGroupItems = (group: string) => props.items?.filter(item => item.group === group)
 
-const itemsContainer = ref<HTMLDivElement | null>(null)
+const itemsContainerRef = useTemplateRef('itemsContainer')
 
 const setItemFocus = (): void => {
-  const firstSelectableItem = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not([disabled])')[0]
+  const firstSelectableItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.multiselect-item button:not(:disabled)')
   firstSelectableItem?.focus()
 }
 
 const onKeyPress = ({ target, key } : KeyboardEvent) => {
   if (key === 'ArrowDown' || key === 'ArrowUp') {
     // all selectable items
-    const selectableItems = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not([disabled])')
+    const selectableItems = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not(:disabled)')
 
     if (selectableItems?.length) {
       // find the current element index in the array

--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -72,7 +72,7 @@ const getGroupItems = (group: string) => props.items?.filter(item => item.group 
 const setFocus = (index: number = 0) => {
   if (kMultiselectItem.value) {
     if (!props.items[index].disabled) {
-      kMultiselectItem.value[index]?.$el?.querySelector('button').focus()
+      kMultiselectItem.value[index]?.$el?.querySelector('button')?.focus()
     } else {
       setFocus(index + 1)
     }

--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -8,7 +8,7 @@
       v-for="item, idx in nonGroupedItems"
       :key="`${item.key ? item.key : idx}-item`"
       :item="item"
-      @keydown="arrowKeyNavigation"
+      @keydown="onKeyPress"
       @selected="handleItemSelect"
     >
       <template #content>
@@ -31,7 +31,7 @@
         v-for="(item, idx) in getGroupItems(group)"
         :key="`${item.key ? item.key : group + '-' + idx + '-item'}`"
         :item="item"
-        @keydown="arrowKeyNavigation"
+        @keydown="onKeyPress"
         @selected="handleItemSelect"
       >
         <template #content>
@@ -49,7 +49,7 @@
       class="multiselect-add-item"
       data-testid="multiselect-add-item"
       :item="{ label: `${filterString} (Add new value)`, value: 'add_item', disabled: !itemCreationValid }"
-      @keydown="arrowKeyNavigation"
+      @keydown="onKeyPress"
       @selected="$emit('add-item')"
     >
       <template #content>
@@ -89,7 +89,10 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['selected', 'add-item'])
+const emit = defineEmits<{
+  (e: 'selected', item: MultiselectItem): void
+  (e: 'add-item'): void
+}>()
 
 const handleItemSelect = (item: MultiselectItem) => emit('selected', item)
 
@@ -101,13 +104,11 @@ const getGroupItems = (group: string) => props.items?.filter(item => item.group 
 const itemsContainer = ref<HTMLDivElement | null>(null)
 
 const setItemFocus = (): void => {
-  const firstSelectableItemButtonElement = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not([disabled])')[0]
-  if (firstSelectableItemButtonElement) {
-    firstSelectableItemButtonElement.focus()
-  }
+  const firstSelectableItem = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not([disabled])')[0]
+  firstSelectableItem?.focus()
 }
 
-const arrowKeyNavigation = ({ target, key } : KeyboardEvent) => {
+const onKeyPress = ({ target, key } : KeyboardEvent) => {
   if (key === 'ArrowDown' || key === 'ArrowUp') {
     // all selectable items
     const selectableItems = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not([disabled])')

--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -67,11 +67,15 @@ const onKeyDown = (event: Event) => {
   const { target, key } = event as KeyboardEvent
 
   if (key === 'ArrowDown' || key === 'ArrowUp') {
+    // find the items container element
     const kSelectItemsContainer = (target as HTMLElement).closest('.multiselect-items-container')
+    // all selectable items
     const selectableItemsElements = kSelectItemsContainer?.querySelectorAll('.multiselect-item button:not([disabled])')
 
     if (selectableItemsElements?.length) {
+      // find the current element index in the array
       const currentElementIndex = Array.from(selectableItemsElements).findIndex(el => el === target)
+      // move to the next or previous element
       const nextElementIndex = key === 'ArrowDown' ? currentElementIndex + 1 : currentElementIndex - 1
       const nextElement = selectableItemsElements[nextElementIndex] as HTMLButtonElement
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -132,6 +132,7 @@
               data-propagate-clicks="false"
             >
               <KSelectItems
+                :key="kSelectItemsKey"
                 ref="kSelectItems"
                 :items="filteredItems"
                 @selected="handleItemSelect"
@@ -562,6 +563,7 @@ const clearSelection = (): void => {
 }
 
 const kSelectItems = ref<InstanceType<typeof KSelectItems> | null>(null)
+const kSelectItemsKey = ref<number>(0)
 
 const triggerFocus = (evt: any, isToggled: Ref<boolean>): void => {
   // Ignore `esc` key
@@ -720,6 +722,10 @@ watch(filterQuery, (query: string) => {
   emit('query-change', query)
   skipQueryChangeEmit.value = false
 })
+
+watch(filteredItems, () => {
+  kSelectItemsKey.value++
+}, { deep: true })
 
 watch(selectedItem, (newVal, oldVal) => {
   if (newVal && newVal !== oldVal) {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -128,12 +128,11 @@
             </div>
             <div
               v-else
+              ref="kSelectItemsContainer"
               class="select-items-container"
               data-propagate-clicks="false"
             >
               <KSelectItems
-                :key="kSelectItemsKey"
-                ref="kSelectItems"
                 :items="filteredItems"
                 @selected="handleItemSelect"
               >
@@ -562,8 +561,7 @@ const clearSelection = (): void => {
   emit('update:modelValue', null)
 }
 
-const kSelectItems = ref<InstanceType<typeof KSelectItems> | null>(null)
-const kSelectItemsKey = ref<number>(0)
+const kSelectItemsContainer = ref<HTMLDivElement | null>(null)
 
 const triggerFocus = (evt: any, isToggled: Ref<boolean>): void => {
   // Ignore `esc` key
@@ -578,7 +576,10 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>): void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp') && isToggled.value) {
-    kSelectItems.value?.setFocus()
+    const firstSelectableItemButtonElement = kSelectItemsContainer.value?.querySelectorAll('.select-item button:not([disabled])')[0] as HTMLButtonElement
+    if (firstSelectableItemButtonElement) {
+      firstSelectableItemButtonElement.focus()
+    }
   }
 }
 
@@ -723,10 +724,6 @@ watch(filterQuery, (query: string) => {
   skipQueryChangeEmit.value = false
 })
 
-watch(filteredItems, () => {
-  kSelectItemsKey.value++
-}, { deep: true })
-
 watch(selectedItem, (newVal, oldVal) => {
   if (newVal && newVal !== oldVal) {
     emit('selected', newVal)
@@ -751,7 +748,11 @@ onMounted(() => {
     if (!props.enableFiltering && document.activeElement?.tagName === 'BODY' && !inputFocused.value && isDropdownOpen.value) {
       if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
         event.preventDefault()
-        kSelectItems.value?.setFocus()
+
+        const firstSelectableItemButtonElement = kSelectItemsContainer.value?.querySelectorAll('.select-item button:not([disabled])')[0] as HTMLButtonElement
+        if (firstSelectableItemButtonElement) {
+          firstSelectableItemButtonElement.focus()
+        }
       }
     }
   })

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -576,10 +576,14 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>): void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp') && isToggled.value) {
-    const firstSelectableItemButtonElement = kSelectItemsContainer.value?.querySelectorAll('.select-item button:not([disabled])')[0] as HTMLButtonElement
-    if (firstSelectableItemButtonElement) {
-      firstSelectableItemButtonElement.focus()
-    }
+    setArrowNavigationFocus()
+  }
+}
+
+const setArrowNavigationFocus = (): void => {
+  const firstSelectableItemButtonElement = kSelectItemsContainer.value?.querySelectorAll('.select-item button:not([disabled])')[0] as HTMLButtonElement
+  if (firstSelectableItemButtonElement) {
+    firstSelectableItemButtonElement.focus()
   }
 }
 
@@ -749,10 +753,7 @@ onMounted(() => {
       if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
         event.preventDefault()
 
-        const firstSelectableItemButtonElement = kSelectItemsContainer.value?.querySelectorAll('.select-item button:not([disabled])')[0] as HTMLButtonElement
-        if (firstSelectableItemButtonElement) {
-          firstSelectableItemButtonElement.focus()
-        }
+        setArrowNavigationFocus()
       }
     }
   })

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -73,11 +73,15 @@ const onKeyDown = (event: Event) => {
   const { target, key } = event as KeyboardEvent
 
   if (key === 'ArrowDown' || key === 'ArrowUp') {
+    // find the items container element
     const kSelectItemsContainer = (target as HTMLElement).closest('.select-items-container')
+    // all selectable items
     const selectableItemsElements = kSelectItemsContainer?.querySelectorAll('.select-item button:not([disabled])')
 
     if (selectableItemsElements?.length) {
+      // find the current element index in the array
       const currentElementIndex = Array.from(selectableItemsElements).findIndex(el => el === target)
+      // move to the next or previous element
       const nextElementIndex = key === 'ArrowDown' ? currentElementIndex + 1 : currentElementIndex - 1
       const nextElement = selectableItemsElements[nextElementIndex] as HTMLButtonElement
 

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import type { PropType } from 'vue'
 import type { SelectItem } from '@/types'
 import KSelectItem from '@/components/KSelect/KSelectItem.vue'
@@ -101,17 +101,17 @@ const groups = computed((): string[] => [...new Set((props.items?.filter(item =>
 
 const getGroupItems = (group: string) => props.items?.filter(item => item.group === group)
 
-const itemsContainer = ref<HTMLDivElement | null>(null)
+const itemsContainerRef = useTemplateRef('itemsContainer')
 
 const setItemFocus = (): void => {
-  const firstSelectableItem = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not([disabled])')[0]
+  const firstSelectableItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.select-item button:not(:disabled)')
   firstSelectableItem?.focus()
 }
 
 const onKeyPress = ({ target, key } : KeyboardEvent) => {
   if (key === 'ArrowDown' || key === 'ArrowUp') {
     // all selectable items
-    const selectableItems = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not([disabled])')
+    const selectableItems = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not(:disabled)')
 
     if (selectableItems?.length) {
       // find the current element index in the array

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -75,7 +75,6 @@ const onKeyDown = (event: Event) => {
   if (key === 'ArrowDown' || key === 'ArrowUp') {
     const kSelectItemsContainer = (target as HTMLElement).closest('.select-items-container')
     const selectableItemsElements = kSelectItemsContainer?.querySelectorAll('.select-item button:not([disabled])')
-    console.log(selectableItemsElements?.length)
 
     if (selectableItemsElements?.length) {
       const currentElementIndex = Array.from(selectableItemsElements).findIndex(el => el === target)

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -108,9 +108,7 @@ const setItemFocus = (): void => {
   firstSelectableItem?.focus()
 }
 
-const onKeyPress = (event: Event) => {
-  const { target, key } = event as KeyboardEvent
-
+const onKeyPress = ({ target, key } : KeyboardEvent) => {
   if (key === 'ArrowDown' || key === 'ArrowUp') {
     // all selectable items
     const selectableItems = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not([disabled])')

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -1,35 +1,10 @@
 <template>
-  <KSelectItem
-    v-for="item in nonGroupedItems"
-    :key="item.key"
-    :item="item"
-    @keydown="onKeyDown"
-    @selected="handleItemSelect"
-  >
-    <template #content>
-      <slot
-        :item="item"
-        name="content"
-      />
-    </template>
-  </KSelectItem>
-
-  <div
-    v-for="group in groups"
-    :key="`${group}-group`"
-    class="select-group"
-    data-propagate-clicks="false"
-  >
-    <span
-      class="select-group-title"
-    >
-      {{ group }}
-    </span>
+  <div ref="itemsContainer">
     <KSelectItem
-      v-for="item in getGroupItems(group)"
+      v-for="item in nonGroupedItems"
       :key="item.key"
       :item="item"
-      @keydown="onKeyDown"
+      @keydown="onKeyPress"
       @selected="handleItemSelect"
     >
       <template #content>
@@ -39,11 +14,55 @@
         />
       </template>
     </KSelectItem>
+
+    <div
+      v-for="group in groups"
+      :key="`${group}-group`"
+      class="select-group"
+      data-propagate-clicks="false"
+    >
+      <span
+        class="select-group-title"
+      >
+        {{ group }}
+      </span>
+      <KSelectItem
+        v-for="item in getGroupItems(group)"
+        :key="item.key"
+        :item="item"
+        @keydown="onKeyPress"
+        @selected="handleItemSelect"
+      >
+        <template #content>
+          <slot
+            :item="item"
+            name="content"
+          />
+        </template>
+      </KSelectItem>
+    </div>
+
+    <KSelectItem
+      v-if="itemCreationEnabled"
+      key="select-add-item"
+      class="select-add-item"
+      data-testid="select-add-item"
+      :item="{ label: `${filterString} (Add new value)`, value: 'add_item', disabled: !itemCreationValid }"
+      @keydown="onKeyPress"
+      @selected="$emit('add-item')"
+    >
+      <template #content>
+        <div class="select-item-description">
+          {{ filterString }}
+          <span class="select-item-new-indicator">(Add new value)</span>
+        </div>
+      </template>
+    </KSelectItem>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { PropType } from 'vue'
 import type { SelectItem } from '@/types'
 import KSelectItem from '@/components/KSelect/KSelectItem.vue'
@@ -56,10 +75,23 @@ const props = defineProps({
     // Items must have a label & value
     validator: (items: SelectItem[]) => !items.length || items.every(i => i.label !== undefined && i.value !== undefined),
   },
+  itemCreationEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  filterString: {
+    type: String,
+    default: '',
+  },
+  itemCreationValid: {
+    type: Boolean,
+    default: true,
+  },
 })
 
 const emit = defineEmits<{
   (e: 'selected', item: SelectItem): void
+  (e: 'add-item'): void
 }>()
 
 const handleItemSelect = (item: SelectItem) => emit('selected', item)
@@ -69,28 +101,33 @@ const groups = computed((): string[] => [...new Set((props.items?.filter(item =>
 
 const getGroupItems = (group: string) => props.items?.filter(item => item.group === group)
 
-const onKeyDown = (event: Event) => {
+const itemsContainer = ref<HTMLDivElement | null>(null)
+
+const setItemFocus = (): void => {
+  const firstSelectableItem = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not([disabled])')[0]
+  firstSelectableItem?.focus()
+}
+
+const onKeyPress = (event: Event) => {
   const { target, key } = event as KeyboardEvent
 
   if (key === 'ArrowDown' || key === 'ArrowUp') {
-    // find the items container element
-    const kSelectItemsContainer = (target as HTMLElement).closest('.select-items-container')
     // all selectable items
-    const selectableItemsElements = kSelectItemsContainer?.querySelectorAll('.select-item button:not([disabled])')
+    const selectableItems = itemsContainer.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not([disabled])')
 
-    if (selectableItemsElements?.length) {
+    if (selectableItems?.length) {
       // find the current element index in the array
-      const currentElementIndex = Array.from(selectableItemsElements).findIndex(el => el === target)
+      const currentElementIndex = [...selectableItems].indexOf(target as HTMLButtonElement)
       // move to the next or previous element
       const nextElementIndex = key === 'ArrowDown' ? currentElementIndex + 1 : currentElementIndex - 1
-      const nextElement = selectableItemsElements[nextElementIndex] as HTMLButtonElement
+      const nextElement = selectableItems[nextElementIndex]
 
-      if (nextElement) {
-        nextElement.focus()
-      }
+      nextElement?.focus()
     }
   }
 }
+
+defineExpose({ setFocus: setItemFocus })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -15,6 +15,7 @@
       />
     </template>
   </KSelectItem>
+
   <div
     v-for="group in groups"
     :key="`${group}-group`"
@@ -77,7 +78,7 @@ const kSelectItem = ref<InstanceType<typeof KSelectItem>[] | null>(null)
 const setFocus = (index: number = 0) => {
   if (kSelectItem.value) {
     if (!props.items[index].disabled) {
-      kSelectItem.value[index]?.$el?.querySelector('button').focus()
+      kSelectItem.value[index]?.$el?.querySelector('button')?.focus()
     } else {
       setFocus(index + 1)
     }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-13956

Fixes broken arrow navigation in KSelect and KMultiselect

Verification steps:
1. Find a sortable instance of KSelect and/or KMultiselect in sandbox or docs
2. Type a query in and after the component shows the results, remove it
3. Try navigating through items using up and down arrows - it should work correctly

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
