### PR TITLE
fix(kbadge): tabindex when has tooltip

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -127,6 +127,10 @@ A string to be used as `id` attribute on underlying `role="tooltip"` element. Us
 
 The `default` slot takes in the element you want the popover to be triggered over.
 
+:::tip NOTE
+Make sure to set appropriate `tabindex` attribute on your tooltip trigger element in order to make popover accessible for assistive technology users.
+:::
+
 ```html
 <KTooltip text="A simple tooltip.">
   <KButton>Button</KButton>

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -38,6 +38,7 @@ const { getSizeFromString } = useUtilities()
 // Must explicitly define components so KTooltip works in tests
 export default {
   name: 'KBadge',
+  // eslint-disable-next-line vue/no-unused-components
   components: { KButton, KTooltip },
 }
 </script>

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -3,13 +3,11 @@
     class="k-badge"
     :class="[appearance, { 'method': isMethodBadge }]"
   >
-    <component
-      :is="showTooltip ? 'KTooltip' : 'div'"
-      :text="showTooltip ? tooltip : undefined"
-    >
+    <KTooltip :text="showTooltip ? tooltip : undefined">
       <div
         class="badge-content"
         :class="{ 'icon-after': !iconBefore }"
+        :tabindex="showTooltip ? 0 : undefined"
       >
         <slot
           v-if="$slots.icon"
@@ -22,7 +20,7 @@
           <slot />
         </div>
       </div>
-    </component>
+    </KTooltip>
   </div>
 </template>
 


### PR DESCRIPTION
# Summary

Assign `tabindex="0"` to badge content element if badge displays tooltip

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
