### PR TITLE
fix(ktable): missing styles, no container class

### DIFF
--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -85,7 +85,10 @@
       </slot>
     </div>
 
-    <div v-else>
+    <div
+      v-else
+      class="table-container"
+    >
       <div
         class="table-wrapper"
         :style="tableWrapperStyles"


### PR DESCRIPTION
A new container class `table-container` has been introduced which nests all styles and has not been added to the KTable component.

---

Related commit that introduced `table-container` class: https://github.com/Kong/kongponents/commit/5782168b1ce5f15283bec327fcf9cb1e9bbd6ddf

Before
![image](https://github.com/user-attachments/assets/67c0d623-2a6c-4f26-9b05-a7de0988c295)


After
![image](https://github.com/user-attachments/assets/1570eff9-36e1-4bd9-9199-84e307800824)

