### PR TITLE
fix(kbadge): slotted link styles [KHCP-14774]

### DIFF
--- a/.stylelintrc.mjs
+++ b/.stylelintrc.mjs
@@ -28,6 +28,7 @@ export default {
     'custom-property-no-missing-var-function': true,
     'rule-empty-line-before': ['always', { ignore: ['after-comment', 'first-nested'] }],
     '@stylistic/block-opening-brace-space-before': 'always',
+    'selector-pseudo-class-no-unknown': [true, { ignorePseudoClasses: ['deep', 'slotted'] }],
     // Disable the following rules
     'no-descending-specificity': null,
   },

--- a/sandbox/pages/SandboxBadge.vue
+++ b/sandbox/pages/SandboxBadge.vue
@@ -101,9 +101,62 @@
       <SandboxSectionComponent
         title="default"
       >
-        <KBadge>
-          <b>Default</b> slot
-        </KBadge>
+        <div class="horizontal-spacing">
+          <KBadge>
+            Info.
+            <KExternalLink
+              href="https://kongponents.konghq.com/components/badge.html"
+              target="_blank"
+            >
+              Link
+            </KExternalLink>
+          </KBadge>
+          <KBadge appearance="success">
+            Success.
+            <KExternalLink
+              href="https://kongponents.konghq.com/components/badge.html"
+              target="_blank"
+            >
+              Link
+            </KExternalLink>
+          </KBadge>
+          <KBadge appearance="warning">
+            Warning.
+            <KExternalLink
+              href="https://kongponents.konghq.com/components/badge.html"
+              target="_blank"
+            >
+              Link
+            </KExternalLink>
+          </KBadge>
+          <KBadge appearance="danger">
+            Danger.
+            <KExternalLink
+              href="https://kongponents.konghq.com/components/badge.html"
+              target="_blank"
+            >
+              Link
+            </KExternalLink>
+          </KBadge>
+          <KBadge appearance="decorative">
+            Decorative.
+            <KExternalLink
+              href="https://kongponents.konghq.com/components/badge.html"
+              target="_blank"
+            >
+              Link
+            </KExternalLink>
+          </KBadge>
+          <KBadge appearance="neutral">
+            Neutral.
+            <KExternalLink
+              href="https://kongponents.konghq.com/components/badge.html"
+              target="_blank"
+            >
+              Link
+            </KExternalLink>
+          </KBadge>
+        </div>
         <p>Using icon within the default slot basically becomes a don't unless you are willing to override some default component styles.</p>
         <div class="horizontal-spacing">
           <KBadge>
@@ -398,6 +451,7 @@ import { inject } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 import { KongIcon, WarningOutlineIcon, CloseIcon } from '@kong/icons'
+import KExternalLink from '@/components/KExternalLink/KExternalLink.vue'
 
 const handleIconClick = (): void => {
   alert('Icon clicked!')

--- a/src/styles/mixins/_badges.scss
+++ b/src/styles/mixins/_badges.scss
@@ -29,7 +29,6 @@
   background-color: $bgColor;
   color: $textColor;
 
-  /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
   :deep([role="button"]):not([disabled]):not(#{$kongponentsKCopyTooltipWrapperSelector}):not(.badge-content) {
     &:hover,
     &:focus {

--- a/src/styles/mixins/_badges.scss
+++ b/src/styles/mixins/_badges.scss
@@ -36,6 +36,16 @@
       color: $hoverColor !important;
     }
   }
+
+  :deep(a) {
+    color: $textColor;
+    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+    text-decoration: none;
+
+    &:hover {
+      color: $hoverColor;
+    }
+  }
 }
 
 @mixin decorativeBadgeAppearance {


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-14774

Fixes slotted link styles in KBadge

Before
![Screenshot 2025-01-21 at 10 40 36 AM](https://github.com/user-attachments/assets/839b7473-9550-4b1a-9988-885d9298e95b)


After
![Screenshot 2025-01-21 at 12 07 44 PM](https://github.com/user-attachments/assets/17cd26d0-0486-4939-8948-11623988f7aa)

Also fixes `selector-pseudo-class-no-unknown` stylelint flagging `:deep` selector (screenshot)

![Screenshot 2025-01-21 at 12 14 56 PM](https://github.com/user-attachments/assets/e65a30bc-25b9-49d3-872b-8ce940928857)

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
