### PR TITLE
fix(ktabledata): initial sorting table header undefined

### DIFF
--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -440,7 +440,7 @@ const { debouncedFn: debouncedRevalidate } = useDebounce(_revalidate, 500)
 const sortHandler = ({ sortColumnKey: columnKey, prevKey, sortColumnOrder: sortOrder }: TableSortPayload<ColumnKey>): void => {
   initialSortHandled.value = true
 
-  const header: TableDataHeader<ColumnKey> = tableHeaders.value.find((header) => header.key === columnKey)!
+  const header: TableDataHeader<ColumnKey> = tableHeaders.value.find((header) => header.key === columnKey) || {} as TableDataHeader<ColumnKey>
   const { useSortHandlerFunction } = header
 
   emit('sort', {


### PR DESCRIPTION
# Summary

Fixes the bug where if a values is passed through `initialFetcherParams.sortColumnKey` that doesn't correspond to any of the `key` parameters passed through `headers` prop, KTableData will try to destructure an `undefined` and break

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
