### PR TITLE
chore(*): fix `@default` annotation

### DIFF
--- a/src/types/file-upload.ts
+++ b/src/types/file-upload.ts
@@ -45,14 +45,14 @@ export interface FileUploadProps {
 
   /**
    * Boolean to indicate whether the element is in an error state and should apply error styling.
-   * @defaults false
+   * @default false
    */
   error?: boolean
 
   /**
    * String to be displayed as an error message if `error` prop is `true`.
    * This prop will supersede the `help` prop if both have a value and `error` is `true`.
-   * @defaults false
+   * @default false
    */
   errorMessage?: string
 

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -3,46 +3,46 @@ import type { LabelAttributes } from './label'
 export interface InputProps {
   /**
    * To set the value of the input element without using `v-model`.
-   * @defaults ''
+   * @default ''
    */
   modelValue?: string | number
 
   /**
    * String to be used as the input label.
-   * @defaults ''
+   * @default ''
    */
   label?: string
 
   /**
    * KCheckbox has an instance of KLabel for supporting tooltip text.
    * Use the labelAttributes prop to configure the KLabel's props.
-   * @defaults {}
+   * @default {}
    */
   labelAttributes?: LabelAttributes
 
   /**
    * String to be displayed as help text.
-   * @defaults ''
+   * @default ''
    */
   help?: string
 
   /**
    * Boolean to indicate whether the element is in an error state and should apply error styling.
-   * @defaults false
+   * @default false
    */
   error?: boolean
 
   /**
    * String to be displayed as an error message if `error` prop is `true`.
    * This prop will supersede the `help` prop if both have a value and `error` is `true`.
-   * @defaults false
+   * @default false
    */
   errorMessage?: string
 
   /**
    * Use this prop to specify a character limit for the input.
    * See the @char-limit-exceeded event for more details.
-   * @defaults null
+   * @default null
    */
   characterLimit?: number
 
@@ -53,7 +53,7 @@ export interface InputProps {
 
   /**
    * HTML Input Element `type` attribute.
-   * @defaults 'text'
+   * @default 'text'
    */
   type?: string
 
@@ -61,7 +61,7 @@ export interface InputProps {
    * When passing type="password", setting showPasswordMaskToggle to true
    * will render an eye icon to the right of input clicking on which
    * allows toggling masking the input value on and off.
-   * @defaults false
+   * @default false
    */
   showPasswordMaskToggle?: boolean
 }

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -191,7 +191,7 @@ export interface SelectProps<T extends string | number, U extends boolean> {
 
   /**
    * String to be displayed as help text.
-   * @defaults ''
+   * @default ''
    */
   help?: string
 }


### PR DESCRIPTION
# Summary

[KM-1093](https://konghq.atlassian.net/browse/KM-1093)

`@default` is the correct annotation tag for most related toolings, eg. JSDoc, TSDoc, TypeDoc, etc.

[KM-1093]: https://konghq.atlassian.net/browse/KM-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ