### PR TITLE
feat(*): add number support for css lengths

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -143,7 +143,7 @@ A `boolean` to conditionally display the [`tooltip`](#tooltip) only when the bad
 
 ### maxWidth
 
-A `string`, in pixels, to limit the badge width and truncate the text. Works just like `max-width` property in CSS. Default value is `200px`. Text content that is wider than the provided value will be truncated.
+A `number` or `string`, to limit the badge width and truncate the text. Works just like `max-width` property in CSS. Default value is `200px`. Text content that is wider than the provided value will be truncated.
 
 <KBadge max-width="auto" appearance="warning">
   Very long text that should be truncated but isn't thanks to max-width="auto"

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -22,7 +22,7 @@ interface BreadcrumbItem {
   text?: string // breadcrumb text that will appear inside of anchor tag
   title?: string // will be used for html title attribute on the anchor tag, helpful when text is truncated
   key?: string // identifier, must be unique for each breadcrumb item
-  maxWidth?: string
+  maxWidth?: number | string
 }
 ```
 

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -283,8 +283,7 @@ Use the `labelAttributes` prop to configure the KLabel's [props](/components/lab
 
 ### width
 
-You can pass a `width` string for the dropdown. By default the `width` is `100%`. This is the width of the input, dropdown, and selected item.
-Currently we support numbers (will be converted to `px`), `auto`, and percentages for width.
+You can pass a `width` number or string for the dropdown. By default the `width` is `100%`. This is the width of the input, dropdown, and selected item. Currently we support any valid CSS length value.
 
 ::: tip NOTE
 Because we are controlling the widths of multiple elements, we recommend using this prop to control the width instead of explicitly adding classes or styles to the `KMultiselect` component.
@@ -328,7 +327,7 @@ By default KMultiselect displays selected items as badges. However, you can set 
 
 ### dropdownMaxHeight
 
-You can pass a `dropdownMaxHeight` string for the dropdown. By default, the `dropdownMaxHeight` is `300px`. This is the maximum height of the `KMultiselect` dropdown when open. You can pass a number (will be converted to `px`), `auto`, percentages, or `vh` units.
+You can pass a `dropdownMaxHeight` number or string for the dropdown. By default, the `dropdownMaxHeight` is `300px`. This is the maximum height of the `KMultiselect` dropdown when open. You can pass any valid CSS length value.
 
 <ClientOnly>
   <KMultiselect :items="deepClone(defaultItemsLongList)" dropdown-max-height="150" />

--- a/docs/components/stepper.md
+++ b/docs/components/stepper.md
@@ -42,7 +42,7 @@ const steps = ref<StepItem[]>([
 
 ### maxLabelWidth
 
-The width of step labels (default is `170px`). We support numbers (will be converted to `px`), `auto`, and percentages (e.g. `25%`) for values.
+The width of step labels (default is `170px`). We support any valid CSS length (e.g. `25%`) value.
 
 <KStepper :steps="longSteps" max-label-width="120" />
 

--- a/docs/components/table-view.md
+++ b/docs/components/table-view.md
@@ -661,7 +661,7 @@ The passed function receives an object with these parameters as an argument:
 
 ### maxHeight
 
-Limit the table height by passing a number, in pixels. If the table height exceeds the specified number, it will be scrollable. Table header is a `position: sticky;` element and will always be visible.
+Limit the table height by passing a number or string. If the table height exceeds the specified number, it will be scrollable. Table header is a `position: sticky;` element and will always be visible.
 
 <KTableView
   max-height="300"

--- a/docs/components/tree-list.md
+++ b/docs/components/tree-list.md
@@ -207,7 +207,7 @@ Try moving any item under the Settings item in the example below and compare it 
 
 ### width
 
-You can pass a `width` string for the entire tree. By default it will take the full width.
+You can pass a `width` number or string for the entire tree. By default it will take the full width.
 
 <KTreeList width="50%" :items="widthItems" />
 

--- a/docs/components/truncate.md
+++ b/docs/components/truncate.md
@@ -96,7 +96,7 @@ When `true`, the component will not truncate the content and the collapse trigge
 
 ### width
 
-Width of container element that wraps content passed through the `default` slot. Works just like `width` property in CSS. Default value is `100%`.
+Width of container element that wraps content passed through the `default` slot. Accepts a string (interpreted as a CSS width value) or a number (automatically appended with `px`). Default value is `100%`.
 
 <KCard>
   <KTruncate truncate-text :rows="2" width="50%">

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -39,7 +39,7 @@ const {
   appearance = 'info',
   tooltip = '',
   truncationTooltip = false,
-  maxWidth: maxWidthProp = '200px',
+  maxWidth = '200px',
   iconBefore = true,
   tooltipAttributes = {},
 } = defineProps<BadgeProps>()
@@ -54,7 +54,7 @@ const badgeTextElement = ref<HTMLDivElement | null>()
 
 const isTruncated = ref<boolean>(false)
 
-const maxWidth = computed((): string => normalizeSize(maxWidthProp))
+const _maxWidth = computed((): string => normalizeSize(maxWidth))
 
 const setTruncation = async (): Promise<void> => {
   if (badgeTextElement.value) {
@@ -112,7 +112,7 @@ $kBadgeMethodWidth: 85px;
   .badge-content-wrapper {
     @include truncate;
 
-    max-width: v-bind('maxWidth');
+    max-width: v-bind('_maxWidth');
   }
 
   :deep(#{$kongponentsKongIconSelector}) {

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -31,7 +31,7 @@
 import { ref, computed, nextTick, onMounted } from 'vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
 import { BadgeMethodAppearances } from '@/types'
-import useUtilities from '@/composables/useUtilities'
+import { normalizeSize } from '@/utilities/css'
 
 import type { BadgeProps, BadgeSlots } from '@/types'
 
@@ -39,14 +39,12 @@ const {
   appearance = 'info',
   tooltip = '',
   truncationTooltip = false,
-  maxWidth: maxWidthProp = '200',
+  maxWidth: maxWidthProp = '200px',
   iconBefore = true,
   tooltipAttributes = {},
 } = defineProps<BadgeProps>()
 
 defineSlots<BadgeSlots>()
-
-const { getSizeFromString } = useUtilities()
 
 const isMethodBadge = computed(() => {
   return Object.keys(BadgeMethodAppearances).includes(appearance)
@@ -56,7 +54,7 @@ const badgeTextElement = ref<HTMLDivElement | null>()
 
 const isTruncated = ref<boolean>(false)
 
-const maxWidth = computed((): string => getSizeFromString(maxWidthProp))
+const maxWidth = computed((): string => normalizeSize(maxWidthProp))
 
 const setTruncation = async (): Promise<void> => {
   if (badgeTextElement.value) {

--- a/src/components/KBreadcrumbs/KBreadcrumbs.vue
+++ b/src/components/KBreadcrumbs/KBreadcrumbs.vue
@@ -23,7 +23,7 @@
         <span
           v-if="item.text"
           class="breadcrumbs-text"
-          :style="{ maxWidth: item.maxWidth? getSizeFromString(item.maxWidth) : getSizeFromString(itemMaxWidth) }"
+          :style="{ maxWidth: normalizeSize(item.maxWidth ?? itemMaxWidth) }"
         >
           {{ item.text }}
         </span>
@@ -44,15 +44,13 @@
 
 <script setup lang="ts">
 import type { BreadcrumbItem, BreadcrumbProps } from '@/types'
-import useUtilities from '@/composables/useUtilities'
+import { normalizeSize } from '@/utilities/css'
 
 defineOptions({
   inheritAttrs: false,
 })
 
 const { itemMaxWidth = '100px', items } = defineProps<BreadcrumbProps>()
-
-const { getSizeFromString } = useUtilities()
 
 const getComponentAttrs = (item: BreadcrumbItem) => {
   const title = item.title || item.text

--- a/src/components/KCodeBlock/KCodeBlock.vue
+++ b/src/components/KCodeBlock/KCodeBlock.vue
@@ -247,13 +247,11 @@ import {
   normalizeHighlightedLines,
 } from '@/utilities/codeBlockHelpers'
 import type { CodeBlockProps, CodeBlockEmits, CodeBlockSlots, CodeBlockEventData, CommandKeywords } from '@/types'
-import useUtilities from '@/composables/useUtilities'
 import { CopyIcon, SearchIcon, ProgressIcon, CloseIcon, RegexIcon, FilterIcon, ArrowUpIcon, ArrowDownIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_NEUTRAL_STRONG, KUI_ICON_SIZE_30, KUI_LINE_HEIGHT_30 } from '@kong/design-tokens'
 import KCodeBlockIconButton from './KCodeBlockIconButton.vue'
 import { IS_MAYBE_MAC } from '@/utilities/browser'
-
-const { getSizeFromString } = useUtilities()
+import { normalizeSize } from '@/utilities/css'
 
 const ALT_SHORTCUT_LABEL = IS_MAYBE_MAC ? 'Option' : 'Alt'
 
@@ -364,7 +362,7 @@ const finalCode = computed(() =>
     : escapeHTMLIfNeeded(code),
 )
 
-const maxHeightValue = computed(() => getSizeFromString(maxHeight))
+const maxHeightValue = computed(() => normalizeSize(maxHeight))
 
 watch(() => code, async function() {
   // Waits one Vue tick in which the code block is re-rendered. Only then does it make sense to emit the corresponding event. Otherwise, consuming components applying syntax highlighting would have to do this because if syntax highlighting is applied before re-rendering is done, re-rendering will effectively undo the syntax highlighting.

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -146,10 +146,8 @@ import 'v-calendar/dist/style.css'
 import { ModeArrayCustom, ModeArrayRelative, ModeDateOnly, DateTimePickerModes } from '@/types'
 import type { DateTimePickerState, TimePeriod, TimeRange, DatePickerModel, ButtonAppearance, DateTimePickerProps, DateTimePickerEmits } from '@/types'
 import { CalIcon } from '@kong/icons'
-import useUtilities from '@/composables/useUtilities'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-
-const { getSizeFromString } = useUtilities()
+import { normalizeSize } from '@/utilities/css'
 
 const {
   clearButton,
@@ -222,7 +220,7 @@ const vCalendarRules = ref({
 
 const widthStyle = computed((): CSSProperties => {
   return {
-    width: getSizeFromString(width),
+    width: normalizeSize(width),
   }
 })
 

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -123,7 +123,7 @@ const defaultKPopAttributes: PopoverAttributes = {
 const boundKPopAttributes: PopoverAttributes = {
   ...defaultKPopAttributes,
   ...kpopAttributes,
-  width: width ? width : undefined,
+  width: width || undefined,
   popoverClasses: `${defaultKPopAttributes.popoverClasses} ${kpopAttributes?.popoverClasses || ''}`,
 }
 

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -96,15 +96,13 @@ import { FocusTrap } from 'focus-trap-vue'
 import { useTextSelection } from '@vueuse/core'
 import KButton from '@/components/KButton/KButton.vue'
 import type { ModalProps, ModalEmits, ModalSlots } from '@/types'
-import useUtilities from '@/composables/useUtilities'
 import { CloseIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
+import { normalizeSize } from '@/utilities/css'
 
 defineOptions({
   inheritAttrs: false,
 })
-
-const { getSizeFromString } = useUtilities()
 
 const {
   visible,
@@ -137,8 +135,8 @@ const textSelection = useTextSelection()
 const focusTrapElement = ref<InstanceType<typeof FocusTrap> | null>(null)
 const modalWrapperElement = ref<HTMLElement | null>(null)
 
-const maxWidthValue = computed((): string => fullScreen && !slots.content ? '95%' : getSizeFromString(maxWidth))
-const maxHeightValue = computed((): string => fullScreen && !slots.content ? '95vh' : getSizeFromString(maxHeight))
+const maxWidthValue = computed((): string => fullScreen && !slots.content ? '95%' : normalizeSize(maxWidth))
+const maxHeightValue = computed((): string => fullScreen && !slots.content ? '95vh' : normalizeSize(maxHeight))
 
 const sanitizedAttrs = computed(() => {
   const attributes = Object.assign({}, attrs)

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -299,6 +299,7 @@ import { ResizeObserverHelper } from '@/utilities/resizeObserverHelper'
 import { sanitizeInput } from '@/utilities/sanitizeInput'
 import { useEventListener } from '@vueuse/core'
 import { getUniqueStringId } from '@/utilities'
+import { normalizeSize } from '@/utilities/css'
 
 // functions used in prop validators
 const getValues = (items: MultiselectItem[]) => {
@@ -327,7 +328,7 @@ type Item = MultiselectItem<Value>
 const attrs = useAttrs()
 const slots = defineSlots<MultiselectSlots<Value>>()
 
-const { getSizeFromString, cloneDeep, stripRequiredLabel } = useUtilities()
+const { cloneDeep, stripRequiredLabel } = useUtilities()
 const SELECTED_ITEMS_SINGLE_LINE_HEIGHT = 36
 const DEFAULT_SEARCH_PLACEHOLDER = 'Filter...'
 
@@ -488,7 +489,7 @@ const createKPopAttributes = computed((): PopoverAttributes => {
 })
 
 // Calculate the `.popover-content` max-height
-const popoverContentMaxHeight = computed((): string => getSizeFromString(dropdownMaxHeight))
+const popoverContentMaxHeight = computed((): string => normalizeSize(dropdownMaxHeight))
 
 // TypeScript complains if I bind the original object
 const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
@@ -496,7 +497,7 @@ const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))
 const widthValue = computed(() => {
   const w = width ? width : '300'
 
-  return getSizeFromString(w)
+  return normalizeSize(w)
 })
 
 const widthStyle = computed(() => {

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -91,13 +91,13 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, computed, watch, useId } from 'vue'
 import { useFloating, autoUpdate, autoPlacement, flip, shift } from '@floating-ui/vue'
-import type { PopProps, PopEmits, PopSlots, PopPlacements } from '@/types'
+import type { PopProps, PopEmits, PopSlots, PopPlacement } from '@/types'
 import KButton from '@/components/KButton/KButton.vue'
-import useUtilities from '@/composables/useUtilities'
 import { CloseIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_30, KUI_SPACE_60 } from '@kong/design-tokens'
 import KPopTeleportWrapper from './KPopTeleportWrapper.vue'
 import { useEventListener } from '@vueuse/core'
+import { normalizeSize } from '@/utilities/css'
 
 const {
   buttonText = '',
@@ -121,8 +121,6 @@ const {
 
 const emit = defineEmits<PopEmits>()
 const slots = defineSlots<PopSlots>()
-
-const { getSizeFromString } = useUtilities()
 
 const popoverId = useId()
 const titleId = useId()
@@ -205,7 +203,7 @@ const clickHandler = (event: Event) => {
  * Converts the placement prop to the correct format for Floating UI
  * E.g.: 'topStart' -> 'top-start'
  */
-const popoverPlacement = computed((): PopPlacements => placement.trim().replace(/ /g, '-').replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase()).replace(/--+/g, '-').replace(/-+$/g, '') as PopPlacements)
+const popoverPlacement = computed((): PopPlacement => placement.trim().replace(/ /g, '-').replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase()).replace(/--+/g, '-').replace(/-+$/g, '') as PopPlacement)
 
 const { floatingStyles, placement: calculatedPlacement, update: updatePosition } = useFloating(popoverTrigger, popoverElement, {
   ...(popoverPlacement.value === 'auto' && { middleware: [autoPlacement()] }), // when placement is auto just use autoPlacement middleware
@@ -220,7 +218,7 @@ const { floatingStyles, placement: calculatedPlacement, update: updatePosition }
   transform: false,
 })
 
-const popoverOffset = computed(() => getSizeFromString(offset))
+const popoverOffset = computed(() => normalizeSize(offset))
 const marginStyles = computed(() => {
   if (calculatedPlacement.value.includes('top')) {
     return {
@@ -253,9 +251,9 @@ const popoverStyles = computed(() => {
 const popoverContainerStyles = computed(() => {
   return {
     ...marginStyles.value,
-    width: getSizeFromString(width),
-    maxWidth: getSizeFromString(maxWidth),
-    maxHeight: getSizeFromString(maxHeight),
+    width: normalizeSize(width),
+    maxWidth: normalizeSize(maxWidth),
+    maxHeight: normalizeSize(maxHeight),
   }
 })
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -213,6 +213,7 @@ import { ResizeObserverHelper } from '@/utilities/resizeObserverHelper'
 import { sanitizeInput } from '@/utilities/sanitizeInput'
 import { useEventListener } from '@vueuse/core'
 import { getUniqueStringId } from '@/utilities'
+import { normalizeSize } from '@/utilities/css'
 
 type Value = U extends true ? T | string : T
 type Item = SelectItem<Value>
@@ -221,7 +222,7 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const { getSizeFromString, stripRequiredLabel } = useUtilities()
+const { stripRequiredLabel } = useUtilities()
 
 const {
   modelValue = '',
@@ -314,7 +315,7 @@ const value = computed({
   },
 })
 
-const elementWidth = computed((): string => getSizeFromString(width || '100%'))
+const elementWidth = computed((): string => normalizeSize(width || '100%'))
 const actualElementWidth = ref<string>('') // the pixel value of the element width for KPop container
 
 const modifiedAttrs = computed(() => {
@@ -338,7 +339,7 @@ const createKPopAttributes = computed(() => {
 })
 
 // Calculate the `.popover-content` max-height
-const popoverContentMaxHeight = computed((): string => getSizeFromString(dropdownMaxHeight))
+const popoverContentMaxHeight = computed((): string => normalizeSize(dropdownMaxHeight))
 
 // TypeScript complains if I bind the original object
 const boundKPopAttributes = computed(() => ({ ...createKPopAttributes.value }))

--- a/src/components/KSkeleton/CardSkeleton.vue
+++ b/src/components/KSkeleton/CardSkeleton.vue
@@ -38,10 +38,8 @@
 import { computed } from 'vue'
 import KSkeletonBox from '@/components/KSkeleton/KSkeletonBox.vue'
 import { KUI_SPACE_50 } from '@kong/design-tokens'
-import useUtilities from '@/composables/useUtilities'
 import type { SkeletonCardProps, SkeletonCardSlots } from '@/types'
-
-const { getSizeFromString } = useUtilities()
+import { normalizeSize } from '@/utilities/css'
 
 const {
   cardCount,
@@ -52,7 +50,7 @@ defineSlots<SkeletonCardSlots>()
 
 const cardMaxWidth = computed((): string => {
   if (maxWidth) {
-    return getSizeFromString(maxWidth)
+    return normalizeSize(maxWidth)
   }
 
   if (cardCount === 1) {

--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -47,11 +47,11 @@
 
 <script lang="ts" setup>
 import { computed, useTemplateRef, onUnmounted, watch } from 'vue'
-import useUtilities from '@/composables/useUtilities'
 import { onClickOutside } from '@vueuse/core'
 import { CloseIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
 import type { KSlideoutEmits, KSlideoutProps, KSlideoutSlots } from '@/types/slideout'
+import { normalizeSize } from '@/utilities/css'
 
 const {
   visible,
@@ -68,16 +68,9 @@ const emit = defineEmits<KSlideoutEmits>()
 
 defineSlots<KSlideoutSlots>()
 
-const { getSizeFromString } = useUtilities()
 const slideoutContainerElement = useTemplateRef('slideoutContainerElement')
 
-const offsetTopValue = computed((): string => {
-  if (typeof offsetTop === 'number') {
-    return getSizeFromString(String(offsetTop))
-  }
-
-  return offsetTop
-})
+const offsetTopValue = computed((): string => normalizeSize(offsetTop))
 
 onClickOutside(slideoutContainerElement, (event) => {
   if (event.isTrusted && closeOnBlur) {

--- a/src/components/KStepper/KStep.vue
+++ b/src/components/KStepper/KStep.vue
@@ -41,12 +41,10 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import useUtilities from '@/composables/useUtilities'
 import type { StepProps } from '@/types'
 import { CheckIcon, ProgressIcon, CloseIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_INVERSE, KUI_COLOR_TEXT_PRIMARY, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-
-const { getSizeFromString } = useUtilities()
+import { normalizeSize } from '@/utilities/css'
 
 const {
   label,
@@ -56,7 +54,7 @@ const {
 
 const labelStyle = computed(() => {
   return {
-    maxWidth: getSizeFromString(maxLabelWidth),
+    maxWidth: normalizeSize(maxLabelWidth),
   }
 })
 </script>

--- a/src/components/KTable/KTable.vue
+++ b/src/components/KTable/KTable.vue
@@ -279,8 +279,9 @@ import type {
 import { EmptyStateIconVariants } from '@/types'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import ColumnVisibilityMenu from './../KTableView/ColumnVisibilityMenu.vue'
+import { normalizeSize } from '@/utilities/css'
 
-const { useDebounce, useRequest, useSwrvState, clientSideSorter: defaultClientSideSorter, getSizeFromString } = useUtilities()
+const { useDebounce, useRequest, useSwrvState, clientSideSorter: defaultClientSideSorter } = useUtilities()
 
 const props = defineProps({
   /**
@@ -561,7 +562,7 @@ const isClickable = ref(false)
 const hasInitialized = ref(false)
 const hasToolbarSlot = computed((): boolean => !!slots.toolbar || hasColumnVisibilityMenu.value)
 const tableWrapperStyles = computed((): Record<string, string> => ({
-  maxHeight: getSizeFromString(props.maxHeight),
+  maxHeight: normalizeSize(props.maxHeight),
 }))
 
 /**

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -440,7 +440,6 @@ import type {
 import { EmptyStateIconVariants, TableViewHeaderKeys } from '@/types'
 import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_30, KUI_SPACE_60 } from '@kong/design-tokens'
 import ColumnVisibilityMenu from './ColumnVisibilityMenu.vue'
-import useUtilities from '@/composables/useUtilities'
 import KPagination from '@/components/KPagination/KPagination.vue'
 import KDropdown from '@/components/KDropdown/KDropdown.vue'
 import KCheckbox from '@/components/KCheckbox/KCheckbox.vue'
@@ -450,6 +449,7 @@ import { getScrollbarSize } from '@/utilities/browser'
 import { useResizeObserver } from '@vueuse/core'
 import type { CSSProperties, Ref } from 'vue'
 import { mapValues } from 'lodash-es'
+import { normalizeSize } from '@/utilities/css'
 
 type ColumnKey = TableColumnKey<Header>
 type ColumnVisibility = TableColumnVisibility<Header>
@@ -497,7 +497,6 @@ const emit = defineEmits<TableViewEmits<Header, Data>>()
 const slots = defineSlots<TableViewSlots<Header, Data>>()
 
 const tableId = useId()
-const { getSizeFromString } = useUtilities()
 
 const getRowKey = (row: Row): string => {
   if (typeof rowKey === 'function' && typeof rowKey(row) === 'string') {
@@ -556,7 +555,7 @@ const isClickable = ref(false)
 const hasToolbarSlot = computed((): boolean => !hideToolbar && !nested && (!!slots.toolbar || hasColumnVisibilityMenu.value || showBulkActionsToolbar.value))
 const isActionsDropdownHovered = ref<boolean>(false)
 const tableWrapperStyles = computed((): CSSProperties => ({
-  maxHeight: getSizeFromString(maxHeight),
+  maxHeight: normalizeSize(maxHeight),
 }))
 const scrollbarWidth = computed((): string => `${getScrollbarSize()}px`)
 

--- a/src/components/KTreeList/KTreeList.vue
+++ b/src/components/KTreeList/KTreeList.vue
@@ -41,11 +41,11 @@
 <script lang="ts">
 import type { PropType } from 'vue'
 import { computed, ref, watch, onMounted } from 'vue'
-import useUtilities from '@/composables/useUtilities'
 import KTreeDraggable from '@/components/KTreeList/KTreeDraggable.vue'
 import { getMaximumDepth } from './KTreeDraggable.vue'
 import { itemsHaveRequiredProps } from './KTreeItem.vue'
 import type { TreeListItem, TreeListChangeEvent, TreeListChildChangeEvent } from '@/types'
+import { normalizeSize } from '@/utilities/css'
 
 const getIds = (items: TreeListItem[], ids: string[]): string[] => {
   items.forEach((item: TreeListItem) => {
@@ -148,11 +148,9 @@ const value = computed({
   },
 })
 
-const { getSizeFromString } = useUtilities()
-
 const widthStyle = computed((): Record<string, any> => {
   return {
-    maxWidth: getSizeFromString(props.width),
+    maxWidth: normalizeSize(props.width),
   }
 })
 

--- a/src/components/KTruncate/KTruncate.vue
+++ b/src/components/KTruncate/KTruncate.vue
@@ -99,12 +99,10 @@
 
 <script setup lang="ts">
 import { onMounted, ref, nextTick, computed, onBeforeUnmount } from 'vue'
-import useUtilities from '@/composables/useUtilities'
 import { ChevronUpIcon } from '@kong/icons'
 import { KUI_ICON_SIZE_30, KUI_SPACE_40 } from '@kong/design-tokens'
 import { ResizeObserverHelper } from '@/utilities/resizeObserverHelper'
-
-const { getSizeFromString } = useUtilities()
+import { normalizeSize } from '@/utilities/css'
 
 const props = defineProps({
   rows: {
@@ -230,7 +228,7 @@ const handleToggleClick = async (): Promise<void> => {
 
 const widthStyle = computed((): Record<string, string> => {
   return {
-    width: getSizeFromString(props.width),
+    width: normalizeSize(props.width),
   }
 })
 

--- a/src/composables/useUtilities.cy.ts
+++ b/src/composables/useUtilities.cy.ts
@@ -4,7 +4,7 @@
 
 import useUtilities from '@/composables/useUtilities'
 
-const { clientSideSorter, getSizeFromString, stripRequiredLabel } = useUtilities()
+const { clientSideSorter, stripRequiredLabel } = useUtilities()
 
 describe('Client-side sorting (deprecated in favor of server-side sorting)', () => {
   it('clientSideSorter(): sorts the items by string', () => {
@@ -179,64 +179,6 @@ describe('Client-side sorting (deprecated in favor of server-side sorting)', () 
     ])
     expect(sortKey2).equal('favoriteNumbers')
     expect(sortOrder2).equal('descending')
-  })
-})
-
-describe('getSizeFromString(): ', () => {
-  it('handles integers', () => {
-    const sizeStr = '500'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(`${sizeStr}px`)
-  })
-
-  it('handles floats', () => {
-    const sizeStr = '500.500'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal('500.5px')
-  })
-
-  it('handles auto', () => {
-    const sizeStr = 'auto'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(sizeStr)
-  })
-
-  it('handles percentages', () => {
-    const sizeStr = '500%'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(sizeStr)
-  })
-
-  it('handles vh', () => {
-    const sizeStr = '500vh'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(sizeStr)
-  })
-
-  it('handles vw', () => {
-    const sizeStr = '500vw'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(sizeStr)
-  })
-
-  it('handles px', () => {
-    const sizeStr = '500px'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(sizeStr)
-  })
-
-  it('handles invalid values', () => {
-    const sizeStr = 'foo'
-    const result = getSizeFromString(sizeStr)
-
-    expect(result).equal(sizeStr)
   })
 })
 

--- a/src/composables/useUtilities.ts
+++ b/src/composables/useUtilities.ts
@@ -217,16 +217,6 @@ export default function useUtilities() {
   }
 
   /**
-   * Convert a given string to a height with units. If pure number, append `px`.
-   * @param sizeStr A string that can be used for the height of an element.
-   * @returns A string to be used for the height of an element.
-   */
-  const getSizeFromString = (sizeStr: string): string => {
-    const numeric = Number(sizeStr)
-    return !Number.isNaN(numeric) ? `${numeric}px` : sizeStr
-  }
-
-  /**
    * Create a deep clone of an object
    * @param val Object to be cloned
    * @returns Cloned object
@@ -264,7 +254,6 @@ export default function useUtilities() {
     useDebounce,
     clientSideSorter,
     useSwrvState,
-    getSizeFromString,
     cloneDeep,
     stripRequiredLabel,
   }

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -38,22 +38,26 @@ export interface BadgeProps {
 
   /**
    * Tooltip text that will be displayed on hover.
+   * @default false
    */
   tooltip?: string
 
   /**
    * Whether tooltip should only be shown when the badge is truncated.
+   * @default true
    */
   truncationTooltip?: boolean
 
   /**
    * Max width to apply truncation at
    * Is superseded by CSS variable if both provided.
+   * @default '200px'
    */
-  maxWidth?: string
+  maxWidth?: number | string
 
   /**
    * A boolean whether or not to show the icon before the badge text (or after).
+   * @default true
    */
   iconBefore?: boolean
 

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -7,7 +7,7 @@ export interface BreadcrumbItem {
   title?: string
   /** Identifier, must be unique for each breadcrumb item */
   key?: string
-  maxWidth?: string
+  maxWidth?: number | string
 }
 
 export interface BreadcrumbProps {
@@ -21,5 +21,5 @@ export interface BreadcrumbProps {
    * Maximum width of each breadcrumb item for truncating to ellipsis.
    * @default '100px'
    */
-  itemMaxWidth?: string
+  itemMaxWidth?: number | string
 }

--- a/src/types/code-block.ts
+++ b/src/types/code-block.ts
@@ -95,7 +95,7 @@ export interface CodeBlockProps {
 
   /**
    * Controls the color scheme of the component.
-   * @default light
+   * @default 'light'
    */
   theme?: Theme
 
@@ -107,9 +107,9 @@ export interface CodeBlockProps {
 
   /**
    * The max-height of the code block.
-   * @default none
+   * @default 'none'
    */
-  maxHeight?: string
+  maxHeight?: number | string
 }
 
 export interface CodeBlockEmits {

--- a/src/types/date-time-picker.ts
+++ b/src/types/date-time-picker.ts
@@ -1,4 +1,4 @@
-import type { PopPlacements } from './popover'
+import type { PopPlacement } from './popover'
 
 // v-calendar defines these types internally, but does not export them
 export interface SimpleDateParts {
@@ -167,7 +167,7 @@ export interface DateTimePickerProps {
    * Sets the input field to a fixed width.
    * @default '100%'
    */
-  width?: string
+  width?: number | string
 
   /**
    * Whether the input field is disabled.
@@ -180,7 +180,7 @@ export interface DateTimePickerProps {
    * One of ['auto', 'top', 'top-start', 'top-end', 'left', 'left-start', 'left-end', 'right', 'right-start', 'right-end', 'bottom', 'bottom-start', 'bottom-end'].
    * @default 'bottom-start'
    */
-  popoverPlacement?: PopPlacements
+  popoverPlacement?: PopPlacement
 }
 
 export interface DateTimePickerEmits {

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -136,7 +136,7 @@ export interface DropdownProps<T extends string | number> {
    * The width of the dropdown body (defaults to `''`).
    * @default ''
    */
-  width?: string
+  width?: number | string
 
   /**
    * Use the `kpopAttributes` prop to configure the KPop props dropdown.

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -67,13 +67,13 @@ export interface ModalProps {
    * Max width of the modal.
    * @default '500px'
    */
-  maxWidth?: string
+  maxWidth?: number | string
 
   /**
    * Max height of the modal.
    * @default 'calc(100vh - 200px)'
    */
-  maxHeight?: string
+  maxHeight?: number | string
 
   /**
    * Whether clicking on backdrop should close the modal.

--- a/src/types/multi-select.ts
+++ b/src/types/multi-select.ts
@@ -111,13 +111,13 @@ export interface MultiselectProps<T extends string, U extends boolean> {
    * The maximum height of the dropdown.
    * @default '300px'
    */
-  dropdownMaxHeight?: string
+  dropdownMaxHeight?: number | string
 
   /**
    * The width of the multiselect and popover's min-width.
    * @default '100%'
    */
-  width?: string
+  width?: number | string
 
   /**
    * Number of rows of selections to show when focused.

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -107,19 +107,19 @@ export interface PopProps {
    * Width of the popover container.
    * @default '200px'
    */
-  width?: string
+  width?: number | string
 
   /**
    * Maximum width of the popover container.
    * @default 'none'
    */
-  maxWidth?: string
+  maxWidth?: number | string
 
   /**
    * Maximum height of the popover container.
    * @default 'none'
    */
-  maxHeight?: string
+  maxHeight?: number | string
 
   /**
    * List of class names you want to assign to `.k-popover` element.

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -88,7 +88,7 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    * Maximum height for dropdown container.
    * @default '300px'
    */
-  dropdownMaxHeight?: string
+  dropdownMaxHeight?: number | string
 
   /**
    * Label associated with the select element.
@@ -106,7 +106,7 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    * The width of the select and popover's min-width.
    * @default '100%'
    */
-  width?: string
+  width?: number | string
 
   /**
    * Placeholder to be displayed when no item is selected.

--- a/src/types/skeleton.ts
+++ b/src/types/skeleton.ts
@@ -60,7 +60,7 @@ export interface SkeletonProps {
    * Width of the skeleton card in relative units.
    * @default ''
    */
-  cardMaxWidth?: string
+  cardMaxWidth?: number | string
 
   /**
    * Number of the skeleton table rows.

--- a/src/types/slideout.ts
+++ b/src/types/slideout.ts
@@ -39,7 +39,7 @@ export interface KSlideoutProps {
    * The maximum width of the slideout.
    * @default '500px'
    */
-  maxWidth?: string
+  maxWidth?: number | string
 
   /**
    * The z-index of the slideout.

--- a/src/types/stepper.ts
+++ b/src/types/stepper.ts
@@ -15,7 +15,7 @@ export interface StepItem {
 export interface StepProps {
   label: string
   state?: StepperState
-  maxLabelWidth: string
+  maxLabelWidth: number | string
 }
 
 export interface StepperProps {
@@ -28,5 +28,5 @@ export interface StepperProps {
    * Maximum width of each step's label.
    * @default '170px'
    */
-  maxLabelWidth?: string
+  maxLabelWidth?: number | string
 }

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -358,7 +358,7 @@ type TablePropsShared<
    * Limit the table height by passing a number, in pixels.
    * @default 'none'
    */
-  maxHeight?: string
+  maxHeight?: number | string
 
   /**
    * Whether to hide pagination element.

--- a/src/types/tooltip.ts
+++ b/src/types/tooltip.ts
@@ -18,7 +18,7 @@ export interface TooltipProps {
    * Set the max-width of the ktooltip.
    * @default 'none'
    */
-  maxWidth?: string
+  maxWidth?: number | string
 
   /**
    * Text to show in tooltip.

--- a/src/utilities/css.cy.ts
+++ b/src/utilities/css.cy.ts
@@ -1,0 +1,74 @@
+import { normalizeSize } from './css'
+
+describe('normalizeSize', () => {
+  it('handles numbers', () => {
+    const sizeNum = 500
+    const result = normalizeSize(sizeNum)
+
+    expect(result).equal(`${sizeNum}px`)
+  })
+
+  it('handles integer strings', () => {
+    const sizeStr = '500'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(`${sizeStr}px`)
+  })
+
+  it('handles floats', () => {
+    const sizeNum = 500.5
+    const result = normalizeSize(sizeNum)
+
+    expect(result).equal(`${sizeNum}px`)
+  })
+
+  it('handles float strings', () => {
+    const sizeStr = '500.500'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal('500.5px')
+  })
+
+  it('handles auto', () => {
+    const sizeStr = 'auto'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(sizeStr)
+  })
+
+  it('handles percentages', () => {
+    const sizeStr = '500%'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(sizeStr)
+  })
+
+  it('handles vh', () => {
+    const sizeStr = '500vh'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(sizeStr)
+  })
+
+  it('handles vw', () => {
+    const sizeStr = '500vw'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(sizeStr)
+  })
+
+  it('handles px', () => {
+    const sizeStr = '500px'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(sizeStr)
+  })
+
+  it('handles invalid values', () => {
+    const sizeStr = 'foo'
+    const result = normalizeSize(sizeStr)
+
+    expect(result).equal(sizeStr)
+  })
+})
+

--- a/src/utilities/css.ts
+++ b/src/utilities/css.ts
@@ -1,0 +1,9 @@
+/**
+ * Convert a given number or string to a length with units. If number or numeric string, append `px`.
+ * @param size A number or a string that can be used for a CSS size.
+ * @returns A CSS size string with unit.
+ */
+export const normalizeSize = (size: number | string): string => {
+  const numeric = Number(size)
+  return !Number.isNaN(numeric) ? `${numeric}px` : `${size}`
+}


### PR DESCRIPTION
# Summary

[KM-1361](https://konghq.atlassian.net/browse/KM-1361)

This PR:

- Make all props accepting CSS length as values accept number
- Rename `getSizeFromString` to `normalizeSize` and move it from `composables` to `utilities/css`

Preview PR: https://github.com/Kong/konnect-ui-apps/pull/7061

[KM-1361]: https://konghq.atlassian.net/browse/KM-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ