### PR TITLE
fix(browser): platform is undefined

### DIFF
--- a/src/utilities/browser.ts
+++ b/src/utilities/browser.ts
@@ -1,6 +1,6 @@
 export const IS_MAYBE_MAC = typeof navigator !== 'undefined' &&
   ('userAgentData' in navigator && navigator.userAgentData === 'macOS' ||
-    navigator.platform.toLowerCase().includes('mac'))
+    navigator.platform?.toLowerCase().includes('mac'))
 
 export const IS_MAYBE_FIREFOX = typeof navigator !== 'undefined' &&
   navigator.userAgent.includes('Firefox')


### PR DESCRIPTION
# Summary

`navigator.platform` is undefined in some browser environments and throwing an error in SSR builds.

Issue introduced in https://github.com/Kong/kongponents/pull/2587
