### PR TITLE
fix(ktableview): update overlay visibility when the table is resized

### DIFF
--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -118,6 +118,7 @@
         @scroll.passive="scrollHandler"
       >
         <table
+          ref="table"
           class="table"
           :class="{
             'has-hover': rowHover && !isActionsDropdownHovered,
@@ -556,6 +557,7 @@ const getRowKey = (row: Row): string => {
 }
 
 const tableWrapperRef = useTemplateRef('table-wrapper')
+const tableRef = useTemplateRef('table')
 const headerRowRef = useTemplateRef('header-row')
 // all headers
 const tableHeaders = ref([]) as Ref<Array<TableViewHeader<ColumnKey>>>
@@ -1384,8 +1386,8 @@ watch(() => tablePreferences, (newVal) => {
   columnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : columnVisibility.value
 })
 
-useResizeObserver(tableWrapperRef, (entries) => {
-  const el = entries[0]?.target
+useResizeObserver([tableWrapperRef, tableRef], () => {
+  const el = tableWrapperRef.value
 
   if (el) {
     // check if the table is scrollable horizontally


### PR DESCRIPTION
# Summary

[KM-1906]

This PR fixes that the scrollable overlay is not updated when the table is resized.

### Before

https://github.com/user-attachments/assets/d4dbe5eb-b358-464e-85a4-8e330118654d


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[KM-1906]: https://konghq.atlassian.net/browse/KM-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ