### PR TITLE
fix(kemptystate): add action-button-icon slot

### DIFF
--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -528,7 +528,7 @@ const onActionClick = (): void => {
 ```
 
 <script setup lang="ts">
-import { KongIcon, AddCircleIcon, WavingHandIcon, SparklesIcon, RocketIcon, DesignIcon } from '@kong/icons'
+import { KongIcon, AddCircleIcon, WavingHandIcon, SparklesIcon, RocketIcon, DesignIcon, AddIcon } from '@kong/icons'
 import type { EmptyStateFeature } from '@/types'
 
 const onActionClick = (): void => {

--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -358,7 +358,7 @@ Slot for providing your custom action button.
 >
   <template #action>
     <KButton>
-      <AddCircleIcon />
+      <AddCircleIcon decorative />
       Create New
     </KButton>
   </template>
@@ -372,9 +372,35 @@ Slot for providing your custom action button.
 >
   <template #action>
     <KButton>
-      <AddCircleIcon />
+      <AddCircleIcon decorative />
       Create New
     </KButton>
+  </template>
+</KEmptyState>
+```
+
+### action-button-icon
+
+Slot for custom action button icon.
+
+<KEmptyState
+  action-button-text="Create New"
+  message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec purus feugiat, molestie ipsum et, consequat nibh."
+  title="Empty State Slotted Action Button Icon"
+>
+  <template #action-button-icon>
+    <AddIcon decorative />
+  </template>
+</KEmptyState>
+
+```html
+<KEmptyState
+  action-button-text="Create New"
+  message="Lorem ipsum dolor sit amet..."
+  title="Empty State Slotted Action Button Icon"
+>
+  <template #action-button-icon>
+    <AddIcon decorative />
   </template>
 </KEmptyState>
 ```

--- a/sandbox/pages/SandboxEmptyState.vue
+++ b/sandbox/pages/SandboxEmptyState.vue
@@ -148,6 +148,17 @@
           </template>
         </KEmptyState>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="action-button-icon">
+        <KEmptyState
+          action-button-text="Create New"
+          message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec purus feugiat, molestie ipsum et, consequat nibh."
+          title="Empty State Slotted Action Button Icon"
+        >
+          <template #action-button-icon>
+            <AddIcon decorative />
+          </template>
+        </KEmptyState>
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="image">
         <KEmptyState
           message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec purus feugiat, molestie ipsum et, consequat nibh."
@@ -258,7 +269,7 @@
 import { inject } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
-import { KongIcon, AddCircleIcon, DesignIcon, WavingHandIcon, SparklesIcon, RocketIcon } from '@kong/icons'
+import { KongIcon, AddCircleIcon, DesignIcon, WavingHandIcon, SparklesIcon, RocketIcon, AddIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_PRIMARY, KUI_ICON_SIZE_80 } from '@kong/design-tokens'
 import type { EmptyStateFeature } from '@/types'
 

--- a/src/components/KEmptyState/KEmptyState.cy.ts
+++ b/src/components/KEmptyState/KEmptyState.cy.ts
@@ -49,6 +49,21 @@ describe('KEmptyState', () => {
     cy.get('.empty-state-action').should('be.visible').should('contain', actionButtonText)
   })
 
+  it('renders action button icon when slotted', () => {
+    const testId = 'action-button-slotted-icon'
+
+    cy.mount(KEmptyState, {
+      props: {
+        actionButtonText: 'Action',
+      },
+      slots: {
+        'action-button-icon': h('span', { 'data-testid': testId }, 'Action Icon'),
+      },
+    })
+
+    cy.get('.empty-state-action').findTestId(testId).should('be.visible')
+  })
+
   it('does not render action button when hidden', () => {
     cy.mount(KEmptyState, {
       props: {

--- a/src/components/KEmptyState/KEmptyState.vue
+++ b/src/components/KEmptyState/KEmptyState.vue
@@ -47,6 +47,8 @@
             type="button"
             @click="emit('click-action')"
           >
+            <slot name="action-button-icon" />
+
             {{ actionButtonText }}
           </KButton>
         </slot>

--- a/src/types/empty-state.ts
+++ b/src/types/empty-state.ts
@@ -92,6 +92,11 @@ export interface EmptyStateSlots {
   action?(): any
 
   /**
+   * Slot for custom action button icon.
+   */
+  'action-button-icon'?(): any
+
+  /**
    * Slot for custom image to be displayed at the top of the empty state instead of the icon.
    */
   image?(): any


### PR DESCRIPTION
# Summary

Add `action-button-icon` slot in KEmptyState to make rendering icon in action button easy (screenshot)

<img width="761" height="262" alt="Screenshot 2025-08-20 at 11 09 35 AM" src="https://github.com/user-attachments/assets/184a3932-ad63-4422-aeee-82c8a520190e" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
