### PR TITLE
fix(ktableview): make header non-sticky in firefox

### DIFF
--- a/src/styles/mixins/_tables.scss
+++ b/src/styles/mixins/_tables.scss
@@ -72,6 +72,10 @@
           top: 0;
           z-index: 2;
 
+          @-moz-document url-prefix() {
+            position: unset; // make header non-sticky in Firefox because otherwise tooltips are cut off by the table boundaries
+          }
+
           &.is-scrolled {
             background-color: var(--kui-color-background, $kui-color-background);
           }


### PR DESCRIPTION
# Summary

Before
![Screenshot 2025-03-14 at 3 45 26 PM](https://github.com/user-attachments/assets/18c4600c-7906-4944-a2b9-f2dc9c711438)

After
![Screenshot 2025-03-14 at 3 46 13 PM](https://github.com/user-attachments/assets/164f2046-be76-4ccf-a23b-b8b3f07a7c19)

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
