### PR TITLE
feat(kmultiselect): add item-badge-icon slot [KHCP-17046]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -730,6 +730,28 @@ You can use the `item-template` slot to customize the look and feel of your item
 </KMultiselect>
 ```
 
+### item-badge-icon
+
+Slot for passing a custom icon to be displayed in front of item label in selected item badge.
+
+<ClientOnly>
+  <KMultiselect :items="deepClone(defaultItems)">
+    <template #item-badge-icon="{ item }">
+      <DisabledIcon v-if="item.disabled" />
+      <KongIcon v-else />
+    </template>
+  </KMultiselect>
+</ClientOnly>
+
+```html
+<KMultiselect :items="myItems">
+  <template #item-badge-icon="{ item }">
+    <DisabledIcon v-if="item.disabled" />
+    <KongIcon v-else />
+  </template>
+</KMultiselect>
+```
+
 ### empty
 
 You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
@@ -855,7 +877,7 @@ const handleSelection = (selectedItems) => {
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { KongIcon } from '@kong/icons'
+import { KongIcon, DisabledIcon } from '@kong/icons'
 
 function getItems(count) {
   let myItems = []
@@ -887,7 +909,7 @@ const allItems = new Array(10).fill().map((_, i) => ({
 }));
 
 export default defineComponent({
-  components: { KongIcon },
+  components: { KongIcon, DisabledIcon },
   data() {
     return {
       myItems: getItems(5),

--- a/sandbox/pages/SandboxMultiselect.vue
+++ b/sandbox/pages/SandboxMultiselect.vue
@@ -243,6 +243,20 @@
           </template>
         </KMultiselect>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="itemBadgeIcon">
+        <KMultiselect :items="multiselectItems">
+          <template #item-badge-icon="{ item }">
+            <DisabledIcon
+              v-if="item.disabled"
+              decorative
+            />
+            <KongIcon
+              v-else
+              decorative
+            />
+          </template>
+        </KMultiselect>
+      </SandboxSectionComponent>
 
       <!-- Examples -->
       <SandboxTitleComponent
@@ -293,7 +307,7 @@ import { computed, ref, inject } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 import type { MultiselectItem } from '@/types'
-import { KongIcon } from '@kong/icons'
+import { KongIcon, DisabledIcon } from '@kong/icons'
 
 const multiselectItems: MultiselectItem[] = [
   {

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -135,6 +135,8 @@ export default {
 /* Component styles */
 
 .k-button {
+  outline: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border-primary, $kui-color-border-primary);
+
   // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
   // stylelint-disable-next-line no-duplicate-selectors
   & {

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -135,8 +135,6 @@ export default {
 /* Component styles */
 
 .k-button {
-  outline: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border-primary, $kui-color-border-primary);
-
   // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
   // stylelint-disable-next-line no-duplicate-selectors
   & {

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -307,6 +307,40 @@ describe('KMultiselect', () => {
     cy.getTestId(`multiselect-item-${itemValue}`).should('contain.text', itemSlotContent)
   })
 
+  it('allows slotting the icon through item-badge-icon slot', () => {
+    const itemIcon = 'slotted-badge-icon'
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+
+    cy.mount(KMultiselect, {
+      props: {
+        items: [{
+          label: labels[0],
+          value: vals[0],
+          selected: true,
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+      },
+      slots: {
+        'item-badge-icon': `<span data-testid="${itemIcon}">${itemIcon}</span>`,
+      },
+    })
+
+    cy.getTestId('selection-badges-container').should('contain.text', labels[0])
+    cy.getTestId('selection-badges-container').findTestId(itemIcon).should('be.visible').should('have.length', 1)
+
+    cy.getTestId('multiselect-trigger').click()
+    cy.getTestId(`multiselect-item-${vals[1]}`).click()
+    cy.getTestId('multiselect-trigger').click()
+
+    cy.getTestId('selection-badges-container').findTestId(itemIcon).should('have.length', 2)
+  })
+
   it('works in autosuggest mode', () => {
     const onQueryChange = cy.spy().as('onQueryChange')
     cy.mount(KMultiselect, {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -92,7 +92,13 @@
                 truncation-tooltip
                 @click.stop
               >
-                {{ item.label }}
+                <slot
+                  :item="item"
+                  name="item-badge-icon"
+                />
+                <span class="multiselect-selection-badge-label">
+                  {{ item.label }}
+                </span>
                 <template
                   v-if="item.selected && !item.disabled && !isDisabled && !isReadonly"
                   #icon
@@ -253,7 +259,13 @@
           class="multiselect-selection-badge"
           :icon-before="false"
         >
-          {{ item.label }}
+          <slot
+            :item="item"
+            name="item-badge-icon"
+          />
+          <span class="multiselect-selection-badge-label">
+            {{ item.label }}
+          </span>
           <template
             v-if="item.selected && !item.disabled && !isDisabled && !isReadonly"
             #icon
@@ -1045,7 +1057,19 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
       position: relative;
     }
 
-    .multiselect-selection-badge,
+    .multiselect-selection-badge {
+      cursor: auto;
+
+      .multiselect-selection-badge-label {
+        @include truncate;
+      }
+
+      :deep(.badge-content-wrapper) {
+        display: inline-flex;
+        gap: var(--kui-space-20, $kui-space-20);
+      }
+    }
+
     .hidden-selection-count {
       cursor: auto;
     }

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -1066,7 +1066,7 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
 
       :deep(.badge-content-wrapper) {
         display: inline-flex;
-        gap: var(--kui-space-20, $kui-space-20);
+        gap: var(--kui-space-30, $kui-space-30);
       }
     }
 

--- a/src/types/multi-select.ts
+++ b/src/types/multi-select.ts
@@ -217,4 +217,9 @@ export interface MultiselectSlots<T extends string = string> {
    * Slot for dropdown footer in multiselect.
    */
   'dropdown-footer-text'?: () => any
+
+  /**
+   * Slot for icon in the selected item badge.
+   */
+  'item-badge-icon'?: (props: { item: MultiselectItem<T> }) => any
 }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-17046

Adds `item-badge-icon` slot in KMultiselect

<img width="721" height="357" alt="Screenshot 2025-07-10 at 3 46 54 PM" src="https://github.com/user-attachments/assets/91cb6aed-5352-4fd6-8a4f-e0aa9c0c6992" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
