### PR TITLE
fix(ktabledata): fetcher firing twice when initial sorting provided

### DIFF
--- a/docs/components/table-data.md
+++ b/docs/components/table-data.md
@@ -196,7 +196,7 @@ For ease of configuration, all properties in the `initialFetcherParams` object h
   page: 1,
   query: '',
   sortColumnKey: '',
-  sortColumnOrder: '',
+  sortColumnOrder: 'desc',
   offset: null
 }
 ```

--- a/sandbox/pages/SandboxTableData.vue
+++ b/sandbox/pages/SandboxTableData.vue
@@ -3,48 +3,7 @@
     :links="inject('app-links', [])"
     title="KTableData"
   >
-    <SandboxSectionComponent title="rowHover & maxHeight & clientSort & sortHandlerFunction & sortable">
-      <KComponent
-        v-slot="{ data }"
-        :data="{ tableKey: 0, tableRowHover: false, tableSortable: true, initialSorting: true }"
-      >
-        <div class="horizontal-container">
-          <KInputSwitch
-            v-model="data.tableRowHover"
-            label="Has hover"
-            @change="data.tableKey++"
-          />
-          <KInputSwitch
-            v-model="data.tableSortable"
-            label="Sortable"
-            @change="data.tableKey++"
-          />
-          <KInputSwitch
-            v-model="data.initialSorting"
-            label="Initial sorting"
-            @change="data.tableKey++"
-          />
-        </div>
-
-        <KTableData
-          :key="data.tableKey"
-          :fetcher="fetcher"
-          :headers="headers(false, true)"
-          :initial-fetcher-params="data.initialSorting ? { sortColumnKey: 'username', sortColumnOrder: 'asc' } : undefined"
-          max-height="300"
-          :row-hover="data.tableRowHover"
-          :sortable="data.tableSortable"
-        >
-          <template #action-items>
-            <SandboxTableViewActions />
-          </template>
-        </KTableData>
-      </KComponent>
-    </SandboxSectionComponent>
-    <div
-      v-if="false"
-      class="k-table-data-sandbox"
-    >
+    <div class="k-table-data-sandbox">
       <!-- Props -->
       <SandboxTitleComponent
         is-subtitle
@@ -494,15 +453,14 @@ const headers = (hidable: boolean = false, sortable: boolean = false, bulkAction
       label: 'Username',
       tooltip: sortable ? undefined : 'Column with a tooltip.',
       sortable,
-      // ...(sortable && { useSortHandlerFunction: true }),
+      ...(sortable && { useSortHandlerFunction: true }),
     },
     { key: 'email', label: 'Email', hidable },
     ...(bulkActions ? [{ key: 'bulkActions', label: 'Bulk actions' }] : []),
   ]
 }
 
-const fetcher = async (fetcherParams: any): Promise<any> => {
-  console.log(fetcherParams)
+const fetcher = async (): Promise<any> => {
   // Fake delay
   await new Promise((resolve) => setTimeout(resolve, 2000))
 

--- a/sandbox/pages/SandboxTableData.vue
+++ b/sandbox/pages/SandboxTableData.vue
@@ -3,7 +3,48 @@
     :links="inject('app-links', [])"
     title="KTableData"
   >
-    <div class="k-table-data-sandbox">
+    <SandboxSectionComponent title="rowHover & maxHeight & clientSort & sortHandlerFunction & sortable">
+      <KComponent
+        v-slot="{ data }"
+        :data="{ tableKey: 0, tableRowHover: false, tableSortable: true, initialSorting: true }"
+      >
+        <div class="horizontal-container">
+          <KInputSwitch
+            v-model="data.tableRowHover"
+            label="Has hover"
+            @change="data.tableKey++"
+          />
+          <KInputSwitch
+            v-model="data.tableSortable"
+            label="Sortable"
+            @change="data.tableKey++"
+          />
+          <KInputSwitch
+            v-model="data.initialSorting"
+            label="Initial sorting"
+            @change="data.tableKey++"
+          />
+        </div>
+
+        <KTableData
+          :key="data.tableKey"
+          :fetcher="fetcher"
+          :headers="headers(false, true)"
+          :initial-fetcher-params="data.initialSorting ? { sortColumnKey: 'username', sortColumnOrder: 'asc' } : undefined"
+          max-height="300"
+          :row-hover="data.tableRowHover"
+          :sortable="data.tableSortable"
+        >
+          <template #action-items>
+            <SandboxTableViewActions />
+          </template>
+        </KTableData>
+      </KComponent>
+    </SandboxSectionComponent>
+    <div
+      v-if="false"
+      class="k-table-data-sandbox"
+    >
       <!-- Props -->
       <SandboxTitleComponent
         is-subtitle
@@ -453,14 +494,15 @@ const headers = (hidable: boolean = false, sortable: boolean = false, bulkAction
       label: 'Username',
       tooltip: sortable ? undefined : 'Column with a tooltip.',
       sortable,
-      ...(sortable && { useSortHandlerFunction: true }),
+      // ...(sortable && { useSortHandlerFunction: true }),
     },
     { key: 'email', label: 'Email', hidable },
     ...(bulkActions ? [{ key: 'bulkActions', label: 'Bulk actions' }] : []),
   ]
 }
 
-const fetcher = async (): Promise<any> => {
+const fetcher = async (fetcherParams: any): Promise<any> => {
+  console.log(fetcherParams)
   // Fake delay
   await new Promise((resolve) => setTimeout(resolve, 2000))
 

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -262,7 +262,7 @@ const pageSize = ref<number>(getInitialPageSize(tablePreferences, paginationAttr
 const filterQuery = ref<string>(searchInput ?? '')
 const sortColumnKey = ref(tablePreferences.sortColumnKey || initialFetcherParams.sortColumnKey || '') as Ref<ColumnKey>
 const sortColumnOrder = ref<SortColumnOrder>(tablePreferences.sortColumnOrder || initialFetcherParams.sortColumnOrder || 'desc')
-const initialSortHandled = ref<boolean>(!sortColumnKey.value) // if sortColumnKey is set, that means we need to handle initial sort
+const initialSortHandled = ref<boolean>(!(sortColumnKey.value && clientSort)) // For clientSort tables, if sortColumnKey is set, that means we need to handle initial sort
 const offset = ref(null) as Ref<Offset | null>
 const offsets = ref([]) as Ref<Array<Offset | null>>
 const hasNextPage = ref<boolean>(true)
@@ -580,8 +580,8 @@ watch(fetcherResponse, (res) => {
     offset.value = null
   }
 
-  // For clientSort tables, call sortHandler if the initial sort is not handled yet
-  if (sortable && clientSort && !initialSortHandled.value) {
+  // Call sortHandler if the initial sort has not been handled yet
+  if (sortable && !initialSortHandled.value) {
     sortHandler({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value })
   }
 }, { deep: true, immediate: true })

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -580,8 +580,8 @@ watch(fetcherResponse, (res) => {
     offset.value = null
   }
 
-  // call sortHandler if the initial sort is not handled yet
-  if (sortable && !initialSortHandled.value) {
+  // For clientSort tables, call sortHandler if the initial sort is not handled yet
+  if (sortable && clientSort && !initialSortHandled.value) {
     sortHandler({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value })
   }
 }, { deep: true, immediate: true })


### PR DESCRIPTION
# Summary

Fixing the issue in KTableData where `fetcher` is firing twice on component mount when `clientSort` is `false`

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
