### PR TITLE
fix(ktableview): overlay should be hidden when no room to scroll right

### DIFF
--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -1055,7 +1055,7 @@ const scrollHandler = (event: Event): void => {
     }
 
     // determine if there's still room to scroll right
-    if (target.scrollWidth === target.scrollLeft + target.clientWidth) {
+    if (target.scrollWidth <= target.scrollLeft + target.clientWidth) {
       isScrollableRight.value = false
     } else {
       isScrollableRight.value = true


### PR DESCRIPTION
# Summary

[KM-1897]
<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

In some cases, when scrolling the table to the right end, the overlay remains visible.

Currently, we determine whether the table has been scrolled to the end using:
```ts
scrollLeft + clientWidth === scrollWidth
```
However, `scrollLeft` may be a floating-point number, which can cause this check to fail.

https://github.com/user-attachments/assets/c924ef97-1493-4d6a-84fc-61d853afd2b7



[KM-1897]: https://konghq.atlassian.net/browse/KM-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ