### PR TITLE
fix(ktabledata): client sort should not trigger cache invalidation

### DIFF
--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -507,6 +507,33 @@ describe('KTableData', () => {
         cy.wrap($el).should('not.have.class', 'sortable')
       })
     })
+
+    it('should support client-side sorting', () => {
+      const fns = {
+        fetcher: () => {
+          return { data: options.data }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          headers: options.headers,
+          clientSort: true,
+          fetcher: fns.fetcher,
+        },
+      })
+
+      cy.get('@fetcher')
+        .should('have.callCount', 1)
+
+      cy.get('th').eq(0).click()
+      cy.get('td').eq(0).should('contain.text', 'Android App')
+
+      cy.get('@fetcher')
+        .should('have.callCount', 1) // ensure fetcher is NOT called again on client-side sort
+
+    })
   })
 
   describe('pagination', () => {


### PR DESCRIPTION
# Summary

[KM-946](https://konghq.atlassian.net/browse/KM-946)

- When `client-sort` is enabled, exclude sort-related parameters from the cache key.
- Removed an unintended `console.log`.

Konnect Preview: https://github.com/Kong/konnect-ui-apps/pull/5733


[KM-946]: https://konghq.atlassian.net/browse/KM-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ