### PR TITLE
fix(kmodal): prevent backdrop close when selecting text [KHCP-15048]

### DIFF
--- a/src/components/KModal/KModal.cy.ts
+++ b/src/components/KModal/KModal.cy.ts
@@ -297,6 +297,28 @@ describe('KModal', () => {
     })
   })
 
+  it('does not emit cancel event when backdrop is clicked while text selected and closeOnBackdropClick is true', () => {
+    cy.mount(KModal, {
+      props: {
+        visible: true,
+        closeOnBackdropClick: true,
+      },
+      slots: {
+        default: '<p data-testid="modal-text">Select this text to test</p>',
+      },
+    })
+
+    cy.get('[data-testid="modal-text"]')
+      .trigger('mousedown')
+      .trigger('mousemove', { clientX: 100, clientY: 100 })
+      .trigger('mouseup')
+
+    cy.get('.k-modal .modal-backdrop').click('topRight')
+
+
+    cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'cancel')
+  })
+
   it('sets focus on first input field when inputAutofocus is true', () => {
     cy.mount(KModal, {
       props: {

--- a/src/components/KModal/KModal.cy.ts
+++ b/src/components/KModal/KModal.cy.ts
@@ -308,15 +308,27 @@ describe('KModal', () => {
       },
     })
 
-    cy.get('[data-testid="modal-text"]')
-      .trigger('mousedown')
-      .trigger('mousemove', { clientX: 100, clientY: 100 })
-      .trigger('mouseup')
+    // select text
+    cy.get('[data-testid="modal-text"]').then(($el) => {
+      const doc = $el[0].ownerDocument
+      const range = doc.createRange()
+      range.selectNodeContents($el[0])
+      const selection = doc.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+    })
 
-    cy.get('.k-modal .modal-backdrop').click('topRight')
+
+    // check if text is selected
+    cy.document().then((doc) => {
+      const selectedText = doc.getSelection()?.toString()
+      expect(selectedText).to.equal('Select this text to test')
+    })
 
 
-    cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'cancel')
+    cy.get('.k-modal .modal-backdrop').click('topRight').then(() => {
+      cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'cancel')
+    })
   })
 
   it('sets focus on first input field when inputAutofocus is true', () => {

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -94,6 +94,7 @@
 import type { PropType } from 'vue'
 import { computed, nextTick, onBeforeUnmount, ref, useAttrs, watch, useSlots } from 'vue'
 import { FocusTrap } from 'focus-trap-vue'
+import { useTextSelection } from '@vueuse/core'
 import KButton from '@/components/KButton/KButton.vue'
 import type { ButtonAppearance } from '@/types'
 import useUtilities from '@/composables/useUtilities'
@@ -192,6 +193,8 @@ const emit = defineEmits<{
 const attrs = useAttrs()
 const slots = useSlots()
 
+const textSelection = useTextSelection()
+
 const focusTrapElement = ref<InstanceType<typeof FocusTrap> | null>(null)
 const modalWrapperElement = ref<HTMLElement | null>(null)
 
@@ -219,7 +222,7 @@ const handleKeydown = (event: any): void => {
 
 const close = (force = false, event?: any): void => {
   // Close if force === true or if the user clicks on .modal-backdrop
-  if (force || (event?.target?.classList?.contains('modal-backdrop') && props.closeOnBackdropClick)) {
+  if (force || (event?.target?.classList?.contains('modal-backdrop') && props.closeOnBackdropClick && !textSelection.text.value)) {
     emit('cancel')
   }
 }


### PR DESCRIPTION
## Ticket

https://konghq.atlassian.net/browse/KHCP-15048

## Description

This PR fixes issue with backdrop closing modal during text selection or drag outside, see video below:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/8ab96894-d511-468f-b172-ea4389773c3f" /> | <video src="https://github.com/user-attachments/assets/929f9b10-b77a-4014-b8aa-ec5a2525ef46" /> | 
