### PR TITLE
feat(klabel): improve prevent default logic to allow tooltip links

### DIFF
--- a/src/components/KLabel/KLabel.cy.ts
+++ b/src/components/KLabel/KLabel.cy.ts
@@ -88,7 +88,9 @@ describe('KLabel', () => {
             id: 'label-input',
             type: 'checkbox',
           }),
-          'Full Name',
+          h('span', {
+            id: 'label-text',
+          }, 'Full Name'),
         ],
         tooltip: () => h('a', {
           id: 'link',
@@ -106,7 +108,7 @@ describe('KLabel', () => {
     cy.location('hash').should('eq', '#docs-link')
     cy.get('#label-input').should('not.be.checked')
 
-    cy.get('.k-label').click()
-    cy.get('#label-input').should('be.checked')
+    cy.get('#label-text').click()
+    cy.get('input[type="checkbox"]').should('be.checked')
   })
 })


### PR DESCRIPTION
# Summary

[KM-1891]

Only call `preventDefault` if the event target is neither an interactive element nor inside one, since the activation behavior there is defined as a no-op by HTML spec. Otherwise we’ll end up blocking anchor clicks.

[KM-1891]: https://konghq.atlassian.net/browse/KM-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ