### PR TITLE
fix(kalert, kbadge, ktoaster): info appearance tokens [KHCP-17541]

### DIFF
--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -84,10 +84,10 @@ const getAlertIcon = computed((): AlertIcon => {
 /* Component mixins */
 
 @mixin kAlertAppearance(
-  $backgroundColor: var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest),
-  $textColor: var(--kui-color-text-primary, $kui-color-text-primary),
-  $hoverColor: var(--kui-color-text-primary-strong, $kui-color-text-primary-strong),
-  $codeBackgroundColor: var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker)) {
+  $backgroundColor: var(--kui-color-background-info-weakest, $kui-color-background-info-weakest),
+  $textColor: var(--kui-color-text-info, $kui-color-text-info),
+  $hoverColor: var(--kui-color-text-info-strong, $kui-color-text-info-strong),
+  $codeBackgroundColor: var(--kui-color-background-info-weaker, $kui-color-background-info-weaker)) {
   background-color: $backgroundColor;
   color: $textColor;
 

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -114,7 +114,7 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
 
     .toaster-icon-container {
       align-items: center;
-      background-color: var(--kui-color-background-primary-weak, $kui-color-background-primary-weak); // info appearance as default in case of invalid appearance
+      background-color: var(--kui-color-background-info-weak, $kui-color-background-info-weak); // info appearance as default in case of invalid appearance
       border-radius: var(--kui-border-radius-circle, $kui-border-radius-circle);
       display: flex;
       height: 32px;
@@ -166,7 +166,7 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
 
     &.info {
       .toaster-icon-container {
-        background-color: var(--kui-color-background-primary-weak, $kui-color-background-primary-weak);
+        background-color: var(--kui-color-background-info-weak, $kui-color-background-info-weak);
       }
     }
 

--- a/src/styles/mixins/_badges.scss
+++ b/src/styles/mixins/_badges.scss
@@ -22,9 +22,9 @@
 
 // uses info badge appearance colors as default
 @mixin badgeAppearance(
-  $bgColor: var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest),
-  $textColor: var(--kui-color-text-primary, $kui-color-text-primary),
-  $hoverColor: var(--kui-color-text-primary-strong, $kui-color-text-primary-strong)
+  $bgColor: var(--kui-color-background-info-weakest, $kui-color-background-info-weakest),
+  $textColor: var(--kui-color-text-info, $kui-color-text-info),
+  $hoverColor: var(--kui-color-text-info-strong, $kui-color-text-info-strong)
 ) {
   background-color: $bgColor;
   color: $textColor;


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-17541

Pick up `kui-color-text-info` and `kui-color-background-info` tokens for `info` apearances in KAlert, Kbadge and KToaster

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
