### PR TITLE
fix(ktreelist): collapse handle click behavior

### DIFF
--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -4,6 +4,7 @@
     class="tree-draggable"
     direction="vertical"
     :disabled="disableDrag"
+    filter=".tree-item-expanded-button"
     :group="{ name: group, pull: [group], put: maxLevelReached ? [] : [group] }"
     :level="level"
     :list="internalList"


### PR DESCRIPTION
# Summary

Add `filter` prop in KTreeList to make sure item cannot be dragged by grabbing the expand / collapse handle so that clicks on caret never trigger unintentional dragging

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
