### PR TITLE
fix(kdatetimepicker): add validation for start and end time

### DIFF
--- a/docs/components/datetime-picker.md
+++ b/docs/components/datetime-picker.md
@@ -128,9 +128,9 @@ Whether KDateTimePicker is read-only. Defaults to `false`.
 
 Prop to define the positioning of the popover in relation to the trigger element (see [KPopover placement prop](/components/popover#placement) for details). Default value is `bottom-start`.
 
-### errorMessage
+### invalidTimeErrorMessage
 
-String to be displayed as an error message.
+String to be displayed as an error message for the time inputs.
 Defaults to 'Start time cannot exceed end time.'
 
 ## Examples

--- a/docs/components/datetime-picker.md
+++ b/docs/components/datetime-picker.md
@@ -128,6 +128,11 @@ Whether KDateTimePicker is read-only. Defaults to `false`.
 
 Prop to define the positioning of the popover in relation to the trigger element (see [KPopover placement prop](/components/popover#placement) for details). Default value is `bottom-start`.
 
+### errorMessage
+
+String to be displayed as an error message.
+Defaults to 'Start time cannot exceed end time.'
+
 ## Examples
 
 ### Single date

--- a/sandbox/pages/SandboxDateTimePicker.vue
+++ b/sandbox/pages/SandboxDateTimePicker.vue
@@ -104,7 +104,9 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent title="width">
         <KDateTimePicker
+          error-message="There was an error."
           mode="dateTime"
+          :model-value="{ start: new Date(), end: new Date() }"
           placeholder="Select a date and time"
           range
           width="300"

--- a/sandbox/pages/SandboxDateTimePicker.vue
+++ b/sandbox/pages/SandboxDateTimePicker.vue
@@ -104,7 +104,7 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent title="width">
         <KDateTimePicker
-          error-message="There was an error."
+          invalid-time-error-message="There was an error."
           mode="dateTime"
           :model-value="{ start: new Date(), end: new Date() }"
           placeholder="Select a date and time"

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useId, watch } from 'vue'
 import { DatePicker } from 'v-calendar'
 import type { DatePickerModel, DatePickerRangeObject, DateTimePickerMode } from '@/types'
 import { format } from 'date-fns'
@@ -98,7 +98,7 @@ const calendarVModel = defineModel<DatePickerModel>({ required: true })
 const hasError = defineModel<boolean>('error', { default: false })
 const startTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
 const endTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
-const componentId = ref<string>(crypto.randomUUID())
+const componentId = useId()
 
 const showTime = computed(() => {
   return ['time', 'dateTime', 'relativeDateTime'].includes(props.kDatePickerMode)

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -58,12 +58,12 @@
         mode="out-in"
         name="kongponents-fade-transition"
       >
-        <p
-          v-if="helpText"
+        <div
+          v-if="hasError && errorMessage"
           class="help-text"
         >
-          {{ helpText }}
-        </p>
+          {{ errorMessage }}
+        </div>
       </Transition>
     </div>
   </div>
@@ -75,12 +75,17 @@ import { DatePicker } from 'v-calendar'
 import type { DatePickerModel, DatePickerRangeObject, DateTimePickerMode } from '@/types'
 import { format } from 'date-fns'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   isRange: boolean
   kDatePickerMode: DateTimePickerMode
   maxDate?: Date
   minDate?: Date
-}>()
+  errorMessage?: string
+}>(), {
+  maxDate: undefined,
+  minDate: undefined,
+  errorMessage: 'Start time cannot exceed end time.',
+})
 const calendarVModel = defineModel<DatePickerModel>({ required: true })
 const hasError = defineModel<boolean>('error', { default: false })
 const startTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
@@ -88,13 +93,6 @@ const endTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
 
 const showTime = computed(() => {
   return ['time', 'dateTime', 'relativeDateTime'].includes(props.kDatePickerMode)
-})
-
-const helpText = computed(() => {
-  if (hasError.value) {
-    return 'Start time cannot exceed end time.'
-  }
-  return ''
 })
 
 const isInvalidRange = (start: Date, end: Date): boolean => {
@@ -187,7 +185,7 @@ watch(() => calendarVModel.value, () => {
 
     calendarVModel.value.setHours(startTime.getHours(), startTime.getMinutes(), startTime.getSeconds(), 0)
   }
-})
+}, { immediate: true })
 
 const showRange = (rangeType: 'start' | 'end') => {
   const value = calendarVModel.value as { start: Date, end: Date }

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -21,7 +21,10 @@
       <div
         class="time-input"
       >
-        <div class="time-input-label">
+        <label
+          class="time-input-label"
+          :for="`time-input-start-${componentId}`"
+        >
           <span v-if="showRange('start')">
             <!-- @vue-ignore: typeguard in showRange -->
             {{ format(calendarVModel.start, 'EEE MMM d yyyy') }}
@@ -29,8 +32,9 @@
           <span v-else-if="(calendarVModel && calendarVModel instanceof Date)">
             {{ format(calendarVModel, 'EEE MMM d yyyy') }}
           </span>
-        </div>
+        </label>
         <input
+          :id="`time-input-start-${componentId}`"
           v-model="startTimeValue"
           class="time-input-start"
           :class="{ 'input-error': hasError }"
@@ -38,14 +42,18 @@
           :step="60"
           type="time"
         >
-        <div class="time-input-label">
+        <label
+          class="time-input-label"
+          :for="`time-input-end-${componentId}`"
+        >
           <span v-if="showRange('end')">
             <!-- @vue-ignore: typeguard in showRange -->
             {{ format(calendarVModel.end, 'EEE MMM d yyyy') }}
           </span>
-        </div>
+        </label>
         <input
           v-if="isRange"
+          :id="`time-input-end-${componentId}`"
           v-model="endTimeValue"
           class="time-input-end"
           :class="{ 'input-error': hasError }"
@@ -90,6 +98,7 @@ const calendarVModel = defineModel<DatePickerModel>({ required: true })
 const hasError = defineModel<boolean>('error', { default: false })
 const startTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
 const endTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
+const componentId = ref<string>(crypto.randomUUID())
 
 const showTime = computed(() => {
   return ['time', 'dateTime', 'relativeDateTime'].includes(props.kDatePickerMode)

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -92,7 +92,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   maxDate: undefined,
   minDate: undefined,
-  errorMessage: 'Start time cannot exceed end time.',
+  errorMessage: undefined,
 })
 const calendarVModel = defineModel<DatePickerModel>({ required: true })
 const hasError = defineModel<boolean>('error', { default: false })

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -67,6 +67,7 @@
           v-if="hasCalendar && showCalendar"
           v-model="calendarVModel"
           v-model:error="hasCalendarError"
+          :error-message="errorMessage"
           :is-range="!isSingleDatepicker"
           :k-date-picker-mode="mode"
           :max-date="maxDate"
@@ -156,6 +157,7 @@ const {
   disabled,
   readonly,
   popoverPlacement = 'bottom-start',
+  errorMessage = undefined,
 } = defineProps<DateTimePickerProps>()
 
 const emit = defineEmits<DateTimePickerEmits>()

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -66,6 +66,7 @@
         <CalendarWrapper
           v-if="hasCalendar && showCalendar"
           v-model="calendarVModel"
+          v-model:error="hasCalendarError"
           :is-range="!isSingleDatepicker"
           :k-date-picker-mode="mode"
           :max-date="maxDate"
@@ -115,7 +116,7 @@
             appearance="tertiary"
             class="action-button"
             data-testid="datetime-picker-submit"
-            :disabled="submitDisabled"
+            :disabled="submitDisabled || hasCalendarError"
             @click="submitTimeFrame()"
           >
             Apply
@@ -168,6 +169,7 @@ const isSingleDatepicker = computed((): boolean => ModeArrayCustom.includes(mode
 const hasTimePeriods = computed((): boolean => timePeriods.length > 0)
 const showCalendar = computed((): boolean => state.tabName === 'custom' || !hasTimePeriods.value)
 const submitDisabled = ref<boolean>(true)
+const hasCalendarError = ref<boolean>(false)
 
 const defaultTimeRange: TimeRange = {
   start: null,

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -67,7 +67,7 @@
           v-if="hasCalendar && showCalendar"
           v-model="calendarVModel"
           v-model:error="hasCalendarError"
-          :error-message="errorMessage"
+          :error-message="invalidTimeErrorMessage"
           :is-range="!isSingleDatepicker"
           :k-date-picker-mode="mode"
           :max-date="maxDate"
@@ -157,7 +157,7 @@ const {
   disabled,
   readonly,
   popoverPlacement = 'bottom-start',
-  errorMessage = undefined,
+  invalidTimeErrorMessage = undefined,
 } = defineProps<DateTimePickerProps>()
 
 const emit = defineEmits<DateTimePickerEmits>()

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -157,7 +157,7 @@ const {
   disabled,
   readonly,
   popoverPlacement = 'bottom-start',
-  invalidTimeErrorMessage = undefined,
+  invalidTimeErrorMessage = 'Start time cannot exceed end time.',
 } = defineProps<DateTimePickerProps>()
 
 const emit = defineEmits<DateTimePickerEmits>()

--- a/src/types/date-time-picker.ts
+++ b/src/types/date-time-picker.ts
@@ -186,6 +186,13 @@ export interface DateTimePickerProps {
    * @default 'bottom-start'
    */
   popoverPlacement?: PopPlacement
+
+  /**
+   * String to be displayed as an error message.
+   * If not provided, the default message is 'Start time cannot exceed end time.'
+   * @default undefined
+   */
+  errorMessage?: string
 }
 
 export interface DateTimePickerEmits {

--- a/src/types/date-time-picker.ts
+++ b/src/types/date-time-picker.ts
@@ -192,7 +192,7 @@ export interface DateTimePickerProps {
    * If not provided, the default message is 'Start time cannot exceed end time.'
    * @default undefined
    */
-  errorMessage?: string
+  invalidTimeErrorMessage?: string
 }
 
 export interface DateTimePickerEmits {


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4122

Adds validation to prevent users from selecting a start time that exceeds the end time when using the custom time range picker.

#### Changes 

- Added hasCalendarError reactive flag and bound it to the submit button to prevent submission on invalid ranges
- Introduced helpText to surface validation errors to the user (e.g., "Start time cannot exceed end time")
- Added input-error class styling for invalid inputs
- Extended watchers on startTimeValue and endTimeValue to validate the full range on each update
- Corrected a bug in the endTimeParts assignment (was reading startTimeValue)

<img width="305" height="553" alt="image" src="https://github.com/user-attachments/assets/904d13d0-7152-4de1-ba6c-882bed931eff" />


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
