### PR TITLE
feat(*): support specifying target for dropdown/select/multiselect popovers

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -652,6 +652,11 @@ Search input placeholder (when [`collapsedContext` prop](#collapsedcontext) is `
 />
 ```
 
+### kpopAttributes
+
+Attributes to be passed to underlying KPopover component. See [KPopover's props](/components/popover#props) for more info.
+
+
 ## Attribute Binding
 
 You can pass any input attribute and it will get properly bound to the element.

--- a/sandbox/pages/SandboxDropdown.vue
+++ b/sandbox/pages/SandboxDropdown.vue
@@ -131,7 +131,19 @@
           trigger-text="Disabled with a tooltip"
         />
       </SandboxSectionComponent>
-
+      <SandboxSectionComponent
+        title="kpopAttributes"
+      >
+        <KDropdown
+          :items="[
+            { label: 'Home', to: { name: 'home' } },
+            { label: 'KAlert', to: { name: 'alert' } },
+            { label: 'Stay', to: { name: 'dropdown' } },
+          ]"
+          :kpop-attributes="{ target: 'body' }"
+          trigger-text="KPop attributes"
+        />
+      </SandboxSectionComponent>
       <!-- Slots -->
       <SandboxTitleComponent
         is-subtitle

--- a/sandbox/pages/SandboxMultiselect.vue
+++ b/sandbox/pages/SandboxMultiselect.vue
@@ -32,6 +32,15 @@
         />
       </SandboxSectionComponent>
       <SandboxSectionComponent
+        title="kpopAttributes"
+      >
+        <KMultiselect
+          :items="multiselectItems"
+          :kpop-attributes="{ target: 'body' }"
+          label="Label"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
         title="selectedRowCount"
       >
         <KMultiselect

--- a/sandbox/pages/SandboxSelect.vue
+++ b/sandbox/pages/SandboxSelect.vue
@@ -55,6 +55,15 @@
         />
       </SandboxSectionComponent>
       <SandboxSectionComponent
+        title="kpopAttributes"
+      >
+        <KSelect
+          :items="selectItems"
+          :kpop-attributes="{ target: 'body' }"
+          label="Label"
+        />
+      </SandboxSectionComponent>
+      <SandboxSectionComponent
         title="clearable"
       >
         <KSelect

--- a/src/components/KDropdown/KDropdown.vue
+++ b/src/components/KDropdown/KDropdown.vue
@@ -117,7 +117,7 @@ const tooltipComponent = computed(() => disabledTooltip ? KTooltip : 'div')
 const kPopRef = useTemplateRef('kPop')
 const defaultKPopAttributes: PopoverAttributes = {
   hideCaret: true,
-  popoverClasses: 'dropdown-popover',
+  popoverClasses: 'k-dropdown-popover dropdown-popover',
   popoverTimeout: 0,
   placement: 'bottom-start',
 }
@@ -186,16 +186,21 @@ defineExpose({
   .dropdown-trigger {
     width: 100%;
   }
+}
+</style>
 
-  :deep(.popover.dropdown-popover > .popover-container) {
-    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
-    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
-    padding: var(--kui-space-0, $kui-space-0);
+<style lang="scss">
+// We use a global style here because the popover may be teleported outside the component.
+// The selector might look unusual, but it’s intentional: keeping the same specificity
+// as before supporting teleportation ensures backward compatibility and avoids style conflicts.
+.k-dropdown-popover.dropdown-popover.popover > .popover-container {
+  border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+  border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+  padding: var(--kui-space-0, $kui-space-0);
 
-    ul {
-      margin: 0;
-      padding: var(--kui-space-20, $kui-space-20) 0;
-    }
+  .dropdown-list {
+    margin: 0;
+    padding: var(--kui-space-20, $kui-space-20) 0;
   }
 }
 </style>

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -400,7 +400,7 @@ const defaultKPopAttributes = {
   hideCaret: true,
   placement: 'bottom-start' as PopPlacements,
   popoverTimeout: 0,
-  popoverClasses: 'multiselect-popover',
+  popoverClasses: 'k-multiselect-popover multiselect-popover',
 }
 
 // keys and ids
@@ -1002,13 +1002,6 @@ $kMultiselectChevronIconSize: var(--kui-icon-size-40, $kui-icon-size-40);
 $kMultiselectSelectionsPaddingRight: calc($kMultiselectInputPaddingX + $kMultiselectChevronIconSize + var(--kui-space-40, $kui-space-40));
 $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20); // corresponds to mixin
 
-/* Component mixins */
-
-@mixin kMultiselectPopoverMaxHeight {
-  max-height: v-bind('popoverContentMaxHeight');
-  overflow-y: auto;
-}
-
 /* Component styles */
 
 .k-multiselect {
@@ -1156,44 +1149,6 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
     }
   }
 
-  :deep(.multiselect-popover .popover-container) {
-    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
-    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
-    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
-
-    &.has-dropdown-footer {
-      padding-bottom: var(--kui-space-0, $kui-space-0);
-    }
-
-    .popover-content {
-      @include kMultiselectPopoverMaxHeight;
-
-      // when dropdown footer text position is sticky
-      &:has(.dropdown-footer.dropdown-footer-sticky) {
-        max-height: none;
-
-        .multiselect-list {
-          @include kMultiselectPopoverMaxHeight;
-        }
-      }
-
-      // Firefox workaround
-      // since :has() selector isn't supported in Firefox be default
-      .multiselect-list ~ .dropdown-footer-sticky {
-        bottom: 0;
-        position: sticky;
-      }
-    }
-  }
-
-  .multiselect-input-wrapper {
-    background-color: var(--kui-color-background, $kui-color-background);
-    border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
-    padding: var(--kui-space-40, $kui-space-40);
-    position: sticky;
-    top: 0;
-  }
-
   .multiselect-empty {
     @include selectItemDefaults;
   }
@@ -1245,6 +1200,58 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
 
   .badge-dismiss-button {
     @include defaultButtonReset;
+  }
+}
+</style>
+
+<style lang="scss">
+/* Component mixins */
+
+@mixin kMultiselectPopoverMaxHeight {
+  max-height: v-bind('popoverContentMaxHeight');
+  overflow-y: auto;
+}
+
+// We use a global style here because the popover may be teleported outside the component.
+// The selector might look unusual, but it’s intentional: keeping the same specificity
+// as before supporting teleportation ensures backward compatibility and avoids style conflicts.
+.k-multiselect-popover {
+  .multiselect-input-wrapper {
+    background-color: var(--kui-color-background, $kui-color-background);
+    border-bottom: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+    padding: var(--kui-space-40, $kui-space-40);
+    position: sticky;
+    top: 0;
+  }
+
+  &.multiselect-popover .popover-container {
+    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
+
+    &.has-dropdown-footer {
+      padding-bottom: var(--kui-space-0, $kui-space-0);
+    }
+
+    .popover-content {
+      @include kMultiselectPopoverMaxHeight;
+
+      // when dropdown footer text position is sticky
+      &:has(.dropdown-footer.dropdown-footer-sticky) {
+        max-height: none;
+
+        .multiselect-list {
+          @include kMultiselectPopoverMaxHeight;
+        }
+      }
+
+      // Firefox workaround
+      // since :has() selector isn't supported in Firefox be default
+      .multiselect-list ~ .dropdown-footer-sticky {
+        bottom: 0;
+        position: sticky;
+      }
+    }
   }
 }
 </style>

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -267,7 +267,7 @@ const isDisabled = computed((): boolean => attrs.disabled !== undefined && Strin
 const isReadonly = computed((): boolean => attrs.readonly !== undefined && String(attrs.readonly) !== 'false')
 
 const defaultKPopAttributes: PopoverAttributes = {
-  popoverClasses: `select-popover ${dropdownFooterText || slots['dropdown-footer-text'] ? `has-${dropdownFooterTextPosition}-dropdown-footer` : ''}`,
+  popoverClasses: `k-select-popover select-popover ${dropdownFooterText || slots['dropdown-footer-text'] ? `has-${dropdownFooterTextPosition}-dropdown-footer` : ''}`,
   popoverTimeout: 0,
   placement: 'bottom-start',
   hideCaret: true,
@@ -739,23 +739,6 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
     }
   }
 
-  .select-popover {
-    .select-items-container {
-      max-height: v-bind('popoverContentMaxHeight');
-      overflow-y: auto;
-    }
-  }
-
-  :deep(.select-popover.popover .popover-container) {
-    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
-    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
-    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
-
-    &.has-sticky-dropdown-footer, &.has-static-dropdown-footer {
-      padding-bottom: var(--kui-space-0, $kui-space-0);
-    }
-  }
-
   .select-loading,
   .select-empty {
     @include selectItemDefaults;
@@ -800,6 +783,25 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
 
   .clear-selection-button {
     @include defaultButtonReset;
+  }
+}
+</style>
+
+<style lang="scss">
+.k-select-popover.select-popover {
+  .select-items-container {
+    max-height: v-bind('popoverContentMaxHeight');
+    overflow-y: auto;
+  }
+
+  &.popover .popover-container {
+    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-color-border, $kui-color-border);
+    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
+
+    &.has-sticky-dropdown-footer, &.has-static-dropdown-footer {
+      padding-bottom: var(--kui-space-0, $kui-space-0);
+    }
   }
 }
 </style>

--- a/src/types/dropdown.ts
+++ b/src/types/dropdown.ts
@@ -142,7 +142,7 @@ export interface DropdownProps<T extends string | number> {
    * Use the `kpopAttributes` prop to configure the KPop props dropdown.
    * @default {}
    */
-  kpopAttributes?: Omit<PopoverAttributes, 'target' | 'trigger'>
+  kpopAttributes?: Omit<PopoverAttributes, 'trigger'>
 
   /**
    * An array of objects containing a required `label` property and other optional properties which will render a menu of KDropdownItems.

--- a/src/types/multi-select.ts
+++ b/src/types/multi-select.ts
@@ -105,7 +105,7 @@ export interface MultiselectProps<T extends string, U extends boolean> {
    * Attributes for the popover component.
    * @default {}
    */
-  kpopAttributes?: Omit<PopoverAttributes, 'target' | 'trigger'>
+  kpopAttributes?: Omit<PopoverAttributes, 'trigger'>
 
   /**
    * The maximum height of the dropdown.

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -202,9 +202,8 @@ export type PopoverAttributes = Pick<PopProps,
   | 'hideCaret'
   | 'maxWidth'
   | 'disabled'
-  /** Not supported in KDropdown, KSelect and KMultiselect */
   | 'target'
-  | 'trigger'
+  | 'trigger' // Not supported in KDropdown, KSelect and KMultiselect
 > & {
   'data-testid'?: string
 }

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -82,7 +82,7 @@ export interface SelectProps<T extends string | number, U extends boolean> {
    * See KPopover's props for more info.
    * @default {}
    */
-  kpopAttributes?: Omit<PopoverAttributes, 'target' | 'trigger'>
+  kpopAttributes?: Omit<PopoverAttributes, 'trigger'>
 
   /**
    * Maximum height for dropdown container.


### PR DESCRIPTION
# Summary

[KM-1721](https://konghq.atlassian.net/browse/KM-1721)

Currently, the `target` option is not supported in the `kpop-attributes` prop for `<KDropdown>`, `<KSelect>`, and `<KMultiselect>` at the type level.

This PR updates the approach by applying styles to the popover contents within a global `<style>`, ensuring teleportation works as intended.

<img width="850" height="517" alt="image" src="https://github.com/user-attachments/assets/ae0b418a-074d-4b95-a7ce-66a60629439a" />

For example, we may need to teleport the dropdown popover to `body` or other top-level container to make the dropdown appear above everything else.

[KM-1721]: https://konghq.atlassian.net/browse/KM-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ