### PR TITLE
fix: no pr-audit for renovate bot prs

### DIFF
--- a/.github/workflows/pr-audit.yaml
+++ b/.github/workflows/pr-audit.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-with-dependencies/
 
       - name: PR Audit
+        if: github.actor != 'renovate[bot]'
         uses: Kong/public-shared-actions/pr-previews/audit@main
         with:
           renovate-pr-author: renovate[bot]


### PR DESCRIPTION
# Summary

skip pr-audit for renovate-bot PRs.