### PR TITLE
fix(kmodal): kmodal not scrollable when content slot used [KHCP-15360]

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -358,7 +358,7 @@ onBeforeUnmount(async () => {
       font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
       line-height: var(--kui-line-height-30, $kui-line-height-30);
       max-height: v-bind('maxHeightValue');
-      overflow: hidden;
+      overflow-y: auto;
     }
 
     .modal-header {


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-15360

Fix issue in KModal where it's not scrollable vertically when `content` slot is used

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
