### PR TITLE
fix(types): use NoInfer to specify source of truth for generic types

### DIFF
--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -255,7 +255,7 @@ export interface CatalogEmits<T extends readonly CatalogItem[]> {
   /**
    * Emitted when a KCatalogItem is clicked, the payload is the clicked item's object.
    */
-  'card-click': [item: NoInfer<T[number]>]
+  'card-click': NoInfer<[item: T[number]]>
 
   /**
    * Emitted when error state action button is clicked.
@@ -282,22 +282,22 @@ export interface CatalogSlots<T extends readonly CatalogItem[]> {
   /**
    * The body of the card catalog, if you do not want to use KCatalogItem components for the children.
    */
-  body?(props: { data: NoInfer<T> }): any
+  body?: NoInfer<(props: { data: T }) => any>
 
   /**
    * Will slot the card title for each entry.
    */
-  'card-title'?(props: { item: NoInfer<T[number]> }): any
+  'card-title'?: NoInfer<(props: { item: T[number] }) => any>
 
   /**
    * Slot the card actions for each entry.
    */
-  'card-actions'?(props: { item: NoInfer<T[number]> }): any
+  'card-actions'?: NoInfer<(props: { item: T[number] }) => any>
 
   /**
    * Will slot the card body for each entry.
    */
-  'card-body'?(props: { item: NoInfer<T[number]> }): any
+  'card-body'?: NoInfer<(props: { item: T[number] }) => any>
 
   /**
    * Will slot catalog controls rendered at the top of the .k-catalog element such as a search input or other UI elements.

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -72,7 +72,7 @@ export interface CatalogFetcherParams {
   offset: string | null
 }
 
-export interface CatalogFetcherResponse<T extends CatalogItem[] | readonly CatalogItem[]> {
+export interface CatalogFetcherResponse<T extends readonly CatalogItem[]> {
   data: T
   total?: number
   pagination?: {
@@ -81,7 +81,7 @@ export interface CatalogFetcherResponse<T extends CatalogItem[] | readonly Catal
   }
 }
 
-export interface CatalogProps<T extends CatalogItem[] | readonly CatalogItem[]> {
+export interface CatalogProps<T extends readonly CatalogItem[]> {
   /**
    * HTML element you want title to be rendered as.
    * One of ['div', 'p', 'span', 'a', 'legend', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].
@@ -251,11 +251,11 @@ export interface CatalogProps<T extends CatalogItem[] | readonly CatalogItem[]> 
   paginationOffset?: boolean
 }
 
-export interface CatalogEmits<T extends CatalogItem[] | readonly CatalogItem[]> {
+export interface CatalogEmits<T extends readonly CatalogItem[]> {
   /**
    * Emitted when a KCatalogItem is clicked, the payload is the clicked item's object.
    */
-  'card-click': [item: T[number]]
+  'card-click': [item: NoInfer<T[number]>]
 
   /**
    * Emitted when error state action button is clicked.
@@ -278,26 +278,26 @@ export interface CatalogEmits<T extends CatalogItem[] | readonly CatalogItem[]> 
   state: [value: { state: CatalogState, hasData: boolean }]
 }
 
-export interface CatalogSlots<T extends CatalogItem[] | readonly CatalogItem[]> {
+export interface CatalogSlots<T extends readonly CatalogItem[]> {
   /**
    * The body of the card catalog, if you do not want to use KCatalogItem components for the children.
    */
-  body?(props: { data: T }): any
+  body?(props: { data: NoInfer<T> }): any
 
   /**
    * Will slot the card title for each entry.
    */
-  'card-title'?(props: { item: T[number] }): any
+  'card-title'?(props: { item: NoInfer<T[number]> }): any
 
   /**
    * Slot the card actions for each entry.
    */
-  'card-actions'?(props: { item: T[number] }): any
+  'card-actions'?(props: { item: NoInfer<T[number]> }): any
 
   /**
    * Will slot the card body for each entry.
    */
-  'card-body'?(props: { item: T[number] }): any
+  'card-body'?(props: { item: NoInfer<T[number]> }): any
 
   /**
    * Will slot catalog controls rendered at the top of the .k-catalog element such as a search input or other UI elements.

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -96,7 +96,7 @@ export interface DropdownItemEmits<T extends DropdownItem<string | number> | nul
    * Triggers when the item is clicked when `selectionMenuChild` is true.
    * Returns the selected menu item object or `null`.
    */
-  change: [item: NoInfer<T>]
+  change: NoInfer<[item: T]>
 }
 
 export interface DropdownItemSlots {
@@ -178,7 +178,7 @@ export interface DropdownEmits<T extends string | number> {
   /**
    * Triggers when an item is selected.
    */
-  change: [item: DropdownItem<NoInfer<T>>]
+  change: NoInfer<[item: DropdownItem<T>]>
 }
 
 export interface DropdownSlots {

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -96,7 +96,7 @@ export interface DropdownItemEmits<T extends DropdownItem<string | number> | nul
    * Triggers when the item is clicked when `selectionMenuChild` is true.
    * Returns the selected menu item object or `null`.
    */
-  change: [item: T]
+  change: [item: NoInfer<T>]
 }
 
 export interface DropdownItemSlots {
@@ -178,7 +178,7 @@ export interface DropdownEmits<T extends string | number> {
   /**
    * Triggers when an item is selected.
    */
-  change: [item: DropdownItem<T>]
+  change: [item: DropdownItem<NoInfer<T>>]
 }
 
 export interface DropdownSlots {

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -78,7 +78,7 @@ export interface PaginationEmits<T> {
   /**
    * Emitted when the page changes, pass the current page information along with it.
    */
-  pageChange: [data: PageChangeData<NoInfer<T>>]
+  pageChange: NoInfer<[data: PageChangeData<T>]>
   /**
    * Emitted when the page size changes, pass the current page size and page count.
    */

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -78,7 +78,7 @@ export interface PaginationEmits<T> {
   /**
    * Emitted when the page changes, pass the current page information along with it.
    */
-  pageChange: [data: PageChangeData<T>]
+  pageChange: [data: PageChangeData<NoInfer<T>>]
   /**
    * Emitted when the page size changes, pass the current page size and page count.
    */

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -35,7 +35,7 @@ export interface RadioProps<T extends RadioModelValue | null> {
   /**
    * The value of the KRadio option that will be emitted by the `change` and `update:modelValue` events.
    */
-  selectedValue: Exclude<T, null>
+  selectedValue: Exclude<NoInfer<T>, null>
 
   /**
    * Boolean to indicate whether the element is in an error state and should apply error styling.
@@ -75,12 +75,12 @@ export interface RadioEmits<T extends RadioModelValue> {
   /**
    * Emitted when the radio is selected.
    */
-  change: [value: T]
+  change: [value: NoInfer<T>]
 
   /**
    * Emitted when the radio is selected.
    */
-  'update:modelValue': [value: T]
+  'update:modelValue': [value: NoInfer<T>]
 }
 
 export interface RadioSlots {

--- a/src/types/radio.ts
+++ b/src/types/radio.ts
@@ -35,7 +35,7 @@ export interface RadioProps<T extends RadioModelValue | null> {
   /**
    * The value of the KRadio option that will be emitted by the `change` and `update:modelValue` events.
    */
-  selectedValue: Exclude<NoInfer<T>, null>
+  selectedValue: NoInfer<Exclude<T, null>>
 
   /**
    * Boolean to indicate whether the element is in an error state and should apply error styling.
@@ -75,12 +75,12 @@ export interface RadioEmits<T extends RadioModelValue> {
   /**
    * Emitted when the radio is selected.
    */
-  change: [value: NoInfer<T>]
+  change: NoInfer<[value: T]>
 
   /**
    * Emitted when the radio is selected.
    */
-  'update:modelValue': [value: NoInfer<T>]
+  'update:modelValue': NoInfer<[value: T]>
 }
 
 export interface RadioSlots {

--- a/src/types/segmented-control.ts
+++ b/src/types/segmented-control.ts
@@ -10,7 +10,7 @@ export interface SegmentedControlProps<T extends SegmentedControlOption<string |
   /**
    * The value of the currently selected option.
    */
-  modelValue?: T extends string[] ? T[number] : T extends SegmentedControlOption<string | number | boolean>[] ? T[number]['value'] : never
+  modelValue?: NoInfer<T extends string[] ? T[number] : T extends SegmentedControlOption<string | number | boolean>[] ? T[number]['value'] : never>
 
   /**
    * An array of options for each button.

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -75,7 +75,7 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    * To set the value of the select without using `v-model`.
    * @default ''
    */
-  modelValue?: (U extends true ? T | string : T) | '' | null
+  modelValue?: NoInfer<(U extends true ? T | string : T)> | '' | null
 
   /**
    * Attributes to be passed to underlying KPopover component.
@@ -134,11 +134,13 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    * Override default filter functionality of case-insensitive search on label.
    * @default (params: SelectFilterFunctionParams) => params?.items?.filter((item: SelectItem) => item.label?.toLowerCase().includes(params.query?.toLowerCase()))
    */
-  filterFunction?: (params: SelectFilterFunctionParams<U extends true ? T | string : T>) =>
-    | U extends true
-      ? SelectItem<T | string>[]
-      : SelectItem<T>[]
-    | true
+  filterFunction?: NoInfer<
+    (params: SelectFilterFunctionParams<U extends true ? T | string : T>) =>
+      | U extends true
+        ? SelectItem<T | string>[]
+        : SelectItem<T>[]
+      | true
+  >
 
   /**
    * Loading state in autosuggest.
@@ -200,22 +202,22 @@ export interface SelectEmits<T extends string | number> {
   /**
    * Emitted when a new item is selected.
    */
-  selected: [item: SelectItem<T>]
+  selected: [item: SelectItem<NoInfer<T>>]
 
   /**
    * Emitted when selected item is changed or cleared.
    */
-  input: [value: T | null]
+  input: [value: NoInfer<T> | null]
 
   /**
    * Emitted when selected item is changed or cleared.
    */
-  change: [item: SelectItem<T> | null]
+  change: [item: SelectItem<NoInfer<T>> | null]
 
   /**
    * Emitted when selected item is changed or cleared.
    */
-  'update:modelValue': [value: T | null]
+  'update:modelValue': [value: NoInfer<T> | null]
 
   /**
    * Emitted when the query in the input field changes.
@@ -237,12 +239,12 @@ export interface SelectSlots<T extends string | number> {
   /**
    * Use this slot to pass custom content to the items.
    */
-  'item-template'?(props: { item: SelectItem<T> }): any
+  'item-template'?(props: { item: SelectItem<NoInfer<T>> }): any
 
   /**
    * Use this slot to provide custom content to the selected item.
    */
-  'selected-item-template'?(props: { item: SelectItem<T> }): any
+  'selected-item-template'?(props: { item: SelectItem<NoInfer<T>> }): any
 
   /**
    * A slot alternative for the `dropdownFooterText` prop.

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -75,7 +75,7 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    * To set the value of the select without using `v-model`.
    * @default ''
    */
-  modelValue?: NoInfer<(U extends true ? T | string : T)> | '' | null
+  modelValue?: NoInfer<(U extends true ? T | string : T) | '' | null>
 
   /**
    * Attributes to be passed to underlying KPopover component.
@@ -202,22 +202,22 @@ export interface SelectEmits<T extends string | number> {
   /**
    * Emitted when a new item is selected.
    */
-  selected: [item: SelectItem<NoInfer<T>>]
+  selected: NoInfer<[item: SelectItem<T>]>
 
   /**
    * Emitted when selected item is changed or cleared.
    */
-  input: [value: NoInfer<T> | null]
+  input: NoInfer<[value: T | null]>
 
   /**
    * Emitted when selected item is changed or cleared.
    */
-  change: [item: SelectItem<NoInfer<T>> | null]
+  change: NoInfer<[item: SelectItem<T> | null]>
 
   /**
    * Emitted when selected item is changed or cleared.
    */
-  'update:modelValue': [value: NoInfer<T> | null]
+  'update:modelValue': NoInfer<[value: T | null]>
 
   /**
    * Emitted when the query in the input field changes.
@@ -239,12 +239,12 @@ export interface SelectSlots<T extends string | number> {
   /**
    * Use this slot to pass custom content to the items.
    */
-  'item-template'?(props: { item: SelectItem<NoInfer<T>> }): any
+  'item-template'?: NoInfer<(props: { item: SelectItem<T> }) => any>
 
   /**
    * Use this slot to provide custom content to the selected item.
    */
-  'selected-item-template'?(props: { item: SelectItem<NoInfer<T>> }): any
+  'selected-item-template'?: NoInfer<(props: { item: SelectItem<T> }) => any>
 
   /**
    * A slot alternative for the `dropdownFooterText` prop.

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -136,9 +136,9 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    */
   filterFunction?: NoInfer<
     (params: SelectFilterFunctionParams<U extends true ? T | string : T>) =>
-      | U extends true
+      | (U extends true
         ? SelectItem<T | string>[]
-        : SelectItem<T>[]
+        : SelectItem<T>[])
       | true
   >
 


### PR DESCRIPTION
# Summary

[KM-1093](https://konghq.atlassian.net/browse/KM-1093)

- Use `NoInfer` to ensure single source of truth while inferring generic types.
- Fix `filter-function` prop type for `<KSelect>`.
- Simplify generic type for `<KCatalog>`.