### PR TITLE
feat(kbreadcrumb): typescript improvement [KM-1102]

### DIFF
--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -43,41 +43,31 @@
 </template>
 
 <script setup lang="ts">
-import type { PropType } from 'vue'
-import type { BreadcrumbItem } from '@/types'
+import type { BreadcrumbItem, BreadcrumbProps } from '@/types'
 import useUtilities from '@/composables/useUtilities'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const { itemMaxWidth = '', items } = defineProps<BreadcrumbProps>()
 
 const { getSizeFromString } = useUtilities()
 
-defineProps({
-  items: {
-    type: Array as PropType<BreadcrumbItem[]>,
-    default: [] as BreadcrumbItem[],
-    required: true,
-    validator: (items: BreadcrumbItem[]): boolean => {
-      return items && items.length > 0
-    },
-  },
-  itemMaxWidth: {
-    type: String,
-    required: false,
-    default: '100px',
-  },
-})
-
 const getComponentAttrs = (item: BreadcrumbItem) => {
+  const title = item.title || item.text
   if (!item.to) {
     return {
       type: 'div',
       attrs: {
-        title: item.title || item.text,
+        title,
       },
     }
   } else if (typeof item.to === 'object') {
     return {
       type: 'router-link',
       attrs: {
-        title: item.title || item.text,
+        title,
         to: item.to,
       },
     }
@@ -86,19 +76,13 @@ const getComponentAttrs = (item: BreadcrumbItem) => {
       type: 'a',
       attrs: {
         href: item.to,
-        title: item.title || item.text,
+        title,
       },
     }
   }
 }
 
 const getBreadcrumbKey = (item: BreadcrumbItem, idx: number): string => item.key || `breadcrumb-${idx}`
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -50,7 +50,7 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const { itemMaxWidth = '', items } = defineProps<BreadcrumbProps>()
+const { itemMaxWidth = '100px', items } = defineProps<BreadcrumbProps>()
 
 const { getSizeFromString } = useUtilities()
 

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -9,3 +9,8 @@ export interface BreadcrumbItem {
   key?: string
   maxWidth?: string
 }
+
+export interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+  itemMaxWidth?: string
+}

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -11,6 +11,14 @@ export interface BreadcrumbItem {
 }
 
 export interface BreadcrumbProps {
+  /**
+   * Breadcrumb item list
+   * @type {BreadcrumbItem[]}
+   */
   items: BreadcrumbItem[]
+
+  /**
+   * The maximum width of each breadcrumb item
+   */
   itemMaxWidth?: string
 }

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -19,6 +19,7 @@ export interface BreadcrumbProps {
 
   /**
    * Maximum width of each breadcrumb item for truncating to ellipsis.
+   * @default '100px'
    */
   itemMaxWidth?: string
 }

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -12,13 +12,13 @@ export interface BreadcrumbItem {
 
 export interface BreadcrumbProps {
   /**
-   * Breadcrumb item list
+   * An array of breadcrumb items.
    * @type {BreadcrumbItem[]}
    */
   items: BreadcrumbItem[]
 
   /**
-   * The maximum width of each breadcrumb item
+   * Maximum width of each breadcrumb item for truncating to ellipsis.
    */
   itemMaxWidth?: string
 }


### PR DESCRIPTION
# Summary

Update KBreadcrumb props declaration with `type` instead of object. [KM-1102]

Preview https://github.com/Kong/konnect-ui-apps/pull/6331

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[KM-1102]: https://konghq.atlassian.net/browse/KM-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ