### PR TITLE
fix(kdatetimepicker): Update internal state on modelValue changed

### DIFF
--- a/sandbox/pages/SandboxDateTimePicker.vue
+++ b/sandbox/pages/SandboxDateTimePicker.vue
@@ -104,13 +104,19 @@
       </SandboxSectionComponent>
       <SandboxSectionComponent title="width">
         <KDateTimePicker
+          v-model="datePickerRange"
           invalid-time-error-message="There was an error."
           mode="dateTime"
-          :model-value="{ start: new Date(), end: new Date() }"
           placeholder="Select a date and time"
           range
           width="300"
         />
+        <br>
+        <KButton
+          @click="datePickerRange = { start: new Date(), end: new Date() }"
+        >
+          Reset Date Range
+        </KButton>
       </SandboxSectionComponent>
       <SandboxSectionComponent title="disabled">
         <KDateTimePicker
@@ -153,12 +159,18 @@
 </template>
 
 <script setup lang="ts">
-import { inject } from 'vue'
+import { inject, ref } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 
 const maxDate = new Date()
 maxDate.setMonth(new Date().getMonth() + 3)
+
+const datePickerRange = ref({
+  start: new Date(),
+  end: new Date(),
+})
+
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -142,30 +142,25 @@ const calendarSelectAttributes = {
 
 watch(() => startTimeValue.value, (newTime) => {
   if (calendarVModel.value && props.isRange && 'start' in calendarVModel.value && calendarVModel.value.start instanceof Date && 'end' in calendarVModel.value && calendarVModel.value.end instanceof Date) {
-
     const startTime = new Date()
     const timeParts = newTime.split(':')
     startTime.setHours(parseInt(timeParts[0], 10), parseInt(timeParts[1], 10), 0, 0)
-
-    calendarVModel.value.start.setHours(startTime.getHours(), startTime.getMinutes(), startTime.getSeconds(), 0)
+    calendarVModel.value.start.setHours(startTime.getHours(), startTime.getMinutes(), 0, 0)
     hasError.value = isInvalidRange(calendarVModel.value.start, calendarVModel.value.end)
   } else if (calendarVModel.value instanceof Date) {
     const startTime = new Date()
     const timeParts = newTime.split(':')
     startTime.setHours(parseInt(timeParts[0], 10), parseInt(timeParts[1], 10), 0, 0)
-
     calendarVModel.value.setHours(startTime.getHours(), startTime.getMinutes(), startTime.getSeconds(), 0)
   }
 })
 
 watch(() => endTimeValue.value, (newTime) => {
   if (calendarVModel.value && props.isRange && 'end' in calendarVModel.value && calendarVModel.value.end instanceof Date && 'start' in calendarVModel.value && calendarVModel.value.start instanceof Date) {
-
     const endTime = new Date()
     const timeParts = newTime.split(':')
     endTime.setHours(parseInt(timeParts[0], 10), parseInt(timeParts[1], 10), 0, 0)
-
-    calendarVModel.value.end.setHours(endTime.getHours(), endTime.getMinutes(), endTime.getSeconds(), 0)
+    calendarVModel.value.end.setHours(endTime.getHours(), endTime.getMinutes(), 0, 0)
     hasError.value = isInvalidRange(calendarVModel.value.start, calendarVModel.value.end)
   }
 })
@@ -176,23 +171,11 @@ watch(() => calendarVModel.value, () => {
   calendarVModel.value.start instanceof Date &&
   'end' in calendarVModel.value &&
   calendarVModel.value.end instanceof Date) {
-
-    const startTime = new Date()
-    const endTime = new Date()
-    const startTimeParts = startTimeValue.value.split(':')
-    const endTimeParts = endTimeValue.value.split(':')
-    startTime.setHours(parseInt(startTimeParts[0], 10), parseInt(startTimeParts[1], 10), 0, 0)
-    endTime.setHours(parseInt(endTimeParts[0], 10), parseInt(endTimeParts[1], 10), 0, 0)
-
-    calendarVModel.value.start.setHours(startTime.getHours(), startTime.getMinutes(), startTime.getSeconds(), 0)
-    calendarVModel.value.end.setHours(endTime.getHours(), endTime.getMinutes(), endTime.getSeconds(), 0)
+    startTimeValue.value = format(calendarVModel.value.start, 'HH:mm')
+    endTimeValue.value = format(calendarVModel.value.end, 'HH:mm')
     hasError.value = isInvalidRange(calendarVModel.value.start, calendarVModel.value.end)
   } else if (calendarVModel.value instanceof Date) {
-    const startTime = new Date()
-    const timeParts = startTimeValue.value.split(':')
-    startTime.setHours(parseInt(timeParts[0], 10), parseInt(timeParts[1], 10), 0, 0)
-
-    calendarVModel.value.setHours(startTime.getHours(), startTime.getMinutes(), startTime.getSeconds(), 0)
+    startTimeValue.value = format(calendarVModel.value, 'HH:mm')
   }
 }, { immediate: true, deep: true })
 

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -194,7 +194,7 @@ watch(() => calendarVModel.value, () => {
 
     calendarVModel.value.setHours(startTime.getHours(), startTime.getMinutes(), startTime.getSeconds(), 0)
   }
-}, { immediate: true })
+}, { immediate: true, deep: true })
 
 const showRange = (rangeType: 'start' | 'end') => {
   const value = calendarVModel.value as { start: Date, end: Date }

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -1,6 +1,7 @@
 import { format } from 'date-fns'
 import { TimePeriods, TimeframeKeys } from '@mocks/KDateTimePickerMockData'
 import KDateTimePicker from '@/components/KDateTimePicker/KDateTimePicker.vue'
+import { ref } from 'vue'
 
 const exampleTimeFrames = [
   {
@@ -341,5 +342,36 @@ describe('KDateTimePicker', () => {
     cy.getTestId(segmentedToggle).find('button[data-testid="relative-option"]').eq(0).click()
     cy.getTestId('select-timeframe-86400000').click()
     cy.getTestId(timepickerDisplay).should('contain.text', 'Last 24 hours')
+  })
+
+  it('reacts to changes in the modelValue', () => {
+    const modelValue = ref({
+      start: new Date('2025-01-01T00:00:00'),
+      end: new Date('2025-01-01T00:00:00'),
+      timePeriodsKey: '',
+    })
+
+    const newDate = {
+      start: new Date('2025-01-01T01:00:00'),
+      end: new Date('2025-01-01T01:00:00'),
+      timePeriodsKey: '',
+    }
+
+    cy.mount(KDateTimePicker, {
+      props: {
+        mode: 'dateTime',
+        modelValue: modelValue,
+        range: true,
+      },
+    })
+
+    cy.getTestId(timepickerInput).click()
+    cy.getTestId('time-input-start').should('have.value', '00:00').then(() => {
+
+      modelValue.value = newDate
+
+      cy.getTestId(timepickerInput).click()
+      cy.getTestId('time-input-start').should('have.value', '01:00')
+    })
   })
 })

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -27,7 +27,7 @@
           :style="widthStyle"
           :tabindex="disabled ? -1 : 0"
         >
-          <span
+          <div
             class="datetime-picker-display"
             :class="{ 'has-icon': icon, 'disabled': disabled }"
             data-testid="datetime-picker-display"
@@ -129,7 +129,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, reactive, ref, watch, type CSSProperties } from 'vue'
+import { computed, reactive, ref, watch, type CSSProperties } from 'vue'
 import { format } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import KButton from '@/components/KButton/KButton.vue'
@@ -399,7 +399,7 @@ watch(() => state.tabName, (newValue, oldValue) => {
  * Selects either "Relative" or "Custom" tab, saves the incoming default value to internal state,
  * then updates the input field to display the human-readable time frame.
  */
-onMounted(() => {
+watch(() => modelValue, () => {
   if (ModeArrayRelative.includes(mode) && modelValue.timePeriodsKey) {
     state.tabName = 'relative'
     submitDisabled.value = false
@@ -421,7 +421,7 @@ onMounted(() => {
       updateDisplay()
     }
   }
-})
+}, { immediate: true })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -65,6 +65,7 @@
         </p>
         <CalendarWrapper
           v-if="hasCalendar && showCalendar"
+          :key="calendarRemountKey"
           v-model="calendarVModel"
           v-model:error="hasCalendarError"
           :error-message="invalidTimeErrorMessage"
@@ -172,6 +173,7 @@ const hasTimePeriods = computed((): boolean => timePeriods.length > 0)
 const showCalendar = computed((): boolean => state.tabName === 'custom' || !hasTimePeriods.value)
 const submitDisabled = ref<boolean>(true)
 const hasCalendarError = ref<boolean>(false)
+const calendarRemountKey = ref<number>(0)
 
 const defaultTimeRange: TimeRange = {
   start: null,
@@ -421,6 +423,7 @@ watch(() => modelValue, () => {
       updateDisplay()
     }
   }
+  calendarRemountKey.value++
 }, { immediate: true })
 </script>
 


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/jira/software/c/projects/MA/boards/109

This PR replaces the initialization approach in KDateTimePicker from `onMounted` to  a `watch` on `modelValue` with `{ immediate: true }`. This ensures the component properly initializes and also reacts to external model value changes consistently.

#### Changes
- Set the time input values correctly when v calendar model updates
- Use `watch` with `{ immediate: true }` instead of `onMounted` for both initializing the state and reacting to external changes to `modelValue`
- Added a reset time range button in the sandbox to simulate external updates to the model value

#### Original issue
- When updating the time range externally (e.g. via zoom), the time portion was incorrectly reset to the current time instead of preserving the intended value.
- Updating the time inputs using the time picker would also reset them to the current time after applying.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
