### PR TITLE
fix(kmodal): full screen modal content height [KHCP-18359]

### DIFF
--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -283,6 +283,7 @@ onUnmounted(() => {
 
         .modal-content {
           flex: 1;
+          max-height: none;
         }
       }
     }


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-18359

KModal `fullScreen` content height should not be impacted by `maxHeight` prop value

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
