### PR TITLE
fix: fix default generic type for enable-item-creation

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -286,7 +286,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts" generic="T extends string, U extends boolean = false">
 import type { Ref } from 'vue'
 import { ref, computed, watch, nextTick, onMounted, useAttrs, useId, useTemplateRef, onBeforeUnmount } from 'vue'
 import useUtilities from '@/composables/useUtilities'
@@ -328,9 +328,7 @@ const itemValuesAreUnique = (items: MultiselectItem[]): boolean => {
 
   return vals.length === uniqueValues.size
 }
-</script>
 
-<script setup lang="ts" generic="T extends string, U extends boolean">
 defineOptions({
   inheritAttrs: false,
 })

--- a/src/types/multi-select.ts
+++ b/src/types/multi-select.ts
@@ -58,7 +58,7 @@ export interface MultiselectItemsEmits<T extends string = string> {
   'add-item': []
 }
 
-export interface MultiselectProps<T extends string, U extends boolean> {
+export interface MultiselectProps<T extends string, U extends boolean = false> {
   /**
    * The current value of the multiselect (v-model).
    * @default []

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -70,7 +70,7 @@ export interface SelectFilterFunctionParams<T extends string | number> {
 
 export type SelectDropdownFooterTextPosition = 'sticky' | 'static'
 
-export interface SelectProps<T extends string | number, U extends boolean> {
+export interface SelectProps<T extends string | number, U extends boolean = false> {
   /**
    * To set the value of the select without using `v-model`.
    * @default ''


### PR DESCRIPTION
# Summary

[KM-1739](https://konghq.atlassian.net/browse/KM-1739)

- Merged the global `<script>` block into the existing `<script setup>` in `<KMultiselect>`.
- Provided a default generic type for `enableItemCreation`, resolving related type issues.