### PR TITLE
fix(types): mark all slots as optional

### DIFF
--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -58,7 +58,7 @@ export interface ButtonSlots {
   /**
    * Slot for button text or other content such as an icon.
    */
-  default(): any
+  default?(): any
 }
 
 export const ButtonAppearances: ButtonAppearanceRecord = {

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -87,7 +87,7 @@ export interface RadioSlots {
   /**
    * The label content.
    */
-  default(): any
+  default?(): any
 
   /**
    * The description content.

--- a/src/types/segmented-control.ts
+++ b/src/types/segmented-control.ts
@@ -47,5 +47,5 @@ export interface SegmentedControlSlots<T extends SegmentedControlOption<string |
   /**
    * Each option's content.
    */
-  'option-label'(props: { option: T extends string[] ? SegmentedControlOption<T[number]> : T[number] }): any
+  'option-label'?(props: { option: T extends string[] ? SegmentedControlOption<T[number]> : T[number] }): any
 }

--- a/src/types/slideout.ts
+++ b/src/types/slideout.ts
@@ -59,10 +59,10 @@ export interface KSlideoutSlots {
   /**
    * Slot for custom content inside the slideout.
    */
-  default: []
+  default?: []
 
   /**
    * Slot for custom title content.
    */
-  title: []
+  title?: []
 }


### PR DESCRIPTION
# Summary

[KM-1279](https://konghq.atlassian.net/browse/KM-1279)

Fixes the type errors mentioned at https://github.com/Kong/kongponents/issues/2753.

[KM-1279]: https://konghq.atlassian.net/browse/KM-1279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ