### PR TITLE
fix(ktableview): update table preferences parameters

### DIFF
--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -702,6 +702,38 @@ describe('KTableView', () => {
       cy.getTestId(`table-header-${sortableColumnKey}`).should('have.attr', 'aria-sort', 'descending')
     })
 
+    it('emits update:table-preferences event immediately after initialization with parameters matching tablePreferences', () => {
+      const sortableColumnKey = options.headers.find(header => header.sortable)?.key
+      const pageSize = 30
+      // make ID column hidable
+      options.headers[1].hidable = true
+      const hidableColumnKey = options.headers[1].key
+      const columnVisibility = {
+        [hidableColumnKey]: false,
+      }
+
+      cy.mount(KTableView, {
+        props: {
+          data: options.data,
+          headers: options.headers,
+          tablePreferences: {
+            pageSize: pageSize,
+            sortColumnKey: sortableColumnKey,
+            sortColumnOrder: 'desc',
+            columnVisibility: columnVisibility,
+          },
+        },
+      }).then(() => {
+        // should emit update:table-preferences immediately after initialization
+        cy.wrap(Cypress.vueWrapper.emitted()).should('have.property', 'update:table-preferences')
+        cy.wrap(Cypress.vueWrapper.emitted('update:table-preferences')?.[0]?.[0]).should('have.property', 'pageSize', pageSize)
+        cy.wrap(Cypress.vueWrapper.emitted('update:table-preferences')?.[0]?.[0]).should('have.property', 'sortColumnKey', sortableColumnKey)
+        cy.wrap(Cypress.vueWrapper.emitted('update:table-preferences')?.[0]?.[0]).should('have.property', 'sortColumnOrder', 'desc')
+        cy.wrap(Cypress.vueWrapper.emitted('update:table-preferences')?.[0]?.[0]).should('have.property', 'columnVisibility')
+        cy.wrap(Cypress.vueWrapper.emitted('update:table-preferences')?.[0]?.[0]).should('have.nested.property', `columnVisibility.${hidableColumnKey}`, false)
+      })
+    })
+
     it('emits update:table-preferences event when table preferences are updated', () => {
       const sortableColumnKey = options.headers.find(header => header.sortable)?.key
       const newPageSize = 30

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -556,11 +556,31 @@ const getRowKey = (row: Row): string => {
   return ''
 }
 
+/**
+ * Reorder the headers to ensure bulk actions are first and actions are last
+ */
+const reorderHeaders = (headers: readonly Header[]) => {
+  const result: Header[] = headers.filter((header) => header.key !== TableViewHeaderKeys.BULK_ACTIONS && header.key !== TableViewHeaderKeys.ACTIONS)
+
+  const bulkActionsHeader = headers.find((header) => header.key === TableViewHeaderKeys.BULK_ACTIONS)
+  const actionsHeader = headers.find((header) => header.key === TableViewHeaderKeys.ACTIONS)
+
+  if (bulkActionsHeader) {
+    result.unshift(bulkActionsHeader)
+  }
+
+  if (actionsHeader) {
+    result.push(actionsHeader)
+  }
+
+  return result
+}
+
 const tableWrapperRef = useTemplateRef('table-wrapper')
 const tableRef = useTemplateRef('table')
 const headerRowRef = useTemplateRef('header-row')
 // all headers
-const tableHeaders = ref([]) as Ref<Array<TableViewHeader<ColumnKey>>>
+const tableHeaders = ref(reorderHeaders(headers)) as Ref<Array<TableViewHeader<ColumnKey>>>
 // currently visible headers
 const visibleHeaders = ref([]) as Ref<Array<TableViewHeader<ColumnKey>>>
 // highest priority - column currently being resized (mouse may be completely outside the column)
@@ -1002,26 +1022,7 @@ const showPagination = computed((): boolean => {
 
 // Ensure `headers` are reactive.
 watch(() => headers, (newVal: readonly Header[]) => {
-  if (newVal && newVal.length) {
-    /**
-     * Reorder the headers to ensure bulk actions are first and actions are last
-     */
-
-    const headers: Header[] = newVal.filter((header) => header.key !== TableViewHeaderKeys.BULK_ACTIONS && header.key !== TableViewHeaderKeys.ACTIONS)
-
-    const bulkActionsHeader = newVal.find((header) => header.key === TableViewHeaderKeys.BULK_ACTIONS)
-    const actionsHeader = newVal.find((header) => header.key === TableViewHeaderKeys.ACTIONS)
-
-    if (bulkActionsHeader) {
-      headers.unshift(bulkActionsHeader)
-    }
-
-    if (actionsHeader) {
-      headers.push(actionsHeader)
-    }
-
-    tableHeaders.value = headers
-  }
+  tableHeaders.value = reorderHeaders(newVal)
 }, { deep: true, immediate: true })
 
 const isColumnSortable = (column: TableViewHeader<ColumnKey>): boolean => !column.hideLabel && !!column.sortable && column.key !== TableViewHeaderKeys.BULK_ACTIONS && column.key !== TableViewHeaderKeys.ACTIONS


### PR DESCRIPTION
# Summary

The `update:table-preferences` is emitted immediately after initialization, but the `columnVisibility` in parameter is always `{}`
```vue
<KTableView
  :table-preferences="{
     columnVisibility: { name: false }
  }"
 @update:table-preferences={console.log}
 // { "sortColumnKey": "",  "sortColumnOrder": "desc",  "columnVisibility": {} }
                                                                             ^ wrong value
>
```