### PR TITLE
fix(ktableview): table preferences test coverage [KHCP-17564]

### DIFF
--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -445,6 +445,7 @@
         v-if="showPagination"
         class="table-pagination"
         data-testid="table-pagination"
+        :initial-page-size="paginationPageSize"
         v-bind="paginationAttributes"
         @get-next-offset="emit('get-next-offset')"
         @get-previous-offset="emit('get-previous-offset')"


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-17564

Minor fix in KTableView, also add test coverage for `tablePreferences` prop in KTableView and KTableData

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
