### PR TITLE
fix(klabel): tooltip in label should prevent default behavior

### DIFF
--- a/src/components/KCheckbox/KCheckbox.cy.ts
+++ b/src/components/KCheckbox/KCheckbox.cy.ts
@@ -84,4 +84,29 @@ describe('KCheckbox', () => {
     cy.get('.k-checkbox').find('[data-testid="indeterminate-icon"]').should('be.visible')
     cy.get('.k-checkbox').find('[data-testid="check-icon"]').should('not.exist')
   })
+
+  it('renders KLabel tooltip when `labelAttributes.info` is passed', () => {
+    const tooltipText = 'This is a tooltip'
+
+    cy.mount(KCheckbox, {
+      props: {
+        modelValue: false,
+        label: 'Label with tooltip',
+        labelAttributes: {
+          info: tooltipText,
+        },
+      },
+    })
+
+    cy.get('.k-label .label-tooltip').trigger('mouseenter')
+    cy.get('.k-tooltip').should('be.visible').and('have.text', tooltipText)
+
+    // Clicking the tooltip content should not toggle the checkbox
+    cy.get('.k-label .popover').click()
+    cy.get('input').should('not.be.checked')
+
+    // Clicking the tooltip icon content should not toggle the checkbox
+    cy.get('.k-label .label-tooltip').click()
+    cy.get('input').should('not.be.checked')
+  })
 })

--- a/src/components/KLabel/KLabel.vue
+++ b/src/components/KLabel/KLabel.vue
@@ -10,6 +10,7 @@
       v-bind="tooltipAttributes"
       class="label-tooltip"
       :tooltip-id="tooltipId"
+      @click.prevent
     >
       <InfoIcon
         :aria-describedby="tooltipId"

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -356,6 +356,7 @@ $kPopCaretOffset: 16px;
 
 // need to have these styles not nested under .k-popover so that they still apply when the popover is teleported
 .popover {
+  cursor: auto;
   // need max-width: 100vw; and width: max-content; for Floating UI to work properly
   // gets overwritten by the size middleware once the popover is positioned
   max-width: 100vw;

--- a/src/components/KTooltip/KTooltip.vue
+++ b/src/components/KTooltip/KTooltip.vue
@@ -65,6 +65,8 @@ const randomTooltipId = useId()
 
 <style lang="scss">
 .k-tooltip.popover {
+  cursor: default;
+
   .popover-container {
     background-color: var(--kui-color-background-inverse, $kui-color-background-inverse);
     border: none;


### PR DESCRIPTION
# Summary

[KM-1781](https://konghq.atlassian.net/browse/KM-1781)

Clicking tooltip should not trigger the default behavior of the container like `<label>`.