### PR TITLE
feat(kfileupload): allow drag & drop, dropzone appearance [KHCP-17516]

### DIFF
--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -1,6 +1,6 @@
 # File Upload
 
-KFileUpload provides a wrapper around an `input` element with `type=file` for file upload.
+KFileUpload provides a wrapper around an `input` element with `type="file"` for file upload.
 
 <ClientOnly>
   <KFileUpload label="File upload" :label-attributes="{ info: `Accepted file types: ${acceptedFileType.join(', ')}` }" help="File size must be less than 1MB." :accept="acceptedFileType" />
@@ -15,6 +15,37 @@ KFileUpload provides a wrapper around an `input` element with `type=file` for fi
 ```
 
 ## Props
+
+### appearance
+
+KFileUpload comes in two variations: `input` and `dropzone`. Default value is `input`. Both appearances support drag-and-drop file upload functionality which is the default for `dropzone` appearance and configurable for `input` appearance through [`allowDragAndDrop` prop](#allowdraganddrop).
+
+<ClientOnly>
+  <div class="vertical-spacing-container">
+    <KFileUpload
+      label="Input file upload"
+      :accept="acceptedFileType"
+    />
+    <KFileUpload
+      appearance="dropzone"
+      label="Dropzone file upload"
+      :accept="acceptedFileType"
+    />
+  </div>
+</ClientOnly>
+
+```html
+<KFileUpload
+  label="Input file upload"
+  :accept="acceptedFileType"
+/>
+
+<KFileUpload
+  appearance="dropzone"
+  label="Dropzone file upload"
+  :accept="acceptedFileType"
+/>
+```
 
 ### accept
 
@@ -60,11 +91,34 @@ Use the `labelAttributes` prop to configure the KLabel's [props](/components/lab
 Use the `help` prop to display text under the input.
 
 <ClientOnly>
-  <KFileUpload label="Upload file" help="File size must be less than 1MB." :accept="acceptedFileType" />
+  <div class="vertical-spacing-container">
+    <KFileUpload
+      label="Upload file"
+      help="File size must be less than 1MB."
+      :accept="acceptedFileType"
+    />
+    <KFileUpload
+      appearance="dropzone"
+      label="Upload file"
+      help="File size must be less than 1MB."
+      :accept="acceptedFileType"
+    />
+  </div>
 </ClientOnly>
 
 ```html
-<KFileUpload label="Upload File" help="File size must be less than 1MB." :accept="acceptedFileType" />
+<KFileUpload
+  help="File size must be less than 1MB."
+  label="Upload File"
+  :accept="acceptedFileType"
+/>
+
+<KFileUpload
+  help="File size must be less than 1MB."
+  appearance="dropzone"
+  label="Upload file"
+  :accept="acceptedFileType"
+/>
 ```
 
 ### error
@@ -76,14 +130,36 @@ Boolean value to indicate whether the element has an error and should apply erro
 String to be displayed as error message if `hasError` prop is `true`.
 
 <ClientOnly>
-  <KFileUpload label="Upload file" error error-message="File size must be less than 1MB." :accept="acceptedFileType" />
+  <div class="vertical-spacing-container">
+    <KFileUpload
+      error-message="File size must be less than 1MB."
+      error
+      label="Upload file"
+      :accept="acceptedFileType"
+    />
+    <KFileUpload
+      error-message="File size must be less than 1MB."
+      error
+      appearance="dropzone"
+      label="Upload file"
+      :accept="acceptedFileType"
+    />
+  </div>
 </ClientOnly>
 
 ```html
 <KFileUpload
-  label="Upload file"
-  error
   error-message="File size must be less than 1MB."
+  error
+  label="Upload file"
+  :accept="acceptedFileType"
+/>
+
+<KFileUpload
+  error-message="File size must be less than 1MB."
+  error
+  appearance="dropzone"
+  label="Upload file"
   :accept="acceptedFileType"
 />
 ```
@@ -93,11 +169,30 @@ String to be displayed as error message if `hasError` prop is `true`.
 Use the `placeholder` prop to display placeholder text.
 
 <ClientOnly>
-  <KFileUpload placeholder="Select file on your computer" :accept="acceptedFileType" />
+  <div class="vertical-spacing-container">
+    <KFileUpload
+      placeholder="Select file on your computer"
+      :accept="acceptedFileType"
+    />
+    <KFileUpload
+      placeholder="Select file on your computer"
+      appearance="dropzone"
+      :accept="acceptedFileType"
+    />
+  </div>
 </ClientOnly>
 
 ```html
-<KFileUpload placeholder="Select file on your computer" :accept="acceptedFileType" />
+<KFileUpload
+  placeholder="Select file on your computer"
+  :accept="acceptedFileType"
+/>
+
+<KFileUpload
+  placeholder="Select file on your computer"
+  appearance="dropzone"
+  :accept="acceptedFileType"
+/>
 ```
 
 ### buttonText
@@ -105,11 +200,30 @@ Use the `placeholder` prop to display placeholder text.
 This is the text that will be displayed on the button that triggers the click on KInput.
 
 <ClientOnly>
-  <KFileUpload button-text="Choose file" :accept="acceptedFileType" />
+  <div class="vertical-spacing-container">
+    <KFileUpload
+      button-text="Choose file"
+      :accept="acceptedFileType"
+    />
+    <KFileUpload
+      button-text="Choose file"
+      appearance="dropzone"
+      :accept="acceptedFileType"
+    />
+  </div>
 </ClientOnly>
 
 ```html
-<KFileUpload button-text="Choose file" :accept="acceptedFileType" />
+<KFileUpload
+  button-text="Choose file"
+  :accept="acceptedFileType"
+/>
+
+<KFileUpload
+  button-text="Choose file"
+  appearance="dropzone"
+  :accept="acceptedFileType"
+/>
 ```
 
 ### maxFileSize
@@ -128,6 +242,10 @@ Use this prop to customize the maximize size of file that can be uploaded. Defau
 By default KFileUpload will display the error state with a generic error message when selected file exceeds specified maximum file size. You can use [`errorMessage` prop](#errormessage) in conjunction with the [`error` event](#events) to display a custom error message.
 :::
 
+### allowDragAndDrop
+
+Boolean to control whether to allow drag and drop functionality when `appearance="input"`. Defaults to `true`.
+
 ## Slots
 
 ### icon
@@ -135,15 +253,42 @@ By default KFileUpload will display the error state with a generic error message
 Slot for an icon in front of the input field.
 
 <ClientOnly>
-  <KFileUpload label="Upload image" :accept="['.jpg', '.png']">
-    <template #icon>
-      <ImageIcon />
-    </template>
-  </KFileUpload>
+  <div class="vertical-spacing-container">
+    <KFileUpload
+      label="Upload image"
+      :accept="['.jpg', '.png']"
+    >
+      <template #icon>
+        <ImageIcon />
+      </template>
+    </KFileUpload>
+    <KFileUpload
+      appearance="dropzone"
+      label="Upload image"
+      :accept="['.jpg', '.png']"
+    >
+      <template #icon>
+        <ImageIcon />
+      </template>
+    </KFileUpload>
+  </div>
 </ClientOnly>
 
 ```html
-<KFileUpload label="Upload image" :accept="['.jpg', '.png']">
+<KFileUpload
+  label="Upload image"
+  :accept="['.jpg', '.png']"
+>
+  <template #icon>
+    <ImageIcon />
+  </template>
+</KFileUpload>
+
+<KFileUpload
+  appearance="dropzone"
+  label="Upload image"
+  :accept="['.jpg', '.png']"
+>
   <template #icon>
     <ImageIcon />
   </template>
@@ -235,5 +380,11 @@ const printData = (i) => {
   overflow: hidden;
   background-color: $kui-color-background-neutral-weaker;
   padding-top: $kui-space-50;
+}
+
+.vertical-spacing-container {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-50;
 }
 </style>

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -307,6 +307,38 @@ Use this slot if you want to utilize HTML in the input label's tooltip.
 </KFileUpload>
 ```
 
+### dropzone-footer
+
+Slot for additional content at the bottom of the the dropzone area. Only available when `appearance` prop is set to `dropzone`.
+
+<KFileUpload
+  appearance="dropzone"
+  label="Upload your markdown document"
+  :accept="acceptedFileType"
+>
+  <template #dropzone-footer>
+    <KAlert>
+      We will validate your markdown.
+      <KExternalLink href="https://kongponents.konghq.com/">Learn more</KExternalLink>
+    </KAlert>
+  </template>
+</KFileUpload>
+
+```html
+<KFileUpload
+  appearance="dropzone"
+  label="Upload your markdown document"
+  :accept="acceptedFileType"
+>
+  <template #dropzone-footer>
+    <KAlert>
+      We will validate your markdown.
+      <KExternalLink href="https://kongponents.konghq.com/">Learn more</KExternalLink>
+    </KAlert>
+  </template>
+</KFileUpload>
+```
+
 ## Events
 
 The events below will fire whenever:

--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -18,7 +18,7 @@ KFileUpload provides a wrapper around an `input` element with `type="file"` for 
 
 ### appearance
 
-KFileUpload comes in two variations: `input` and `dropzone`. Default value is `input`. Both appearances support drag-and-drop file upload functionality which is the default for `dropzone` appearance and configurable for `input` appearance through [`allowDragAndDrop` prop](#allowdraganddrop).
+KFileUpload comes in two variations: `input` and `dropzone`. Default value is `input`. Both appearances support drag-and-drop file upload functionality.
 
 <ClientOnly>
   <div class="vertical-spacing-container">
@@ -241,10 +241,6 @@ Use this prop to customize the maximize size of file that can be uploaded. Defau
 :::tip NOTE
 By default KFileUpload will display the error state with a generic error message when selected file exceeds specified maximum file size. You can use [`errorMessage` prop](#errormessage) in conjunction with the [`error` event](#events) to display a custom error message.
 :::
-
-### allowDragAndDrop
-
-Boolean to control whether to allow drag and drop functionality when `appearance="input"`. Defaults to `true`.
 
 ## Slots
 

--- a/sandbox/pages/SandboxFileUpload.vue
+++ b/sandbox/pages/SandboxFileUpload.vue
@@ -84,14 +84,6 @@
           :max-file-size="4002000"
         />
       </SandboxSectionComponent>
-      <SandboxSectionComponent title="allowDragAndDrop">
-        <KFileUpload
-          :accept="['image/*']"
-          :allow-drag-and-drop="false"
-          help="Drag and drop is not allowed"
-          label="Label"
-        />
-      </SandboxSectionComponent>
       <SandboxSectionComponent title="appearance">
         <KFileUpload
           :accept="['image/*']"

--- a/sandbox/pages/SandboxFileUpload.vue
+++ b/sandbox/pages/SandboxFileUpload.vue
@@ -84,6 +84,14 @@
           :max-file-size="4002000"
         />
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="allowDragAndDrop">
+        <KFileUpload
+          :accept="['image/*']"
+          :allow-drag-and-drop="false"
+          help="Drag and drop is not allowed"
+          label="Label"
+        />
+      </SandboxSectionComponent>
 
       <!-- Attributes -->
       <SandboxTitleComponent

--- a/sandbox/pages/SandboxFileUpload.vue
+++ b/sandbox/pages/SandboxFileUpload.vue
@@ -92,6 +92,38 @@
           label="Label"
         />
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="appearance">
+        <KFileUpload
+          :accept="['image/*']"
+          appearance="dropzone"
+        />
+        <KFileUpload
+          :accept="['image/*']"
+          appearance="dropzone"
+          button-text="Choose file"
+          help="Drag and drop files here or click to upload."
+          label="Label"
+          placeholder="This is a dropzone input with a placeholder"
+        >
+          <template #icon>
+            <ImageIcon />
+          </template>
+        </KFileUpload>
+        <KFileUpload
+          :accept="['image/*']"
+          appearance="dropzone"
+          error
+          error-message="This is an error message."
+          label="Label"
+        />
+        <KFileUpload
+          :accept="['image/*']"
+          appearance="dropzone"
+          disabled
+          help="Drag and drop files here or click to upload."
+          label="Label"
+        />
+      </SandboxSectionComponent>
 
       <!-- Attributes -->
       <SandboxTitleComponent

--- a/sandbox/pages/SandboxFileUpload.vue
+++ b/sandbox/pages/SandboxFileUpload.vue
@@ -156,6 +156,20 @@
           </template>
         </KFileUpload>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="dropzone-footer">
+        <KFileUpload
+          :accept="['image/*']"
+          appearance="dropzone"
+          class="dropzone-footer-example"
+          label="Label"
+        >
+          <template #dropzone-footer>
+            <KAlert class="dropzone-alert">
+              Alert message at the bottom of the dropzone.
+            </KAlert>
+          </template>
+        </KFileUpload>
+      </SandboxSectionComponent>
     </div>
   </SandboxLayout>
 </template>
@@ -178,6 +192,21 @@ import { ImageIcon } from '@kong/icons'
 
   .full-width-input {
     width: 100%;
+  }
+}
+
+.dropzone-footer-example {
+  .dropzone-alert {
+    border-top: $kui-border-width-10 solid $kui-color-border;
+    border-top-left-radius: $kui-border-radius-0;
+    border-top-right-radius: $kui-border-radius-0;
+    width: 100%;
+  }
+
+  :deep(.dropzone) {
+    padding-bottom: $kui-space-0 !important;
+    padding-left: $kui-space-0 !important;
+    padding-right: $kui-space-0 !important;
   }
 }
 </style>

--- a/src/components/KFileUpload/KFileUpload.cy.ts
+++ b/src/components/KFileUpload/KFileUpload.cy.ts
@@ -88,19 +88,6 @@ describe('KFileUpload', () => {
       })
     })
 
-    it('should not allow drag and drop when allowDragAndDrop is false', () => {
-      cy.mount(KFileUpload, {
-        props: {
-          accept: ['.md'],
-          allowDragAndDrop: false,
-        },
-      })
-
-      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
-        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
-      })
-    })
-
     it('should not allow drag and drop when input is disabled', () => {
       cy.mount(KFileUpload, {
         props: {
@@ -258,20 +245,6 @@ describe('KFileUpload', () => {
       cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
         cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
         cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
-      })
-    })
-
-    it('ignores allowDragAndDrop prop when appearance is dropzone', () => {
-      cy.mount(KFileUpload, {
-        props: {
-          appearance: 'dropzone',
-          allowDragAndDrop: false,
-          accept: ['.md'],
-        },
-      })
-
-      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
-        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
       })
     })
   })

--- a/src/components/KFileUpload/KFileUpload.cy.ts
+++ b/src/components/KFileUpload/KFileUpload.cy.ts
@@ -247,5 +247,22 @@ describe('KFileUpload', () => {
         cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
       })
     })
+
+    it('displays content passed through dropzone-footer slot', () => {
+      const slotContent = 'This is some footer content'
+      const slotTestId = 'slotted-dropzone-footer'
+
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+        },
+        slots: {
+          'dropzone-footer': `<div data-testid="${slotTestId}">${slotContent}</div>`,
+        },
+      })
+
+      cy.getTestId(slotTestId).should('contain.text', slotContent)
+    })
   })
 })

--- a/src/components/KFileUpload/KFileUpload.cy.ts
+++ b/src/components/KFileUpload/KFileUpload.cy.ts
@@ -233,7 +233,7 @@ describe('KFileUpload', () => {
       })
     })
 
-    it('should not allow drag and drop when input is disabled', () => {
+    it('should not allow drag and drop when dropzone is disabled', () => {
       cy.mount(KFileUpload, {
         props: {
           appearance: 'dropzone',
@@ -258,6 +258,20 @@ describe('KFileUpload', () => {
       cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
         cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
         cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+      })
+    })
+
+    it('ignores allowDragAndDrop prop when appearance is dropzone', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          allowDragAndDrop: false,
+          accept: ['.md'],
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
       })
     })
   })

--- a/src/components/KFileUpload/KFileUpload.cy.ts
+++ b/src/components/KFileUpload/KFileUpload.cy.ts
@@ -1,77 +1,264 @@
 import KFileUpload from '@/components/KFileUpload/KFileUpload.vue'
 
 describe('KFileUpload', () => {
-  it('renders text when value is passed', () => {
-    const text = 'I am a label'
-    cy.mount(KFileUpload, {
-      props: {
-        accept: ['.md'],
-        label: text,
-      },
-    })
-
-    cy.get('.k-label').should('contain.text', text)
-  })
-
-  it('renders label with labelAttributes applied', () => {
-    const labelText = 'A Label Text'
-    cy.mount(KFileUpload, {
-      props: {
-        accept: ['.md'],
-        label: labelText,
-        labelAttributes: {
-          info: 'random text',
+  describe('input appearance', () => {
+    it('renders label when value is passed', () => {
+      const text = 'I am a label'
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+          label: text,
         },
-      },
+      })
+
+      cy.get('.k-label').should('contain.text', text)
     })
 
-    cy.get('.k-label').should('contain.text', labelText)
-    cy.get('.k-label .tooltip-trigger-icon').should('be.visible')
+    it('renders label with labelAttributes applied', () => {
+      const labelText = 'A Label Text'
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+          label: labelText,
+          labelAttributes: {
+            info: 'random text',
+          },
+        },
+      })
+
+      cy.get('.k-label').should('contain.text', labelText)
+      cy.get('.k-label .tooltip-trigger-icon').should('be.visible')
+    })
+
+    it('should emit correct event when a file is selected, removed', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+        },
+      })
+
+      cy.get('input[type=file]').selectFile('cypress/fixtures/file-upload/file-upload-document.md').then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'input')
+      })
+      cy.getTestId('file-upload-button').click().then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-removed')
+      })
+    })
+
+    it('triggers input click on button click', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+        },
+      })
+
+      cy.get('input[type=file]').then(($input) => {
+        cy.spy($input[0], 'click').as('inputClickSpy')
+      })
+
+      cy.getTestId('file-upload-button').click()
+
+      // Assert that the input click was triggered
+      cy.get('@inputClickSpy').should('have.been.calledOnce')
+    })
+
+    it('should emit error when uploading file that exceeds file size', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+          maxFileSize: 0,
+        },
+      })
+
+      cy.get('input[type=file]').selectFile('cypress/fixtures/file-upload/file-upload-document.md').then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+      })
+    })
+
+    it('allows drag and drop', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
+      })
+    })
+
+    it('should not allow drag and drop when allowDragAndDrop is false', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+          allowDragAndDrop: false,
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
+      })
+    })
+
+    it('should not allow drag and drop when input is disabled', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+          disabled: true,
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
+      })
+    })
+
+    it('should not accept unsupported file type and display error', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.png'],
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+      })
+    })
+
+    it('should emit error when drag and drop uploading file that exceeds file size', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          accept: ['.md'],
+          maxFileSize: 0,
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+      })
+    })
   })
 
-  it('should emit correct event when a file is selected, removed', () => {
-    cy.mount(KFileUpload, {
-      props: {
-        accept: ['.md'],
-      },
+  describe('dropzone appearance', () => {
+    it('renders label when value is passed', () => {
+      const text = 'I am a label'
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+          label: text,
+        },
+      })
+
+      cy.get('.k-label').should('contain.text', text)
     })
 
-    cy.get('input[type=file]').selectFile('cypress/fixtures/file-upload/file-upload-document.md').then(() => {
-      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
-      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'input')
-    })
-    cy.getTestId('file-upload-button').click().then(() => {
-      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-removed')
-    })
-  })
+    it('renders label with labelAttributes applied', () => {
+      const labelText = 'A Label Text'
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+          label: labelText,
+          labelAttributes: {
+            info: 'random text',
+          },
+        },
+      })
 
-  it('triggers input click on button click', () => {
-    cy.mount(KFileUpload, {
-      props: {
-        accept: ['.md'],
-      },
-    })
-
-    cy.get('input[type=file]').then(($input) => {
-      cy.spy($input[0], 'click').as('inputClickSpy')
+      cy.get('.k-label').should('contain.text', labelText)
+      cy.get('.k-label .tooltip-trigger-icon').should('be.visible')
     })
 
-    cy.getTestId('file-upload-button').click()
+    it('should emit correct event when a file is selected, removed', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+        },
+      })
 
-    // Assert that the input click was triggered
-    cy.get('@inputClickSpy').should('have.been.calledOnce')
-  })
-
-  it('should emit error event when there is an error with file upload', () => {
-    cy.mount(KFileUpload, {
-      props: {
-        accept: ['.md'],
-        maxFileSize: 0,
-      },
+      cy.getTestId('file-upload-dropzone').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
+      })
+      cy.getTestId('file-upload-button').click().then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-removed')
+      })
     })
 
-    cy.get('input[type=file]').selectFile('cypress/fixtures/file-upload/file-upload-document.md').then(() => {
-      cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+    it('triggers input click on button click', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+        },
+      })
+
+      cy.get('input[type=file]').then(($input) => {
+        cy.spy($input[0], 'click').as('inputClickSpy')
+      })
+
+      cy.getTestId('file-upload-button').click()
+
+      // Assert that the input click was triggered
+      cy.get('@inputClickSpy').should('have.been.calledOnce')
+    })
+
+    it('should emit error when uploading file that exceeds file size', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+          maxFileSize: 0,
+        },
+      })
+
+      cy.getTestId('file-upload-dropzone').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+      })
+    })
+
+    it('allows drag and drop', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'file-added')
+      })
+    })
+
+    it('should not allow drag and drop when input is disabled', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.md'],
+          disabled: true,
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
+      })
+    })
+
+    it('should not accept unsupported file type and display error', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          appearance: 'dropzone',
+          accept: ['.png'],
+        },
+      })
+
+      cy.get('.k-file-upload').selectFile('cypress/fixtures/file-upload/file-upload-document.md', { action: 'drag-drop' }).then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should('not.have.property', 'file-added')
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'error')
+      })
     })
   })
 })

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -344,6 +344,7 @@ const onDrop = (evt: DragEvent): void => {
         emit('file-added', files)
       } else {
         invalidFileTypeError.value = true
+        emit('error', files)
       }
     }
   }

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -229,6 +229,8 @@ const fileName = ref<string>('')
 // A copy of previously selected FileList to restore when user clicks reopen the file uploader and clicks on Cancel
 const previousFiles = ref<FileList | null>(null)
 
+const dropzoneRef = useTemplateRef('dropzone')
+
 const onFileChange = (evt: Event): void => {
   invalidFileTypeError.value = false // file picker only allows selecting accepted files
 
@@ -346,8 +348,6 @@ const onDrop = (evt: DragEvent): void => {
     }
   }
 }
-
-const dropzoneRef = useTemplateRef('dropzone')
 
 const isAppearanceDropzone = computed((): boolean => appearance === 'dropzone')
 

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -464,14 +464,9 @@ $kFileUploadInputPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to
         border-style: solid;
       }
 
-      &:focus:not(.disabled) {
-        border-color: var(--kui-color-border-primary, $kui-color-border-primary);
-        border-style: solid;
-        box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
-      }
-
+      &:focus:not(.disabled),
       &:focus-visible {
-        border-color: var(--kui-color-border-primary-weak, $kui-color-border-primary-weak);
+        border-color: var(--kui-color-border-primary, $kui-color-border-primary);
         border-style: solid;
         box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
       }

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -91,6 +91,7 @@
           dragging: isDragging && !disabled,
           disabled: disabled,
           error: hasError,
+          'has-file': !!fileName,
         }"
         data-testid="file-upload-dropzone"
         role="button"
@@ -123,6 +124,7 @@
         >
           {{ fileName ? 'Clear' : buttonText }}
         </KButton>
+        <slot name="dropzone-footer" />
       </div>
       <p
         v-if="hasError || help"
@@ -432,7 +434,7 @@ $kFileUploadInputPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to
 
       align-items: center;
       background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
-      border: var(--kui-border-width-10, $kui-border-width-10) dashed var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
+      border: var(--kui-border-width-10, $kui-border-width-10) dashed var(--kui-color-border, $kui-color-border);
       border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
       color: var(--kui-color-text-neutral, $kui-color-text-neutral);
       cursor: pointer;
@@ -458,7 +460,16 @@ $kFileUploadInputPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to
         border-style: solid;
       }
 
-      &:focus:not(.disabled),
+      &.has-file {
+        border-style: solid;
+      }
+
+      &:focus:not(.disabled) {
+        border-color: var(--kui-color-border-primary, $kui-color-border-primary);
+        border-style: solid;
+        box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+      }
+
       &:focus-visible {
         border-color: var(--kui-color-border-primary-weak, $kui-color-border-primary-weak);
         border-style: solid;

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -32,7 +32,7 @@
         v-if="!isAppearanceDropzone"
         :key="fileInputKey"
         class="file-upload-input-text"
-        :class="{ 'placeholder': !fileName, 'has-icon': $slots.icon, 'disabled': disabled }"
+        :class="{ placeholder: !fileName, 'has-icon': $slots.icon, disabled: disabled }"
       >
         {{ fileName ? fileName : placeholder || defaultPlaceholder }}
       </span>
@@ -43,7 +43,7 @@
         ref="input"
         :accept="accept"
         class="upload-input"
-        :class="{ 'dragging': isDragging && isDragAndDropAllowed }"
+        :class="{ dragging: isDragging && isDragAndDropAllowed }"
         :disabled="disabled"
         :error="hasError"
         :error-message="errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage"
@@ -88,9 +88,9 @@
         :aria-labelledby="label ? `file-upload-dropzone-label-${fileInputId}` : undefined"
         class="dropzone"
         :class="{
-          'dragging': isDragging && !disabled,
-          'disabled': disabled,
-          'error': hasError,
+          dragging: isDragging && !disabled,
+          disabled: disabled,
+          error: hasError,
         }"
         data-testid="file-upload-dropzone"
         role="button"
@@ -127,7 +127,7 @@
       <p
         v-if="hasError || help"
         class="help-text"
-        :class="{ 'error': hasError }"
+        :class="{ error: hasError }"
       >
         {{ hasError ? errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage || help : help }}
       </p>
@@ -335,7 +335,6 @@ const onDrop = (evt: DragEvent): void => {
         return
       }
 
-      
       if (isAcceptedFile(files[0])) {
         invalidFileTypeError.value = false
         previousFiles.value = files

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -159,7 +159,6 @@ const {
   error,
   errorMessage = '',
   disabled,
-  allowDragAndDrop = true,
   appearance = 'input',
 } = defineProps<FileUploadProps>()
 
@@ -283,12 +282,12 @@ const resetInput = (): void => {
   emit('file-removed')
 }
 
-const isDragAndDropAllowed = computed((): boolean => (isAppearanceDropzone.value || allowDragAndDrop) && !disabled)
+const isDragAndDropAllowed = computed((): boolean => isAppearanceDropzone.value && !disabled)
 const isDragging = ref<boolean>(false)
 
 const invalidFileTypeError = ref<boolean>(false)
 const isAcceptedFile = (file: File): boolean => {
-  if (!accept || !Array.isArray(accept) || accept.length === 0) {
+  if (!accept || !Array.isArray(accept) || !accept.length) {
     // If accept is not defined or empty, accept all files by default
     return true
   }

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -94,7 +94,7 @@
         }"
         data-testid="file-upload-dropzone"
         role="button"
-        :tabindex="!disabled ? 0 : -1"
+        :tabindex="disabled ? -1 : 0"
         @click="onButtonClick"
       >
         <div
@@ -129,12 +129,7 @@
         class="help-text"
         :class="{ 'error': hasError }"
       >
-        <template v-if="hasError">
-          {{ errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage || help }}
-        </template>
-        <template v-else>
-          {{ help }}
-        </template>
+        {{ hasError ? errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage || help : help }}
       </p>
     </div>
   </div>
@@ -293,6 +288,10 @@ const isDragging = ref<boolean>(false)
 
 const invalidFileTypeError = ref<boolean>(false)
 const isAcceptedFile = (file: File): boolean => {
+  if (!accept || !Array.isArray(accept) || accept.length === 0) {
+    // If accept is not defined or empty, accept all files by default
+    return true
+  }
   return accept.some(acceptedType => {
     if (acceptedType.startsWith('.')) {
       // Match file extension
@@ -336,7 +335,7 @@ const onDrop = (evt: DragEvent): void => {
         return
       }
 
-      // TODO: validate file against accept
+      
       if (isAcceptedFile(files[0])) {
         invalidFileTypeError.value = false
         previousFiles.value = files

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -2,7 +2,7 @@
   <div
     class="k-file-upload"
     v-bind="modifiedAttrs"
-    :role="isDragAndDropAllowed ? 'region' : undefined"
+    :role="disabled ? undefined : 'region'"
     @dragleave.prevent="isDragging = false"
     @dragover.prevent="isDragging = true"
     @drop.prevent="onDrop"
@@ -43,7 +43,7 @@
         ref="input"
         :accept="accept"
         class="upload-input"
-        :class="{ dragging: isDragging && isDragAndDropAllowed }"
+        :class="{ dragging: isDragging && !disabled }"
         :disabled="disabled"
         :error="hasError"
         :error-message="errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage"
@@ -284,7 +284,6 @@ const resetInput = (): void => {
   emit('file-removed')
 }
 
-const isDragAndDropAllowed = computed((): boolean => isAppearanceDropzone.value && !disabled)
 const isDragging = ref<boolean>(false)
 
 const invalidFileTypeError = ref<boolean>(false)
@@ -316,7 +315,7 @@ const invalidFileTypeErrorMessage = computed((): string => {
 })
 
 const onDrop = (evt: DragEvent): void => {
-  if (isDragAndDropAllowed.value) {
+  if (!disabled) {
     if (isAppearanceDropzone.value) {
       dropzoneRef.value?.focus()
     } else {

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -10,6 +10,7 @@
     <KLabel
       v-if="label"
       v-bind="labelAttributes"
+      :id="isAppearanceDropzone ? `file-upload-dropzone-label-${fileInputId}` : undefined"
       :for="fileInputId"
       :required="isRequired"
     >
@@ -23,13 +24,17 @@
       </template>
     </KLabel>
 
-    <div class="file-upload-input-wrapper">
+    <div
+      v-show="!isAppearanceDropzone"
+      class="file-upload-input-wrapper"
+    >
       <span
+        v-if="!isAppearanceDropzone"
         :key="fileInputKey"
         class="file-upload-input-text"
         :class="{ 'placeholder': !fileName, 'has-icon': $slots.icon, 'disabled': disabled }"
       >
-        {{ fileName ? fileName : placeholder }}
+        {{ fileName ? fileName : placeholder || defaultPlaceholder }}
       </span>
 
       <KInput
@@ -43,19 +48,23 @@
         :error="hasError"
         :error-message="errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage"
         :help="help"
-        :placeholder="placeholder"
+        :hidden="isAppearanceDropzone"
+        :placeholder="placeholder || defaultPlaceholder"
         title=""
         type="file"
         @change="onFileChange"
       >
         <template
-          v-if="$slots.icon"
+          v-if="$slots.icon && !isAppearanceDropzone"
           #before
         >
           <slot name="icon" />
         </template>
 
-        <template #after>
+        <template
+          v-if="!isAppearanceDropzone"
+          #after
+        >
           <KButton
             appearance="tertiary"
             class="file-upload-button"
@@ -68,6 +77,65 @@
           </KButton>
         </template>
       </KInput>
+    </div>
+    <div
+      v-if="isAppearanceDropzone"
+      class="file-upload-dropzone-wrapper"
+    >
+      <div
+        ref="dropzone"
+        :aria-disabled="disabled ? 'true' : undefined"
+        :aria-labelledby="label ? `file-upload-dropzone-label-${fileInputId}` : undefined"
+        class="dropzone"
+        :class="{
+          'dragging': isDragging && !disabled,
+          'disabled': disabled,
+          'error': hasError,
+        }"
+        data-testid="file-upload-dropzone"
+        role="button"
+        :tabindex="!disabled ? 0 : -1"
+        @click="onButtonClick"
+      >
+        <div
+          aria-hidden="true"
+          class="dropzone-icon"
+        >
+          <slot name="icon">
+            <FileEmptyIcon
+              v-if="fileName"
+              decorative
+            />
+            <UploadIcon
+              v-else
+              decorative
+            />
+          </slot>
+        </div>
+        <span v-if="fileName">{{ fileName }}</span>
+        <span v-else>{{ placeholder || defaultPlaceholder }}</span>
+        <KButton
+          appearance="tertiary"
+          class="file-upload-button"
+          data-testid="file-upload-button"
+          :disabled="disabled"
+          @click.stop="onButtonClick"
+        >
+          {{ fileName ? 'Clear' : buttonText }}
+        </KButton>
+      </div>
+      <p
+        v-if="hasError || help"
+        class="help-text"
+        :class="{ 'error': hasError }"
+      >
+        <template v-if="hasError">
+          {{ errorMessage || invalidFileTypeErrorMessage || fileSizeErrorMessage || help }}
+        </template>
+        <template v-else>
+          {{ help }}
+        </template>
+      </p>
     </div>
   </div>
 </template>
@@ -83,19 +151,21 @@ import KInput from '@/components/KInput/KInput.vue'
 import KButton from '@/components/KButton/KButton.vue'
 import useUtilities from '@/composables/useUtilities'
 import type { FileUploadProps, FileUploadEmits, FileUploadSlots } from '@/types'
+import { UploadIcon, FileEmptyIcon } from '@kong/icons'
 
 const {
   labelAttributes = {},
   label = '',
   help,
   buttonText = 'Select file',
-  placeholder = 'No file selected',
+  placeholder = '',
   accept,
   maxFileSize = null,
   error,
   errorMessage = '',
   disabled,
   allowDragAndDrop = true,
+  appearance = 'input',
 } = defineProps<FileUploadProps>()
 
 const emit = defineEmits<FileUploadEmits>()
@@ -121,6 +191,13 @@ const fileInput = useTemplateRef('input')
 const hasLabelTooltip = computed((): boolean => !!(labelAttributes?.info || slots['label-tooltip']))
 const strippedLabel = computed((): string => stripRequiredLabel(label, isRequired.value))
 const isRequired = computed((): boolean => attrs?.required !== undefined && String(attrs?.required) !== 'false')
+const defaultPlaceholder = computed((): string => {
+  if (isAppearanceDropzone.value) {
+    return 'Drag & drop a file'
+  }
+
+  return 'No file selected'
+})
 
 const hasFileSizeError = ref<boolean>(false)
 const fileSizeErrorMessage = computed((): string => {
@@ -211,7 +288,7 @@ const resetInput = (): void => {
   emit('file-removed')
 }
 
-const isDragAndDropAllowed = computed((): boolean => allowDragAndDrop && !disabled)
+const isDragAndDropAllowed = computed((): boolean => (isAppearanceDropzone.value || allowDragAndDrop) && !disabled)
 const isDragging = ref<boolean>(false)
 
 const invalidFileTypeError = ref<boolean>(false)
@@ -240,7 +317,12 @@ const invalidFileTypeErrorMessage = computed((): string => {
 
 const onDrop = (evt: DragEvent): void => {
   if (isDragAndDropAllowed.value) {
-    fileInput.value?.input?.focus()
+    if (isAppearanceDropzone.value) {
+      dropzoneRef.value?.focus()
+    } else {
+      fileInput.value?.input?.focus()
+    }
+
     isDragging.value = false
     const files = evt.dataTransfer?.files
 
@@ -266,6 +348,10 @@ const onDrop = (evt: DragEvent): void => {
     }
   }
 }
+
+const dropzoneRef = useTemplateRef('dropzone')
+
+const isAppearanceDropzone = computed((): boolean => appearance === 'dropzone')
 
 watch(() => attrs.id, () => {
   fileInputKey.value++
@@ -339,6 +425,70 @@ $kFileUploadInputPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to
     .upload-input.dragging {
       :deep(input) {
         @include inputHover;
+      }
+    }
+  }
+
+  .file-upload-dropzone-wrapper {
+    .dropzone {
+      @include bodyText;
+
+      align-items: center;
+      background-color: var(--kui-color-background-neutral-weakest, $kui-color-background-neutral-weakest);
+      border: var(--kui-border-width-10, $kui-border-width-10) dashed var(--kui-color-border-neutral-weak, $kui-color-border-neutral-weak);
+      border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+      cursor: pointer;
+      display: flex;
+      flex-direction: column;
+      gap: var(--kui-space-40, $kui-space-40);
+      outline: none;
+      padding: var(--kui-space-90, $kui-space-90) var(--kui-space-50, $kui-space-50);
+      text-align: center;
+      transition: border-color $kongponentsTransitionDurTimingFunc, border-style $kongponentsTransitionDurTimingFunc;
+      width: 100%;
+
+      .dropzone-icon {
+        :deep(#{$kongponentsKongIconSelector}) {
+          height: var(--kui-icon-size-40, $kui-icon-size-40) !important;
+          width: var(--kui-icon-size-40, $kui-icon-size-40) !important;
+        }
+      }
+
+      &:hover,
+      &.dragging {
+        border-color: var(--kui-color-border-primary-weak, $kui-color-border-primary-weak);
+        border-style: solid;
+      }
+
+      &:focus:not(.disabled),
+      &:focus-visible {
+        border-color: var(--kui-color-border-primary-weak, $kui-color-border-primary-weak);
+        border-style: solid;
+        box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
+      }
+
+      &.error {
+        border-color: var(--kui-color-border-danger, $kui-color-border-danger) !important;
+        border-style: solid;
+      }
+
+      &.disabled {
+        background-color: var(--kui-color-background-disabled, $kui-color-background-disabled);
+        border-color: var(--kui-color-border-disabled, $kui-color-border-disabled);
+        border-style: solid;
+        cursor: not-allowed;
+      }
+    }
+
+    .help-text {
+      @include inputHelpText;
+
+      margin: var(--kui-space-0, $kui-space-0);
+      margin-top: var(--kui-space-40, $kui-space-40);
+
+      &.error {
+        color: var(--kui-color-text-danger, $kui-color-text-danger);
       }
     }
   }

--- a/src/components/KTreeList/KTreeDraggable.vue
+++ b/src/components/KTreeList/KTreeDraggable.vue
@@ -363,7 +363,7 @@ $kTreeListIdentCollapsible: 6px;
         margin-left: 19px;
       }
 
-      & .tree-item-container {
+      &.tree-item-container {
         padding-left: $kTreeListIdentCollapsible;
 
         &:before {
@@ -387,12 +387,22 @@ $kTreeListIdentCollapsible: 6px;
           &:after {
             width: 40px;
           }
+
+          + .tree-item-container.has-no-children {
+            margin-left: $kui-space-0;
+          }
         }
 
         &:first-of-type {
           &:before {
             top: -3px;
           }
+        }
+      }
+
+      &:not(:has(> .tree-item-container:not(.has-no-children))) {
+        > .tree-item-container.has-no-children .file-list-item-link {
+          padding-left: $kui-space-0 !important;
         }
       }
     }

--- a/src/types/file-upload.ts
+++ b/src/types/file-upload.ts
@@ -1,5 +1,7 @@
 import type { LabelAttributes } from './label'
 
+export type FileUploadAppearance = 'input' | 'dropzone'
+
 export interface FileUploadProps {
   /**
    * Use the `labelAttributes` prop to configure the KLabel's props if using the `label` prop.
@@ -67,6 +69,12 @@ export interface FileUploadProps {
    * @default true
    */
   allowDragAndDrop?: boolean
+
+  /**
+   * The appearance of the file upload component.
+   * @default 'input'
+   */
+  appearance?: FileUploadAppearance
 }
 
 export interface FileUploadEmits {

--- a/src/types/file-upload.ts
+++ b/src/types/file-upload.ts
@@ -61,6 +61,12 @@ export interface FileUploadProps {
    * @default false
    */
   disabled?: boolean
+
+  /**
+   * Whether to allow drag and drop functionality.
+   * @default true
+   */
+  allowDragAndDrop?: boolean
 }
 
 export interface FileUploadEmits {

--- a/src/types/file-upload.ts
+++ b/src/types/file-upload.ts
@@ -65,12 +65,6 @@ export interface FileUploadProps {
   disabled?: boolean
 
   /**
-   * Whether to allow drag and drop functionality.
-   * @default true
-   */
-  allowDragAndDrop?: boolean
-
-  /**
    * The appearance of the file upload component.
    * @default 'input'
    */

--- a/src/types/file-upload.ts
+++ b/src/types/file-upload.ts
@@ -98,4 +98,9 @@ export interface FileUploadSlots {
    * Use this slot if you want to utilize HTML in the input label's tooltip.
    */
   'label-tooltip'?(): any
+
+  /**
+   * Slot for additional content at the bottom of the the dropzone area. Only available when `appearance` prop is set to `dropzone`.
+   */
+  'dropzone-footer'?(): any
 }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-17516

* Add `appearance="dropzone"` prop to support dropzone appearance in KFileUpload ([Figma](https://www.figma.com/design/TKG7r9QQSMDsBRfR0Gphpc/Drop-zone?node-id=0-1&p=f&t=4q58NCsIsnAMjThc-0))

<img width="1391" height="860" alt="Screenshot 2025-09-02 at 9 29 22 AM" src="https://github.com/user-attachments/assets/06437ace-0886-4d40-9435-d192f0be27e5" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
