### PR TITLE
fix(ktoaster): avoid overflow when message or title is too long

### DIFF
--- a/src/components/KToaster/KToaster.cy.ts
+++ b/src/components/KToaster/KToaster.cy.ts
@@ -72,5 +72,17 @@ describe('KToaster', () => {
 
       cy.get('.k-toaster').should('have.css', 'z-index', '9999')
     })
+
+
+    it('shows close button even if content is long', () => {
+      const longTitle = 'title'.repeat(20)
+      const longMessage = 'message'.repeat(20)
+      cy.mount(KToaster, {
+        props: {
+          toasterState: [{ title: longTitle, message: longMessage }],
+        },
+      })
+      cy.get('.toaster .toaster-close-icon').should('be.visible')
+    })
   })
 })

--- a/src/components/KToaster/KToaster.vue
+++ b/src/components/KToaster/KToaster.vue
@@ -127,6 +127,8 @@ const getToastIcon = (appearance?: ToasterAppearance): ToastIcon => {
       flex: 1;
       flex-direction: column;
       gap: var(--kui-space-30, $kui-space-30);
+      min-width: 0;
+      overflow-wrap: break-word;
 
       .toaster-title {
         font-family: var(--kui-font-family-text, $kui-font-family-text);


### PR DESCRIPTION
# Summary

[KM-2013]
When the message returned from the backend is long, the icon becomes elliptical, and the close button runs off the screen.

### Before

<img width="616" height="172" alt="Screenshot 2025-11-17 134519" src="https://github.com/user-attachments/assets/57bced21-c94b-41cf-9ecc-38b8eebc68ae" />

### After

<img width="610" height="288" alt="Screenshot 2025-11-17 134748" src="https://github.com/user-attachments/assets/b99f0cdc-b260-44f8-a746-751f2a80e97c" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[KM-2013]: https://konghq.atlassian.net/browse/KM-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ