### PR TITLE
fix(types): popover attributes allow width

### DIFF
--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -22,7 +22,7 @@ export const PopPlacementsArray = [
 
 export type PopPlacements = AnyElementOf<typeof PopPlacementsArray>
 
-export interface PopoverAttributes {
+export interface PopoverAttributes extends Record<string, any> {
   placement?: PopPlacements
   popoverClasses?: string
   offset?: string

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -26,6 +26,6 @@ export interface PopoverAttributes {
   placement?: PopPlacements
   popoverClasses?: string
   offset?: string
-  width?: string | number
+  width?: string
 }
 

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -22,9 +22,10 @@ export const PopPlacementsArray = [
 
 export type PopPlacements = AnyElementOf<typeof PopPlacementsArray>
 
-export interface PopoverAttributes extends Record<string, any> {
+export interface PopoverAttributes {
   placement?: PopPlacements
   popoverClasses?: string
   offset?: string
+  width?: string | number
 }
 


### PR DESCRIPTION
# Summary

Allow `width` property in `PopoverAttributes` type for backward compatibility 

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
