### PR TITLE
fix(ktruncate): optimize performance by avoiding forced reflow

### DIFF
--- a/src/components/KTruncate/KTruncate.vue
+++ b/src/components/KTruncate/KTruncate.vue
@@ -242,7 +242,9 @@ onMounted(() => {
 
   // `resizeObserver.observe` will trigger callback even if size doesn't change,
   // so updateToggleVisibility will be called in the observer callback if truncateText is false
-  if (truncateText) updateToggleVisibility()
+  if (truncateText) {
+    updateToggleVisibility()
+  }
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
# Summary

[KM-1899]

When using multiple `KTruncate` components on a single page—especially within tables containing many rows, and even more so when combined with other layout-affecting components—significant performance issues were observed due to forced reflow. This happened because the component performed synchronous reads and writes to layout-related properties.

This PR introduces batched layout reading/calculations to eliminate forced reflows and improve performance.

### Context

Rendering a table containing hundreds of KTruncate components (along with other components) inside a modal previously caused the frontend to freeze for around 40 seconds. With this optimization, render time has been reduced to about 1 second.

> All the badges in the table in the following videos are wrapped by a KTruncate

#### Before

https://github.com/user-attachments/assets/9f194e3c-fff3-4a8c-aea4-3926c61d1cff

#### After

https://github.com/user-attachments/assets/d302731c-6d1a-4ca4-b1d1-997eae5cc86c

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[KM-1899]: https://konghq.atlassian.net/browse/KM-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ