### PR TITLE
fix(kinputswitch): add tooltipattributes prop

### DIFF
--- a/docs/components/input-switch.md
+++ b/docs/components/input-switch.md
@@ -64,6 +64,10 @@ Use this prop to display tooltip text when KInputSwitch is disabled.
 <KInputSwitch disabled disabled-tooltip-text="Scale down this cluster first to enable editing" v-model="switchValue" />
 ```
 
+### tooltipAttributes
+
+Use the `tooltipAttributes` prop to configure the KTooltip's [props](/components/tooltip) when using the `disabledTooltipText` prop.
+
 ### HTML Attributes
 
 #### disabled

--- a/sandbox/pages/SandboxInputSwitch.vue
+++ b/sandbox/pages/SandboxInputSwitch.vue
@@ -43,12 +43,13 @@
           label="Disabled"
         />
       </SandboxSectionComponent>
-      <SandboxSectionComponent title="disabledTooltipText">
+      <SandboxSectionComponent title="disabledTooltipText & tooltipAttributes">
         <KInputSwitch
           v-model="vModel1"
           disabled
           disabled-tooltip-text="Disabled tooltip text"
           label="Disabled"
+          :tooltip-attributes="{ placement: 'bottom-start' }"
         />
       </SandboxSectionComponent>
 

--- a/src/components/KInputSwitch/KInputSwitch.vue
+++ b/src/components/KInputSwitch/KInputSwitch.vue
@@ -13,11 +13,10 @@
       type="checkbox"
       @input="handleChange"
     >
-    <component
-      :is="disabled && disabledTooltipText ? 'KTooltip' : 'div'"
+    <KTooltip
       v-bind="disabled && disabledTooltipText ? tooltipAttributes : {}"
       class="switch-control-wrapper"
-      :label="disabledTooltipText"
+      :text="disabled ? disabledTooltipText : ''"
     >
       <span
         :aria-checked="modelValue"
@@ -35,7 +34,7 @@
         <!-- white vertical bar that is visible when switch is enabled -->
         <span class="switch-control-enabled-bar" />
       </span>
-    </component>
+    </KTooltip>
 
     <KLabel
       v-if="label || $slots.label"

--- a/src/components/KInputSwitch/KInputSwitch.vue
+++ b/src/components/KInputSwitch/KInputSwitch.vue
@@ -15,6 +15,7 @@
     >
     <component
       :is="disabled && disabledTooltipText ? 'KTooltip' : 'div'"
+      v-bind="disabled && disabledTooltipText ? tooltipAttributes : {}"
       class="switch-control-wrapper"
       :label="disabledTooltipText"
     >
@@ -50,6 +51,7 @@
 <script lang="ts" setup>
 import type { PropType } from 'vue'
 import { computed, ref, useAttrs, useId } from 'vue'
+import type { TooltipAttributes } from '@/types'
 
 const props = defineProps({
   /**
@@ -79,6 +81,10 @@ const props = defineProps({
   disabledTooltipText: {
     type: String,
     default: '',
+  },
+  tooltipAttributes: {
+    type: Object as PropType<TooltipAttributes>,
+    default: () => ({}),
   },
   /**
    * Whether the label should be placed before the switch


### PR DESCRIPTION
# Summary

Add `tooltipAttributes` prop in KInputSwitch to give a way to control tooltip placement when `disabledTooltipText` prop is used

Before
![Screenshot 2025-02-12 at 11 11 53 AM](https://github.com/user-attachments/assets/0f1e6898-5fe4-4822-b46b-0e5ce2959490)

After
![Screenshot 2025-02-12 at 11 28 40 AM](https://github.com/user-attachments/assets/d4efecf4-dc9a-44f2-8200-04be56f88f9f)

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
