### PR TITLE
feat(kinput, ktextarea): add `help` slot

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -287,6 +287,24 @@ If you want to utilize HTML in the input label's tooltip, use the slot.
 </KInput>
 ```
 
+### help
+
+Content passed in to the `help` slot will be shown as the help content. The slot content takes precedence over the `help` prop.
+
+<KInput label="Some label" help="This will be replaced with a slot">
+  <template #help>
+    Anything goes here
+  </template>
+</KInput>
+
+```html
+<KInput label="Some label" help="This will be replaced with a slot">
+  <template #help>
+    Anything goes here
+  </template>
+</KInput>
+```
+
 ## Events
 
 ### input and update:modelValue

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -164,6 +164,24 @@ If you want to utilize HTML in the textarea label's tooltip, use the slot.
 </KTextArea>
 ```
 
+### help
+
+Content passed in to the `help` slot will be shown as the help content. The slot content takes precedence over the `help` prop.
+
+<KTextArea label="Some label" help="This will be replaced with a slot">
+  <template #help>
+    Anything goes here
+  </template>
+</KTextArea>
+
+```html
+<KTextArea label="Some label" help="This will be replaced with a slot">
+  <template #help>
+    Anything goes here
+  </template>
+</KTextArea>
+```
+
 ## Events
 
 KTextArea has a couple of event bindings.

--- a/sandbox/pages/SandboxInput.vue
+++ b/sandbox/pages/SandboxInput.vue
@@ -177,7 +177,13 @@
           </template>
         </KInput>
       </SandboxSectionComponent>
-
+      <SandboxSectionComponent title="help">
+        <KInput label="Label">
+          <template #help>
+            See <a href="#/input/">the docs</a> for more info.
+          </template>
+        </KInput>
+      </SandboxSectionComponent>
       <!-- Examples -->
       <SandboxTitleComponent
         is-subtitle

--- a/sandbox/pages/SandboxTextarea.vue
+++ b/sandbox/pages/SandboxTextarea.vue
@@ -110,6 +110,13 @@
           </template>
         </KTextArea>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="help">
+        <KTextArea label="Label">
+          <template #help>
+            See <a href="#/input/">the docs</a> for more info.
+          </template>
+        </KTextArea>
+      </SandboxSectionComponent>
     </div>
   </SandboxLayout>
 </template>

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -1,5 +1,5 @@
-import KInput from '@/components/KInput/KInput.vue'
 import { h } from 'vue'
+import KInput from '@/components/KInput/KInput.vue'
 
 describe('KInput', () => {
   it('renders text when value is passed', () => {
@@ -102,6 +102,50 @@ describe('KInput', () => {
     })
 
     cy.get('.k-input .help-text').should('contain.text', helpText)
+  })
+
+  it('renders error message when `error` and `errorMessage` are passed', () => {
+    const helpText = 'I am helpful'
+    const errorMessage = 'This is an error message'
+
+    cy.mount(KInput, {
+      props: {
+        help: helpText,
+        error: true,
+        errorMessage,
+      },
+    })
+
+    cy.get('.k-input .help-text').should('contain.text', errorMessage).and('not.contain.text', helpText)
+  })
+
+  it('renders help with `help` slot applied', () => {
+    const helpText = 'This is help text'
+
+    cy.mount(KInput, {
+      slots: {
+        help: () => h('div', {}, helpText),
+      },
+    })
+
+    cy.get('.k-input .help-text').should('contain.text', helpText)
+  })
+
+  it('renders the error message with `error` and `error-message` props and `help` slot applied', () => {
+    const helpText = 'This is help text'
+    const errorMessage = 'This is an error message'
+
+    cy.mount(KInput, {
+      props: {
+        error: true,
+        errorMessage,
+      },
+      slots: {
+        help: () => h('div', {}, helpText),
+      },
+    })
+
+    cy.get('.k-input .help-text').should('contain.text', errorMessage)
   })
 
   it('shows character count when characterLimit prop is set and exceeded', () => {

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -1,3 +1,4 @@
+import { h } from 'vue'
 import KTextArea from '@/components/KTextArea/KTextArea.vue'
 
 // Helper function to get the number of rendered rows in a textarea
@@ -46,6 +47,30 @@ describe('KTextArea', () => {
 
     cy.get('.k-label').should('contain.text', labelText)
     cy.get('.k-label .tooltip-trigger-icon').should('be.visible')
+  })
+
+  it('renders help when value is passed', () => {
+    const helpText = 'I am helpful'
+
+    cy.mount(KTextArea, {
+      props: {
+        help: helpText,
+      },
+    })
+
+    cy.get('.k-textarea .help-text').should('contain.text', helpText)
+  })
+
+  it('renders help with `help` slot applied', () => {
+    const helpText = 'This is help text'
+
+    cy.mount(KTextArea, {
+      slots: {
+        help: () => h('div', {}, helpText),
+      },
+    })
+
+    cy.get('.k-textarea .help-text').should('contain.text', helpText)
   })
 
   it('handles `required` attribute correctly', () => {

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -59,11 +59,19 @@
       name="kongponents-fade-transition"
     >
       <p
-        v-if="helpText"
+        v-if="helpText || slots.help"
         :key="String(helpTextKey)"
         class="help-text"
       >
-        {{ helpText }}
+        <slot
+          v-if="showHelp"
+          name="help"
+        >
+          {{ helpText }}
+        </slot>
+        <template v-else>
+          {{ helpText }}
+        </template>
       </p>
     </Transition>
   </div>
@@ -177,6 +185,8 @@ const inputHandler = (e: any): void => {
   emit('update:modelValue', val)
   currValue.value = val
 }
+
+const showHelp = computed((): boolean => !charLimitExceeded.value && !!(help || slots.help))
 
 const helpText = computed((): string => {
   const limit = typeof characterLimit === 'number' ? characterLimit : DEFAULT_CHARACTER_LIMIT

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -88,14 +88,21 @@ export interface InputSlots {
    * Inserting icons before the input field.
    */
   before?(): any
+
   /**
    * Inserting icons after the input field.
    */
   after?(): any
+
   /**
    * Slot for customizing the input label's tooltip.
    */
   'label-tooltip'?(): any
+
+  /**
+   * Slot for customizing the help text.
+   */
+  help?(): any
 }
 
 export interface LimitExceededData {

--- a/src/types/text-area.ts
+++ b/src/types/text-area.ts
@@ -99,4 +99,9 @@ export interface TextAreaSlots {
    * Slot for tooltip content if textarea has a label and label has tooltip.
    */
   'label-tooltip'?: () => any
+
+  /**
+   * Slot for customizing the help text.
+   */
+  help?(): any
 }


### PR DESCRIPTION
# Summary

[KM-1730](https://konghq.atlassian.net/browse/KM-1730)

This PR:

- Added a `help` slot to `<KInput>` and `<KTextArea>`.
- Added tests for the `help` prop and slot.
- Replaced special template bindings such as `$attrs` and `$slots` with variables declared in `script setup`.

[KM-1730]: https://konghq.atlassian.net/browse/KM-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ