### PR TITLE
fix: reset time picker values if date picker is "cancelled"

### DIFF
--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -98,6 +98,10 @@ const calendarVModel = defineModel<DatePickerModel>({ required: true })
 const hasError = defineModel<boolean>('error', { default: false })
 const startTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
 const endTimeValue = ref<string>(format(new Date(), 'HH:mm:ss'))
+const originalTimeValues = ref<{ start: string, end: string }>({
+  start: format(new Date(), 'HH:mm:ss'),
+  end: format(new Date(), 'HH:mm:ss'),
+})
 const componentId = useId()
 
 const showTime = computed(() => {
@@ -119,6 +123,10 @@ onMounted(() => {
     } else {
       startTimeValue.value = format(new Date(), 'HH:mm')
     }
+
+    // Keep track of original time values in case time picker is cancelled
+    originalTimeValues.value.start = startTimeValue.value
+    originalTimeValues.value.end = endTimeValue.value
   }
 })
 
@@ -183,6 +191,15 @@ const showRange = (rangeType: 'start' | 'end') => {
   const value = calendarVModel.value as { start: Date, end: Date }
   return props.isRange && value && rangeType in value && value[rangeType] instanceof Date
 }
+
+const resetTime = () => {
+  startTimeValue.value = originalTimeValues.value.start
+  endTimeValue.value = originalTimeValues.value.end
+}
+
+defineExpose({
+  resetTime,
+})
 
 </script>
 

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -112,7 +112,7 @@ const isInvalidRange = (start: Date, end: Date): boolean => {
   return start > end
 }
 
-onMounted(() => {
+const initTimeInputs = () => {
   if (calendarVModel.value && showTime.value) {
     if (props.isRange && (calendarVModel.value as DatePickerRangeObject).start && (calendarVModel.value as DatePickerRangeObject).end) {
       const dateRange = calendarVModel.value as DatePickerRangeObject
@@ -123,11 +123,14 @@ onMounted(() => {
     } else {
       startTimeValue.value = format(new Date(), 'HH:mm')
     }
-
-    // Keep track of original time values in case time picker is cancelled
-    originalTimeValues.value.start = startTimeValue.value
-    originalTimeValues.value.end = endTimeValue.value
   }
+}
+
+onMounted(() => {
+  initTimeInputs()
+  // Keep track of original time values in case time picker is cancelled
+  originalTimeValues.value.start = startTimeValue.value
+  originalTimeValues.value.end = endTimeValue.value
 })
 
 const modelConfig = { type: 'number' }
@@ -199,6 +202,7 @@ const resetTime = () => {
 
 defineExpose({
   resetTime,
+  initTimeInputs,
 })
 
 </script>

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -367,8 +367,11 @@ describe('KDateTimePicker', () => {
 
     cy.getTestId(timepickerInput).click()
     cy.getTestId('time-input-start').should('have.value', '00:00').then(() => {
-      modelValue.value = newDate
-      cy.getTestId('time-input-start').should('have.value', '01:00')
+      cy.getTestId(timepickerInput).click().then(() => {
+        modelValue.value = newDate
+        cy.getTestId(timepickerInput).click()
+        cy.getTestId('time-input-start').should('have.value', '01:00')
+      })
     })
   })
 

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -367,11 +367,41 @@ describe('KDateTimePicker', () => {
 
     cy.getTestId(timepickerInput).click()
     cy.getTestId('time-input-start').should('have.value', '00:00').then(() => {
-
       modelValue.value = newDate
-
-      cy.getTestId(timepickerInput).click()
       cy.getTestId('time-input-start').should('have.value', '01:00')
     })
+  })
+
+  it('resets time to original values when popover is closed without applying changes', () => {
+    const modelValue = ref({
+      start: new Date('2025-01-01T00:00:00'),
+      end: new Date('2025-01-01T00:00:00'),
+      timePeriodsKey: '',
+    })
+
+    cy.mount(KDateTimePicker, {
+      props: {
+        mode: 'dateTime',
+        modelValue: modelValue,
+        range: true,
+      },
+    })
+
+    // Open the picker, change the time values, then close the popover without applying
+    cy.getTestId(timepickerInput).click()
+    cy.getTestId('time-input-start').should('have.value', '00:00')
+    cy.getTestId('time-input-end').should('have.value', '00:00')
+
+    cy.getTestId('time-input-end').type('01:00', { force: true })
+
+    cy.getTestId('time-input-end').should('have.value', '01:00')
+
+    // Close the popover without applying
+    cy.getTestId(timepickerInput).click()
+
+    // Reopen the popover, and check that time values are reset to original
+    cy.getTestId(timepickerInput).click()
+    cy.getTestId('time-input-start').should('have.value', '00:00')
+    cy.getTestId('time-input-end').should('have.value', '00:00')
   })
 })

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -13,7 +13,7 @@
       :placement="popoverPlacement"
       width="auto"
       @close="onClosePopover"
-      @open="state.popoverOpen = true"
+      @open="onOpenPopover"
     >
       <div
         class="datetime-picker-trigger-wrapper"
@@ -432,6 +432,13 @@ const onClosePopover = (): void => {
   state.popoverOpen = false
   if (calendarWrapperRef.value) {
     calendarWrapperRef.value.resetTime()
+  }
+}
+
+const onOpenPopover = (): void => {
+  state.popoverOpen = true
+  if (calendarWrapperRef.value) {
+    calendarWrapperRef.value.initTimeInputs()
   }
 }
 </script>

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -12,7 +12,7 @@
       hide-close-icon
       :placement="popoverPlacement"
       width="auto"
-      @close="state.popoverOpen = false"
+      @close="onClosePopover"
       @open="state.popoverOpen = true"
     >
       <div
@@ -66,6 +66,7 @@
         <CalendarWrapper
           v-if="hasCalendar && showCalendar"
           :key="calendarRemountKey"
+          ref="calendarWrapperRef"
           v-model="calendarVModel"
           v-model:error="hasCalendarError"
           :error-message="invalidTimeErrorMessage"
@@ -130,7 +131,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive, ref, watch, type CSSProperties } from 'vue'
+import { computed, reactive, ref, useTemplateRef, watch, type CSSProperties } from 'vue'
 import { format } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
 import KButton from '@/components/KButton/KButton.vue'
@@ -191,6 +192,7 @@ const calendarVModel = isSingleDatepicker.value
   ? calendarSingleDate as DatePickerModel
   : calendarRange as DatePickerModel
 
+const calendarWrapperRef = useTemplateRef('calendarWrapperRef')
 
 const widthStyle = computed((): CSSProperties => {
   return {
@@ -425,6 +427,13 @@ watch(() => modelValue, () => {
   }
   calendarRemountKey.value++
 }, { immediate: true })
+
+const onClosePopover = (): void => {
+  state.popoverOpen = false
+  if (calendarWrapperRef.value) {
+    calendarWrapperRef.value.resetTime()
+  }
+}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4158

Reset time inputs if the date picker popover is closed without applying changes.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
