### PR TITLE
fix: resize-observer not cleaned up

### DIFF
--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, onMounted, onUnmounted, useId } from 'vue'
+import { computed, ref, watch, onMounted, useId, onBeforeUnmount } from 'vue'
 import { ResizeObserverHelper } from '@/utilities/resizeObserverHelper'
 import { CopyIcon } from '@kong/icons'
 import KClipboardProvider from '@/components/KClipboardProvider/KClipboardProvider.vue'
@@ -172,7 +172,7 @@ onMounted(() => {
   resizeObserver.value.observe(copyTextElement.value as HTMLDivElement)
 })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   if (resizeObserver.value) {
     resizeObserver.value.unobserve(copyTextElement.value as HTMLDivElement)
   }

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -275,7 +275,7 @@
 
 <script lang="ts">
 import type { Ref, PropType } from 'vue'
-import { ref, computed, watch, nextTick, onMounted, onUnmounted, useAttrs, useSlots, useId, useTemplateRef } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, useAttrs, useSlots, useId, useTemplateRef, onBeforeUnmount } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import KBadge from '@/components/KBadge/KBadge.vue'
 import KInput from '@/components/KInput/KInput.vue'
@@ -1068,7 +1068,7 @@ onMounted(() => {
   resizeObserver.value.observe(multiselectElementRef.value as HTMLDivElement)
 })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   if (resizeObserver.value && multiselectElementRef.value) {
     resizeObserver.value.unobserve(multiselectElementRef.value)
   }

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -150,7 +150,7 @@
 </template>
 
 <script setup lang="ts" generic="T">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, nextTick, onBeforeUnmount } from 'vue'
 import KDropdown from '@/components/KDropdown/KDropdown.vue'
 import KButton from '@/components/KButton/KButton.vue'
 import PaginationOffset from './PaginationOffset.vue'
@@ -388,7 +388,7 @@ onMounted(() => {
   }
 })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   if (!disablePageJump && !offset) {
     resizeObserver.value?.unobserve(kPaginationElement.value as HTMLDivElement)
   }

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -192,7 +192,7 @@
 
 <script setup lang="ts" generic="T extends string | number, U extends boolean = false">
 import type { Ref } from 'vue'
-import { ref, computed, watch, nextTick, useAttrs, onUnmounted, onMounted, useId, useTemplateRef } from 'vue'
+import { ref, computed, watch, nextTick, useAttrs, onMounted, useId, useTemplateRef, onBeforeUnmount } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import KLabel from '@/components/KLabel/KLabel.vue'
 import KInput from '@/components/KInput/KInput.vue'
@@ -638,7 +638,7 @@ onMounted(() => {
   })
 })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   if (selectWrapperRef.value) {
     resizeObserver.value?.unobserve(selectWrapperRef.value)
   }

--- a/src/components/KTruncate/KTruncate.vue
+++ b/src/components/KTruncate/KTruncate.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, nextTick, computed } from 'vue'
+import { onMounted, ref, nextTick, computed, onBeforeUnmount } from 'vue'
 import useUtilities from '@/composables/useUtilities'
 import { ChevronUpIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_30, KUI_SPACE_40 } from '@kong/design-tokens'
@@ -241,7 +241,7 @@ onMounted(() => {
   updateToggleVisibility()
 })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   resizeObserver.value?.unobserve(kTruncateContainer.value as HTMLDivElement)
 })
 </script>


### PR DESCRIPTION
The lifecycle hook `onUnmounted` is triggered as soon as all child components are unmounted. When the `unobserve` method on the resize-observer ref is being called at this point with the param of a ref to a child element, the child element is `null` and the `unobserve` method returns without cleaning up the resize observer.
