### PR TITLE
fix(klabel): required indicator icon not aligned properly [KM-1034]

### DIFF
--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -90,7 +90,7 @@ $kLabelRequiredDotSize: 6px;
     &::before {
       background-color: var(--kui-color-background-danger, $kui-color-background-danger);
       border-radius: var(--kui-border-radius-circle, $kui-border-radius-circle);
-      bottom: calc(50% - 2px); // place the dot in the middle of the text
+      bottom: calc(50% - $kLabelRequiredDotSize / 2); // place the dot in the middle of the text
       content: '';
       height: $kLabelRequiredDotSize;
       left: 0px;


### PR DESCRIPTION
Fix the required indicator bottom value did not include  $kLabelRequiredDotSize to calculate

# Summary

The value of the red dot `bottom` did not include the `$kLabelRequiredDotSize` into its calculation, this PR simply brings the value to the equation so that the red dot can be properly aligned with the label text.

## Screenshots

| Before | After |
| ------ | ----- |
| ![CleanShot 2025-03-11 at 17 48 52@2x](https://github.com/user-attachments/assets/a0936c1a-67e4-40ec-a5c6-ce18b322d972) |  ![CleanShot 2025-03-11 at 17 49 27@2x](https://github.com/user-attachments/assets/3e56f1a8-cdf7-48a2-b92d-745d42df693b) |



<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
