### PR TITLE
feat(ktreelist): add prop to filter draggable element selectors

### DIFF
--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -185,8 +185,10 @@ Boolean to turn off drag-n-drop reordering of the list. Defaults to `false`.
 
 A `string` or (`function` that returns a `string`) of selectors that should not result in dragging tree list items.
 
+For multiple selectors, you **must** pass in a comma-delimited list of selectors.
+
 ```html
-<KTreeList ignore-drag-selectors=".button-element .another-element" :items="items" />
+<KTreeList ignore-drag-selectors=".button-element, .another-element > .nested-property" :items="items" />
 ```
 
 ### maxDepth

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -181,6 +181,14 @@ Boolean to turn off drag-n-drop reordering of the list. Defaults to `false`.
 <KTreeList disable-drag :items="items" />
 ```
 
+### ignoreDragSelectors
+
+A `string` or (`function` that returns a `string`) of selectors that should not result in dragging tree list items.
+
+```html
+<KTreeList ignore-drag-selectors=".button-element .another-element" :items="items" />
+```
+
 ### maxDepth
 
 Use this prop to customize the maximum supported depth of the tree. The default value is `3`. The maximum supported value for `maxDepth` is 5.

--- a/sandbox/pages/SandboxTreeList.vue
+++ b/sandbox/pages/SandboxTreeList.vue
@@ -36,6 +36,22 @@
           :items="items4"
         />
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="ignoreDragSelectors">
+        <KTreeList
+          ignore-drag-selectors=".internal-button"
+          :items="items12"
+        >
+          <template #item-label="{ item }">
+            <KButton
+              appearance="secondary"
+              class="internal-button"
+              size="small"
+            >
+              {{ item.name }}
+            </KButton>
+          </template>
+        </KTreeList>
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="maxDepth">
         <KTreeList
           :items="items5"
@@ -198,6 +214,7 @@ const items8 = ref<TreeListItem[]>(JSON.parse(JSON.stringify(defaultItems)))
 const items9 = ref<TreeListItem[]>(JSON.parse(JSON.stringify(defaultItems)))
 const items10 = ref<TreeListItem[]>(JSON.parse(JSON.stringify(defaultItems)))
 const items11 = ref<TreeListItem[]>(JSON.parse(JSON.stringify(defaultItems)))
+const items12 = ref<TreeListItem[]>(JSON.parse(JSON.stringify(defaultItems)))
 
 const toggleItems = ref<boolean>(true)
 const kTreeRef = useTemplateRef('k-tree-ref')

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -62,7 +62,7 @@
         }"
         :collapsible="collapsible"
         :disable-drag="disableDrag"
-        :filter="filter"
+        :filter="computedDragFilter"
         :group="group"
         :hide-icons="hideIcons"
         :initial-collapse-all="initialCollapseAll"

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -62,6 +62,7 @@
         }"
         :collapsible="collapsible"
         :disable-drag="disableDrag"
+        :filter="filter"
         :group="group"
         :hide-icons="hideIcons"
         :initial-collapse-all="initialCollapseAll"
@@ -182,8 +183,8 @@ const dragging = ref<boolean>(false)
 
 const computedDragFilter = computed((): string => {
   const selectorList: string = typeof props.filter === 'function' ? props.filter() : props.filter
-  // Always append the internal `.tree-item-expanded-button` selector
-  return `.tree-item-expanded-button ${selectorList}`
+  // Always append the internal `.tree-item-expanded-button` selector and separate selectors with a comma
+  return ['.tree-item-expanded-button', ...selectorList.split(' ').filter(Boolean)].join(', ')
 })
 
 const hasNoChildren = (item: TreeListItem): boolean => {

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -184,7 +184,7 @@ const dragging = ref<boolean>(false)
 const computedDragFilter = computed((): string => {
   const selectorList: string = typeof props.filter === 'function' ? props.filter() : props.filter
   // Always append the internal `.tree-item-expanded-button` selector and separate selectors with a comma
-  return ['.tree-item-expanded-button', ...selectorList.split(' ').filter(Boolean)].join(', ')
+  return ['.tree-item-expanded-button', ...(selectorList.split(',').map(s => s.trim()).filter(Boolean))].join(', ')
 })
 
 const hasNoChildren = (item: TreeListItem): boolean => {

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -4,7 +4,7 @@
     class="tree-draggable"
     direction="vertical"
     :disabled="disableDrag"
-    filter=".tree-item-expanded-button"
+    :filter="computedDragFilter"
     :group="{ name: group, pull: [group], put: maxLevelReached ? [] : [group] }"
     :level="level"
     :list="internalList"
@@ -121,6 +121,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  filter: {
+    type: [String, Function] as PropType<string | (() => string)>,
+    default: () => '',
+  },
   maxDepth: {
     type: Number,
     default: 3,
@@ -175,6 +179,12 @@ const draggableAttrs = {
   class: 'child-drop-zone',
 }
 const dragging = ref<boolean>(false)
+
+const computedDragFilter = computed((): string => {
+  const selectorList: string = typeof props.filter === 'function' ? props.filter() : props.filter
+  // Always append the internal `.tree-item-expanded-button` selector
+  return `.tree-item-expanded-button ${selectorList}`
+})
 
 const hasNoChildren = (item: TreeListItem): boolean => {
   return !internalList.value.filter(anItem => anItem.id === item.id)?.[0].children?.length

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -9,6 +9,7 @@
       :collapsible="collapsible"
       :data-testid="`k-tree-list-${group}`"
       :disable-drag="disableDrag"
+      :filter="ignoreDragSelectors"
       :group="group"
       :hide-icons="hideIcons"
       :initial-collapse-all="initialCollapseAll"
@@ -96,6 +97,11 @@ const props = defineProps({
   disableDrag: {
     type: Boolean,
     default: false,
+  },
+  /** A `string` or `function` that returns a `string` of selectors that should not result in dragging tree list items. */
+  ignoreDragSelectors: {
+    type: [String, Function] as PropType<string | (() => string)>,
+    default: () => '',
   },
   maxDepth: {
     type: Number,


### PR DESCRIPTION
# Summary

Add a new `ignoreDragSelectors` prop that can be utilized to disable dragging on slotted elements within the `KTreeList`