### PR TITLE
fix(ktabledata): prioritize bound pagination attributes

### DIFF
--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -270,12 +270,12 @@ const defaultFetcherProps = {
 }
 
 const tablePaginationAttributes = computed((): TablePaginationAttributes => ({
-  ...props.paginationAttributes,
   totalCount: total.value,
   initialPageSize: pageSize.value,
   currentPage: page.value,
   offsetPreviousButtonDisabled: !previousOffset.value,
   offsetNextButtonDisabled: !nextOffset.value || !hasNextPage.value,
+  ...props.paginationAttributes,
 }))
 
 function isTableColumnSlotName(slot: string): slot is TableColumnSlotName {


### PR DESCRIPTION
# Summary

Bound `paginationAttributes` are getting overridden by the component which is incorrect.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
