### PR TITLE
fix(ktableview): row links tabindex [KHCP-15202]

### DIFF
--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -249,7 +249,7 @@
                   'last-row': rowIndex === data.length - 1 && !expandedRows.includes(rowIndex),
                 }"
                 :role="!!rowLink(row).to ? 'link' : undefined"
-                :tabindex="isClickable || !!rowLink(row).to ? 0 : undefined"
+                :tabindex="isClickable && !rowLink(row).to ? 0 : undefined"
                 v-bind="rowAttrs(row)"
               >
                 <td
@@ -1240,7 +1240,7 @@ watch([() => props.data, dataSelectState], (newVals) => {
     const selectableRowsState = newDataSelectState.filter((rowState) => !rowState.disabled && newData.find((row) => getRowKey(row) === rowState.rowKey))
 
     // all are selected
-    if (selectableRowsState.filter((rowState) => rowState.selected).length === selectableRowsState.length) {
+    if (selectableRowsState.length && selectableRowsState.filter((rowState) => rowState.selected).length === selectableRowsState.length) {
       bulkActionsAll.value = true
       // all are unselected
     } else if (selectableRowsState.filter((rowState) => !rowState.selected).length === selectableRowsState.length) {


### PR DESCRIPTION
# Summary

Don't set `tabindex` on rows when `rowLink` prop is provided

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
