### PR TITLE
fix(kdropdownitem): apply disabled styles to div [KHCP-16667]

### DIFF
--- a/sandbox/pages/SandboxDropdown.vue
+++ b/sandbox/pages/SandboxDropdown.vue
@@ -205,6 +205,14 @@
               Disabled external link
             </KDropdownItem>
             <KDropdownItem
+              data-testid="disabled-plain-item"
+              disabled
+              :item="{ label: 'Plain item' }"
+            >
+              <ExternalLinkIcon />
+              Disabled plain item
+            </KDropdownItem>
+            <KDropdownItem
               danger
               data-testid="button"
               has-divider

--- a/src/components/KDropdown/KDropdownItem.vue
+++ b/src/components/KDropdown/KDropdownItem.vue
@@ -140,7 +140,8 @@ const availableComponents = computed((): DropdownItemRenderedRecord => ({
   div: {
     tag: 'div',
     attrs: {
-      class: dropdownItemTriggerClass,
+      // add disabled class instead of disabled attribute because disabled is not a valid attribute for div
+      class: `${dropdownItemTriggerClass} ${disabled ? 'disabled' : ''}`,
       ...strippedAttrs.value,
     },
   },


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-16667

Apply `.disabled` class to dropdown item element even when no even listener is bound

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
