### PR TITLE
fix(ktableview, ktabledata): table preference wathcers

### DIFF
--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -1,7 +1,7 @@
 import { h } from 'vue'
 import KTableData from '@/components/KTableData/KTableData.vue'
 import { offsetPaginationHeaders, offsetPaginationFetcher } from '../../../mocks/KTableMockData'
-import type { TableDataHeader } from '@/types'
+import type { TableDataHeader, SortHandlerFunctionParam } from '@/types'
 import { DEFAULT_PAGE_SIZE } from '@/utilities/tableHelpers'
 
 interface FetchParams {
@@ -100,6 +100,15 @@ const options = {
       enabled: 'true',
     },
   ],
+}
+
+const DEFAULT_FETCHER_PARAMS = {
+  pageSize: 15,
+  page: 1,
+  offset: null,
+  query: '',
+  sortColumnKey: '',
+  sortColumnOrder: 'desc',
 }
 
 describe('KTableData', () => {
@@ -965,21 +974,32 @@ describe('KTableData', () => {
       })
     })
 
-    it('applies update table preferences when prop is updated', () => {
+    it('clientSort = true: applies new table preferences when prop is updated', () => {
       const sortableColumnKey = options.headers.find(header => header.sortable)?.key
       const pageSize = 30
       options.headers[1].hidable = true
       const hidableColumnKey = options.headers[1].key
 
+      const fns = {
+        fetcher: () => {
+          return { data: options.data }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
       cy.mount(KTableData, {
         props: {
           headers: options.headers,
-          fetcher: () => {
-            return { data: options.data }
-          },
+          fetcher: fns.fetcher,
         },
       }).then((component) => {
         // initial state
+        // calls fetcher with default page size, sort column key and order
+        cy.get('@fetcher')
+          .should('have.callCount', 1)
+          .its('lastCall')
+          .should('have.been.calledWith', DEFAULT_FETCHER_PARAMS)
+
         cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', DEFAULT_PAGE_SIZE.toString())
         options.headers.forEach((header) => {
           cy.getTestId(`table-header-${header.key}`).should('be.visible')
@@ -997,6 +1017,88 @@ describe('KTableData', () => {
             },
           }).then(() => {
             // updated state
+            // calls fetcher with new page size, sort column key and order
+            cy.get('@fetcher')
+              .should('have.callCount', 2)
+              .its('lastCall')
+              .should('have.been.calledWith', {
+                ...DEFAULT_FETCHER_PARAMS,
+                pageSize: pageSize,
+                sortColumnKey: sortableColumnKey,
+                sortColumnOrder: 'asc',
+              })
+
+            cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', pageSize.toString())
+            cy.getTestId(`table-header-${sortableColumnKey}`).should('have.attr', 'aria-sort', 'ascending')
+            options.headers.forEach((header) => {
+              if (header.key === hidableColumnKey) {
+                cy.getTestId(`table-header-${header.key}`).should('not.exist')
+              } else {
+                cy.getTestId(`table-header-${header.key}`).should('be.visible')
+              }
+            })
+          })
+        }))
+      })
+    })
+
+    it('clientSort = true: applies new table preferences when prop is updated', () => {
+      const sortableColumnKey = options.headers.find(header => header.sortable)?.key
+      options.headers.find(header => header.key === sortableColumnKey)!.useSortHandlerFunction = true
+      const pageSize = 30
+      options.headers[1].hidable = true
+      const hidableColumnKey = options.headers[1].key
+
+      const shf = {
+        sortHandlerFunction: ({ data }: SortHandlerFunctionParam) => {
+          return data
+        },
+      }
+      cy.spy(shf, 'sortHandlerFunction').as('sortHandlerFunction')
+
+      cy.mount(KTableData, {
+        props: {
+          headers: options.headers,
+          fetcher: () => {
+            return { data: options.data }
+          },
+          clientSort: true,
+          sortHandlerFunction: shf.sortHandlerFunction,
+        },
+      }).then((component) => {
+        // initial state
+        // does not call sortHandlerFunction on load
+        cy.get('@sortHandlerFunction')
+          .should('have.callCount', 0)
+
+        cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', DEFAULT_PAGE_SIZE.toString())
+        options.headers.forEach((header) => {
+          cy.getTestId(`table-header-${header.key}`).should('be.visible')
+        })
+        cy.get('thead th[aria-sort]').should('not.exist').then((() => {
+          // update table preferences prop
+          component.wrapper.setProps({
+            tablePreferences: {
+              pageSize: pageSize,
+              sortColumnKey: sortableColumnKey,
+              sortColumnOrder: 'asc',
+              columnVisibility: {
+                [hidableColumnKey]: false, // hide ID column
+              },
+            },
+          }).then(() => {
+            // updated state
+            // calls fetcher with new page size, sort column key and order
+            cy.get('@sortHandlerFunction')
+              .should('have.callCount', 1)
+              .its('lastCall')
+              .should('have.been.calledWith', {
+                key: sortableColumnKey,
+                prevKey: '',
+                sortColumnOrder: 'asc',
+                data: options.data,
+              })
+
             cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', pageSize.toString())
             cy.getTestId(`table-header-${sortableColumnKey}`).should('have.attr', 'aria-sort', 'ascending')
             options.headers.forEach((header) => {

--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -964,6 +964,52 @@ describe('KTableData', () => {
         })
       })
     })
+
+    it('applies update table preferences when prop is updated', () => {
+      const sortableColumnKey = options.headers.find(header => header.sortable)?.key
+      const pageSize = 30
+      options.headers[1].hidable = true
+      const hidableColumnKey = options.headers[1].key
+
+      cy.mount(KTableData, {
+        props: {
+          headers: options.headers,
+          fetcher: () => {
+            return { data: options.data }
+          },
+        },
+      }).then((component) => {
+        // initial state
+        cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', DEFAULT_PAGE_SIZE.toString())
+        options.headers.forEach((header) => {
+          cy.getTestId(`table-header-${header.key}`).should('be.visible')
+        })
+        cy.get('thead th[aria-sort]').should('not.exist').then((() => {
+          // update table preferences prop
+          component.wrapper.setProps({
+            tablePreferences: {
+              pageSize: pageSize,
+              sortColumnKey: sortableColumnKey,
+              sortColumnOrder: 'asc',
+              columnVisibility: {
+                [hidableColumnKey]: false, // hide ID column
+              },
+            },
+          }).then(() => {
+            // updated state
+            cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', pageSize.toString())
+            cy.getTestId(`table-header-${sortableColumnKey}`).should('have.attr', 'aria-sort', 'ascending')
+            options.headers.forEach((header) => {
+              if (header.key === hidableColumnKey) {
+                cy.getTestId(`table-header-${header.key}`).should('not.exist')
+              } else {
+                cy.getTestId(`table-header-${header.key}`).should('be.visible')
+              }
+            })
+          })
+        }))
+      })
+    })
   })
 
   describe('misc', () => {

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -516,6 +516,14 @@ const tableDataPreferences = computed((): TablePreferences<Header['key']> => ({
   ...(tableViewColumnVisibility.value ? { columnVisibility: tableViewColumnVisibility.value } : {}),
 }))
 
+watch(() => tablePreferences, (newVal) => {
+  pageSize.value = newVal?.pageSize ? newVal.pageSize : pageSize.value
+  sortColumnKey.value = newVal?.sortColumnKey ? newVal.sortColumnKey : sortColumnKey.value
+  sortColumnOrder.value = newVal?.sortColumnOrder ? newVal.sortColumnOrder : sortColumnOrder.value
+  tableViewColumnWidths.value = newVal?.columnWidths ? newVal.columnWidths : tableViewColumnWidths.value
+  tableViewColumnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : tableViewColumnVisibility.value
+})
+
 const emitTablePreferences = (): void => {
   if (tableState.value === 'success') {
     emit('update:table-preferences', tableDataPreferences.value)

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -454,17 +454,19 @@ const stateData = computed((): SwrvStateData => ({
 const tableState = computed((): TableState => fetcherIsLoading.value ? 'loading' : fetcherError.value ? 'error' : 'success')
 const { debouncedFn: debouncedRevalidate } = useDebounce(_revalidate, 500)
 
-const sortHandler = ({ sortColumnKey: columnKey, prevKey, sortColumnOrder: sortOrder }: TableSortPayload<ColumnKey>): void => {
+const sortHandler = ({ sortColumnKey: columnKey, prevKey, sortColumnOrder: sortOrder }: TableSortPayload<ColumnKey>, emitSortEvent: boolean = true): void => {
   initialSortHandled.value = true
 
   const header: TableDataHeader<ColumnKey> = tableHeaders.value.find((header) => header.key === columnKey) || {} as TableDataHeader<ColumnKey>
   const { useSortHandlerFunction } = header
 
-  emit('sort', {
-    prevKey,
-    sortColumnKey: columnKey,
-    sortColumnOrder: sortOrder,
-  })
+  if (emitSortEvent) {
+    emit('sort', {
+      prevKey,
+      sortColumnKey: columnKey,
+      sortColumnOrder: sortOrder,
+    })
+  }
 
   page.value = 1
 
@@ -543,7 +545,7 @@ watch(() => tablePreferences, (newVal) => {
       sortColumnKey: newVal.sortColumnKey!,
       prevKey: sortColumnKey.value,
       sortColumnOrder: newVal.sortColumnOrder!,
-    })
+    }, false) // don't emit sort event when updating from prop change
   }
 })
 
@@ -620,7 +622,7 @@ watch(fetcherResponse, (res) => {
 
   // Call sortHandler if the initial sort has not been handled yet
   if (sortable && !initialSortHandled.value) {
-    sortHandler({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value })
+    sortHandler({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value }, false) // don't emit sort event when handling initial sort
   }
 }, { deep: true, immediate: true })
 

--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -664,6 +664,50 @@ describe('KTableView', () => {
         })
       })
     })
+
+    it('applies update table preferences when prop is updated', () => {
+      const sortableColumnKey = options.headers.find(header => header.sortable)?.key
+      const pageSize = 30
+      options.headers[1].hidable = true
+      const hidableColumnKey = options.headers[1].key
+
+      cy.mount(KTableView, {
+        props: {
+          data: options.data,
+          headers: options.headers,
+        },
+      }).then((component) => {
+        // initial state
+        cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', DEFAULT_PAGE_SIZE.toString())
+        options.headers.forEach((header) => {
+          cy.getTestId(`table-header-${header.key}`).should('be.visible')
+        })
+        cy.get('thead th[aria-sort]').should('not.exist').then((() => {
+          // update table preferences prop
+          component.wrapper.setProps({
+            tablePreferences: {
+              pageSize: pageSize,
+              sortColumnKey: sortableColumnKey,
+              sortColumnOrder: 'asc',
+              columnVisibility: {
+                [hidableColumnKey]: false, // hide ID column
+              },
+            },
+          }).then(() => {
+          // updated state
+            cy.getTestId('table-pagination').findTestId('page-size-dropdown-trigger').should('contain.text', pageSize.toString())
+            cy.getTestId(`table-header-${sortableColumnKey}`).should('have.attr', 'aria-sort', 'ascending')
+            options.headers.forEach((header) => {
+              if (header.key === hidableColumnKey) {
+                cy.getTestId(`table-header-${header.key}`).should('not.exist')
+              } else {
+                cy.getTestId(`table-header-${header.key}`).should('be.visible')
+              }
+            })
+          })
+        }))
+      })
+    })
   })
 
   describe('expandable rows and nested tables', () => {

--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -665,7 +665,7 @@ describe('KTableView', () => {
       })
     })
 
-    it('applies update table preferences when prop is updated', () => {
+    it('applies new table preferences when prop is updated', () => {
       const sortableColumnKey = options.headers.find(header => header.sortable)?.key
       const pageSize = 30
       options.headers[1].hidable = true

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -1370,7 +1370,7 @@ watch(bulkActionsSelectedRows, (newVal) => {
 watch(() => tablePreferences, (newVal) => {
   columnWidths.value = newVal?.columnWidths ? newVal.columnWidths : columnWidths.value
   columnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : columnVisibility.value
-}, { deep: true })
+})
 
 useResizeObserver(tableWrapperRef, (entries) => {
   const el = entries[0]?.target

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -443,6 +443,7 @@
 
       <KPagination
         v-if="showPagination"
+        :key="`table-${tableId}-pagination-${paginationKey}`"
         class="table-pagination"
         data-testid="table-pagination"
         :initial-page-size="paginationPageSize"
@@ -1135,6 +1136,7 @@ const getRowLinkAttrs = (row: Row, columnKey: ColumnKey): Record<string, unknown
 }
 
 
+const paginationKey = ref<number>(0)
 const paginationPageSize = ref<number>(getInitialPageSize(tablePreferences, paginationAttributes))
 const onPaginationPageSizeChange = (data: PageSizeChangeData): void => {
   paginationPageSize.value = data.pageSize
@@ -1368,6 +1370,12 @@ watch(bulkActionsSelectedRows, (newVal) => {
 })
 
 watch(() => tablePreferences, (newVal) => {
+  if (newVal?.pageSize) {
+    paginationPageSize.value = newVal.pageSize
+    paginationKey.value ++ // Force re-render of pagination component when pageSize changes from the host app
+  }
+  sortColumnKey.value = newVal?.sortColumnKey ? newVal.sortColumnKey : sortColumnKey.value
+  sortColumnOrder.value = newVal?.sortColumnOrder ? newVal.sortColumnOrder : sortColumnOrder.value
   columnWidths.value = newVal?.columnWidths ? newVal.columnWidths : columnWidths.value
   columnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : columnVisibility.value
 })

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -1368,9 +1368,8 @@ watch(bulkActionsSelectedRows, (newVal) => {
 })
 
 watch(() => tablePreferences, (newVal) => {
-  if (newVal?.columnWidths) {
-    columnWidths.value = newVal.columnWidths
-  }
+  columnWidths.value = newVal?.columnWidths ? newVal.columnWidths : columnWidths.value
+  columnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : columnVisibility.value
 })
 
 useResizeObserver(tableWrapperRef, (entries) => {

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -1370,7 +1370,7 @@ watch(bulkActionsSelectedRows, (newVal) => {
 watch(() => tablePreferences, (newVal) => {
   columnWidths.value = newVal?.columnWidths ? newVal.columnWidths : columnWidths.value
   columnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : columnVisibility.value
-})
+}, { deep: true })
 
 useResizeObserver(tableWrapperRef, (entries) => {
   const el = entries[0]?.target


### PR DESCRIPTION
# Summary

Add watchers for `tablePreferences` in KTableView and KTableData in case `tablePreferences` are updated later after component has mounted (issue discovered in https://github.com/Kong/konnect-ui-apps/pull/8561 where `tablePreferences` fetched from the API didn't work correctly in tables).

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
