### PR TITLE
fix(actions): use kong changed files

### DIFF
--- a/.github/workflows/get-changed-files.yaml
+++ b/.github/workflows/get-changed-files.yaml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Check if component (`src` directory) files have changed
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         id: component-files-changed
         # Return 'true' for any directories listed here that changed
         with:
@@ -41,7 +41,7 @@ jobs:
             src/**
 
       - name: Check if docs (`docs` directory) files have changed
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         id: docs-files-changed
         # Return 'true' for any directories listed here that changed
         with:
@@ -49,7 +49,7 @@ jobs:
             docs/**
 
       - name: Check if files changed in `src/`, `docs/`, or `cypress/` directories
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         id: components-or-docs-or-cypress-files-changed
         # Return 'true' for any directories listed here that changed
         with:
@@ -59,7 +59,7 @@ jobs:
             cypress/**
 
       - name: Check if package.json or pnpm.lock files changed
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         id: package-json-pnpm-lock-files-changed
         # Return 'true' for any directories listed here that changed
         with:


### PR DESCRIPTION
Use kong changed-files github actions as the original upstream has been compromised and shut down. See #incident-456.