### PR TITLE
fix: add sameDayFullRange prop to allow valid time range for same day queries [MA-4646]

### DIFF
--- a/sandbox/pages/SandboxDateTimePicker.vue
+++ b/sandbox/pages/SandboxDateTimePicker.vue
@@ -55,6 +55,26 @@
           range
         />
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="sameDayFullRange">
+        <KComponent
+          v-slot="{ data }"
+          :data="{ sameDayFullRange: true, value: { start: null, end: null } }"
+        >
+          <KDateTimePicker
+            v-model="data.value"
+            mode="dateTime"
+            range
+            :same-day-full-range="data.sameDayFullRange"
+          />
+
+          <KInputSwitch
+            v-model="data.sameDayFullRange"
+            label="Enable same day full range"
+          />
+
+          <div>Emitted value: <pre class="json">{{ data.value }}</pre></div>
+        </KComponent>
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="mode">
         <KComponent
           v-slot="{ data }"

--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -94,6 +94,7 @@ const {
   errorMessage = undefined,
   timeGranularity = 'minutely',
   sameDayFullRange = false,
+  customRangeValidation = undefined,
 } = defineProps<{
   isRange: boolean
   kDatePickerMode: DateTimePickerMode
@@ -102,6 +103,7 @@ const {
   errorMessage?: string
   timeGranularity?: TimeGranularity
   sameDayFullRange?: boolean
+  customRangeValidation?: (start: Date, end: Date) => boolean
 }>()
 
 const formatTimeForInput = (date: Date, granularity: TimeGranularity): string => {
@@ -166,7 +168,15 @@ const timeStep = computed(() => {
 })
 
 const isInvalidRange = (start: Date, end: Date): boolean => {
-  return start > end
+  if (start > end) {
+    return true
+  }
+
+  if (customRangeValidation) {
+    return customRangeValidation(start, end)
+  }
+
+  return false
 }
 
 const isValidDateRange = (

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -645,4 +645,84 @@ describe('KDateTimePicker', () => {
       cy.getTestId(submitButton).should('not.be.disabled')
     })
   })
+
+  describe('customRangeValidation', () => {
+    it('disables Apply button when customRangeValidation returns true', () => {
+      const calendarTargetDateString = format(new Date(), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+
+      const customValidation = (start: Date, end: Date) => start.getTime() === end.getTime()
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          range: true,
+          sameDayFullRange: true,
+          customRangeValidation: customValidation,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+
+      // Select the same day twice
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      // 00:00 !== 23:59
+      cy.getTestId(submitButton).should('not.be.disabled')
+
+      // Manually set end time to equal start time 00:00
+      cy.getTestId('time-input-end').clear()
+      cy.getTestId('time-input-end').type('00:00')
+
+      cy.getTestId(submitButton).should('be.disabled')
+    })
+
+    it('does not affect validation when customRangeValidation is not provided', () => {
+      const calendarTargetDateString = format(new Date(), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          range: true,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      cy.getTestId(submitButton).should('not.be.disabled')
+    })
+
+    it('combines with built-in validation (start > end still invalid)', () => {
+      const customValidation = () => false
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          range: true,
+          customRangeValidation: customValidation,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+
+      const calendarTargetDateString = format(new Date(), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      cy.getTestId('time-input-start').clear()
+      cy.getTestId('time-input-start').type('23:00')
+      cy.getTestId('time-input-end').clear()
+      cy.getTestId('time-input-end').type('01:00')
+
+      cy.getTestId(submitButton).should('be.disabled')
+    })
+  })
 })

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -570,4 +570,79 @@ describe('KDateTimePicker', () => {
 
     cy.getTestId(timepickerDisplay).should('contain.text', 'Last hour (UTC)')
   })
+
+  describe('sameDayFullRange', () => {
+    it('applies full-day range when same day selected with sameDayFullRange enabled', () => {
+      const calendarTargetDateString = format(new Date(), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          range: true,
+          sameDayFullRange: true,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+
+      // Select the same day twice for start and end
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      cy.getTestId('time-input-start').should('have.value', '00:00')
+      cy.getTestId('time-input-end').should('have.value', '23:59')
+      cy.getTestId(submitButton).should('not.be.disabled')
+    })
+
+    it('does not apply full-day range when sameDayFullRange is false (default)', () => {
+      const calendarTargetDateString = format(new Date(), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          range: true,
+          sameDayFullRange: false,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      // both should show current time
+      cy.getTestId('time-input-start').invoke('val').then((startVal) => {
+        cy.getTestId('time-input-end').invoke('val').then((endVal) => {
+          expect(startVal).to.equal(endVal)
+        })
+      })
+    })
+
+    it('does not apply full-day range for different days even with sameDayFullRange enabled', () => {
+      const today = new Date()
+      const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000)
+      const todayDateString = format(today, 'yyyy-MM-dd')
+      const yesterdayDateString = format(yesterday, 'yyyy-MM-dd')
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          range: true,
+          sameDayFullRange: true,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+      cy.get(`.id-${yesterdayDateString}`).click()
+      cy.get(`.id-${todayDateString}`).click()
+
+      cy.getTestId('time-input-start').should('not.have.value', '00:00')
+      cy.getTestId('time-input-end').should('not.have.value', '23:59')
+      cy.getTestId(submitButton).should('not.be.disabled')
+    })
+  })
 })

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -70,6 +70,7 @@
           ref="calendarWrapperRef"
           v-model="calendarVModel"
           v-model:error="hasCalendarError"
+          :custom-range-validation="customRangeValidation"
           :error-message="invalidTimeErrorMessage"
           :is-range="!isSingleDatepicker"
           :k-date-picker-mode="mode"
@@ -165,6 +166,7 @@ const {
   invalidTimeErrorMessage = 'Start time cannot exceed end time.',
   timeGranularity = 'minutely',
   sameDayFullRange = false,
+  customRangeValidation,
 } = defineProps<DateTimePickerProps>()
 
 const emit = defineEmits<DateTimePickerEmits>()

--- a/src/components/KDateTimePicker/KDateTimePicker.vue
+++ b/src/components/KDateTimePicker/KDateTimePicker.vue
@@ -75,6 +75,7 @@
           :k-date-picker-mode="mode"
           :max-date="maxDate"
           :min-date="minDate"
+          :same-day-full-range="sameDayFullRange"
           :time-granularity="timeGranularity"
         />
         <div
@@ -163,6 +164,7 @@ const {
   popoverPlacement = 'bottom-start',
   invalidTimeErrorMessage = 'Start time cannot exceed end time.',
   timeGranularity = 'minutely',
+  sameDayFullRange = false,
 } = defineProps<DateTimePickerProps>()
 
 const emit = defineEmits<DateTimePickerEmits>()

--- a/src/types/date-time-picker.ts
+++ b/src/types/date-time-picker.ts
@@ -206,6 +206,14 @@ export interface DateTimePickerProps {
    * @default false
    */
   sameDayFullRange?: boolean
+
+  /**
+   * Custom validation function for date range
+   * @param start - Start date of the range
+   * @param end - End date of the range
+   * @returns boolean - true if range is invalid
+   */
+  customRangeValidation?: (start: Date, end: Date) => boolean
 }
 
 export type TimeGranularity = 'minutely' | 'secondly'

--- a/src/types/date-time-picker.ts
+++ b/src/types/date-time-picker.ts
@@ -200,6 +200,12 @@ export interface DateTimePickerProps {
    * @default 'minutely'
    */
   timeGranularity?: TimeGranularity
+
+  /**
+   * Automatically adjust times to create a full-day range (00:00 - 23:59:59)
+   * @default false
+   */
+  sameDayFullRange?: boolean
 }
 
 export type TimeGranularity = 'minutely' | 'secondly'


### PR DESCRIPTION
Fix [MA-4646](https://konghq.atlassian.net/browse/MA-4646)

# Summary

This will add a new prop (`sameDayFullRange`) to the `KDateTimePicker` and `CalendarWrapper` components to allow for valid time ranges when a user selects the same day for a start and end time.

When enabled and the same date is chosen for the start and end, the time range will automatically be adjusted to `12:00` am to `11:59` pm of the same day, as opposed to the `12:00` am and `12:00` am for both start and end times.

Another callback prop has been added `customValidationRange` which will allow for custom validation of `start` and `end` times to disable the "Apply" button in KDateTimePicker.

This also refactors a little bit of repeated and messy type guarding within the CalendarWrapper.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[MA-4646]: https://konghq.atlassian.net/browse/MA-4646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ