### PR TITLE
fix(k-radio): lint error

### DIFF
--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -168,7 +168,7 @@ const kRadioClasses = computed((): Record<string, boolean> => {
 })
 
 const cardLabelTestId = computed(() => {
-  return props.card && attrs['data-testid'] ? `${attrs['data-testid']}-label` : undefined
+  return card && attrs['data-testid'] ? `${attrs['data-testid']}-label` : undefined
 })
 </script>
 


### PR DESCRIPTION
# Description

#2747 was merged without rebasing with the changes in #2739, which removed the `const props = defineProps` from the file and caused lint errors