### PR TITLE
feat(kpop): add target prop and teleport [KHCP-15449]

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -394,6 +394,30 @@ Prop for specifying popover offset (string). Default value is `16px`.
 </KPop>
 ```
 
+### target
+
+In certain scenarios, you may need to render the popover above other elements. To achieve this, use the `target` prop to specify a selector for the element where the popover will be teleported. When falsy value us passed, the teleport will be disabled, therefore popover won't be [teleported](https://vuejs.org/guide/built-ins/teleport). Defaults to `null`.
+
+<KPop
+  target="body"
+  button-text="Open popover"
+>
+  <template #content>
+    Popover teleported to body.
+  </template>
+</KPop>
+
+```html
+<KPop
+  target="body"
+  button-text="Open popover"
+>
+  <template #content>
+    Popover teleported to body.
+  </template>
+</KPop>
+```
+
 ## Slots
 
 ### content

--- a/sandbox/pages/SandboxPop.vue
+++ b/sandbox/pages/SandboxPop.vue
@@ -324,9 +324,12 @@
       />
       <div>
         <KTooltip
-          :kpop-attributes="{ offset: KUI_SPACE_100 }"
+          :kpop-attributes="{
+            offset: KUI_SPACE_100,
+            target: '#teleport-target'
+          }"
           placement="right"
-          text="Tooltip offset by 40px."
+          text="Teleported tooltip offset by 40px."
         >
           <InfoIcon tabindex="0" />
         </KTooltip>

--- a/sandbox/pages/SandboxPop.vue
+++ b/sandbox/pages/SandboxPop.vue
@@ -200,6 +200,16 @@
           </KPop>
         </div>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="target">
+        <KPop
+          button-text="Button"
+          target="#teleport-target"
+        >
+          <template #content>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          </template>
+        </KPop>
+      </SandboxSectionComponent>
 
       <!-- Slots -->
       <SandboxTitleComponent

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -162,6 +162,7 @@ const defaultKPopAttributes = {
 const boundKPopAttributes = {
   ...defaultKPopAttributes,
   ...props.kpopAttributes,
+  target: '', // unset target in case it was passed in
   width: props.width ? props.width : undefined,
   popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes?.popoverClasses || ''}`,
 }

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -162,7 +162,7 @@ const defaultKPopAttributes = {
 const boundKPopAttributes = {
   ...defaultKPopAttributes,
   ...props.kpopAttributes,
-  target: '', // unset target in case it was passed in
+  target: null, // unset target in case it was passed in; we don't want to teleport the popover because it should always be the descendant of .k-dropdown
   width: props.width ? props.width : undefined,
   popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes?.popoverClasses || ''}`,
 }

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -572,7 +572,7 @@ const createKPopAttributes = computed((): Record<string, any> => {
   return {
     ...defaultKPopAttributes,
     ...props.kpopAttributes,
-    target: '', // unset target in case it was passed in
+    target: null, // unset target in case it was passed in; we don't want to teleport the popover because it should always be the descendant of .k-multiselect
     popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes?.popoverClasses ?? ''} ${props.dropdownFooterText || slots['dropdown-footer-text'] ? 'has-dropdown-footer' : ''}`,
     width: numericWidth.value + 'px',
     maxWidth: numericWidth.value + 'px',

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -572,6 +572,7 @@ const createKPopAttributes = computed((): Record<string, any> => {
   return {
     ...defaultKPopAttributes,
     ...props.kpopAttributes,
+    target: '', // unset target in case it was passed in
     popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes?.popoverClasses ?? ''} ${props.dropdownFooterText || slots['dropdown-footer-text'] ? 'has-dropdown-footer' : ''}`,
     width: numericWidth.value + 'px',
     maxWidth: numericWidth.value + 'px',

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -31,12 +31,12 @@
           class="popover"
           :class="popoverClassesObj"
           role="dialog"
-          :style="floatingStyles"
+          :style="popoverStyles"
           :x-placement="calculatedPlacement"
         >
           <div
             class="popover-container"
-            :style="popoverStyles"
+            :style="popoverContainerStyles"
           >
             <button
               v-if="!hideCloseIcon"
@@ -251,16 +251,6 @@ const clickHandler = (event: Event) => {
   }
 }
 
-const popoverStyles = computed(() => {
-  return {
-    width: getSizeFromString(props.width),
-    maxWidth: getSizeFromString(props.maxWidth),
-    maxHeight: getSizeFromString(props.maxHeight),
-  }
-})
-
-const popoverClassesObj = computed(() => [props.popoverClasses, { 'hide-caret': props.hideCaret }])
-
 /**
  * Backwards compatibility for the placement prop
  * Converts the placement prop to the correct format for Floating UI
@@ -281,9 +271,48 @@ const { floatingStyles, placement: calculatedPlacement, update: updatePosition }
   transform: false,
 })
 
-const floatingUpdates = ref<() => void>()
-
 const popoverOffset = computed(() => getSizeFromString(props.offset))
+const marginStyles = computed(() => {
+  if (calculatedPlacement.value.includes('top')) {
+    return {
+      marginBottom: popoverOffset.value,
+    }
+  } else if (calculatedPlacement.value.includes('bottom')) {
+    return {
+      marginTop: popoverOffset.value,
+    }
+  } else if (calculatedPlacement.value.includes('right')) {
+    return {
+      marginLeft: popoverOffset.value,
+    }
+  } else if (calculatedPlacement.value.includes('left')) {
+    return {
+      marginRight: popoverOffset.value,
+    }
+  } else {
+    return {}
+  }
+})
+
+const popoverStyles = computed(() => {
+  return {
+    ...floatingStyles.value,
+    zIndex: props.zIndex,
+  }
+})
+
+const popoverContainerStyles = computed(() => {
+  return {
+    ...marginStyles.value,
+    width: getSizeFromString(props.width),
+    maxWidth: getSizeFromString(props.maxWidth),
+    maxHeight: getSizeFromString(props.maxHeight),
+  }
+})
+
+const popoverClassesObj = computed(() => [props.popoverClasses, { 'hide-caret': props.hideCaret }])
+
+const floatingUpdates = ref<() => void>()
 
 defineExpose({
   hidePopover,
@@ -399,7 +428,8 @@ $kPopCaretOffset: 16px;
   // gets overwritten by the size middleware once the popover is positioned
   max-width: 100vw;
   width: max-content;
-  z-index: v-bind('zIndex');
+  // This won't work until https://github.com/vuejs/core/issues/7312 is fixed
+  // z-index: v-bind('zIndex');
 
   // need to wrap popover content in a container because we cannot set position: relative; as that will break the floating-ui positioning
   .popover-container {
@@ -483,11 +513,12 @@ $kPopCaretOffset: 16px;
   &[x-placement^="top"] .popover-container {
     @include kPopCaret;
 
+    // This won't work until https://github.com/vuejs/core/issues/7312 is fixed
     // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
     // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      margin-bottom: v-bind('popoverOffset');
-    }
+    // & {
+    //   margin-bottom: v-bind('popoverOffset');
+    // }
 
     &:after, &:before {
       left: 50%;
@@ -507,11 +538,12 @@ $kPopCaretOffset: 16px;
   &[x-placement^="right"] .popover-container {
     @include kPopCaret;
 
+    // This won't work until https://github.com/vuejs/core/issues/7312 is fixed
     // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
     // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      margin-left: v-bind('popoverOffset');
-    }
+    // & {
+    //   margin-left: v-bind('popoverOffset');
+    // }
 
     &:after, &:before {
       right: 100%;
@@ -532,11 +564,12 @@ $kPopCaretOffset: 16px;
   &[x-placement^="bottom"] .popover-container {
     @include kPopCaret;
 
+    // This won't work until https://github.com/vuejs/core/issues/7312 is fixed
     // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
     // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      margin-top: v-bind('popoverOffset');
-    }
+    // & {
+    //   margin-top: v-bind('popoverOffset');
+    // }
 
     &:after, &:before {
       bottom: 100%;
@@ -556,11 +589,12 @@ $kPopCaretOffset: 16px;
   &[x-placement^="left"] .popover-container {
     @include kPopCaret;
 
+    // This won't work until https://github.com/vuejs/core/issues/7312 is fixed
     // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
     // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      margin-right: v-bind('popoverOffset');
-    }
+    // & {
+    //   margin-right: v-bind('popoverOffset');
+    // }
 
     &:after, &:before {
       left: 100%;

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -20,7 +20,6 @@
     </div>
 
     <Teleport
-      defer
       :disabled="!target"
       :to="target ? target : `#${popoverWrapperId}`"
     >

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -21,6 +21,7 @@
 
     <Teleport
       defer
+      :disabled="!target"
       :to="target ? target : `#${popoverWrapperId}`"
     >
       <Transition name="kongponents-fade-transition">

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -1,6 +1,7 @@
 <template>
   <component
     :is="tag"
+    :id="popoverWrapperId"
     ref="kPopoverElement"
     class="k-popover"
   >
@@ -18,72 +19,77 @@
       </slot>
     </div>
 
-    <Transition name="kongponents-fade-transition">
-      <div
-        v-show="isVisible"
-        :id="popoverId"
-        ref="popoverElement"
-        :aria-labelledby="$slots.title || title ? titleId : undefined"
-        class="popover"
-        :class="popoverClassesObj"
-        role="dialog"
-        :style="floatingStyles"
-        :x-placement="calculatedPlacement"
-      >
+    <Teleport
+      defer
+      :to="target ? target : `#${popoverWrapperId}`"
+    >
+      <Transition name="kongponents-fade-transition">
         <div
-          class="popover-container"
-          :style="popoverStyles"
+          v-show="isVisible"
+          :id="popoverId"
+          ref="popoverElement"
+          :aria-labelledby="$slots.title || title ? titleId : undefined"
+          class="popover"
+          :class="popoverClassesObj"
+          role="dialog"
+          :style="floatingStyles"
+          :x-placement="calculatedPlacement"
         >
-          <button
-            v-if="!hideCloseIcon"
-            ref="popoverCloseButton"
-            aria-label="Close popover"
-            class="popover-close-button"
-            :tabindex="isVisible ? 0 : -1"
-            type="button"
-            @click="hidePopover"
-          >
-            <CloseIcon
-              class="popover-close-icon"
-              decorative
-              :size="KUI_ICON_SIZE_30"
-            />
-          </button>
           <div
-            v-if="$slots.title || title"
-            class="popover-header"
+            class="popover-container"
+            :style="popoverStyles"
           >
+            <button
+              v-if="!hideCloseIcon"
+              ref="popoverCloseButton"
+              aria-label="Close popover"
+              class="popover-close-button"
+              :tabindex="isVisible ? 0 : -1"
+              type="button"
+              @click="hidePopover"
+            >
+              <CloseIcon
+                class="popover-close-icon"
+                decorative
+                :size="KUI_ICON_SIZE_30"
+              />
+            </button>
             <div
               v-if="$slots.title || title"
-              :id="titleId"
-              class="popover-title"
-              :class="{ 'close-icon-spacing': !hideCloseIcon }"
+              class="popover-header"
             >
-              <slot name="title">
-                {{ title }}
-              </slot>
+              <div
+                v-if="$slots.title || title"
+                :id="titleId"
+                class="popover-title"
+                :class="{ 'close-icon-spacing': !hideCloseIcon }"
+              >
+                <slot name="title">
+                  {{ title }}
+                </slot>
+              </div>
+            </div>
+            <div
+              class="popover-content"
+              :class="{ 'close-icon-spacing': !hideCloseIcon && !($slots.title || title) }"
+            >
+              <slot name="content" />
+            </div>
+            <div
+              v-if="$slots.footer"
+              class="popover-footer"
+            >
+              <slot name="footer" />
             </div>
           </div>
-          <div
-            class="popover-content"
-            :class="{ 'close-icon-spacing': !hideCloseIcon && !($slots.title || title) }"
-          >
-            <slot name="content" />
-          </div>
-          <div
-            v-if="$slots.footer"
-            class="popover-footer"
-          >
-            <slot name="footer" />
-          </div>
         </div>
-      </div>
-    </Transition>
+      </Transition>
+    </Teleport>
   </component>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, computed, watch, useId } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch, useId, useAttrs } from 'vue'
 import type { PropType } from 'vue'
 import { useFloating, autoUpdate, autoPlacement, flip, shift } from '@floating-ui/vue'
 import type { PopPlacements, PopTrigger } from '@/types'
@@ -160,14 +166,21 @@ const props = defineProps({
     type: String,
     default: KUI_SPACE_60,
   },
+  target: {
+    type: String,
+    default: '',
+  },
 })
 
 const emit = defineEmits(['open', 'close', 'popover-click'])
+
+const attrs = useAttrs()
 
 const { getSizeFromString } = useUtilities()
 
 const popoverId = useId()
 const titleId = useId()
+const popoverWrapperId = attrs.id ? String(attrs.id) : useId()
 const kPopoverElement = ref<HTMLElement | null>(null)
 const triggerWrapperElement = ref<HTMLElement | null>(null)
 const popoverElement = ref<HTMLElement | null>(null)
@@ -382,224 +395,225 @@ $kPopCaretOffset: 16px;
     display: inline-flex;
     width: 100%;
   }
+}
 
-  .popover {
-    // need max-width: 100vw; and width: max-content; for Floating UI to work properly
-    // gets overwritten by the size middleware once the popover is positioned
-    max-width: 100vw;
-    width: max-content;
-    z-index: v-bind('zIndex');
+// need to have these styles not nested under .k-popover so that they still apply when the popover is teleported
+.popover {
+  // need max-width: 100vw; and width: max-content; for Floating UI to work properly
+  // gets overwritten by the size middleware once the popover is positioned
+  max-width: 100vw;
+  width: max-content;
+  z-index: v-bind('zIndex');
 
-    // need to wrap popover content in a container because we cannot set position: relative; as that will break the floating-ui positioning
-    .popover-container {
-      background-color: var(--kui-color-background, $kui-color-background);
-      border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
-      border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
-      box-shadow: var(--kui-shadow, $kui-shadow);
+  // need to wrap popover content in a container because we cannot set position: relative; as that will break the floating-ui positioning
+  .popover-container {
+    background-color: var(--kui-color-background, $kui-color-background);
+    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+    box-shadow: var(--kui-shadow, $kui-shadow);
+    display: flex;
+    flex-direction: column;
+    font-family: var(--kui-font-family-text, $kui-font-family-text);
+    gap: var(--kui-space-40, $kui-space-40);
+    padding: var(--kui-space-60, $kui-space-60);
+    position: relative;
+    text-align: left;
+    white-space: normal;
+
+    .popover-close-button {
+      @include defaultButtonReset;
+
+      // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
+      // stylelint-disable-next-line no-duplicate-selectors
+      & {
+        border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
+        color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+        margin: var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0) var(--kui-space-0, $kui-space-0);
+        outline: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      &:hover, &:focus {
+        color: var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong) !important;
+      }
+
+      &:focus-visible {
+        box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+      }
+
+      .popover-close-icon {
+        pointer-events: none;
+      }
+    }
+
+    .popover-header {
+      align-items: baseline;
       display: flex;
-      flex-direction: column;
-      font-family: var(--kui-font-family-text, $kui-font-family-text);
-      gap: var(--kui-space-40, $kui-space-40);
-      padding: var(--kui-space-60, $kui-space-60);
-      position: relative;
-      text-align: left;
-      white-space: normal;
 
-      .popover-close-button {
-        @include defaultButtonReset;
-
-        // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-        // stylelint-disable-next-line no-duplicate-selectors
-        & {
-          border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
-          color: var(--kui-color-text-neutral, $kui-color-text-neutral);
-          margin: var(--kui-space-60, $kui-space-60) var(--kui-space-60, $kui-space-60) var(--kui-space-0, $kui-space-0) var(--kui-space-0, $kui-space-0);
-          outline: none;
-          position: absolute;
-          right: 0;
-          top: 0;
-        }
-
-        &:hover, &:focus {
-          color: var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong) !important;
-        }
-
-        &:focus-visible {
-          box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
-        }
-
-        .popover-close-icon {
-          pointer-events: none;
-        }
-      }
-
-      .popover-header {
-        align-items: baseline;
-        display: flex;
-
-        .popover-title {
-          color: var(--kui-color-text, $kui-color-text);
-          font-size: var(--kui-font-size-40, $kui-font-size-40);
-          font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
-          line-height: var(--kui-line-height-30, $kui-line-height-30);
-
-          &.close-icon-spacing {
-            margin-right: var(--kui-space-60, $kui-space-60);
-          }
-        }
-      }
-
-      .popover-content {
-        color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger);
-        font-size: var(--kui-font-size-20, $kui-font-size-20);
-        font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
-        line-height: var(--kui-line-height-20, $kui-line-height-20);
+      .popover-title {
+        color: var(--kui-color-text, $kui-color-text);
+        font-size: var(--kui-font-size-40, $kui-font-size-40);
+        font-weight: var(--kui-font-weight-bold, $kui-font-weight-bold);
+        line-height: var(--kui-line-height-30, $kui-line-height-30);
 
         &.close-icon-spacing {
           margin-right: var(--kui-space-60, $kui-space-60);
         }
       }
+    }
 
-      .popover-footer {
-        align-items: center;
-        display: flex;
-        gap: var(--kui-space-40, $kui-space-40);
+    .popover-content {
+      color: var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger);
+      font-size: var(--kui-font-size-20, $kui-font-size-20);
+      font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
+      line-height: var(--kui-line-height-20, $kui-line-height-20);
+
+      &.close-icon-spacing {
+        margin-right: var(--kui-space-60, $kui-space-60);
       }
     }
 
-    // placement and caret styles
+    .popover-footer {
+      align-items: center;
+      display: flex;
+      gap: var(--kui-space-40, $kui-space-40);
+    }
+  }
 
-    &[x-placement^="top"] .popover-container {
-      @include kPopCaret;
+  // placement and caret styles
 
-      // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-      // stylelint-disable-next-line no-duplicate-selectors
-      & {
-        margin-bottom: v-bind('popoverOffset');
-      }
+  &[x-placement^="top"] .popover-container {
+    @include kPopCaret;
 
-      &:after, &:before {
-        left: 50%;
-        top: 100%;
-      }
-
-      &:after {
-        /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
-        border-top-color: var(--kui-color-background, $kui-color-background);
-      }
-
-      &:before {
-        border-top-color: var(--kui-color-border, $kui-color-border);
-      }
+    // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      margin-bottom: v-bind('popoverOffset');
     }
 
-    &[x-placement^="right"] .popover-container {
-      @include kPopCaret;
-
-      // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-      // stylelint-disable-next-line no-duplicate-selectors
-      & {
-        margin-left: v-bind('popoverOffset');
-      }
-
-      &:after, &:before {
-        right: 100%;
-        top: 50%;
-        transform: translateY(-50%);
-      }
-
-      &:after {
-        /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
-        border-right-color: var(--kui-color-background, $kui-color-background);
-      }
-
-      &:before {
-        border-right-color: var(--kui-color-border, $kui-color-border);
-      }
+    &:after, &:before {
+      left: 50%;
+      top: 100%;
     }
 
-    &[x-placement^="bottom"] .popover-container {
-      @include kPopCaret;
-
-      // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-      // stylelint-disable-next-line no-duplicate-selectors
-      & {
-        margin-top: v-bind('popoverOffset');
-      }
-
-      &:after, &:before {
-        bottom: 100%;
-        left: 50%;
-      }
-
-      &:after {
-        /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
-        border-bottom-color: var(--kui-color-background, $kui-color-background);
-      }
-
-      &:before {
-        border-bottom-color: var(--kui-color-border, $kui-color-border);
-      }
+    &:after {
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      border-top-color: var(--kui-color-background, $kui-color-background);
     }
 
-    &[x-placement^="left"] .popover-container {
-      @include kPopCaret;
+    &:before {
+      border-top-color: var(--kui-color-border, $kui-color-border);
+    }
+  }
 
-      // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-      // stylelint-disable-next-line no-duplicate-selectors
-      & {
-        margin-right: v-bind('popoverOffset');
-      }
+  &[x-placement^="right"] .popover-container {
+    @include kPopCaret;
 
-      &:after, &:before {
-        left: 100%;
-        top: 50%;
-        transform: translate(50%, -50%);
-      }
-
-      &:after {
-        /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
-        border-left-color: var(--kui-color-background, $kui-color-background);
-      }
-
-      &:before {
-        border-left-color: var(--kui-color-border, $kui-color-border);
-      }
+    // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      margin-left: v-bind('popoverOffset');
     }
 
-    &[x-placement^="top-start"] .popover-container,
-    &[x-placement^="bottom-start"] .popover-container {
-      &:after, &:before {
-        left: $kPopCaretOffset;
-      }
+    &:after, &:before {
+      right: 100%;
+      top: 50%;
+      transform: translateY(-50%);
     }
 
-    &[x-placement^="right-start"] .popover-container,
-    &[x-placement^="left-start"] .popover-container {
-      &:after, &:before {
-        top: $kPopCaretOffset;
-      }
+    &:after {
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      border-right-color: var(--kui-color-background, $kui-color-background);
     }
 
-    &[x-placement^="top-end"] .popover-container,
-    &[x-placement^="bottom-end"] .popover-container {
-      &:after, &:before {
-        left: calc(100% - $kPopCaretOffset);
-      }
+    &:before {
+      border-right-color: var(--kui-color-border, $kui-color-border);
+    }
+  }
+
+  &[x-placement^="bottom"] .popover-container {
+    @include kPopCaret;
+
+    // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      margin-top: v-bind('popoverOffset');
     }
 
-    &[x-placement^="right-end"] .popover-container,
-    &[x-placement^="left-end"] .popover-container {
-      &:after, &:before {
-        top: calc(100% - $kPopCaretOffset);
-      }
+    &:after, &:before {
+      bottom: 100%;
+      left: 50%;
     }
 
-    &.hide-caret .popover-container {
-      &:after,
-      &:before {
-        display: none;
-      }
+    &:after {
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      border-bottom-color: var(--kui-color-background, $kui-color-background);
+    }
+
+    &:before {
+      border-bottom-color: var(--kui-color-border, $kui-color-border);
+    }
+  }
+
+  &[x-placement^="left"] .popover-container {
+    @include kPopCaret;
+
+    // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
+    // stylelint-disable-next-line no-duplicate-selectors
+    & {
+      margin-right: v-bind('popoverOffset');
+    }
+
+    &:after, &:before {
+      left: 100%;
+      top: 50%;
+      transform: translate(50%, -50%);
+    }
+
+    &:after {
+      /* stylelint-disable-next-line @kong/design-tokens/use-proper-token */
+      border-left-color: var(--kui-color-background, $kui-color-background);
+    }
+
+    &:before {
+      border-left-color: var(--kui-color-border, $kui-color-border);
+    }
+  }
+
+  &[x-placement^="top-start"] .popover-container,
+  &[x-placement^="bottom-start"] .popover-container {
+    &:after, &:before {
+      left: $kPopCaretOffset;
+    }
+  }
+
+  &[x-placement^="right-start"] .popover-container,
+  &[x-placement^="left-start"] .popover-container {
+    &:after, &:before {
+      top: $kPopCaretOffset;
+    }
+  }
+
+  &[x-placement^="top-end"] .popover-container,
+  &[x-placement^="bottom-end"] .popover-container {
+    &:after, &:before {
+      left: calc(100% - $kPopCaretOffset);
+    }
+  }
+
+  &[x-placement^="right-end"] .popover-container,
+  &[x-placement^="left-end"] .popover-container {
+    &:after, &:before {
+      top: calc(100% - $kPopCaretOffset);
+    }
+  }
+
+  &.hide-caret .popover-container {
+    &:after,
+    &:before {
+      display: none;
     }
   }
 }

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -1,7 +1,6 @@
 <template>
   <component
     :is="tag"
-    :id="popoverWrapperId"
     ref="kPopoverElement"
     class="k-popover"
   >
@@ -21,7 +20,7 @@
 
     <Teleport
       :disabled="!target"
-      :to="target ? target : `#${popoverWrapperId}`"
+      :to="target ? target : undefined"
     >
       <Transition name="kongponents-fade-transition">
         <div
@@ -89,7 +88,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, computed, watch, useId, useAttrs } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch, useId } from 'vue'
 import type { PropType } from 'vue'
 import { useFloating, autoUpdate, autoPlacement, flip, shift } from '@floating-ui/vue'
 import type { PopPlacements, PopTrigger } from '@/types'
@@ -174,13 +173,10 @@ const props = defineProps({
 
 const emit = defineEmits(['open', 'close', 'popover-click'])
 
-const attrs = useAttrs()
-
 const { getSizeFromString } = useUtilities()
 
 const popoverId = useId()
 const titleId = useId()
-const popoverWrapperId = attrs.id ? String(attrs.id) : useId()
 const kPopoverElement = ref<HTMLElement | null>(null)
 const triggerWrapperElement = ref<HTMLElement | null>(null)
 const popoverElement = ref<HTMLElement | null>(null)

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -168,8 +168,8 @@ const props = defineProps({
     default: KUI_SPACE_60,
   },
   target: {
-    type: String,
-    default: '',
+    type: [String, null],
+    default: null,
   },
 })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -431,6 +431,7 @@ const createKPopAttributes = computed(() => {
   return {
     ...defaultKPopAttributes,
     ...props.kpopAttributes,
+    target: '', // unset target in case it was passed in
     popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes?.popoverClasses ?? ''}`,
     width: String(actualElementWidth.value),
     maxWidth: String(actualElementWidth.value),

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -431,7 +431,7 @@ const createKPopAttributes = computed(() => {
   return {
     ...defaultKPopAttributes,
     ...props.kpopAttributes,
-    target: '', // unset target in case it was passed in
+    target: null, // unset target in case it was passed in; we don't want to teleport the popover because it should always be the descendant of .k-select
     popoverClasses: `${defaultKPopAttributes.popoverClasses} ${props.kpopAttributes?.popoverClasses ?? ''}`,
     width: String(actualElementWidth.value),
     maxWidth: String(actualElementWidth.value),

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -102,8 +102,8 @@ const showTooltip = computed((): boolean => !!props.text || !!props.label || !!s
 const randomTooltipId = useId()
 </script>
 
-<style lang="scss" scoped>
-:deep(.k-tooltip.popover) {
+<style lang="scss">
+.k-tooltip.popover {
   .popover-container {
     background-color: var(--kui-color-background-inverse, $kui-color-background-inverse);
     border: none;

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -27,5 +27,7 @@ export interface PopoverAttributes {
   popoverClasses?: string
   offset?: string
   width?: string
+  /** Not supported in KDropdown, KSelect and KMultiselect */
+  target?: string
 }
 

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -28,6 +28,6 @@ export interface PopoverAttributes {
   offset?: string
   width?: string
   /** Not supported in KDropdown, KSelect and KMultiselect */
-  target?: string
+  target?: string | null
 }
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-15449

Add `target` prop in KPop to specify a selector for the element where the popover will be teleported. Also expose it through `kpopAttributes` prop for KTooltip

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
