### PR TITLE
fix(k-radio): apply data-testid to wrapper for card radio [KHCP-16147]

### DIFF
--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -5,7 +5,6 @@
       $attrs.class ? $attrs.class : '',
       kRadioClasses
     ]"
-    :data-testid="card ? attrs['data-testid'] : undefined"
   >
     <input
       :id="inputId"
@@ -54,6 +53,7 @@
       v-else-if="label || $slots.default"
       class="radio-card-wrapper radio-label-wrapper"
       :class="{ 'has-label': label, 'has-description': showCardDescription, 'show-radio': cardRadioVisible }"
+      :data-testid="cardLabelTestId"
       :for="inputId"
       :tabindex="isDisabled || isChecked ? -1 : 0"
       @keydown.space.prevent
@@ -204,12 +204,6 @@ const modifiedAttrs = computed((): Record<string, any> => {
   // delete classes because we bind them to the parent
   delete $attrs.class
 
-  if (props.card) {
-    // for card radio, we need to bind the data-testid to the wrapper
-    // so we need to delete it from the input
-    delete $attrs['data-testid']
-  }
-
   return $attrs
 })
 
@@ -224,6 +218,10 @@ const kRadioClasses = computed((): Record<string, boolean> => {
     // Add vertical class for `vertical` or an invalid prop value
     'card-vertical': props.card && props.cardOrientation !== 'horizontal',
   }
+})
+
+const cardLabelTestId = computed(() => {
+  return props.card && attrs['data-testid'] ? `${attrs['data-testid']}-label` : undefined
 })
 </script>
 

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -5,6 +5,7 @@
       $attrs.class ? $attrs.class : '',
       kRadioClasses
     ]"
+    :data-testid="card ? attrs['data-testid'] : undefined"
   >
     <input
       :id="inputId"
@@ -202,6 +203,12 @@ const modifiedAttrs = computed((): Record<string, any> => {
 
   // delete classes because we bind them to the parent
   delete $attrs.class
+
+  if (props.card) {
+    // for card radio, we need to bind the data-testid to the wrapper
+    // so we need to delete it from the input
+    delete $attrs['data-testid']
+  }
 
   return $attrs
 })


### PR DESCRIPTION
# Summary

In `KRadio`, `data-testid` is applied to `input` element. However, for card radio, most of the actual click area is taken up by the `label` instead of the `input`. But since the `data-testid` was on the `input` element and not on the `label`, Datadog wasn't registering any clicks on the card radio.

This PR adds a `data-testid` to the label for radio cards, by appending `-label` to the `data-testid` applied to the `KRadio`, so that clicks on anywhere on the component get registered in Datadog.

# Previews

## `data-testid` applied to `KRadio`
![image](https://github.com/user-attachments/assets/5c4b0f64-1e92-4781-8b4a-ccf9c160899e)

## `data-testid` NOT applied to `KRadio`
![image](https://github.com/user-attachments/assets/e5a9a69e-df3b-4186-91f4-e4f42adfc0da)
