### PR TITLE
feat(ktextarea): add `autosize` for `<KTextArea>`

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -54,10 +54,22 @@ You can specify `rows` to adjust the height of the textarea.
 
 Boolean value to allow vertically resizing using the drag handle in the right-hand corner of the textarea.
 
+Double-clicking the drag handle will reset the textarea to its default height.
+
 <KTextArea resizable />
 
 ```html
 <KTextArea resizable />
+```
+
+### autosize
+
+Boolean value to automatically adjust the height of the textarea based on its content.
+
+<KTextArea autosize />
+
+```html
+<KTextArea autosize />
 ```
 
 ### help

--- a/sandbox/pages/SandboxTextarea.vue
+++ b/sandbox/pages/SandboxTextarea.vue
@@ -68,7 +68,7 @@
           autosize
           label="Label"
           resizable
-          :rows="6"
+          :rows="3"
         />
       </SandboxSectionComponent>
 

--- a/sandbox/pages/SandboxTextarea.vue
+++ b/sandbox/pages/SandboxTextarea.vue
@@ -63,6 +63,14 @@
           :rows="2"
         />
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="autosize">
+        <KTextArea
+          autosize
+          label="Label"
+          resizable
+          :rows="6"
+        />
+      </SandboxSectionComponent>
 
       <!-- Attributes -->
       <SandboxTitleComponent

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -248,12 +248,10 @@ import useUtilities from '@/composables/useUtilities'
 import { CopyIcon, SearchIcon, ProgressIcon, CloseIcon, RegexIcon, FilterIcon, ArrowUpIcon, ArrowDownIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_NEUTRAL_STRONG, KUI_ICON_SIZE_30, KUI_LINE_HEIGHT_30 } from '@kong/design-tokens'
 import KCodeBlockIconButton from './KCodeBlockIconButton.vue'
+import { IS_MAYBE_MAC } from '@/utilities/browser'
 
 const { getSizeFromString } = useUtilities()
 
-const IS_MAYBE_MAC = typeof navigator !== 'undefined' &&
-  ('userAgentData' in navigator && navigator.userAgentData === 'macOS' ||
-    navigator.platform.toLowerCase().includes('mac'))
 const ALT_SHORTCUT_LABEL = IS_MAYBE_MAC ? 'Option' : 'Alt'
 
 // Debounces the search handler which ensures that we don’t trigger several searches while the user is still typing.

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -1,10 +1,13 @@
 import KTextArea from '@/components/KTextArea/KTextArea.vue'
 
+// Helper function to get the number of rendered rows in a textarea
 function getRenderedRows(el: HTMLElement) {
-  const { paddingTop, paddingBottom, lineHeight } = window.getComputedStyle(el)
-  const padding = parseFloat(paddingTop) + parseFloat(paddingBottom)
+  const { paddingTop, paddingBottom, borderTopWidth, borderBottomWidth, lineHeight } = window.getComputedStyle(el)
+  const extraSpacing = [paddingTop, paddingBottom, borderTopWidth, borderBottomWidth]
+    .map((value) => parseFloat(value))
+    .reduce((acc, val) => acc + val, 0)
   const lineHeightValue = parseFloat(lineHeight)
-  return Math.round((el.offsetHeight - padding) / lineHeightValue)
+  return Math.round((el.offsetHeight - extraSpacing) / lineHeightValue)
 }
 
 describe('KTextArea', () => {
@@ -148,7 +151,7 @@ describe('KTextArea', () => {
       },
     })
 
-    cy.get('.input-wrapper').should('have.class', 'autosize')
+    cy.get('.input-textarea-wrapper').should('have.class', 'autosize')
 
     cy.get('textarea')
       .type('1\n2\n3\n4').then(($el) => {
@@ -159,6 +162,23 @@ describe('KTextArea', () => {
       })
       .type('{backspace}'.repeat(6)).then(($el) => {
         expect(getRenderedRows($el[0])).to.eq(3)
+      })
+  })
+
+  it('should not auto-adjust height when `autosize` is not provided', () => {
+    cy.mount(KTextArea, {
+      props: {
+        rows: 2,
+      },
+    })
+
+    cy.get('.input-textarea-wrapper').should('not.have.class', 'autosize')
+
+    cy.get('textarea')
+      .should('have.attr', 'rows', '2')
+      .type('1\n2\n3\n4')
+      .then(($el) => {
+        expect(getRenderedRows($el[0])).to.eq(2)
       })
   })
 })

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -132,4 +132,23 @@ describe('KTextArea', () => {
 
     cy.get('textarea').should('have.class', 'resizable')
   })
+
+  it('should handle `autosize` prop correctly', () => {
+    cy.mount(KTextArea, {
+      props: {
+        autosize: true,
+        rows: 2,
+      },
+    })
+
+    cy.get('.input-wrapper').should('have.class', 'autosize')
+
+    cy.get('textarea').type('1\n2\n3\n4').then(($el) => {
+      const textarea = $el[0]
+      const { paddingTop, paddingBottom, lineHeight } = window.getComputedStyle(textarea)
+      const padding = parseFloat(paddingTop) + parseFloat(paddingBottom)
+      const lineHeightValue = parseFloat(lineHeight)
+      expect(textarea.offsetHeight).to.eq(4 * lineHeightValue + padding)
+    })
+  })
 })

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -1,5 +1,12 @@
 import KTextArea from '@/components/KTextArea/KTextArea.vue'
 
+function getRenderedRows(el: HTMLElement) {
+  const { paddingTop, paddingBottom, lineHeight } = window.getComputedStyle(el)
+  const padding = parseFloat(paddingTop) + parseFloat(paddingBottom)
+  const lineHeightValue = parseFloat(lineHeight)
+  return Math.round((el.offsetHeight - padding) / lineHeightValue)
+}
+
 describe('KTextArea', () => {
   it('renders text when value is passed', () => {
     const value = 'Howdy!'
@@ -143,12 +150,15 @@ describe('KTextArea', () => {
 
     cy.get('.input-wrapper').should('have.class', 'autosize')
 
-    cy.get('textarea').type('1\n2\n3\n4').then(($el) => {
-      const textarea = $el[0]
-      const { paddingTop, paddingBottom, lineHeight } = window.getComputedStyle(textarea)
-      const padding = parseFloat(paddingTop) + parseFloat(paddingBottom)
-      const lineHeightValue = parseFloat(lineHeight)
-      expect(textarea.offsetHeight).to.eq(4 * lineHeightValue + padding)
-    })
+    cy.get('textarea')
+      .type('1\n2\n3\n4').then(($el) => {
+        expect(getRenderedRows($el[0])).to.eq(4)
+      })
+      .type('\n5\n6').then(($el) => {
+        expect(getRenderedRows($el[0])).to.eq(6)
+      })
+      .type('{backspace}'.repeat(6)).then(($el) => {
+        expect(getRenderedRows($el[0])).to.eq(3)
+      })
   })
 })

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -25,7 +25,7 @@
       See https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/
     -->
     <div
-      class="input-wrapper"
+      class="input-textarea-wrapper"
       :class="{
         autosize,
         legacy: autosize && !SUPPORT_FIELD_SIZING_CONTENT
@@ -314,7 +314,7 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
     margin-top: var(--kui-space-40, $kui-space-40) !important; // need important to override some overrides of default p margin in other components
   }
 
-  .input-wrapper {
+  .input-textarea-wrapper {
     // We use `field-sizing: content` for browsers that support it, and a grid fallback for those that don't.
     &.autosize {
       .input-textarea {
@@ -339,15 +339,21 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
     }
   }
 
-  .input-wrapper.legacy::after,
+  .input-textarea-wrapper.legacy::after,
   .input-textarea {
     @include inputDefaults;
 
     // required by the grid fallback
-    grid-area: 1 / 1 / 2 / 2;
+    /* stylelint-disable-next-line no-duplicate-selectors */
+    & {
+      grid-area: 1 / 1 / 2 / 2;
+    }
   }
 
   .input-textarea {
+    // A fallback max-height. Referenced GitHub’s implementation for the current value.
+    // It’s highly unlikely that we would need an input box taller than the viewport—this isn’t a document editor.
+    max-height: calc(100vh - 200px);
     min-height: calc(($kTextAreaLineHeight * 2) + ($kTextAreaPaddingY * 2)); // 2 lines + padding
     resize: none;
 

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -23,15 +23,22 @@
       The data-value attribute is used here to render the textarea content in the grid fallback. It’s rendered via
       a CSS pseudo-element with `content: attr(data-value) " "`, ensuring it’s at least one line tall.
       See https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/
+      We are rendering the legacy mode on serverside so that it won't cause any flickering on the client side for
+      browsers that don't support `field-sizing: content`. Then for Chromium based browsers, we will switch to the
+      new mode on hydration. This will inevitably cause a hyration mismatch, but it's safe to ignore it as Chromium
+      based browsers also support the grid hack.
     -->
+    <!-- eslint-disable vue/no-restricted-static-attribute -->
     <div
       class="input-textarea-wrapper"
       :class="{
         autosize,
         legacy: autosize && !SUPPORT_FIELD_SIZING_CONTENT
       }"
+      data-allow-mismatch="class"
       :data-value="SUPPORT_FIELD_SIZING_CONTENT ? null : currValue"
     >
+      <!-- eslint-enable vue/no-restricted-static-attribute -->
       <textarea
         :id="textAreaId"
         v-bind="modifiedAttrs"

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -18,11 +18,17 @@
       </template>
     </KLabel>
 
+    <!--
+      The wrapper element is required for the grid fallback for browsers that don’t support `field-sizing: content`.
+      The data-value attribute is used here to render the textarea content in the grid fallback. It’s rendered via
+      a CSS pseudo-element with `content: attr(data-value) " "`, ensuring it’s at least one line tall.
+      See https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/
+    -->
     <div
       class="input-wrapper"
       :class="{
         autosize,
-        legacy: !SUPPORT_FIELD_SIZING_CONTENT
+        legacy: autosize && !SUPPORT_FIELD_SIZING_CONTENT
       }"
       :data-value="SUPPORT_FIELD_SIZING_CONTENT ? null : currValue"
     >
@@ -309,9 +315,6 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
   }
 
   .input-wrapper {
-    display: contents;
-
-    // https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/
     // We use `field-sizing: content` for browsers that support it, and a grid fallback for those that don't.
     &.autosize {
       .input-textarea {
@@ -324,6 +327,7 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
       display: grid;
 
       &::after {
+        // The `data-value` attribute holds the textarea content for browsers that don’t support `field-sizing: content`.
         content: attr(data-value) " ";
         visibility: hidden;
         white-space: pre-wrap;

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -23,7 +23,10 @@
       v-bind="modifiedAttrs"
       :aria-invalid="ariaInvalid"
       class="input-textarea"
-      :class="[resizable || isResizable ? 'resizable' : undefined]"
+      :class="{
+        resizable: resizable || isResizable,
+        autosize,
+      }"
       :rows="rows"
       :value="getValue()"
       @input="inputHandler"
@@ -90,6 +93,10 @@ const props = defineProps({
     default: false,
   },
   resizable: {
+    type: Boolean,
+    default: false,
+  },
+  autosize: {
     type: Boolean,
     default: false,
   },
@@ -289,6 +296,11 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
 
     &.resizable {
       resize: vertical;
+    }
+
+    &.autosize {
+      field-sizing: content;
+      min-height: calc(($kTextAreaLineHeight * v-bind('rows')) + ($kTextAreaPaddingY * 2));
     }
 
     &:hover {

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -303,17 +303,22 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
   .help-text {
     @include inputHelpText;
 
-    // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-    // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      // reset default margin from browser
-      margin: 0;
-      margin-top: var(--kui-space-40, $kui-space-40) !important; // need important to override some overrides of default p margin in other components
-    }
+    // reset default margin from browser
+    margin: 0;
+    margin-top: var(--kui-space-40, $kui-space-40) !important; // need important to override some overrides of default p margin in other components
   }
 
   .input-wrapper {
     display: contents;
+
+    // https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/
+    // We use `field-sizing: content` for browsers that support it, and a grid fallback for those that don't.
+    &.autosize {
+      .input-textarea {
+        field-sizing: content;
+        min-height: calc(($kTextAreaLineHeight * v-bind('rows')) + ($kTextAreaPaddingY * 2));
+      }
+    }
 
     &.autosize.legacy {
       display: grid;
@@ -328,23 +333,14 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
         overflow: hidden;
       }
     }
-
-    &.autosize {
-      .input-textarea {
-        field-sizing: content;
-        min-height: calc(($kTextAreaLineHeight * v-bind('rows')) + ($kTextAreaPaddingY * 2));
-      }
-    }
   }
 
   .input-wrapper.legacy::after,
   .input-textarea {
     @include inputDefaults;
 
-    // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      grid-area: 1 / 1 / 2 / 2;
-    }
+    // required by the grid fallback
+    grid-area: 1 / 1 / 2 / 2;
   }
 
   .input-textarea {

--- a/src/utilities/browser.ts
+++ b/src/utilities/browser.ts
@@ -1,0 +1,32 @@
+export const IS_MAYBE_MAC = typeof navigator !== 'undefined' &&
+  ('userAgentData' in navigator && navigator.userAgentData === 'macOS' ||
+    navigator.platform.toLowerCase().includes('mac'))
+
+export const IS_MAYBE_FIREFOX = typeof navigator !== 'undefined' &&
+  navigator.userAgent.includes('Firefox')
+
+export function cssSupports(key: string, value: string): boolean {
+  return typeof CSS !== 'undefined' && CSS.supports(key, value)
+}
+
+let scrollbarSize: number | null = null
+export function getScrollbarSize(): number {
+  if (scrollbarSize !== null) {
+    return scrollbarSize
+  }
+
+  if (typeof document === 'undefined') {
+    return 0
+  }
+
+  const div = document.createElement('div')
+  div.style.width = '100px'
+  div.style.height = '100px'
+  div.style.overflow = 'scroll'
+  div.style.position = 'absolute'
+  div.style.top = '-9999px'
+  document.body.appendChild(div)
+  scrollbarSize = div.offsetWidth - div.clientWidth
+  document.body.removeChild(div)
+  return scrollbarSize
+}


### PR DESCRIPTION
# Summary

- Introduced a new `autosize` prop that dynamically adjusts the height of the textarea based on its content.
- Added an enhancement for `resizable` textareas where double-clicking the drag handle resets the default sizing (which Firefox supports natively)
- Added a new browser utilities module for handling user-agent detection and ensuring browser compatibility.

![Jan-22-2025 10-22-48](https://github.com/user-attachments/assets/f96aad76-ccc0-4431-9c80-927224e84c7c)
