### PR TITLE
fix(*): kpop offset [KHCP-17692]

### DIFF
--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -10,6 +10,7 @@
       :disabled="disabled || readonly"
       hide-caret
       hide-close-icon
+      :offset="KUI_SPACE_40"
       :placement="popoverPlacement"
       width="auto"
       @close="onClosePopover"
@@ -141,7 +142,7 @@ import 'v-calendar/dist/style.css'
 import { ModeArrayCustom, ModeArrayRelative, ModeDateOnly, DateTimePickerModes } from '@/types'
 import type { DateTimePickerState, TimePeriod, TimeRange, DatePickerModel, ButtonAppearance, DateTimePickerProps, DateTimePickerEmits } from '@/types'
 import { CalIcon } from '@kong/icons'
-import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_NEUTRAL, KUI_ICON_SIZE_40, KUI_SPACE_40 } from '@kong/design-tokens'
 import { normalizeSize } from '@/utilities/css'
 import CalendarWrapper from './CalendarWrapper.vue'
 

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -10,6 +10,7 @@
         close-on-popover-click
         data-testid="dropdown-popover"
         hide-close-icon
+        :offset="KUI_SPACE_20"
         @close="() => handleTriggerToggle(isToggled, toggle, false)"
         @open="() => handleTriggerToggle(isToggled, toggle, true)"
         @popover-click="() => handleTriggerToggle(isToggled, toggle, false)"
@@ -80,6 +81,7 @@ import KPop from '@/components/KPop/KPop.vue'
 import KToggle from '@/components/KToggle/KToggle.vue'
 import KDropdownItem from './KDropdownItem.vue'
 import { ChevronDownIcon } from '@kong/icons'
+import { KUI_SPACE_20 } from '@kong/design-tokens'
 
 const {
   selectionMenu,
@@ -188,7 +190,6 @@ defineExpose({
   :deep(.popover.dropdown-popover > .popover-container) {
     border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
     border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
-    margin-top: var(--kui-space-30, $kui-space-30);
     padding: var(--kui-space-0, $kui-space-0);
 
     ul {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -25,6 +25,7 @@
         <KPop
           ref="popper"
           hide-close-icon
+          :offset="KUI_SPACE_40"
           v-bind="boundKPopAttributes"
           @close="() => handleToggle(false, isToggled, toggle)"
           @open="() => handleToggle(true, isToggled, toggle)"
@@ -306,7 +307,7 @@ import type {
   PopoverAttributes,
 } from '@/types'
 import { CloseIcon, ChevronDownIcon, ProgressIcon } from '@kong/icons'
-import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_40, KUI_SPACE_40 } from '@kong/design-tokens'
 import { ResizeObserverHelper } from '@/utilities/resizeObserverHelper'
 import { sanitizeInput } from '@/utilities/sanitizeInput'
 import { useEventListener } from '@vueuse/core'

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -26,6 +26,7 @@
         v-bind="boundKPopAttributes"
         close-on-popover-click
         hide-close-icon
+        :offset="KUI_SPACE_40"
         @close="() => onClose(toggle, isToggled.value)"
         @open="() => onOpen(toggle)"
         @popover-click="() => onPopoverClick(toggle)"
@@ -215,6 +216,7 @@ import { sanitizeInput } from '@/utilities/sanitizeInput'
 import { useEventListener } from '@vueuse/core'
 import { getUniqueStringId } from '@/utilities'
 import { normalizeSize } from '@/utilities/css'
+import { KUI_SPACE_40 } from '@kong/design-tokens'
 
 type Value = U extends true ? T | string : T
 type Item = SelectItem<Value>


### PR DESCRIPTION
# Summary

Increase spacing betweet popover and trigger elements in KDropdown as per component [Figma](https://www.figma.com/design/Yze0SWXl5nKjR0rFdilljK/Components?node-id=466-9443)

Before
<img width="224" height="222" alt="Screenshot 2025-09-02 at 4 08 43 PM" src="https://github.com/user-attachments/assets/64ea01e0-1777-4ff0-a994-4b81c7b6b3fc" />

After
<img width="228" height="214" alt="Screenshot 2025-09-02 at 4 08 10 PM" src="https://github.com/user-attachments/assets/37d796d2-7752-430d-9d08-51eee5bfb82d" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
