### PR TITLE
fix(kbutton): type property invalid for anchor

### DIFF
--- a/src/components/KButton/KButton.cy.ts
+++ b/src/components/KButton/KButton.cy.ts
@@ -111,4 +111,48 @@ describe('KButton', () => {
       },
     )).to.not.throw()
   })
+
+  it('adds `type` property when rendering a native button element', () => {
+    cy.mount(KButton, {
+      props: {
+        appearance: 'secondary',
+      },
+      slots: {
+        default: () => "I'm a native link",
+      },
+    })
+
+    cy.get('button').invoke('attr', 'type').should('eq', 'button')
+    cy.get('button').invoke('attr', 'role').should('eq', undefined)
+  })
+
+  it('adds `type` property as defined on component when rendering a native button element', () => {
+    cy.mount(KButton, {
+      props: {
+        appearance: 'secondary',
+        type: 'submit',
+      },
+      slots: {
+        default: () => "I'm a native link",
+      },
+    })
+
+    cy.get('button').invoke('attr', 'type').should('eq', 'submit')
+  })
+
+  it('adds `role` property and does not render `type` property when rendering an anchor tag', () => {
+    cy.mount(KButton, {
+      props: {
+        to: 'https://google.com',
+        appearance: 'secondary',
+        type: 'submit',
+      },
+      slots: {
+        default: () => "I'm a native link",
+      },
+    })
+
+    cy.get('a').invoke('attr', 'type').should('eq', undefined)
+    cy.get('a').invoke('attr', 'role').should('eq', 'button')
+  })
 })

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -4,8 +4,9 @@
     class="k-button"
     :class="[buttonSize, buttonAppearance, { 'icon-button': icon === true || (!slots.default && slots.icon /* TODO: remove this once we remove icon slot */) }]"
     :disabled="disabled ? disabled : undefined"
+    :role="buttonType !== 'button' ? 'button' : undefined"
     :tabindex="disabled && buttonType !== 'button' ? '-1' : undefined"
-    :type="type"
+    :type="buttonType === 'button' ? type : undefined"
     v-bind="strippedAttrs"
     v-on="listeners"
   >
@@ -40,7 +41,7 @@ watch(() => icon, (value) => {
 const slots = defineSlots<ButtonSlots>()
 const attrs = useAttrs()
 
-const buttonType = computed((): string => {
+const buttonType = computed(() => {
   if (to && typeof to === 'string') {
     return 'a'
   } else if (to) {


### PR DESCRIPTION
# Summary

The `KButton` component was improperly adding a `type="button"` property when rendering an anchor tag (invalid property).

This PR only adds the `type` property when rendering a `button` element, and adds a `role="button"` property for anchor tags.
