### PR TITLE
fix(kradio): card tooltip slot [KHCP-17236]

### DIFF
--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -357,6 +357,26 @@ Provides a slot for tooltip content displayed after the radio label.
 </KRadio>
 ```
 
+<KRadio
+  card
+  label="My tooltip"
+  v-model="tooltipSlotRadio"
+  :selected-value="false"
+>
+  <template #tooltip>Roses are <code>#FF0000</code>, violets are <code>#0000FF</code></template>
+</KRadio>
+
+```html
+<KRadio
+  card
+  label="My tooltip"
+  v-model="checked"
+  :selected-value="false"
+>
+  <template #tooltip>Roses are <code>#FF0000</code>, violets are <code>#0000FF</code></template>
+</KRadio>
+```
+
 ## Events
 
 KRadio emits two events with same payload.

--- a/sandbox/pages/SandboxRadio.vue
+++ b/sandbox/pages/SandboxRadio.vue
@@ -292,6 +292,16 @@
             Lorem ipsum <b>dolor</b> sit amet.
           </template>
         </KRadio>
+        <KRadio
+          v-model="modelValue0"
+          card
+          label="Label"
+          selected-value="foobar11"
+        >
+          <template #tooltip>
+            Lorem ipsum <b>dolor</b> sit amet.
+          </template>
+        </KRadio>
       </SandboxSectionComponent>
     </div>
   </SandboxLayout>

--- a/src/components/KRadio/KRadio.cy.ts
+++ b/src/components/KRadio/KRadio.cy.ts
@@ -59,7 +59,7 @@ describe('KRadio', () => {
     cy.get('.radio-card').should('contain.text', slotText)
   })
 
-  it('renders input element when card prop is true', () => {
+  it('renders input element and no tooltip by default when card prop is true', () => {
     cy.mount(KRadio, {
       props: {
         modelValue: false,
@@ -70,6 +70,7 @@ describe('KRadio', () => {
     })
 
     cy.get('input').should('be.visible')
+    cy.get('.label-tooltip').should('not.exist')
   })
 
   it('renders input element hidden when cardRadioVisible prop is false', () => {
@@ -143,5 +144,24 @@ describe('KRadio', () => {
     cy.get('label').click().then(() => {
       cy.get('input').should('not.be.checked')
     })
+  })
+
+  it('renders tooltip next to the label when passed through slot and card prop is true', () => {
+    cy.mount(KRadio, {
+      props: {
+        modelValue: false,
+        selectedValue: true,
+        label: 'Some label',
+        card: true,
+      },
+      attrs: {
+        disabled: true,
+      },
+      slots: {
+        tooltip: () => 'Hello',
+      },
+    })
+
+    cy.get('.label-tooltip').should('be.visible')
   })
 })

--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -74,6 +74,20 @@
           class="radio-label"
         >
           {{ label }}
+
+          <KTooltip
+            v-if="slots.tooltip"
+            class="label-tooltip"
+          >
+            <InfoIcon
+              class="tooltip-trigger-icon"
+              :color="`var(--kui-color-text-neutral, ${KUI_COLOR_TEXT_NEUTRAL})`"
+              tabindex="0"
+            />
+            <template #content>
+              <slot name="tooltip" />
+            </template>
+          </KTooltip>
         </span>
         <span
           v-if="showCardDescription"
@@ -92,6 +106,8 @@
 import { computed, useAttrs, useId, watch } from 'vue'
 import type { RadioTypes, LabelAttributes, RadioProps, RadioModelValue, RadioEmits, RadioSlots } from '@/types'
 import KLabel from '@/components/KLabel/KLabel.vue'
+import { InfoIcon } from '@kong/icons'
+import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
 
 export default {
   inheritAttrs: false,
@@ -349,7 +365,16 @@ $kRadioDotSize: 6px;
         .radio-label {
           @include labelDefaults;
 
+          align-items: center;
+          display: flex;
+          gap: var(--kui-space-40, $kui-space-40);
           transition: color $kongponentsTransitionDurTimingFunc;
+
+          .tooltip-trigger-icon {
+            cursor: help;
+            height: var(--kui-icon-size-30, $kui-icon-size-30) !important;
+            width: var(--kui-icon-size-30, $kui-icon-size-30) !important;
+          }
         }
       }
     }
@@ -376,6 +401,10 @@ $kRadioDotSize: 6px;
             height: auto;
             margin-bottom: var(--kui-space-40, $kui-space-40);
           }
+        }
+
+        .radio-label {
+          justify-content: center;
         }
       }
 


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-17236

Add `tooltip` slot in KRadio card

<img width="714" height="344" alt="Screenshot 2025-07-24 at 3 28 26 PM" src="https://github.com/user-attachments/assets/a4d94d32-ba82-42c3-aa00-940c582ae7a8" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
