### PR TITLE
fix(kmodal): kmodal max-height on shorter viewports

### DIFF
--- a/sandbox/pages/SandboxModals.vue
+++ b/sandbox/pages/SandboxModals.vue
@@ -341,7 +341,7 @@
           </div>
 
           <KModal
-            max-height="200px"
+            max-height="500px"
             title="KModal"
             :visible="data.modalVisible"
             @cancel="data.modalVisible = false"
@@ -352,7 +352,7 @@
             </p>
           </KModal>
           <KPrompt
-            :modal-attributes="{ maxHeight: '200px' }"
+            :modal-attributes="{ maxHeight: '500px' }"
             title="KPrompt"
             :visible="data.promptVisible"
             @cancel="data.promptVisible = false"

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -345,7 +345,7 @@ onBeforeUnmount(async () => {
       font-size: var(--kui-font-size-30, $kui-font-size-30);
       font-weight: var(--kui-font-weight-regular, $kui-font-weight-regular);
       line-height: var(--kui-line-height-30, $kui-line-height-30);
-      max-height: v-bind('maxHeightValue');
+      max-height: min(v-bind('maxHeightValue'), calc(100vh - 200px));
       overflow-y: auto;
       padding: var(--kui-space-80, $kui-space-80);
 


### PR DESCRIPTION
# Summary

Fix KModal height on smaller viewport when `maxHeight` is provided

Before
https://github.com/user-attachments/assets/0b2269e7-32ea-495a-8214-1654b3fc652e

After
https://github.com/user-attachments/assets/02da6eeb-6693-4617-9c6b-158004686911

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
