### PR TITLE
fix: column sort indications reflect truth [MA-4062]

### DIFF
--- a/docs/components/table-data.md
+++ b/docs/components/table-data.md
@@ -38,6 +38,8 @@ interface TableDataHeader {
   label: string
   /** this property defines whether sort icon should be displayed next to the column header and whether the column header will emit sort event upon clicking on it */
   sortable?: boolean
+  /** When provided, determines the intial arrow direction on the column header, if more than one header has this value only the first is applied */
+  initialSort?: 'asc' | 'desc'
   /** allow toggling column visibility */
   hidable?: boolean
   /** when provided, an info icon will be rendered next to the column label, upon hovering on which the tooltip will be revealed */

--- a/docs/components/table-view.md
+++ b/docs/components/table-view.md
@@ -34,6 +34,8 @@ interface TableViewHeader {
   label: string
   /** this property defines whether sort icon should be displayed next to the column header and whether the column header will emit sort event upon clicking on it */
   sortable?: boolean
+  /** When provided, determines the intial arrow direction on the column header, if more than one header has this value only the first is applied */
+  initialSort?: 'asc' | 'desc'
   /** allow toggling column visibility */
   hidable?: boolean
   /** when provided, an info icon will be rendered next to the column label, upon hovering on which the tooltip will be revealed */

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -212,12 +212,20 @@
                     </template>
                   </KTooltip>
 
-                  <ArrowDownIcon
-                    v-if="!column.hideLabel && column.sortable && column.key !== TableViewHeaderKeys.BULK_ACTIONS && column.key !== TableViewHeaderKeys.ACTIONS"
-                    class="sort-icon"
-                    :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
-                    :size="KUI_ICON_SIZE_30"
-                  />
+                  <template v-if="!column.hideLabel && column.sortable && column.key !== TableViewHeaderKeys.BULK_ACTIONS && column.key !== TableViewHeaderKeys.ACTIONS">
+                    <ArrowDownIcon
+                      v-if="column.key === sortColumnKey"
+                      class="sort-icon"
+                      :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
+                      :size="KUI_ICON_SIZE_30"
+                    />
+                    <CodeIcon
+                      v-else
+                      class="sort-possible-icon"
+                      :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
+                      :size="KUI_ICON_SIZE_30"
+                    />
+                  </template>
                 </div>
 
                 <div
@@ -419,7 +427,7 @@ import KButton from '@/components/KButton/KButton.vue'
 import KEmptyState from '@/components/KEmptyState/KEmptyState.vue'
 import KSkeleton from '@/components/KSkeleton/KSkeleton.vue'
 import KTooltip from '@/components/KTooltip/KTooltip.vue'
-import { InfoIcon, ArrowDownIcon, MoreIcon, ChevronRightIcon } from '@kong/icons'
+import { InfoIcon, ArrowDownIcon, CodeIcon, MoreIcon, ChevronRightIcon } from '@kong/icons'
 import type {
   TablePreferences,
   TableViewHeader,
@@ -933,6 +941,13 @@ watch(() => headers, (newVal: readonly Header[]) => {
 
     if (actionsHeader) {
       headers.push(actionsHeader)
+    }
+
+    const firstInitialSort = newVal.find(({ initialSort }) => initialSort)
+    if (!sortColumnKey.value && firstInitialSort) {
+      sortColumnKey.value = firstInitialSort.key
+      // @ts-ignore - initialSort can't be undefined here because we filtered for it already
+      sortColumnOrder.value = firstInitialSort.initialSort
     }
 
     tableHeaders.value = headers

--- a/src/styles/mixins/_tables.scss
+++ b/src/styles/mixins/_tables.scss
@@ -161,6 +161,15 @@
               &.sortable {
                 cursor: pointer;
 
+                .sort-possible-icon {
+                  transform: rotate(90deg);
+                }
+
+                .sort-icon {
+                  transform: rotate(0deg);
+                  transition: transform $kongponentsTransitionDurTimingFunc;
+                }
+
                 &.asc .sort-icon {
                   transform: rotate(-180deg);
                 }

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -79,6 +79,8 @@ export interface TableViewHeader<Key extends string = string> {
   label?: string
   /** This property defines whether sort icon should be displayed next to the column header and whether the column header will emit sort event upon clicking on it */
   sortable?: boolean
+  /** When provided, determines the intial arrow direction on the column */
+  initialSort?: SortColumnOrder
   /** Allow toggling column visibility */
   hidable?: boolean
   /** When provided, an info icon will be rendered next to the column label, upon hovering on which the tooltip will be revealed */


### PR DESCRIPTION
Satisfies [MA-4062](https://konghq.atlassian.net/browse/MA-4062)

I'm a little bit opinionated in this PR and I haven't run this past design. Very willing to change anything that's in here, particularly the style choices.

---

### Issues that are addressed by this PR

1. column headers that are sortable always initially show a downward pointing arrow no matter what the actual state of the data is.
2. multi-column sorting is not supported out of the box but when multiple columns are sortable it looks like it is, particularly before you click on any header

**Description of changes**

To address those two concerns, I made two changes. First, we use a different icon to indicate that a column _could_ be sorted. Second, you can provide an `initialSort` in your header to make the arrow initialized in the direction you want it to appear.

I haven't run these changes past design, so I'm happy to change anything about the styles of this.

### Screenshots

**arrow position on initial load**

*before*

![Screenshot 2025-06-27 at 3 21 35 PM](https://github.com/user-attachments/assets/1dc372d3-bac2-4c13-ae12-357daaf0dbbb)

*after*

![Screenshot 2025-06-27 at 3 40 50 PM](https://github.com/user-attachments/assets/a5602f23-40c8-45c1-b0be-305f5de54281)

**arrow position after clicking on a column**

*before*

![Screenshot 2025-06-27 at 3 44 24 PM](https://github.com/user-attachments/assets/fccb423d-3cea-4653-aa33-1e75d7a56a8a)

*after*

![Screenshot 2025-06-27 at 3 43 41 PM](https://github.com/user-attachments/assets/19e1bed6-bbb9-432b-ac98-b59c9f012146)

**Initial load with the initialSort set to 'asc'**

![Screenshot 2025-06-27 at 3 45 47 PM](https://github.com/user-attachments/assets/809a100f-a5cb-4144-a28e-38e326207e50)



[MA-4062]: https://konghq.atlassian.net/browse/MA-4062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ