### PR TITLE
fix(clipboardprovider): update method signature to prevent downstream…

### DIFF
--- a/docs/components/renderless/clipboard-provider.md
+++ b/docs/components/renderless/clipboard-provider.md
@@ -3,14 +3,12 @@
 KClipboardProvider provides clipboard functionality to components.
 
 <KCard>
-  <template #body>
     <KInput :model-value="dataToCopy" @input="newValue => dataToCopy = newValue" type="text" class="vertical-spacing" />
     <KClipboardProvider v-slot="{ copyToClipboard }">
       <KButton @click="() => { if (copyToClipboard(dataToCopy)) alert(`Copied: '${dataToCopy}'`) }">
         Copy to Clipboard
       </KButton>
     </KClipboardProvider>
-  </template>
 </KCard>
 
 ```html
@@ -42,7 +40,7 @@ const alert = (msg: string): void => {
 
 | Props             | Type     | Description                             |
 | :---------------- | :------- | :-------------------------------------- |
-| `copyToClipboard` | Function | Copy to clipboard; `@returns {Boolean}` |
+| `copyToClipboard` | Function | Copy to clipboard; `@returns {Promise<boolean>}` |
 
 <script setup lang="ts">
 import { ref } from 'vue'

--- a/src/components/KClipboardProvider/KClipboardProvider.vue
+++ b/src/components/KClipboardProvider/KClipboardProvider.vue
@@ -1,5 +1,5 @@
 <template>
-  <slot :copy-to-clipboard="copyTextToClipboard" />
+  <slot :copy-to-clipboard="copyAdapter" />
 </template>
 
 <script setup lang="ts">
@@ -8,4 +8,11 @@ import { copyTextToClipboard } from '@/utilities/copyTextToClipboard'
 import type { ClipboardProviderSlots } from '@/types/clipboard-provider'
 
 defineSlots<ClipboardProviderSlots>()
+
+/**
+ * This function is essential to shadow the actual function signature of `copyTextToClipboard`,
+ * since `ClipboardProvider` is used in many places and we do not wish to break anything at the downstream.
+ * @param text The text to copy to the clipboard
+ */
+const copyAdapter = (text: string | undefined = '') => copyTextToClipboard(text)
 </script>

--- a/src/types/clipboard-provider.ts
+++ b/src/types/clipboard-provider.ts
@@ -4,5 +4,5 @@ export interface ClipboardProviderSlots {
   /**
    * Slot for providing `copyToClipboard` method to the children.
    */
-  default?(props: { copyToClipboard: typeof copyTextToClipboard }): any
+  default?(props: { copyToClipboard: (arg: string | undefined) => ReturnType<typeof copyTextToClipboard> }): any
 }


### PR DESCRIPTION
Right now, the updated typescript definition breaks the CI since the signature passed to consumers did not match, in this PR we wish to introduce a proxy layer for allowing tolerances. 

See: https://github.com/Kong/konnect-ui-apps/actions/runs/14481370936/job/40618905147?pr=6489

# Summary

| Before | After |
|--------|--------|
|  ![CleanShot 2025-04-16 at 11 32 51@2x](https://github.com/user-attachments/assets/f42a5f2f-b27c-410b-8731-d4a8ad6f6a54) |  ![CleanShot 2025-04-16 at 11 32 55@2x](https://github.com/user-attachments/assets/824a208a-9218-4f6a-a78a-2f19f29c659d) | 

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
