### PR TITLE
fix(ktoaster): loosen Toast type

### DIFF
--- a/src/types/toaster.ts
+++ b/src/types/toaster.ts
@@ -2,7 +2,7 @@ export type ToasterAppearance = 'info' | 'success' | 'danger' | 'warning' | 'sys
 
 export interface Toast {
   /** Unique identifier of toaster */
-  key: string
+  key?: string
   /** Title of toaster */
   title?: string
   /** Text to display in toaster */
@@ -30,7 +30,7 @@ export interface ToasterProps {
    * The toaster state.
    * @default []
    */
-  toasterState: Toast[]
+  toasterState: (Toast & { key: string }) []
 
   /**
    * The z-index of the toaster.


### PR DESCRIPTION
# Summary

[KM-1093](https://konghq.atlassian.net/browse/KM-1093)

Loosen type for `Toast` as `key` is autogenerated by `ToastManager`.