### PR TITLE
fix(ktextarea): fix mixin inclusion to prevent invalid css

### DIFF
--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -306,10 +306,8 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
     }
   }
 
-  .input-textarea-wrapper.legacy::after,
-  .input-textarea {
-    @include inputDefaults;
-
+  .input-textarea,
+  .input-textarea-wrapper.legacy::after {
     // required by the grid fallback
     /* stylelint-disable-next-line no-duplicate-selectors */
     & {
@@ -317,12 +315,18 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
     }
   }
 
+  .input-textarea-wrapper.legacy::after {
+    @include inputDefaults(false);
+  }
+
   .input-textarea {
-    // A fallback max-height. Referenced GitHub’s implementation for the current value.
-    // It’s highly unlikely that we would need an input box taller than the viewport—this isn’t a document editor.
-    max-height: calc(100vh - 200px);
-    min-height: calc(($kTextAreaLineHeight * 2) + ($kTextAreaPaddingY * 2)); // 2 lines + padding
-    resize: none;
+    @include inputDefaults {
+      // A fallback max-height. Referenced GitHub’s implementation for the current value.
+      // It’s highly unlikely that we would need an input box taller than the viewport—this isn’t a document editor.
+      max-height: calc(100vh - 200px);
+      min-height: calc(($kTextAreaLineHeight * 2) + ($kTextAreaPaddingY * 2)); // 2 lines + padding
+      resize: none;
+    }
 
     &.resizable {
       resize: vertical;

--- a/src/styles/mixins/_input-text.scss
+++ b/src/styles/mixins/_input-text.scss
@@ -30,7 +30,7 @@
   }
 }
 
-@mixin inputDefaults {
+@mixin inputDefaults($with-placeholder: true) {
   @include inputBoxShadow;
 
   & {
@@ -43,15 +43,19 @@
     // Variables that reference the same value. If this value changes, all of those need to be updated too.
     padding: var(--kui-space-40, $kui-space-40) var(--kui-space-50, $kui-space-50); // $kInputPaddingX, $kTextAreaPaddingY, $kSelectInputPaddingX, $kSelectInputPaddingY, $kMultiselectInputPaddingY, $kMultiselectInputPaddingX, $kFileUploadInputPaddingX, $kFileUploadInputPaddingY, $kDateTimePickerInputPaddingX, $kDateTimePickerInputPaddingY
     width: 100%;
+
+    @content;
   }
 
-  &::placeholder {
-    @include inputText;
+  @if $with-placeholder {
+    &::placeholder {
+      @include inputText;
 
-    // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
-    // stylelint-disable-next-line no-duplicate-selectors
-    & {
-      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+      // fixing mixed-decls deprecation: https://sass-lang.com/d/mixed-decls
+      // stylelint-disable-next-line no-duplicate-selectors
+      & {
+        color: var(--kui-color-text-neutral, $kui-color-text-neutral);
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary

[KM-2105]

Current implementation would produce the following CSS:

```css
.input-textarea-wrapper.legacy[data-v-2080bcde]:after::-webkit-input-placeholder
```

which is an invalid CSS selector and will fail tools like LightningCSS.

[KM-2105]: https://konghq.atlassian.net/browse/KM-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ