### PR TITLE
docs: improve code section scrollbar color scheme

### DIFF
--- a/docs/.vitepress/theme/index.scss
+++ b/docs/.vitepress/theme/index.scss
@@ -16,6 +16,10 @@ pre.json {
   white-space: pre-wrap;
 }
 
+.vp-code.material-theme-palenight {
+  color-scheme: dark;
+}
+
 .VPContent {
   // Tables
   table {
@@ -52,6 +56,7 @@ pre.json {
     0% {
       transform: rotate(0deg);
     }
+
     100% {
       transform: rotate(1turn);
     }


### PR DESCRIPTION
# Summary

Before:

<img width="710" alt="image" src="https://github.com/user-attachments/assets/8c469319-0965-46fd-a76f-147b2d5c2a4f" />

After:

<img width="710" alt="image" src="https://github.com/user-attachments/assets/39016ad5-44b1-4057-ae1b-ece7ce00f673" />
