### PR TITLE
ci: renovate bot name change [TDX-6747]

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   commitlint:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
-    if: ${{ github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'renovate[bot]' && github.actor != 'mend[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/renovate-auto-approve.yaml
+++ b/.github/workflows/renovate-auto-approve.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     # Do not auto-approve branches `alpha` or `beta`
-    if: github.actor == 'renovate[bot]' && !contains(github.head_ref || github.ref_name, 'alpha') && !contains(github.head_ref || github.ref_name, 'beta')
+    if: (github.actor == 'renovate[bot]' || github.actor == 'mend[bot]') && !contains(github.head_ref || github.ref_name, 'alpha') && !contains(github.head_ref || github.ref_name, 'beta')
     steps:
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Publish Package Preview
         id: package-preview
         # Do not run for `alpha` or `beta` branches
-        if: github.event_name == 'pull_request' && (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'create preview package'))
+        if: github.event_name == 'pull_request' && (github.actor != 'renovate[bot]' || github.actor != 'mend[bot]' || contains(github.event.pull_request.labels.*.name, 'create preview package'))
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}
         run: |


### PR DESCRIPTION
# Description

Renovate is changing their Github app name https://github.com/renovatebot/renovate/discussions/37842

ticket: https://konghq.atlassian.net/browse/TDX-6747