### PR TITLE
fix(ktabledata): `loading` prop should override internal loading state

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "commitizen": "^4.3.1",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
-    "cypress": "^13.15.2",
+    "cypress": "^13.17.0",
     "cypress-fail-fast": "^7.1.1",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^9.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 19.5.0
       '@cypress/vite-dev-server':
         specifier: ^6.0.2
-        version: 6.0.2(cypress@13.15.2)
+        version: 6.0.2(cypress@13.17.0)
       '@digitalroute/cz-conventional-changelog-for-jira':
         specifier: ^8.0.1
         version: 8.0.1(@types/node@20.17.16)(typescript@5.6.3)
@@ -133,11 +133,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       cypress:
-        specifier: ^13.15.2
-        version: 13.15.2
+        specifier: ^13.17.0
+        version: 13.17.0
       cypress-fail-fast:
         specifier: ^7.1.1
-        version: 7.1.1(cypress@13.15.2)
+        version: 7.1.1(cypress@13.17.0)
       cz-conventional-changelog:
         specifier: 3.3.0
         version: 3.3.0(@types/node@20.17.16)(typescript@5.6.3)
@@ -465,8 +465,8 @@ packages:
     resolution: {integrity: sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==}
     engines: {node: '>=6.9.0'}
 
-  '@bufbuild/protobuf@2.2.0':
-    resolution: {integrity: sha512-+imAQkHf7U/Rwvu0wk1XWgsP3WnpCWmK7B48f0XqSNzgk64+grljTKC7pnO/xBiEMUziF7vKRfbBnOQhg126qQ==}
+  '@bufbuild/protobuf@2.2.3':
+    resolution: {integrity: sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -986,7 +986,6 @@ packages:
 
   '@evilmartians/lefthook@1.10.10':
     resolution: {integrity: sha512-MRIA0zJzUBbmcbecI7QjI08li4ffpmZ6DeVydEiZSg0vSx5mElEMEjDEjkI60eSV0XOm7LRbQKz2rfW6NqH8Cw==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2206,8 +2205,8 @@ packages:
     peerDependencies:
       cypress: '>=8.0.0'
 
-  cypress@13.15.2:
-    resolution: {integrity: sha512-ARbnUorjcCM3XiPwgHKuqsyr5W9Qn+pIIBPaoilnoBkLdSC2oLQjV1BUpnmc7KR+b7Avah3Ly2RMFnfxr96E/A==}
+  cypress@13.17.0:
+    resolution: {integrity: sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -3060,8 +3059,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  immutable@4.3.6:
-    resolution: {integrity: sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==}
+  immutable@4.3.7:
+    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
 
   immutable@5.0.2:
     resolution: {integrity: sha512-1NU7hWZDkV7hJ4PJ9dur9gTNQ4ePNPN4k9/0YhwjzykTi/+3Q5pF93YU5QoVj8BuOnhLgaY8gs0U2pj4kSYVcw==}
@@ -5709,7 +5708,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@bufbuild/protobuf@2.2.0':
+  '@bufbuild/protobuf@2.2.3':
     optional: true
 
   '@colors/colors@1.5.0':
@@ -5918,9 +5917,9 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/vite-dev-server@6.0.2(cypress@13.15.2)':
+  '@cypress/vite-dev-server@6.0.2(cypress@13.17.0)':
     dependencies:
-      cypress: 13.15.2
+      cypress: 13.17.0
       debug: 4.3.6(supports-color@8.1.1)
       find-up: 6.3.0
       node-html-parser: 5.3.3
@@ -7617,12 +7616,12 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  cypress-fail-fast@7.1.1(cypress@13.15.2):
+  cypress-fail-fast@7.1.1(cypress@13.17.0):
     dependencies:
       chalk: 4.1.2
-      cypress: 13.15.2
+      cypress: 13.17.0
 
-  cypress@13.15.2:
+  cypress@13.17.0:
     dependencies:
       '@cypress/request': 3.0.6
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
@@ -8699,7 +8698,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  immutable@4.3.6:
+  immutable@4.3.7:
     optional: true
 
   immutable@5.0.2: {}
@@ -9907,10 +9906,10 @@ snapshots:
 
   sass-embedded@1.79.5:
     dependencies:
-      '@bufbuild/protobuf': 2.2.0
+      '@bufbuild/protobuf': 2.2.3
       buffer-builder: 0.2.0
       colorjs.io: 0.5.2
-      immutable: 4.3.6
+      immutable: 4.3.7
       rxjs: 7.8.1
       supports-color: 8.1.1
       varint: 6.0.0

--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -189,6 +189,26 @@ describe('KTableData', () => {
       cy.get('.skeleton-table-wrapper').should('be.visible')
       cy.get('.k-empty-state').should('not.exist')
     })
+
+    it('does not display a loading state when `loading` is false, regardless of fetcher state', () => {
+      const slowFetcher = () => {
+        return new Promise((resolve) => setTimeout(resolve, 2500))
+      }
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: slowFetcher,
+          headers: options.headers,
+          cacheIdentifier: 'loading-test',
+          loading: false,
+          paginationAttributes: {
+            pageSizes: [10, 20, 30, 40],
+          },
+        },
+      })
+
+      cy.get('.skeleton-table-wrapper').should('not.exist')
+    })
   })
 
   describe('default', () => {

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -19,7 +19,7 @@
     :hide-pagination="hidePagination || !showPagination"
     :hide-pagination-when-optional="false"
     :hide-toolbar="hideToolbar"
-    :loading="loading || fetcherIsLoading"
+    :loading="loading ?? fetcherIsLoading"
     :max-height="maxHeight"
     :nested="nested"
     :pagination-attributes="tablePaginationAttributes"
@@ -188,7 +188,7 @@ const props = withDefaults(defineProps<TableDataProps>(), {
   rowBulkActionEnabled: () => true,
   rowKey: '',
   cellAttrs: () => ({}),
-  loading: false,
+  loading: undefined,
   emptyStateTitle: 'No Data',
   emptyStateMessage: 'There is no data to display.',
   emptyStateActionMessage: '',


### PR DESCRIPTION
# Summary

Currently, our products usually follow the approach described in the Kongponents documentation, where revalidation is triggered by incrementing the `fetcherCacheKey` (although strictly speaking, this is not the correct method, as it actually caches data for the same query at different locations, which is loading new data instead of revalidation).

After adding the `isLoading` state for SWRV, `<KTableData>` also triggers the loading state when the `fetcherCacheKey` changes (which is technically correct, but the semantics of incrementing the `fetcherCacheKey` are slightly different). This is generally acceptable (for example, after adding or removing list items).

However, in certain scenarios like polling, we actually don’t want to trigger the loading state. But since we haven’t exposed the revalidate-related primitives, users can only achieve this by incrementing the `fetcherCacheKey`, which may lead to unexpected loading states. A quick workaround is for users to control the `loading` prop themselves to prevent the loading state during polling.

This PR implements a solution where, if the user passes the `loading` prop, it will always override the internal loading state of the component (which is also the expected behavior for the `loading` prop), helping users with a quick workaround.

Also updated Cypress to fix https://github.com/cypress-io/cypress/issues/30715.