### PR TITLE
fix(kselect, kmultiselect): apply flex layout

### DIFF
--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -1003,6 +1003,8 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
 /* Component styles */
 
 .k-multiselect {
+  display: flex;
+  flex-direction: column;
   position: relative; // so staging area is positioned around this node
   width: fit-content; // necessary for correct placement of popup
 

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -661,6 +661,8 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
 /* Component styles */
 
 .k-select {
+  display: flex;
+  flex-direction: column;
   width: v-bind('elementWidth');
 
   .select-wrapper {


### PR DESCRIPTION
# Summary

[KM-2029]

`<KInput>` uses flex layout, but `<KMultiSelect>` and `<KSelect>` don't. When placing them side-by-side in two columns, they may become misaligned as the height of `<KSelect>` is affected by `line-height` (label is an `inline-flex` while the container is a block).

<img width="720" height="81" alt="image" src="https://github.com/user-attachments/assets/7a1a0dee-531a-4d44-a4a4-d0acacdf8d17" />

I checked the documentation pages for `KSelect` and `KMultiselect`. The PR doesn't introduce visual changes, but we haven't verified it across all consumers to ensure there are no unintended impacts.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[KM-2029]: https://konghq.atlassian.net/browse/KM-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ