### PR TITLE
fix(kskeleton): fix kskeletonbox default value

### DIFF
--- a/src/components/KSkeleton/KSkeletonBox.vue
+++ b/src/components/KSkeleton/KSkeletonBox.vue
@@ -8,7 +8,10 @@
 <script lang="ts" setup>
 import type { SkeletonBoxProps } from '@/types'
 
-defineProps<SkeletonBoxProps>()
+const {
+  width = '1',
+  height = '1',
+} = defineProps<SkeletonBoxProps>()
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
# Summary

[KM-1247](https://konghq.atlassian.net/browse/KM-1247)

`KSkeletonBox` is not internal and the default values should be provided.

[KM-1247]: https://konghq.atlassian.net/browse/KM-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ