### PR TITLE
fix: better error handling for time inputs

### DIFF
--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -27,10 +27,10 @@
         >
           <span v-if="showRange('start')">
             <!-- @vue-ignore: typeguard in showRange -->
-            {{ format(calendarVModel.start, 'EEE MMM d yyyy') }}
+            {{ formatDateDisplay(calendarVModel.start) }}
           </span>
           <span v-else-if="(calendarVModel && calendarVModel instanceof Date)">
-            {{ format(calendarVModel, 'EEE MMM d yyyy') }}
+            {{ formatDateDisplay(calendarVModel) }}
           </span>
         </label>
         <input
@@ -152,6 +152,9 @@ const calendarSelectAttributes = {
 }
 
 watch(() => startTimeValue.value, (newTime) => {
+  if (!newTime) {
+    return
+  }
   if (calendarVModel.value && props.isRange && 'start' in calendarVModel.value && calendarVModel.value.start instanceof Date && 'end' in calendarVModel.value && calendarVModel.value.end instanceof Date) {
     const startTime = new Date()
     const timeParts = newTime.split(':')
@@ -167,6 +170,9 @@ watch(() => startTimeValue.value, (newTime) => {
 })
 
 watch(() => endTimeValue.value, (newTime) => {
+  if (!newTime) {
+    return
+  }
   if (calendarVModel.value && props.isRange && 'end' in calendarVModel.value && calendarVModel.value.end instanceof Date && 'start' in calendarVModel.value && calendarVModel.value.start instanceof Date) {
     const endTime = new Date()
     const timeParts = newTime.split(':')
@@ -198,6 +204,14 @@ const showRange = (rangeType: 'start' | 'end') => {
 const resetTime = () => {
   startTimeValue.value = originalTimeValues.value.start
   endTimeValue.value = originalTimeValues.value.end
+}
+
+const formatDateDisplay = (date: Date) => {
+  try {
+    return format(date, 'EEE MMM d yyyy')
+  } catch (error) {
+    console.warn('Error formatting date:', error)
+  }
 }
 
 defineExpose({

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -407,4 +407,30 @@ describe('KDateTimePicker', () => {
     cy.getTestId('time-input-start').should('have.value', '00:00')
     cy.getTestId('time-input-end').should('have.value', '00:00')
   })
+
+  it('gracefully handles clearing time inputs', () => {
+    const modelValue = ref({
+      start: new Date('2025-01-01T00:00:00'),
+      end: new Date('2025-01-01T00:00:00'),
+      timePeriodsKey: '',
+    })
+
+    cy.mount(KDateTimePicker, {
+      props: {
+        mode: 'dateTime',
+        modelValue: modelValue,
+        range: true,
+      },
+    })
+
+    cy.getTestId(timepickerInput).click()
+    cy.getTestId('time-input-start').should('have.value', '00:00')
+    cy.getTestId('time-input-end').should('have.value', '00:00')
+
+    cy.getTestId('time-input-start').clear({ force: true })
+    cy.getTestId('time-input-end').clear({ force: true })
+
+    cy.getTestId('time-input-start').should('have.value', '')
+    cy.getTestId('time-input-end').should('have.value', '')
+  })
 })


### PR DESCRIPTION
# Summary

https://konghq.atlassian.net/browse/MA-4240

When clearing the time input calendar v-model was ending up as an "Invalid Date" -> date-fns was throwing error when attempting to format the invalid date.

Changes
- Check if new time value is defined in watcher
- Wrap date-fns format() fn in a try - catch and console.warn the error

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
