### PR TITLE
fix(ktoaster): prevent duplicate containers via a shared pool

### DIFF
--- a/sandbox/composables/useSandboxToaster.ts
+++ b/sandbox/composables/useSandboxToaster.ts
@@ -2,7 +2,10 @@ import { onBeforeUnmount } from 'vue'
 import { ToastManager } from '@/index'
 
 export default function useSandboxToaster() {
-  const toaster = new ToastManager()
+  const toasters = Array.from({ length: 20 }).map(() => new ToastManager())
+  const toaster = toasters.pop()!
+
+  toasters.forEach(item => setTimeout(() => item.destroy(), Math.ceil(Math.random() * 10000)))
 
   onBeforeUnmount(() => {
     toaster.destroy()

--- a/sandbox/pages/SandboxToaster.vue
+++ b/sandbox/pages/SandboxToaster.vue
@@ -62,6 +62,11 @@
           KToaster
         </KButton>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="destroy manager">
+        <KButton @click="() => toaster.destroy()">
+          Destroy
+        </KButton>
+      </SandboxSectionComponent>
     </div>
   </SandboxLayout>
 </template>

--- a/src/components/KToaster/SharedPool.ts
+++ b/src/components/KToaster/SharedPool.ts
@@ -1,0 +1,55 @@
+type Transition<K, T> = (state: 'creating' | 'acquiring' | 'releasing' | 'destroying', key: K, item: T) => T
+type Entry<T> = {
+  value: T
+  references: Set<symbol>
+}
+export default class SharedPool<K, T> {
+  constructor(
+    protected transition: Transition<K, T>,
+    protected pool: Map<K, Entry<T>> = new Map(),
+  ) {}
+
+  // getter, not init
+  acquire(key: K, ref: symbol): T {
+    const create = !this.pool.has(key)
+    if (create) {
+      const references = {
+        value: this.transition('creating', key, {} as T),
+        references: new Set<symbol>(),
+      }
+      this.pool.set(key, references)
+    }
+    // there is no way pool/usage.get(item) can be undefined due to using has
+    // above hence we use ! to avoid typescript
+    const item = this.pool.get(key)!
+    if (!create) {
+      this.transition('acquiring', key, item.value)
+    }
+    item.references.add(ref)
+    return item.value
+  }
+
+  // deleter
+  release(key: K, ref: symbol) {
+    if (this.pool.has(key)) {
+      // there is no way pool/usage.get(item) can be undefined due to using has
+      // above hence we use ! to avoid typescript
+      const item = this.pool.get(key)!
+      item.references.delete(ref)
+      if (item.references.size === 0) {
+        this.pool.delete(key)
+        this.transition('destroying', key, item.value)
+      } else {
+        this.transition('releasing', key, item.value)
+      }
+    }
+  }
+
+  destroy() {
+    Array.from(this.pool.entries()).forEach(([key, item]) => {
+      Array.from(item.references).forEach((ref) => {
+        this.release(key, ref)
+      })
+    })
+  }
+}


### PR DESCRIPTION
https://github.com/Kong/kongponents/pull/3017 has been up in draft for a little while which was already a replacement for https://github.com/Kong/kongponents/pull/2980 which was reverted in https://github.com/Kong/kongponents/pull/3015 and as we've been seeing this for a while over in kuma-land I've also seen mention of this elsewhere.

So as a potential alternative, I decided to put a draft up using our [SharedPool](https://github.com/kumahq/kuma-gui/blob/e60fe3fe6781be4ee928cf22c6f448bb930c4dcb/packages/data/src/SharedPool.ts) which aims to enforce the DOM container as a shared singleton.

The changes to `ToastManager` itself are very minor and it all just relies on the SharedPool functionality instead, making it very easy to grok whats going on in the `ToastManager` without having to worry about the implementation. Just `acquire` things and `release` them when you are done, once the last `release` happens the "thing" gets `destroy`ed.

---

I believe the constraints here were to not change the `new ToastManager()` API even though we essentially require a singleton. This PR keeps the multiple `ToastManager`s but implements the singleton inside, thus maintaining the API.

SharedPool itself was built many moons ago for our own application and I've just copy/pasta'ed it over here as is. I'd probably fiddle with it a bit more now if I had more chance, but it's easier to just drop in what we have over in kuma in here also.

Its basically a MultiMap with lifecycle hooks so you can tell it how to to `create`, `acquire`, `release` and finally `destroy` things when they are no longer in use. In our application we have many many singletons using this, but here we just need the one, keyed by the previous `id` of `kongponents-toaster-container`.

The DOM `id` itself I now randomise, via `Date`, so you its harder to fiddle with from the outside. I don't think this impacts SSR judging by the code here previous to the PR, but then again the "fiddle prevention" is probably not super necessary in the real-world.

I added something that you can play with in the sandbox: I add a bunch of ToastManager instances all at once, and then slowly remove all but the one we are using and you can see that having multiple managers doesn't produce multiple root containers. I then added a button to remove the `ToastManager` we are actually using. If you push this button either at the end or before others are removed, everything is cleaned up properly once all the ToastManagers have been destroyed (you'll notice the DOM element is removed)

I might have totally missed something here, so let me know if so. Also more than happy to close this if it's not the desired approach, just lemme know!

There's probably a few more things to say here, but if its not needed then its not worth me going over, but do let me know if anyone has any more questions.