### PR TITLE
fix(kcodeblock): docs search height jump [KHCP-14696]

### DIFF
--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -724,6 +724,7 @@ $kCodeBlockDarkLineMatchBackgroundColor: rgba(255, 255, 255, 0.12); // we don't 
         font-size: var(--kui-font-size-20, $kui-font-size-20);
         font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
         line-height: var(--kui-line-height-20, $kui-line-height-20);
+        margin: var(--kui-space-0, $kui-space-0);
         white-space: nowrap;
       }
     }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-14696

Fix little jump in KCodeBlock docs when searching through code

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
