### PR TITLE
feat(ktabledata): expose revalidate method

### DIFF
--- a/docs/components/table-data.md
+++ b/docs/components/table-data.md
@@ -294,6 +294,12 @@ type TableState = 'loading' | 'error' | 'success' | 'empty'
 
 This event only fires when KTableData is in `success` state (see [`state` event](#state) for details).
 
+## Methods
+
+### revalidate
+
+Revalidates the cached data without triggering the loading state if data is already cached.
+
 <script setup lang="ts">
 import { AddIcon, SearchIcon, MoreIcon } from '@kong/icons'
 

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -587,4 +587,10 @@ watch([filterQuery, pageSize], async (newData, oldData) => {
 onMounted(() => {
   initData()
 })
+
+defineExpose({
+  revalidate: () => {
+    _revalidate()
+  },
+})
 </script>


### PR DESCRIPTION
# Summary

[KM-952](https://konghq.atlassian.net/browse/KM-952)

Reasoning: see #2614 for details.

This PR offers an alternate way to mitigate the original issue discussed in #2614.

I'm also I’m still considering whether to expose the SWRV options inside `<KTableData>` as a prop, which would support more declarative revalidation.

[KM-952]: https://konghq.atlassian.net/browse/KM-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ