### PR TITLE
fix(ktoaster): prevent duplicate containers via a shared pool v2

### DIFF
--- a/sandbox/composables/useSandboxToaster.ts
+++ b/sandbox/composables/useSandboxToaster.ts
@@ -2,7 +2,17 @@ import { onBeforeUnmount } from 'vue'
 import { ToastManager } from '@/index'
 
 export default function useSandboxToaster() {
-  const toaster = new ToastManager()
+  const toasters = Array.from({ length: 20 }).map(() => new ToastManager())
+  const toaster = toasters.pop()!
+
+  toasters.forEach(item => setTimeout(() => item.destroy(), Math.ceil(Math.random() * 10000)))
+
+  Array.from({ length: 20 }).forEach(() => {
+    setTimeout(() => {
+      const item = new ToastManager()
+      setTimeout(() => item.destroy(), Math.ceil(Math.random() * 10000))
+    }, Math.ceil(Math.random() * 10000))
+  })
 
   onBeforeUnmount(() => {
     toaster.destroy()

--- a/sandbox/pages/SandboxToaster.vue
+++ b/sandbox/pages/SandboxToaster.vue
@@ -62,6 +62,11 @@
           KToaster
         </KButton>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="destroy manager">
+        <KButton @click="() => toaster.destroy()">
+          Destroy
+        </KButton>
+      </SandboxSectionComponent>
     </div>
   </SandboxLayout>
 </template>

--- a/src/components/KToaster/SharedPool.ts
+++ b/src/components/KToaster/SharedPool.ts
@@ -1,0 +1,55 @@
+type Transition<K, T> = (state: 'creating' | 'acquiring' | 'releasing' | 'destroying', key: K, item: T) => T
+type Entry<T> = {
+  value: T
+  references: Set<symbol>
+}
+export default class SharedPool<K, T> {
+  constructor(
+    protected transition: Transition<K, T>,
+    protected pool: Map<K, Entry<T>> = new Map(),
+  ) {}
+
+  // getter, not init
+  acquire(key: K, ref: symbol): T {
+    const create = !this.pool.has(key)
+    if (create) {
+      const references = {
+        value: this.transition('creating', key, {} as T),
+        references: new Set<symbol>(),
+      }
+      this.pool.set(key, references)
+    }
+    // there is no way pool/usage.get(item) can be undefined due to using has
+    // above hence we use ! to avoid typescript
+    const item = this.pool.get(key)!
+    if (!create) {
+      this.transition('acquiring', key, item.value)
+    }
+    item.references.add(ref)
+    return item.value
+  }
+
+  // deleter
+  release(key: K, ref: symbol) {
+    if (this.pool.has(key)) {
+      // there is no way pool/usage.get(item) can be undefined due to using has
+      // above hence we use ! to avoid typescript
+      const item = this.pool.get(key)!
+      item.references.delete(ref)
+      if (item.references.size === 0) {
+        this.pool.delete(key)
+        this.transition('destroying', key, item.value)
+      } else {
+        this.transition('releasing', key, item.value)
+      }
+    }
+  }
+
+  destroy() {
+    Array.from(this.pool.entries()).forEach(([key, item]) => {
+      Array.from(item.references).forEach((ref) => {
+        this.release(key, ref)
+      })
+    })
+  }
+}

--- a/src/components/KToaster/ToastManager.ts
+++ b/src/components/KToaster/ToastManager.ts
@@ -1,10 +1,19 @@
 import { createVNode, render, ref } from 'vue'
 import type { Ref, VNode } from 'vue'
-import type { Toast, ToasterAppearance, ToasterOptions } from '@/types'
+import type { Toast, ToasterOptions } from '@/types'
 import { ToasterAppearances } from '@/types'
 import KToaster from '@/components/KToaster/KToaster.vue'
 import { getUniqueStringId } from '@/utilities'
 import SharedPool from './SharedPool'
+
+interface IToastManager {
+  toasts: Ref<Toast[]>
+  setTimer(key: string, timeout: number): number
+  open(args: Record<string, any> | string): void
+  close(key: string): void
+  closeAll(): void
+  destroy(): void
+}
 
 const toasterContainerId = 'kongponents-toaster-container'
 
@@ -13,19 +22,26 @@ const toasterDefaults = {
   appearance: ToasterAppearances.info,
 }
 
-class InternalToastManager {
+class SSRToastManager implements IToastManager {
+  public toasts = ref<Toast[]>([])
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setTimer(...args: Parameters<IToastManager['setTimer']>) {
+    return 0
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public open(...args: Parameters<IToastManager['open']>) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  close(...args: Parameters<IToastManager['close']>) {}
+  closeAll() {}
+  public destroy() {}
+
+}
+class DOMToastManager implements IToastManager {
   private toastersContainer: HTMLElement | null = null
   private toaster: VNode | null = null
-  public toasts: Ref<Toast[]> = ref<Toast[]>([])
+  public toasts = ref<Toast[]>([])
 
   constructor() {
-    // For SSR, prevents failing on the build)
-    if (typeof document === 'undefined') {
-      console.warn('ToastManager should only be initialized in the browser environment. Docs: https://kongponents.konghq.com/components/toaster.html')
-
-      return
-    }
-
     this.toastersContainer = document.createElement('div')
     this.toastersContainer.id = toasterContainerId
     document.body.appendChild(this.toastersContainer)
@@ -40,18 +56,19 @@ class InternalToastManager {
     }
   }
 
-  setTimer(key: string, timeout: number): number {
+  setTimer(key: string, timeout: number) {
     return window?.setTimeout(() => this.close(key), timeout) || 0
   }
 
-  public open(args: Record<string, any> | string): void {
+  public open(args: Record<string, any> | string) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const { key, timeoutMilliseconds, appearance, message, title } = args
 
-    const toastKey: string = key ? String(key) : getUniqueStringId()
-    const toastAppearance: ToasterAppearance = (appearance && Object.keys(ToasterAppearances).indexOf(appearance) !== -1) ? appearance : toasterDefaults.appearance
-    const timer: number = this.setTimer(key, timeoutMilliseconds || toasterDefaults.timeoutMilliseconds)
+    const toastKey = key ? String(key) : getUniqueStringId()
+    const toastAppearance = ((appearance && Object.keys(ToasterAppearances).indexOf(appearance) !== -1) ?
+      appearance : toasterDefaults.appearance) as (keyof typeof ToasterAppearances)
+    const timer = this.setTimer(toastKey, timeoutMilliseconds || toasterDefaults.timeoutMilliseconds)
     const toasterMessage = typeof args === 'string' ? args : message
 
     // Add toaster to state
@@ -65,13 +82,13 @@ class InternalToastManager {
     })
   }
 
-  close(key: string): void {
-    const i: number = this.toasts.value?.findIndex(n => key === n.key)
+  close(key: string) {
+    const i = this.toasts.value?.findIndex(n => key === n.key)
     clearTimeout(this.toasts.value[i]?.timer)
     this.toasts.value.splice(i, 1)
   }
 
-  closeAll(): void {
+  closeAll() {
     this.toasts.value.forEach(toast => clearTimeout(toast?.timer))
     this.toasts.value = []
   }
@@ -83,10 +100,17 @@ class InternalToastManager {
     }
   }
 }
-const pool = new SharedPool<string, InternalToastManager>((state, id, item) => {
+
+const pool = new SharedPool<string, IToastManager>((state, id, item) => {
   switch (state) {
     case 'creating':
-      return new InternalToastManager()
+      // For SSR, prevents failing on the build)
+      if (typeof document === 'undefined') {
+        console.warn('ToastManager should only be initialized in the browser environment, all methods are noops. Docs: https://kongponents.konghq.com/components/toaster.html')
+        return new SSRToastManager()
+      }
+
+      return new DOMToastManager()
     case 'acquiring':
       return item
     case 'releasing':
@@ -109,29 +133,34 @@ export default class ToastManager {
   constructor(options?: ToasterOptions)
 
   // internal usage
-  constructor(options: ToasterOptions | undefined, manager: InternalToastManager)
+  constructor(options: ToasterOptions | undefined, manager: IToastManager)
   constructor(
     options?: ToasterOptions,
-    protected manager: InternalToastManager = pool.acquire(toasterContainerId, this.sym),
+    protected manager: IToastManager = pool.acquire(toasterContainerId, this.sym),
   ) {}
 
-  setTimer(...args: Parameters<InternalToastManager['setTimer']>): number {
+  get toasts() {
+    return this.manager.toasts
+  }
+
+  setTimer(...args: Parameters<IToastManager['setTimer']>) {
     return this.manager.setTimer(...args)
   }
 
-  open(...args: Parameters<InternalToastManager['open']>): void {
+  open(...args: Parameters<IToastManager['open']>) {
     return this.manager.open(...args)
   }
 
-  close(...args: Parameters<InternalToastManager['close']>): void {
+  close(...args: Parameters<IToastManager['close']>) {
     return this.manager.close(...args)
   }
 
-  closeAll(...args: Parameters<InternalToastManager['closeAll']>): void {
+  closeAll(...args: Parameters<IToastManager['closeAll']>) {
     return this.manager.closeAll(...args)
   }
 
-  destroy() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  destroy(...args: Parameters<IToastManager['destroy']>) {
     return pool.release(toasterContainerId, this.sym)
   }
 }

--- a/src/components/KToaster/ToastManager.ts
+++ b/src/components/KToaster/ToastManager.ts
@@ -4,6 +4,7 @@ import type { Toast, ToasterAppearance, ToasterOptions } from '@/types'
 import { ToasterAppearances } from '@/types'
 import KToaster from '@/components/KToaster/KToaster.vue'
 import { getUniqueStringId } from '@/utilities'
+import SharedPool from './SharedPool'
 
 const toasterContainerId = 'kongponents-toaster-container'
 
@@ -12,24 +13,12 @@ const toasterDefaults = {
   appearance: ToasterAppearances.info,
 }
 
-const defaultZIndex = 10000
-
-export default class ToastManager {
+class InternalToastManager {
   private toastersContainer: HTMLElement | null = null
   private toaster: VNode | null = null
   public toasts: Ref<Toast[]> = ref<Toast[]>([])
 
-  private zIndex: number = defaultZIndex
-
-  constructor(options?: ToasterOptions) {
-    if (options?.zIndex) {
-      this.zIndex = options.zIndex
-    }
-
-    this.setupToastersContainer()
-  }
-
-  private setupToastersContainer(): void {
+  constructor() {
     // For SSR, prevents failing on the build)
     if (typeof document === 'undefined') {
       console.warn('ToastManager should only be initialized in the browser environment. Docs: https://kongponents.konghq.com/components/toaster.html')
@@ -37,18 +26,12 @@ export default class ToastManager {
       return
     }
 
-    const toastersContainerEl = document.getElementById(toasterContainerId)
-    if (toastersContainerEl) {
-      this.toastersContainer = toastersContainerEl as HTMLElement
-    } else {
-      this.toastersContainer = document.createElement('div')
-      this.toastersContainer.id = toasterContainerId
-      document.body.appendChild(this.toastersContainer)
-    }
+    this.toastersContainer = document.createElement('div')
+    this.toastersContainer.id = toasterContainerId
+    document.body.appendChild(this.toastersContainer)
 
     this.toaster = createVNode(KToaster, {
       toasterState: this.toasts.value,
-      zIndex: this.zIndex,
       onClose: (key: string) => this.close(key),
     })
 
@@ -62,15 +45,13 @@ export default class ToastManager {
   }
 
   public open(args: Record<string, any> | string): void {
-    this.setupToastersContainer()
-
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const { key, timeoutMilliseconds, appearance, message, title } = args
 
     const toastKey: string = key ? String(key) : getUniqueStringId()
     const toastAppearance: ToasterAppearance = (appearance && Object.keys(ToasterAppearances).indexOf(appearance) !== -1) ? appearance : toasterDefaults.appearance
-    const timer: number = this.setTimer(toastKey, timeoutMilliseconds || toasterDefaults.timeoutMilliseconds)
+    const timer: number = this.setTimer(key, timeoutMilliseconds || toasterDefaults.timeoutMilliseconds)
     const toasterMessage = typeof args === 'string' ? args : message
 
     // Add toaster to state
@@ -95,18 +76,62 @@ export default class ToastManager {
     this.toasts.value = []
   }
 
-  /**
-   * Destroys the ToastManager instance and removes the toasters container element from the DOM
-   * @param removeToastersContainer - Whether to remove the toasters container element from the DOM (defaults to false)
-   */
-  public destroy(removeToastersContainer: boolean = false) {
-    const toastersContainerEl = document?.getElementById(toasterContainerId)
-    if (removeToastersContainer && toastersContainerEl) {
-      render(null, toastersContainerEl)
-      toastersContainerEl.remove()
+  public destroy() {
+    if (this.toastersContainer) {
+      render(null, this.toastersContainer)
+      this.toastersContainer.remove()
     }
+  }
+}
+const pool = new SharedPool<string, InternalToastManager>((state, id, item) => {
+  switch (state) {
+    case 'creating':
+      return new InternalToastManager()
+    case 'acquiring':
+      return item
+    case 'releasing':
+      return item
+    case 'destroying':
+      item.destroy()
+      return item
+  }
+})
 
-    this.toastersContainer = null
-    this.toaster = null
+export default class ToastManager {
+  protected sym = Symbol(toasterContainerId)
+  // public usage
+  constructor()
+  /**
+   * @deprecated If you are using options to set zIndex, this never worked as
+   * expected and doing this is now deprecated. You can remove `options` as an
+   * argument.
+   */
+  constructor(options?: ToasterOptions)
+
+  // internal usage
+  constructor(options: ToasterOptions | undefined, manager: InternalToastManager)
+  constructor(
+    options?: ToasterOptions,
+    protected manager: InternalToastManager = pool.acquire(toasterContainerId, this.sym),
+  ) {}
+
+  setTimer(...args: Parameters<InternalToastManager['setTimer']>): number {
+    return this.manager.setTimer(...args)
+  }
+
+  open(...args: Parameters<InternalToastManager['open']>): void {
+    return this.manager.open(...args)
+  }
+
+  close(...args: Parameters<InternalToastManager['close']>): void {
+    return this.manager.close(...args)
+  }
+
+  closeAll(...args: Parameters<InternalToastManager['closeAll']>): void {
+    return this.manager.closeAll(...args)
+  }
+
+  destroy() {
+    return pool.release(toasterContainerId, this.sym)
   }
 }


### PR DESCRIPTION
Alternative to https://github.com/Kong/kongponents/pull/3041

This one makes the entire ToastManager a singleton instead of just its DOM target.

It does this by creating a new proxy ToastManager class which can be instantiated multiple times, this new ToastManager instantiates the old ToastManager as a singleton, so we only ever have one ToastManager.

The one caveat with this is the `zIndex` option can't really be guaranteed to be set it we have a ToastManager singleton, but looking at the code it never worked as intended anyway (it set the zIndex of the Toasters inside of the DOM target, which form what I see is pointless)

I found the PR where this zIndex option was added (https://github.com/Kong/kongponents/pull/2130) and it looks like it wasn't a specific ask anyway as its in amongst a more general refactor of "add zIndex to all overlaying components" so I'm guessing no-one is using this anyway (and if they are its not working as intended).

I deprecated the options argument here also, and I'd see this approach as backwards compatible because, if I'm not mistaken, the zIndexing wasn't working as intended anyway (and can't be supported properly if we want a shared singleton DOM target), although there maybe other opinions on this. Personally I prefer this approach to https://github.com/Kong/kongponents/pull/3041, but I'd be happy with either.

Small note: I spotted quite a few things/potential issues here with other things in the older code, but didn't want to mix that up with this singleton task.