### PR TITLE
fix(ktabledata): incorrect page size on table preferences update

### DIFF
--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -502,12 +502,11 @@ const tablePreferencesUpdateHandler = ({ columnWidths: newColumnWidth, columnVis
 const tableViewColumnWidths = ref<ColumnWidths | undefined>({})
 const tableViewColumnVisibility = ref<ColumnVisibility | undefined>({})
 const tableDataPreferences = computed((): TablePreferences<Header['key']> => ({
+  pageSize: pageSize.value,
   sortColumnKey: sortColumnKey.value,
   sortColumnOrder: sortColumnOrder.value,
   ...(tableViewColumnWidths.value ? { columnWidths: tableViewColumnWidths.value } : {}),
   ...(tableViewColumnVisibility.value ? { columnVisibility: tableViewColumnVisibility.value } : {}),
-  ...tablePreferences,
-  pageSize: pageSize.value,
 }))
 
 const emitTablePreferences = (): void => {


### PR DESCRIPTION
# Summary

Fix incorrect page size on `update:table-preferences` event

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
