### PR TITLE
fix(ktableview): add tooltip-target prop [KHCP-15528]

### DIFF
--- a/docs/components/table-view.md
+++ b/docs/components/table-view.md
@@ -802,6 +802,10 @@ A boolean to disable some of the table features like column visibility, column r
 
 Prop for hiding toolbar. Useful when elements provided in the toolbar are not actionable (for example, when toolbar contains filter controls, however the fetcher returns no results as there are no records to filter by).
 
+### tooltipTarget
+
+Teleport target element selector for tooltips rendered by KTableView (e.g. column header tooltip, disabled row bulk action checkbox tooltip). Defaults to `body`.
+
 ## States
 
 ### Empty

--- a/sandbox/pages/SandboxTableView/SandboxTableView.vue
+++ b/sandbox/pages/SandboxTableView/SandboxTableView.vue
@@ -461,7 +461,7 @@ const headers = (hidable: boolean = false, sortable: boolean = false, bulkAction
   return [
     { key: 'actions', label: 'Row actions' },
     { key: 'name', label: 'Full Name' },
-    { key: 'username', label: 'Username', tooltip: 'Columns with a tooltip.', sortable },
+    { key: 'username', label: 'Username', tooltip: 'Columns with a tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.', sortable },
     { key: 'email', label: 'Email', hidable },
     ...(bulkActions ? [{ key: 'bulkActions', label: 'Bulk actions' }] : []),
   ]

--- a/sandbox/pages/SandboxTableView/SandboxTableView.vue
+++ b/sandbox/pages/SandboxTableView/SandboxTableView.vue
@@ -461,7 +461,7 @@ const headers = (hidable: boolean = false, sortable: boolean = false, bulkAction
   return [
     { key: 'actions', label: 'Row actions' },
     { key: 'name', label: 'Full Name' },
-    { key: 'username', label: 'Username', tooltip: 'Columns with a tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.', sortable },
+    { key: 'username', label: 'Username', tooltip: 'Columns with a tooltip.', sortable },
     { key: 'email', label: 'Email', hidable },
     ...(bulkActions ? [{ key: 'bulkActions', label: 'Bulk actions' }] : []),
   ]

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -191,6 +191,7 @@
                   <KTooltip
                     v-if="column.tooltip || $slots[getColumnTooltipSlotName(column.key)]"
                     :data-testid="getColumnTooltipSlotName(column.key)"
+                    :kpop-attributes="{ target: tooltipTarget }"
                     max-width="300"
                     :tooltip-id="`${getColumnTooltipSlotName(column.key)}-${tableId}`"
                   >
@@ -284,6 +285,7 @@
 
                     <KTooltip
                       v-else-if="header.key === TableViewHeaderKeys.BULK_ACTIONS && getRowState(row)"
+                      :kpop-attributes="{ target: tooltipTarget }"
                       max-width="200"
                       placement="bottom-start"
                       :text="getRowBulkActionEnabled(row) ? undefined : getRowBulkActionTooltip(row)"
@@ -474,6 +476,7 @@ const props = withDefaults(defineProps<TableViewProps>(), {
   nested: false,
   hidePaginationWhenOptional: false,
   hideToolbar: false,
+  tooltipTarget: 'body',
   /**
    * KTableView props defaults
    */

--- a/src/styles/mixins/_tables.scss
+++ b/src/styles/mixins/_tables.scss
@@ -72,10 +72,6 @@
           top: 0;
           z-index: 2;
 
-          @-moz-document url-prefix() {
-            position: unset; // make header non-sticky in Firefox because otherwise tooltips are cut off by the table boundaries
-          }
-
           &.is-scrolled {
             background-color: var(--kui-color-background, $kui-color-background);
           }

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -223,6 +223,10 @@ interface TablePropsShared {
    * A prop for hiding the toolbar
    */
   hideToolbar?: boolean
+  /**
+   * Target for tooltip teleports (column header tooltip, disabled bulk actions row tooltip)
+   */
+  tooltipTarget?: string | null
 }
 
 export interface TableViewProps extends TablePropsShared {


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-15528

Adds `teleportTarget` prop for passing the teleport target element selector KTableView-rendered tooltips will be teleported to (defaults to `body`).

Testing instructions:
In KTableView and KTableData sandbox and docs, make sure column header tooltips render where they are supposed to be and there are no errors in the console.

Before (all browsers)
![Screenshot 2025-04-07 at 2 51 41 PM](https://github.com/user-attachments/assets/83d56b8e-e71b-4140-b0e6-3264f8d2e7a2)

After
![Screenshot 2025-04-07 at 2 54 59 PM](https://github.com/user-attachments/assets/2b002919-a19b-4d03-b1ca-ab95fe9785c5)

Before (Firefox only)
![Screenshot 2025-04-07 at 2 53 09 PM](https://github.com/user-attachments/assets/dfc5f7e0-290f-4dca-aaa0-3460dc96b397)

After
![Screenshot 2025-04-07 at 2 53 59 PM](https://github.com/user-attachments/assets/08c1e9c1-08ee-44db-87ae-4f5b27b86ba4)

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
