### PR TITLE
fix(kselect, kmultiselect): arrow navigation improvements [KHCP-15520]

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -898,7 +898,7 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp')) {
-    multiselectItemsRef.value?.setFocus()
+    multiselectItemsRef.value?.setFocus(evt.code === 'ArrowDown' ? 'down' : 'up')
   }
 }
 
@@ -908,7 +908,7 @@ const onTriggerKeypress = () => {
 
 const onDropdownInputKeyup = (event: any) => {
   if ((event.code === 'ArrowDown' || event.code === 'ArrowUp')) {
-    multiselectItemsRef.value?.setFocus()
+    multiselectItemsRef.value?.setFocus(event.code === 'ArrowDown' ? 'down' : 'up')
   }
 }
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -897,8 +897,8 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>):void => {
     isToggled.value = false
   }
 
-  if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp')) {
-    multiselectItemsRef.value?.setFocus(evt.code === 'ArrowDown' ? 'down' : 'up')
+  if ((evt.key === 'ArrowDown' || evt.key === 'ArrowUp')) {
+    multiselectItemsRef.value?.setFocus(evt.key === 'ArrowDown' ? 'down' : 'up')
   }
 }
 
@@ -907,8 +907,8 @@ const onTriggerKeypress = () => {
 }
 
 const onDropdownInputKeyup = (event: any) => {
-  if ((event.code === 'ArrowDown' || event.code === 'ArrowUp')) {
-    multiselectItemsRef.value?.setFocus(event.code === 'ArrowDown' ? 'down' : 'up')
+  if ((event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+    multiselectItemsRef.value?.setFocus(event.key === 'ArrowDown' ? 'down' : 'up')
   }
 }
 

--- a/src/components/KMultiselect/KMultiselectItem.vue
+++ b/src/components/KMultiselect/KMultiselectItem.vue
@@ -65,6 +65,7 @@ const handleClick = (): void => {
     background-color: var(--kui-color-background, $kui-color-background);
     border: none;
     display: flex;
+    outline-offset: -1px;
     padding: var(--kui-space-0, $kui-space-0);
     text-align: left;
     width: 100%;

--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -103,9 +103,13 @@ const getGroupItems = (group: string) => props.items?.filter(item => item.group 
 
 const itemsContainerRef = useTemplateRef('itemsContainer')
 
-const setItemFocus = (): void => {
+const setItemFocus = (direction: 'down' | 'up'): void => {
+  let startingItem: HTMLButtonElement | undefined
   const firstSelectableItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.multiselect-item button:not(:disabled)')
-  firstSelectableItem?.focus()
+  const lastSelectableItem = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not(:disabled)')[itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not(:disabled)')?.length - 1]
+
+  startingItem = direction === 'down' ? (firstSelectableItem || undefined) : (lastSelectableItem || undefined)
+  startingItem?.focus()
 }
 
 const onKeyPress = ({ target, key } : KeyboardEvent) => {

--- a/src/components/KMultiselect/KMultiselectItems.vue
+++ b/src/components/KMultiselect/KMultiselectItems.vue
@@ -94,6 +94,8 @@ const emit = defineEmits<{
   (e: 'add-item'): void
 }>()
 
+const SELECTABLE_ITEM_SELECTOR = '.multiselect-item button:not(:disabled)'
+
 const handleItemSelect = (item: MultiselectItem) => emit('selected', item)
 
 const nonGroupedItems = computed((): MultiselectItem[] => props.items?.filter(item => !item.group))
@@ -104,18 +106,20 @@ const getGroupItems = (group: string) => props.items?.filter(item => item.group 
 const itemsContainerRef = useTemplateRef('itemsContainer')
 
 const setItemFocus = (direction: 'down' | 'up'): void => {
-  let startingItem: HTMLButtonElement | undefined
-  const firstSelectableItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.multiselect-item button:not(:disabled)')
-  const lastSelectableItem = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not(:disabled)')[itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not(:disabled)')?.length - 1]
+  const container = itemsContainerRef.value
+  if (!container) {
+    return
+  }
 
-  startingItem = direction === 'down' ? (firstSelectableItem || undefined) : (lastSelectableItem || undefined)
-  startingItem?.focus()
+  const selectableItems = container.querySelectorAll<HTMLButtonElement>(SELECTABLE_ITEM_SELECTOR)
+
+  selectableItems[direction === 'down' ? 0 : selectableItems.length - 1]?.focus()
 }
 
 const onKeyPress = ({ target, key } : KeyboardEvent) => {
   if (key === 'ArrowDown' || key === 'ArrowUp') {
     // all selectable items
-    const selectableItems = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.multiselect-item button:not(:disabled)')
+    const selectableItems = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>(SELECTABLE_ITEM_SELECTOR)
 
     if (selectableItems?.length) {
       // find the current element index in the array

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -562,7 +562,7 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>): void => {
   }
 
   if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp') && isToggled.value) {
-    selectItemsRef.value?.setFocus()
+    selectItemsRef.value?.setFocus(evt.code === 'ArrowDown' ? 'down' : 'up')
   }
 }
 
@@ -732,7 +732,7 @@ onMounted(() => {
       if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
         event.preventDefault()
 
-        selectItemsRef.value?.setFocus()
+        selectItemsRef.value?.setFocus(event.code === 'ArrowDown' ? 'down' : 'up')
       }
     }
   })

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -561,8 +561,8 @@ const triggerFocus = (evt: any, isToggled: Ref<boolean>): void => {
     inputElem.click()
   }
 
-  if ((evt.code === 'ArrowDown' || evt.code === 'ArrowUp') && isToggled.value) {
-    selectItemsRef.value?.setFocus(evt.code === 'ArrowDown' ? 'down' : 'up')
+  if ((evt.key === 'ArrowDown' || evt.key === 'ArrowUp') && isToggled.value) {
+    selectItemsRef.value?.setFocus(evt.key === 'ArrowDown' ? 'down' : 'up')
   }
 }
 
@@ -729,10 +729,10 @@ onMounted(() => {
   useEventListener(document, 'keydown', (event: any) => {
     // When enableFiltering is false, the KInput doesn't have focus so we need to handle arrow key events here
     if (!props.enableFiltering && document.activeElement?.tagName === 'BODY' && !inputFocused.value && isDropdownOpen.value) {
-      if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault()
 
-        selectItemsRef.value?.setFocus(event.code === 'ArrowDown' ? 'down' : 'up')
+        selectItemsRef.value?.setFocus(event.key === 'ArrowDown' ? 'down' : 'up')
       }
     }
   })

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -67,6 +67,7 @@ const handleClick = (e: MouseEvent): void => {
     background-color: var(--kui-color-background, $kui-color-background);
     border: none;
     display: flex;
+    outline-offset: -1px;
     padding: var(--kui-space-0, $kui-space-0);
     text-align: left;
     width: 100%;

--- a/src/components/KSelect/KSelectItems.vue
+++ b/src/components/KSelect/KSelectItems.vue
@@ -103,9 +103,30 @@ const getGroupItems = (group: string) => props.items?.filter(item => item.group 
 
 const itemsContainerRef = useTemplateRef('itemsContainer')
 
-const setItemFocus = (): void => {
-  const firstSelectableItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.select-item button:not(:disabled)')
-  firstSelectableItem?.focus()
+const setItemFocus = (direction: 'down' | 'up'): void => {
+  let startingItem: HTMLButtonElement | undefined
+  const selectedItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.select-item[aria-selected="true"] button:not(:disabled)')
+
+  if (selectedItem) {
+    const selectableItems = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not(:disabled)')
+
+    if (selectableItems?.length) {
+      // find the current element index in the array
+      const selectedElementIndex = [...selectableItems].indexOf(selectedItem as HTMLButtonElement)
+      // move to the next or previous element
+      const nextElementIndex = direction === 'down' ? selectedElementIndex + 1 : selectedElementIndex - 1
+      const nextElement = selectableItems[nextElementIndex]
+
+      startingItem = nextElement
+    }
+  } else {
+    const firstSelectableItem = itemsContainerRef.value?.querySelector<HTMLButtonElement>('.select-item button:not(:disabled)')
+    const lastSelectableItem = itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not(:disabled)')[itemsContainerRef.value?.querySelectorAll<HTMLButtonElement>('.select-item button:not(:disabled)')?.length - 1]
+
+    startingItem = direction === 'down' ? (firstSelectableItem || undefined) : (lastSelectableItem || undefined)
+  }
+
+  startingItem?.focus()
 }
 
 const onKeyPress = ({ target, key } : KeyboardEvent) => {


### PR DESCRIPTION
# Summary

Addresses:
https://konghq.atlassian.net/browse/KHCP-15520
https://konghq.atlassian.net/browse/KHCP-15522

KSelect and KMultiselect arrow navigation impprovements:

KSelect:
- when has selected item
    - upon pressing up or down keys, navigation starts from selected item
- when does not have selected item
    - upon pressing down key, navigation starts with the very first selectable item
    - upon pressing down key, navigation starts with the very last selectable item
- fix outline offset for items in `focus-visible` state

KMultiselect:
- upon pressing down key, navigation starts with the very first selectable item
- upon pressing down key, navigation starts with the very last selectable item
- fix outline offset for items in `focus-visible` state

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
