### PR TITLE
feat(table-data): extract data fetching related code out of k-table-data

### DIFF
--- a/sandbox/pages/SandboxTableData.vue
+++ b/sandbox/pages/SandboxTableData.vue
@@ -432,6 +432,21 @@
           </template>
         </KTableData>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="Inline headers with synchronous fetcher">
+        <KTableData
+          :fetcher="someFetcher"
+          :headers="[
+            { label: 'Name', key: 'name', sortable: true, hideLabel: false },
+            { label: 'ID', key: 'id', sortable: true, hideLabel: false },
+            { label: 'Enabled', key: 'enabled', sortable: false, hideLabel: false },
+            { label: '', key: 'link', sortable: false, hideLabel: true },
+          ]"
+        >
+          <template #action-items>
+            <SandboxTableViewActions />
+          </template>
+        </KTableData>
+      </SandboxSectionComponent>
     </div>
   </SandboxLayout>
 </template>
@@ -470,6 +485,27 @@ const fetcher = async (): Promise<any> => {
   return {
     data: responseData,
     total: responseData.length,
+  }
+}
+const someFetcher = () => {
+  return {
+    data: [
+      {
+        name: 'Basic Auth',
+        id: '517526354743085',
+        enabled: 'true',
+      },
+      {
+        name: 'Website Desktop',
+        id: '328027447731198',
+        enabled: 'false',
+      },
+      {
+        name: 'Android App',
+        id: '405383051040955',
+        enabled: 'true',
+      },
+    ],
   }
 }
 
@@ -578,7 +614,7 @@ const getRowOneTwoLink = (row: Record<string, any>): RowLink => {
   .horizontal-container {
     display: flex;
     flex-wrap: wrap;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .username-link {

--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -898,6 +898,244 @@ describe('KTableData', () => {
         .its('lastCall')
         .should('have.been.calledWith', { pageSize: 10, page: 2, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
     })
+
+    it('offset pagination: correctly navigates forward and backward across 4 pages', () => {
+      const data: Array<{ name: string }> = []
+      for (let i = 0; i < 12; i++) {
+        data.push({ name: 'row' + i })
+      }
+      const fns = {
+        fetcher: (params: FetchParams) => {
+          const { pageSize, offset } = params
+          const start = offset ? Number(offset) : 0
+          const end = Math.min(start + pageSize, data.length)
+          return {
+            data: data.slice(start, end),
+            pagination: {
+              offset: end < data.length ? `${end}` : null,
+              hasNextPage: end < data.length,
+            },
+          }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: fns.fetcher,
+          initialFetcherParams: { pageSize: 3 },
+          headers: options.headers,
+          paginationAttributes: {
+            pageSizes: [3],
+            offset: true,
+          },
+        },
+      })
+
+      // page 1: rows 0-2
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.get('@fetcher').should('have.callCount', 1)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 1, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // page 2: rows 3-5
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.get('@fetcher').should('have.callCount', 2)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 2, offset: '3', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // page 3: rows 6-8
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row6')
+      cy.get('@fetcher').should('have.callCount', 3)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 3, offset: '6', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // page 4: rows 9-11
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row9')
+      cy.get('@fetcher').should('have.callCount', 4)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 4, offset: '9', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // back to page 3: should use offset '6'
+      cy.getTestId('previous-button').click()
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row6')
+      cy.get('@fetcher').should('have.callCount', 5)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 3, offset: '6', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // back to page 2: should use offset '3'
+      cy.getTestId('previous-button').click()
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.get('@fetcher').should('have.callCount', 6)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 2, offset: '3', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // back to page 1: should use offset null
+      cy.getTestId('previous-button').click()
+      cy.get('.table tbody').find('tr').should('have.length', 3)
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.get('@fetcher').should('have.callCount', 7)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 1, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+    })
+
+    it('offset pagination: forward-backward-forward does not duplicate offsets', () => {
+      const data: Array<{ name: string }> = []
+      for (let i = 0; i < 9; i++) {
+        data.push({ name: 'row' + i })
+      }
+      const fns = {
+        fetcher: (params: FetchParams) => {
+          const { pageSize, offset } = params
+          const start = offset ? Number(offset) : 0
+          const end = Math.min(start + pageSize, data.length)
+          return {
+            data: data.slice(start, end),
+            pagination: {
+              offset: end < data.length ? `${end}` : null,
+              hasNextPage: end < data.length,
+            },
+          }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: fns.fetcher,
+          initialFetcherParams: { pageSize: 3 },
+          headers: options.headers,
+          paginationAttributes: {
+            pageSizes: [3],
+            offset: true,
+          },
+        },
+      })
+
+      // page 1 → 2 → 3
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').should('contain.text', 'row6')
+      cy.get('@fetcher').should('have.callCount', 3)
+
+      // back to page 2
+      cy.getTestId('previous-button').click()
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.get('@fetcher').should('have.callCount', 4)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 2, offset: '3', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+
+      // forward to page 3 again: should still use offset '6', not a stale or duplicated value
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').should('contain.text', 'row6')
+      cy.get('@fetcher').should('have.callCount', 5)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 3, offset: '6', query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+    })
+
+    it('offset pagination: disables next button on last page', () => {
+      const data: Array<{ name: string }> = []
+      for (let i = 0; i < 6; i++) {
+        data.push({ name: 'row' + i })
+      }
+      const fetcher = (params: FetchParams) => {
+        const { pageSize, offset } = params
+        const start = offset ? Number(offset) : 0
+        const end = Math.min(start + pageSize, data.length)
+        return {
+          data: data.slice(start, end),
+          pagination: {
+            offset: end < data.length ? `${end}` : null,
+            hasNextPage: end < data.length,
+          },
+        }
+      }
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher,
+          initialFetcherParams: { pageSize: 3 },
+          headers: options.headers,
+          paginationAttributes: {
+            pageSizes: [3],
+            offset: true,
+          },
+        },
+      })
+
+      // page 1: next should be enabled
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.getTestId('next-button').should('not.be.disabled')
+
+      // page 2 (last page): next should be disabled
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.getTestId('next-button').should('be.disabled')
+
+      // previous should still work
+      cy.getTestId('previous-button').should('not.be.disabled')
+      cy.getTestId('previous-button').click()
+      cy.get('.table tbody').should('contain.text', 'row0')
+    })
+
+    it('offset pagination: resets pagination state on page size change', () => {
+      const data: Array<{ name: string }> = []
+      for (let i = 0; i < 12; i++) {
+        data.push({ name: 'row' + i })
+      }
+      const fns = {
+        fetcher: (params: FetchParams) => {
+          const { pageSize, offset } = params
+          const start = offset ? Number(offset) : 0
+          const end = Math.min(start + pageSize, data.length)
+          return {
+            data: data.slice(start, end),
+            pagination: {
+              offset: end < data.length ? `${end}` : null,
+              hasNextPage: end < data.length,
+            },
+          }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: fns.fetcher,
+          initialFetcherParams: { pageSize: 3 },
+          headers: options.headers,
+          paginationAttributes: {
+            pageSizes: [3, 6],
+            offset: true,
+          },
+        },
+      })
+
+      // navigate to page 2
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.get('@fetcher').should('have.callCount', 2)
+
+      // change page size: should reset to page 1 with offset null
+      cy.getTestId('page-size-dropdown-trigger').click()
+      cy.get('[data-testid="dropdown-item-trigger"][value="6"]').click({ multiple: true, force: true })
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.get('@fetcher').should('have.callCount', 3)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 6, page: 1, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+    })
   })
 
   describe('table preferences', () => {

--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -482,6 +482,32 @@ describe('KTableData', () => {
         })
       })
     })
+
+    it('refetches when fetcherCacheKey prop changes', () => {
+      const fns = {
+        fetcher: () => {
+          return { data: options.data, total: options.data.length }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          headers: options.headers,
+          fetcher: fns.fetcher,
+          fetcherCacheKey: 'v1',
+        },
+      }).then((component) => {
+        cy.get('@fetcher').should('have.callCount', 1).then(() => {
+          component.wrapper.setProps({ fetcherCacheKey: 'v2' }).then(() => {
+            // changing fetcherCacheKey is the documented escape hatch for forcing a
+            // refetch (e.g. after an out-of-band create/delete) — swrv treats the new
+            // composite key as a different cache entry and re-invokes the fetcher.
+            cy.get('@fetcher').should('have.callCount', 2)
+          })
+        })
+      })
+    })
   })
 
   describe('sorting', () => {
@@ -1136,6 +1162,48 @@ describe('KTableData', () => {
         .its('lastCall')
         .should('have.been.calledWith', { pageSize: 6, page: 1, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
     })
+
+    it('resets to page 1 when data becomes empty after navigating past page 1', () => {
+      // Simulates "user deleted the last row on the last page" — the response watcher
+      // in useTableData should detect empty data on page > 1 and call resetPagination().
+      let returnEmpty = false
+      const fns = {
+        fetcher: () => returnEmpty
+          ? { data: [], total: 0 }
+          : { data: largeDataSet, total: largeDataSet.length },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: fns.fetcher,
+          headers: options.headers,
+          paginationAttributes: { pageSizes: [3, 6] },
+          initialFetcherParams: { pageSize: 3 },
+          fetcherCacheKey: 'v1',
+        },
+      })
+
+      cy.get('@fetcher').should('have.callCount', 1)
+        .its('lastCall').should('have.been.calledWith', { ...DEFAULT_FETCHER_PARAMS, pageSize: 3 })
+
+      // navigate to page 2
+      cy.getTestId('next-button').click()
+      cy.get('@fetcher').should('have.callCount', 2)
+        .its('lastCall').should('have.been.calledWith', { ...DEFAULT_FETCHER_PARAMS, pageSize: 3, page: 2 })
+
+      // Simulate the delete by switching the fetcher to return empty, then bumping
+      // fetcherCacheKey to force a refetch on the same page.
+      cy.then(() => {
+        returnEmpty = true
+      })
+      cy.then(() => cy.wrap(Cypress.vueWrapper.setProps({ fetcherCacheKey: 'v2' })))
+
+      // After the empty response arrives, resetPagination() flips page back to 1, which
+      // triggers another fetch with page: 1. We assert the final fetcher call shape.
+      cy.get('@fetcher', { timeout: 2000 }).should('have.callCount', 4)
+        .its('lastCall').should('have.been.calledWith', { ...DEFAULT_FETCHER_PARAMS, pageSize: 3, page: 1 })
+    })
   })
 
   describe('table preferences', () => {
@@ -1283,7 +1351,7 @@ describe('KTableData', () => {
       })
     })
 
-    it('clientSort = true: applies new table preferences when prop is updated', () => {
+    it('applies new table preferences when prop is updated and triggers refetch (server-sort)', () => {
       const sortableColumnKey = options.headers.find(header => header.sortable)?.key
       const pageSize = 30
       options.headers[1].hidable = true
@@ -1421,6 +1489,59 @@ describe('KTableData', () => {
         }))
       })
     })
+
+    it('clientSort = true with default sorter: tablePreferences sort prop change re-sorts data without refetching', () => {
+      const fns = {
+        fetcher: () => {
+          return { data: options.data }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      // Use a local headers copy to avoid leaking the `hidable` mutation made by the
+      // earlier tests in this describe block into this one.
+      const localHeaders = options.headers.map((header) => ({ ...header }))
+
+      cy.mount(KTableData, {
+        props: {
+          headers: localHeaders,
+          clientSort: true,
+          fetcher: fns.fetcher,
+        },
+      }).then((component) => {
+        cy.get('@fetcher').should('have.callCount', 1)
+
+        // initial fetcher order: Basic Auth, Website Desktop, Android App
+        cy.get('tbody tr').eq(0).find('td').first().should('contain.text', 'Basic Auth')
+        cy.get('tbody tr').eq(1).find('td').first().should('contain.text', 'Website Desktop')
+        cy.get('tbody tr').eq(2).find('td').first().should('contain.text', 'Android App')
+
+        component.wrapper.setProps({
+          tablePreferences: {
+            sortColumnKey: 'name',
+            sortColumnOrder: 'desc',
+          },
+        }).then(() => {
+          // client-sort must NOT trigger a refetch — the cache key omits sort params for
+          // client-sort tables, and a regression here would flicker the table on every
+          // header click.
+          cy.get('@fetcher').should('have.callCount', 1)
+
+          // Data is reordered by the default client-side sorter (no sortHandlerFunction
+          // was provided). Note: useUtilities().clientSideSorter sorts ascending whenever
+          // `key !== previousKey`, so even though the prop asks for `'desc'` the first
+          // tablePreferences-driven sort always lands ascending. The point of this
+          // assertion is to prove the default-sorter branch ran and reordered the rows
+          // off their fetcher order, distinguishing this code path from L1286 (server-sort,
+          // no client sorter) and L1354 (client-sort with custom sortHandlerFunction).
+          cy.get('tbody tr').eq(0).find('td').first().should('contain.text', 'Android App')
+          cy.get('tbody tr').eq(1).find('td').first().should('contain.text', 'Basic Auth')
+          cy.get('tbody tr').eq(2).find('td').first().should('contain.text', 'Website Desktop')
+
+          cy.getTestId('table-header-name').should('have.attr', 'aria-sort', 'descending')
+        })
+      })
+    })
   })
 
   describe('misc', () => {
@@ -1464,6 +1585,43 @@ describe('KTableData', () => {
       cy.get('@fetcher', { timeout: 350 })
         .should('have.callCount', 3) // fetcher's 3rd call
         .should('returned', { data: [{ query: '' }] })
+    })
+
+    it('search query change resets pagination to page 1', () => {
+      // The composable watches filterQuery (driven by searchInput) and calls
+      // resetPagination() whenever the query changes while the user is past page 1.
+      // This guards against showing an empty page-N for a fresh query.
+      const fns = {
+        fetcher: () => {
+          return { data: largeDataSet, total: largeDataSet.length }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: fns.fetcher,
+          headers: options.headers,
+          paginationAttributes: { pageSizes: [3, 6] },
+          initialFetcherParams: { pageSize: 3 },
+          searchInput: '',
+        },
+      })
+
+      cy.get('@fetcher').should('have.callCount', 1)
+
+      // navigate to page 2
+      cy.getTestId('next-button').click()
+      cy.get('@fetcher').should('have.callCount', 2)
+        .its('lastCall').should('have.been.calledWith', { ...DEFAULT_FETCHER_PARAMS, pageSize: 3, page: 2 })
+
+      cy.then(() => cy.wrap(Cypress.vueWrapper.setProps({ searchInput: 'kw' })))
+
+      // After the 350ms search debounce, the cache key recomputes with the new query;
+      // the filterQuery watcher resets page to 1 first, so the next fetcher call must
+      // carry page: 1 (not page: 2 — that was the bd2b2a77c regression shape).
+      cy.get('@fetcher', { timeout: 1000 }).should('have.callCount', 3)
+        .its('lastCall').should('have.been.calledWith', { ...DEFAULT_FETCHER_PARAMS, pageSize: 3, page: 1, query: 'kw' })
     })
   })
 })

--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -1163,6 +1163,57 @@ describe('KTableData', () => {
         .should('have.been.calledWith', { pageSize: 6, page: 1, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
     })
 
+    it('offset pagination: numeric 0 cursor is preserved across navigation', () => {
+      // Regression: `Offset` permits `string | number`. Truthy checks (`|| null`,
+      // `!res?.pagination?.offset`) misread `0` as absent and broke forward/back
+      // navigation. The composable must use nullish checks instead.
+      const data: Array<{ name: string }> = []
+      for (let i = 0; i < 9; i++) {
+        data.push({ name: 'row' + i })
+      }
+      const fns = {
+        fetcher: (params: FetchParams) => {
+          const { pageSize, offset } = params
+          const start = offset == null ? 0 : Number(offset)
+          const end = Math.min(start + pageSize, data.length)
+          return {
+            data: data.slice(start, end),
+            pagination: {
+              // Return numeric `0` for the first-page cursor (the regression case).
+              offset: end < data.length ? end : 0,
+              hasNextPage: end < data.length,
+            },
+          }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          fetcher: fns.fetcher,
+          initialFetcherParams: { pageSize: 3 },
+          headers: options.headers,
+          paginationAttributes: {
+            pageSizes: [3],
+            offset: true,
+          },
+        },
+      })
+
+      // page 1 → 2 — must succeed even though page 1's response carries `offset: 0`.
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.getTestId('next-button').click()
+      cy.get('.table tbody').should('contain.text', 'row3')
+      cy.get('@fetcher').should('have.callCount', 2)
+
+      // back to page 1 — must use the seeded `null` offset, and the row data must reload.
+      cy.getTestId('previous-button').click()
+      cy.get('.table tbody').should('contain.text', 'row0')
+      cy.get('@fetcher').should('have.callCount', 3)
+        .its('lastCall')
+        .should('have.been.calledWith', { pageSize: 3, page: 1, offset: null, query: '', sortColumnKey: '', sortColumnOrder: 'desc' })
+    })
+
     it('resets to page 1 when data becomes empty after navigating past page 1', () => {
       // Simulates "user deleted the last row on the last page" — the response watcher
       // in useTableData should detect empty data on page > 1 and call resetPagination().
@@ -1540,6 +1591,57 @@ describe('KTableData', () => {
 
           cy.getTestId('table-header-name').should('have.attr', 'aria-sort', 'descending')
         })
+      })
+    })
+
+    it('partial tablePreferences sort update preserves the unmentioned slot', () => {
+      // Regression: the watcher used non-null assertions on both `sortColumnKey` and
+      // `sortColumnOrder`. A parent setting only `{ sortColumnOrder: 'desc' }` would
+      // leak `undefined` into `sortHandler` and the resulting fetcher call. Each
+      // missing slot must fall back to the current local value.
+      const sortableColumnKey = options.headers.find(header => header.sortable)?.key
+      const fns = {
+        fetcher: () => {
+          return { data: options.data }
+        },
+      }
+      cy.spy(fns, 'fetcher').as('fetcher')
+
+      cy.mount(KTableData, {
+        props: {
+          headers: options.headers,
+          fetcher: fns.fetcher,
+          initialFetcherParams: {
+            sortColumnKey: sortableColumnKey,
+            sortColumnOrder: 'asc',
+          },
+        },
+      }).then((component) => {
+        cy.get('@fetcher')
+          .should('have.callCount', 1)
+          .its('lastCall')
+          .should('have.been.calledWith', {
+            ...DEFAULT_FETCHER_PARAMS,
+            sortColumnKey: sortableColumnKey,
+            sortColumnOrder: 'asc',
+          })
+          .then(() => {
+            // Parent updates only the order. The key must come from existing local state.
+            component.wrapper.setProps({
+              tablePreferences: {
+                sortColumnOrder: 'desc',
+              },
+            }).then(() => {
+              cy.get('@fetcher')
+                .should('have.callCount', 2)
+                .its('lastCall')
+                .should('have.been.calledWith', {
+                  ...DEFAULT_FETCHER_PARAMS,
+                  sortColumnKey: sortableColumnKey,
+                  sortColumnOrder: 'desc',
+                })
+            })
+          })
       })
     })
   })

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -36,13 +36,13 @@
     v-bind="listenerProps"
     @empty-state-action-click="emit('empty-state-action-click')"
     @error-action-click="emit('error-action-click')"
-    @get-next-offset="getNextOffsetHandler"
-    @get-previous-offset="getPreviousOffsetHandler"
+    @get-next-offset="toNextPageOffset"
+    @get-previous-offset="toPreviousPageOffset"
     @page-change="pageChangeHandler"
     @page-size-change="pageSizeChangeHandler"
     @row-actions-toggle="($event) => $emit('row-actions-toggle', $event)"
     @row-select="($event) => emit('row-select', $event)"
-    @sort="sortHandler"
+    @sort="onSort"
     @update:row-expanded="($event) => emit('update:row-expanded', $event)"
     @update:table-preferences="tablePreferencesUpdateHandler"
   >
@@ -153,38 +153,29 @@
 </template>
 
 <script setup lang="ts" generic="const Header extends TableDataHeader = TableDataHeader, Data extends readonly Record<string, any>[] = readonly Record<string, any>[], Offset extends string | number = string | number">
-import type { Ref } from 'vue'
-import { ref, watch, computed, onMounted, useId } from 'vue'
+import { watch, computed, onMounted, reactive } from 'vue'
 import KTableView from '@/components/KTableView/KTableView.vue'
 import useUtilities from '@/composables/useUtilities'
+import { useTableData } from './useTableFetcher'
 import type {
   TablePreferences,
   TableDataHeader,
   TableColumnSlotName,
   TableColumnTooltipSlotName,
-  SortColumnOrder,
-  TableSortPayload,
   ButtonAppearance,
   RowLink,
-  TablePaginationAttributes,
   PageChangeData,
   PageSizeChangeData,
-  TableState,
-  SwrvStateData,
+  TableSortPayload,
   TableDataProps,
   TableColumnKey,
-  TableColumnVisibility,
-  TableColumnWidths,
   TableDataEmits,
   TableDataSlots,
 } from '@/types'
 import { EmptyStateIconVariants } from '@/types'
-import { getInitialPageSize, DEFAULT_PAGE_SIZE } from '@/utilities'
 import { pickBy } from 'lodash-es'
 
 type ColumnKey = TableColumnKey<Header>
-type ColumnVisibility = TableColumnVisibility<Header>
-type ColumnWidths = TableColumnWidths<Header>
 
 const {
   resizeColumns,
@@ -240,14 +231,10 @@ const emit = defineEmits<TableDataEmits<Header, Data>>()
 
 const slots = defineSlots<TableDataSlots<Header, Data>>()
 
-const { useDebounce, useRequest, useSwrvState, clientSideSorter: defaultClientSideSorter } = useUtilities()
-
-const tableId = useId()
+const { useDebounce } = useUtilities()
 
 // Cannot use `ref<Data[number][]>([])` as the items will be inferred incorrectly inside the template.
 // Same applies to other refs that have a generic type.
-const tableData = ref([]) as Ref<Array<Data[number]>>
-const tableHeaders = computed(() => sortable ? headers : headers.map((header) => ({ ...header, sortable: false })))
 const getEmptyStateButtonAppearance = computed((): ButtonAppearance => {
   if (emptyStateButtonAppearance) {
     return emptyStateButtonAppearance
@@ -256,35 +243,62 @@ const getEmptyStateButtonAppearance = computed((): ButtonAppearance => {
   return searchInput ? 'tertiary' : 'primary'
 })
 
-const total = ref<number>(0)
-const page = ref<number>(1)
-const pageSize = ref<number>(getInitialPageSize(tablePreferences, paginationAttributes))
-const filterQuery = ref<string>(searchInput ?? '')
-const sortColumnKey = ref(tablePreferences.sortColumnKey || initialFetcherParams.sortColumnKey || '') as Ref<ColumnKey>
-const sortColumnOrder = ref<SortColumnOrder>(tablePreferences.sortColumnOrder || initialFetcherParams.sortColumnOrder || 'desc')
-const initialSortHandled = ref<boolean>(!(sortColumnKey.value && clientSort)) // For clientSort tables, if sortColumnKey is set, that means we need to handle initial sort
-const offset = ref(null) as Ref<Offset | null>
-const offsets = ref([]) as Ref<Array<Offset | null>>
-const hasNextPage = ref<boolean>(true)
-const hasInitialized = ref<boolean>(false)
-
-const defaultFetcherProps = {
-  pageSize: pageSize.value,
-  page: page.value,
-  query: filterQuery.value,
-  sortColumnKey: sortColumnKey.value,
-  sortColumnOrder: sortColumnOrder.value,
-  offset: offset.value,
+const emitTablePreferences = (tableDataPreferences: TablePreferences): void => {
+  if (tableState.value === 'success') {
+    emit('update:table-preferences', tableDataPreferences)
+  }
 }
 
-const tablePaginationAttributes = computed((): TablePaginationAttributes => ({
-  totalCount: total.value,
-  initialPageSize: pageSize.value,
-  currentPage: page.value,
-  offsetPreviousButtonDisabled: !previousOffset.value,
-  offsetNextButtonDisabled: !nextOffset.value || !hasNextPage.value,
-  ...paginationAttributes,
-}))
+const {
+  tableHeaders,
+  // data props
+  filterQuery,
+  response: fetcherResponse,
+  revalidate: fetchRevalidate,
+  isLoading: fetcherIsLoading,
+  tableState,
+  stateData,
+  tableData,
+  initData,
+
+  // sort props
+  sortColumnKey,
+  sortColumnOrder,
+  initialSortHandled,
+  sortHandler,
+  // pagination props
+  page,
+  pageSize,
+  offsets,
+  offset,
+  showPagination,
+  tablePaginationAttributes,
+  toPreviousPageOffset,
+  toNextPageOffset,
+
+  // preferences props
+  tableViewColumnVisibility,
+  tableViewColumnWidths,
+  tableDataPreferences,
+  tablePreferencesUpdateHandler,
+} = useTableData(
+  reactive({
+    sortable: () => sortable,
+    headers: () => headers,
+    fetcher: () => fetcher,
+    fetcherCacheKey: () => fetcherCacheKey,
+    cacheIdentifier: () => cacheIdentifier,
+    initialFetcherParams: () => initialFetcherParams,
+    clientSort: () => clientSort,
+    sortHandlerFunction: () => sortHandlerFunction,
+    hidePaginationWhenOptional: () => hidePaginationWhenOptional,
+    hidePagination: () => hidePagination,
+    tablePreferences: () => tablePreferences,
+    paginationAttributes: () => paginationAttributes,
+    searchInput: () => searchInput,
+  }), {
+    emitTablePreferences,
+  })
 
 // Whether a string is a valid slot name for a table column header
 const isTableColumnSlotName = (slot: string): slot is TableColumnSlotName<ColumnKey> => {
@@ -325,267 +339,35 @@ const cellSlots = computed((): ColumnKey[] => {
   return Object.keys(slots).filter(isTableColumnKey)
 })
 
-const sortParams = computed(() => ({
-  sortColumnKey: sortColumnKey.value,
-  sortColumnOrder: sortColumnOrder.value,
-}))
-
-// Params that are used in the cache key for the fetcher.
-// For client-side sorting, we don't need to include the sort params in the cache key otherwise the cache key will change on every sort,
-// which will cause the table to re-fetch data on every sort even though we don't need to fetch new data.
-const cacheKeyParams = computed(() => ({
-  pageSize: pageSize.value,
-  page: page.value,
-  query: filterQuery.value,
-  offset: offset.value,
-  ...clientSort ? {} : sortParams.value,
-}))
-
-// We still need all params for the fetcher
-const fetcherParams = computed(() => ({
-  ...cacheKeyParams.value,
-  ...sortParams.value,
-}))
-
-const isInitialFetch = ref<boolean>(true)
-const fetchData = async () => {
-  const res = await fetcher(fetcherParams.value)
-
-  isInitialFetch.value = false
-
-  return res
-}
-
-/**
- * Initialize the table with the initial data
- */
-const initData = () => {
-  const fetcherParams = {
-    ...defaultFetcherProps,
-    ...initialFetcherParams,
-  }
-
-  // don't allow overriding default settings with undefined values
-  page.value = fetcherParams.page ?? defaultFetcherProps.page
-  pageSize.value = fetcherParams.pageSize ?? defaultFetcherProps.pageSize
-  filterQuery.value = fetcherParams.query ?? defaultFetcherProps.query
-  sortColumnKey.value = fetcherParams.sortColumnKey ?? defaultFetcherProps.sortColumnKey
-  sortColumnOrder.value = fetcherParams.sortColumnOrder ?? defaultFetcherProps.sortColumnOrder
-
-  if (clientSort && sortColumnKey.value && sortColumnOrder.value) {
-    const header: TableDataHeader<ColumnKey> = tableHeaders.value.find((header) => header.key === sortColumnKey.value) || {} as TableDataHeader<ColumnKey>
-    const { useSortHandlerFunction } = header
-
-    // If a custom sort function is provided, use it. Otherwise, use the default client-side sorter.
-    if (useSortHandlerFunction && sortHandlerFunction) {
-      const sorted = sortHandlerFunction({
-        key: sortColumnKey.value,
-        prevKey: '',
-        sortColumnOrder: sortColumnOrder.value,
-        data: tableData.value,
-      })
-
-      if (sorted) {
-        tableData.value = [...sorted]
-      }
-    } else {
-      defaultClientSideSorter(sortColumnKey.value, '', sortColumnOrder.value, tableData.value)
-    }
-  }
-
-  if (paginationAttributes?.offset) {
-    offset.value = fetcherParams.offset
-    offsets.value.push(fetcherParams.offset)
-  }
-
-  // trigger setting of tableFetcherCacheKey
-  hasInitialized.value = true
-}
-
-const previousOffset = computed((): Offset | null => offsets.value[page.value - 1] || null)
-const nextOffset = ref(null) as Ref<Offset | null>
-
-// once initData() finishes, setting tableFetcherCacheKey to non-falsey value triggers fetch of data
-const tableFetcherCacheKey = computed((): string => {
-  if (!fetcher || !hasInitialized.value) {
-    return ''
-  }
-
-  // Set the default identifier to a random string
-  let identifierKey: string = tableId
-  if (cacheIdentifier) {
-    identifierKey = cacheIdentifier
-  }
-
-  identifierKey += `-${JSON.stringify(cacheKeyParams.value)}`
-
-  if (fetcherCacheKey) {
-    identifierKey += `-${fetcherCacheKey}`
-  }
-
-  return `k-table_${identifierKey}`
-})
-
 const { debouncedFn: debouncedSearch, generateDebouncedFn: generateDebouncedSearch } = useDebounce((q: string) => {
   filterQuery.value = q
 }, 350)
+
 const search = generateDebouncedSearch(0) // generate a debounced function with zero delay (immediate)
 
-// ALL fetching is done through this useRequest / _revalidate
-// don't fire until tableFetcherCacheKey is set
-const {
-  data: fetcherData,
-  response: fetcherResponse,
-  error: fetcherError,
-  revalidate: _revalidate,
-  isValidating: fetcherIsValidating,
-  isLoading: fetcherIsLoading,
-} = useRequest(
-  () => tableFetcherCacheKey.value,
-  () => fetchData(),
-  { revalidateOnFocus: false, revalidateDebounce: 0 },
-)
-
-const { state, hasData } = useSwrvState(fetcherData, fetcherError, fetcherIsValidating)
-const stateData = computed((): SwrvStateData => ({
-  hasData: hasData.value,
-  state: state.value,
-}))
-const tableState = computed((): TableState => fetcherIsLoading.value ? 'loading' : fetcherError.value ? 'error' : 'success')
-const { debouncedFn: debouncedRevalidate } = useDebounce(_revalidate, 500)
-
-const sortHandler = ({ sortColumnKey: columnKey, prevKey, sortColumnOrder: sortOrder }: TableSortPayload<ColumnKey>, emitSortEvent: boolean = true): void => {
-  initialSortHandled.value = true
-
-  const header: TableDataHeader<ColumnKey> = tableHeaders.value.find((header) => header.key === columnKey) || {} as TableDataHeader<ColumnKey>
-  const { useSortHandlerFunction } = header
-
-  if (emitSortEvent) {
-    emit('sort', {
-      prevKey,
-      sortColumnKey: columnKey,
-      sortColumnOrder: sortOrder,
-    })
-  }
-
-  page.value = 1
-
-  if (!sortColumnKey.value || columnKey !== sortColumnKey.value) {
-    offsets.value = [null]
-  }
-
-  sortColumnKey.value = columnKey
-  sortColumnOrder.value = sortOrder as SortColumnOrder
-
-  if (clientSort) {
-    if (useSortHandlerFunction && sortHandlerFunction) {
-      const sorted = sortHandlerFunction({
-        key: columnKey,
-        prevKey,
-        sortColumnOrder: sortColumnOrder.value,
-        data: tableData.value,
-      })
-
-      // As `sortHandlerFunction` was marked as returning an array but we didn't use the return value
-      // before, we can keep the old behavior when nothing is returned but use the returned value if it exists.
-      if (sorted) {
-        tableData.value = [...sorted]
-      }
-    } else {
-      defaultClientSideSorter(columnKey, prevKey, sortColumnOrder.value, tableData.value)
-    }
-  } else if (!paginationAttributes?.offset) {
-    debouncedRevalidate()
-  }
+const sortEvtEmitter = (params: TableSortPayload<ColumnKey>) => {
+  emit('sort', params)
 }
+
+const onSort = (sortPayload: TableSortPayload<ColumnKey>, shouldEmit: boolean = true) => {
+  sortHandler(sortPayload, shouldEmit ? sortEvtEmitter : undefined)
+}
+
 
 const pageChangeHandler = ({ page: newPage }: PageChangeData) => {
   page.value = newPage
 }
 
-const pageSizeChangeHandler = ({ pageSize: newPageSize }: PageSizeChangeData) => {
+const resetPagination = () => {
   offsets.value = [null]
   offset.value = null
-  pageSize.value = newPageSize
   page.value = 1
 }
 
-const tablePreferencesUpdateHandler = ({ columnWidths: newColumnWidth, columnVisibility: newColumnVisibility }: TablePreferences<ColumnKey>) => {
-  // Update the column width and visibility overriding but keeping the existing properties (in case the new objects are empty)
-  tableViewColumnWidths.value = {
-    ...tableViewColumnWidths.value,
-    ...newColumnWidth,
-  }
-  tableViewColumnVisibility.value = {
-    ...tableViewColumnVisibility.value,
-    ...newColumnVisibility,
-  }
-
-  // Emit an event whenever one of the tablePreferences are updated
-  emitTablePreferences()
+const pageSizeChangeHandler = ({ pageSize: newPageSize }: PageSizeChangeData) => {
+  resetPagination()
+  pageSize.value = newPageSize
 }
-
-const tableViewColumnWidths = ref<ColumnWidths | undefined>(tablePreferences.columnWidths || {})
-const tableViewColumnVisibility = ref<ColumnVisibility | undefined>(tablePreferences.columnVisibility || {})
-const tableDataPreferences = computed((): TablePreferences<Header['key']> => ({
-  pageSize: pageSize.value,
-  sortColumnKey: sortColumnKey.value,
-  sortColumnOrder: sortColumnOrder.value,
-  ...(tableViewColumnWidths.value ? { columnWidths: tableViewColumnWidths.value } : {}),
-  ...(tableViewColumnVisibility.value ? { columnVisibility: tableViewColumnVisibility.value } : {}),
-}))
-
-watch(() => tablePreferences, (newVal) => {
-  pageSize.value = newVal?.pageSize ? newVal.pageSize : pageSize.value
-  tableViewColumnWidths.value = newVal?.columnWidths ? newVal.columnWidths : tableViewColumnWidths.value
-  tableViewColumnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : tableViewColumnVisibility.value
-  // Handle sorting if the sort preferences have changed
-  if ((newVal?.sortColumnKey || newVal?.sortColumnOrder) && (sortColumnKey.value !== newVal.sortColumnKey || sortColumnOrder.value !== newVal.sortColumnOrder)) {
-    sortHandler({
-      sortColumnKey: newVal.sortColumnKey!,
-      prevKey: sortColumnKey.value,
-      sortColumnOrder: newVal.sortColumnOrder!,
-    }, false) // don't emit sort event when updating from prop change
-  }
-})
-
-const emitTablePreferences = (): void => {
-  if (tableState.value === 'success') {
-    emit('update:table-preferences', tableDataPreferences.value)
-  }
-}
-
-const getNextOffsetHandler = (): void => {
-  page.value++
-  offset.value = nextOffset.value
-}
-
-const getPreviousOffsetHandler = (): void => {
-  page.value--
-  offset.value = previousOffset.value
-}
-
-const showPagination = computed((): boolean => {
-  // if fetcher is not defined or hidePagination is true, don't show pagination
-  if (!fetcher || hidePagination) {
-    return false
-  }
-
-  const minPageSize = paginationAttributes?.pageSizes?.[0] ?? DEFAULT_PAGE_SIZE
-
-  // this logic is built around min page size so that pagination doesn't disappear when a higher value is selected and hidePaginationWhenOptional is true
-  if (hidePaginationWhenOptional && page.value === 1) {
-    if (!paginationAttributes?.offset) {
-      // if using cursor-based pagination, hide pagination when number of items is less than min page size
-      return total.value > minPageSize
-    } else {
-      // if using offset-based pagination, hide pagination when neither previous nor next offset is available and total items is less than min page size
-      return !!previousOffset.value || !!nextOffset.value || tableData.value.length >= minPageSize
-    }
-  }
-
-  return true
-})
 
 watch(fetcherResponse, (res) => {
   if (!res?.data) {
@@ -593,38 +375,33 @@ watch(fetcherResponse, (res) => {
   }
 
   tableData.value = [...res.data]
-  total.value = paginationAttributes?.totalCount || res.total || res.data?.length || 0
-
-  // if using offset-based pagination, set the next offset
-  if (paginationAttributes?.offset) {
-    if (!res.pagination?.offset) {
-      nextOffset.value = null
-    } else {
-      nextOffset.value = res.pagination.offset
-
-      if (!offsets.value[page.value]) {
-        offsets.value.push(res.pagination.offset)
-      }
-    }
-
-    // look for hasNextPage in the response, otherwise default to true
-    hasNextPage.value = (res.pagination && 'hasNextPage' in res.pagination) ? res.pagination.hasNextPage || false : true
-  }
 
   // if the data is empty and the page is greater than 1,
   // e.g. user deletes the last item on the last page,
   // reset the page to 1
   if (tableData.value.length === 0 && page.value > 1) {
-    page.value = 1
-    offsets.value = [null]
-    offset.value = null
+    resetPagination()
   }
 
   // Call sortHandler if the initial sort has not been handled yet
   if (sortable && !initialSortHandled.value) {
-    sortHandler({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value }, false) // don't emit sort event when handling initial sort
+    onSort({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value }, false) // don't emit sort event when handling initial sort
   }
 }, { deep: true, immediate: true })
+
+watch(() => tablePreferences, (newVal) => {
+  pageSize.value = newVal?.pageSize ? newVal.pageSize : pageSize.value
+  tableViewColumnWidths.value = newVal?.columnWidths ? newVal.columnWidths : tableViewColumnWidths.value
+  tableViewColumnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : tableViewColumnVisibility.value
+  // Handle sorting if the sort preferences have changed
+  if ((newVal?.sortColumnKey || newVal?.sortColumnOrder) && (sortColumnKey.value !== newVal.sortColumnKey || sortColumnOrder.value !== newVal.sortColumnOrder)) {
+    onSort({
+      sortColumnKey: newVal.sortColumnKey!,
+      prevKey: sortColumnKey.value,
+      sortColumnOrder: newVal.sortColumnOrder!,
+    }, false) // don't emit sort event when updating from prop change
+  }
+})
 
 watch([stateData, tableState], (newState) => {
   const [newStateData, newTableState] = newState
@@ -644,24 +421,21 @@ watch(() => searchInput, (newSearchInput: string) => {
   }
 }, { immediate: true })
 
-watch([filterQuery, pageSize], async (newData, oldData) => {
-  const [oldQuery] = oldData
-  const [newQuery] = newData
-
+// Originally watching [filterQuery, pageSize], but page size plays no role in the
+// callback logic so removing this but keeping the comment here for context.
+// also removing the `async` since no corresponding `await` keyword is present.
+// removing `deep` since we are only watching a string value(primitive).
+watch(filterQuery, (oldQuery, newQuery) => {
   if (newQuery !== oldQuery && page.value !== 1) {
-    page.value = 1
-    offsets.value = [null]
-    offset.value = null
+    resetPagination()
   }
-}, { deep: true, immediate: true })
+}, { immediate: true })
 
 onMounted(() => {
   initData()
 })
 
 defineExpose({
-  revalidate: () => {
-    _revalidate()
-  },
+  revalidate: fetchRevalidate,
 })
 </script>

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -153,9 +153,8 @@
 </template>
 
 <script setup lang="ts" generic="const Header extends TableDataHeader = TableDataHeader, Data extends readonly Record<string, any>[] = readonly Record<string, any>[], Offset extends string | number = string | number">
-import { watch, computed, onMounted, reactive } from 'vue'
+import { watch, computed, reactive } from 'vue'
 import KTableView from '@/components/KTableView/KTableView.vue'
-import useUtilities from '@/composables/useUtilities'
 import { useTableData } from './useTableFetcher'
 import type {
   TablePreferences,
@@ -164,8 +163,6 @@ import type {
   TableColumnTooltipSlotName,
   ButtonAppearance,
   RowLink,
-  PageChangeData,
-  PageSizeChangeData,
   TableSortPayload,
   TableDataProps,
   TableColumnKey,
@@ -231,10 +228,6 @@ const emit = defineEmits<TableDataEmits<Header, Data>>()
 
 const slots = defineSlots<TableDataSlots<Header, Data>>()
 
-const { useDebounce } = useUtilities()
-
-// Cannot use `ref<Data[number][]>([])` as the items will be inferred incorrectly inside the template.
-// Same applies to other refs that have a generic type.
 const getEmptyStateButtonAppearance = computed((): ButtonAppearance => {
   if (emptyStateButtonAppearance) {
     return emptyStateButtonAppearance
@@ -252,33 +245,23 @@ const emitTablePreferences = (tableDataPreferences: TablePreferences): void => {
 const {
   tableHeaders,
   // data props
-  filterQuery,
-  response: fetcherResponse,
   revalidate: fetchRevalidate,
   isLoading: fetcherIsLoading,
   tableState,
   stateData,
   tableData,
-  initData,
 
   // sort props
-  sortColumnKey,
-  sortColumnOrder,
-  initialSortHandled,
   sortHandler,
   // pagination props
-  page,
-  pageSize,
-  offsets,
-  offset,
   showPagination,
   tablePaginationAttributes,
   toPreviousPageOffset,
   toNextPageOffset,
+  pageChangeHandler,
+  pageSizeChangeHandler,
 
   // preferences props
-  tableViewColumnVisibility,
-  tableViewColumnWidths,
   tableDataPreferences,
   tablePreferencesUpdateHandler,
 } = useTableData(
@@ -339,69 +322,17 @@ const cellSlots = computed((): ColumnKey[] => {
   return Object.keys(slots).filter(isTableColumnKey)
 })
 
-const { debouncedFn: debouncedSearch, generateDebouncedFn: generateDebouncedSearch } = useDebounce((q: string) => {
-  filterQuery.value = q
-}, 350)
-
-const search = generateDebouncedSearch(0) // generate a debounced function with zero delay (immediate)
-
 const sortEvtEmitter = (params: TableSortPayload<ColumnKey>) => {
   emit('sort', params)
 }
 
+// Bridges the component-level `shouldEmit` flag onto the composable's `sortEvtEmitter`
+// callback shape. The composable doesn't know about `emit`; it just calls whatever emitter
+// you hand it. We pass the emitter for user-driven sorts and skip it for synthetic sorts
+// (initial sort, preference sync) to avoid round-tripping back to the parent.
 const onSort = (sortPayload: TableSortPayload<ColumnKey>, shouldEmit: boolean = true) => {
   sortHandler(sortPayload, shouldEmit ? sortEvtEmitter : undefined)
 }
-
-
-const pageChangeHandler = ({ page: newPage }: PageChangeData) => {
-  page.value = newPage
-}
-
-const resetPagination = () => {
-  offsets.value = [null]
-  offset.value = null
-  page.value = 1
-}
-
-const pageSizeChangeHandler = ({ pageSize: newPageSize }: PageSizeChangeData) => {
-  resetPagination()
-  pageSize.value = newPageSize
-}
-
-watch(fetcherResponse, (res) => {
-  if (!res?.data) {
-    return
-  }
-
-  tableData.value = [...res.data]
-
-  // if the data is empty and the page is greater than 1,
-  // e.g. user deletes the last item on the last page,
-  // reset the page to 1
-  if (tableData.value.length === 0 && page.value > 1) {
-    resetPagination()
-  }
-
-  // Call sortHandler if the initial sort has not been handled yet
-  if (sortable && !initialSortHandled.value) {
-    onSort({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value }, false) // don't emit sort event when handling initial sort
-  }
-}, { deep: true, immediate: true })
-
-watch(() => tablePreferences, (newVal) => {
-  pageSize.value = newVal?.pageSize ? newVal.pageSize : pageSize.value
-  tableViewColumnWidths.value = newVal?.columnWidths ? newVal.columnWidths : tableViewColumnWidths.value
-  tableViewColumnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : tableViewColumnVisibility.value
-  // Handle sorting if the sort preferences have changed
-  if ((newVal?.sortColumnKey || newVal?.sortColumnOrder) && (sortColumnKey.value !== newVal.sortColumnKey || sortColumnOrder.value !== newVal.sortColumnOrder)) {
-    onSort({
-      sortColumnKey: newVal.sortColumnKey!,
-      prevKey: sortColumnKey.value,
-      sortColumnOrder: newVal.sortColumnOrder!,
-    }, false) // don't emit sort event when updating from prop change
-  }
-})
 
 watch([stateData, tableState], (newState) => {
   const [newStateData, newTableState] = newState
@@ -410,29 +341,6 @@ watch([stateData, tableState], (newState) => {
     state: newTableState,
     hasData: newStateData.hasData,
   })
-})
-
-// handles debounce of search query
-watch(() => searchInput, (newSearchInput: string) => {
-  if (newSearchInput === '') {
-    search(newSearchInput)
-  } else {
-    debouncedSearch(newSearchInput)
-  }
-}, { immediate: true })
-
-// Originally watching [filterQuery, pageSize], but page size plays no role in the
-// callback logic so removing this but keeping the comment here for context.
-// also removing the `async` since no corresponding `await` keyword is present.
-// removing `deep` since we are only watching a string value(primitive).
-watch(filterQuery, (newQuery, oldQuery) => {
-  if (newQuery !== oldQuery && page.value !== 1) {
-    resetPagination()
-  }
-}, { immediate: true })
-
-onMounted(() => {
-  initData()
 })
 
 defineExpose({

--- a/src/components/KTableData/KTableData.vue
+++ b/src/components/KTableData/KTableData.vue
@@ -425,7 +425,7 @@ watch(() => searchInput, (newSearchInput: string) => {
 // callback logic so removing this but keeping the comment here for context.
 // also removing the `async` since no corresponding `await` keyword is present.
 // removing `deep` since we are only watching a string value(primitive).
-watch(filterQuery, (oldQuery, newQuery) => {
+watch(filterQuery, (newQuery, oldQuery) => {
   if (newQuery !== oldQuery && page.value !== 1) {
     resetPagination()
   }

--- a/src/components/KTableData/useTableFetcher.ts
+++ b/src/components/KTableData/useTableFetcher.ts
@@ -1,0 +1,558 @@
+import { computed, ref, useId, toValue } from 'vue'
+import { getInitialPageSize, DEFAULT_PAGE_SIZE } from '@/utilities'
+import useUtilities from '@/composables/useUtilities'
+
+import type { ComputedRef, Ref, UnwrapRef, MaybeRefOrGetter } from 'vue'
+import type { TableDataProps, TableColumnKey, TableDataHeader, SortColumnOrder, TableState, TableSortPayload, TablePaginationAttributes, TableColumnVisibility, TableColumnWidths, TablePreferences } from '@/types/table'
+import type { SwrvStateData } from '@/types/swrv'
+
+export type TableDataRecord = ReadonlyArray<Record<string, any>>
+export type OffsetType = string | number
+
+/**
+ * Utility type that wraps all properties of an object type with MaybeRefOrGetter
+ */
+export type MaybeRefOrGetterProps<T> = {
+  [K in keyof T]: MaybeRefOrGetter<T[K]>
+}
+
+export type TableSortProps<
+  Header extends TableDataHeader,
+  Data extends TableDataRecord,
+  Offset extends OffsetType,
+> = MaybeRefOrGetterProps<Pick<
+  TableDataProps<Header, Data, Offset>,
+  | 'initialFetcherParams' | 'clientSort' | 'tablePreferences'
+  | 'paginationAttributes' | 'sortHandlerFunction' | 'sortable' | 'headers'
+>>
+
+export type SortParams<T extends TableDataHeader> = {
+  sortColumnKey: TableColumnKey<T>
+  sortColumnOrder: SortColumnOrder
+}
+
+const DEFAULT_SORT_ORDER: SortColumnOrder = 'desc'
+
+export const useTableSort = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
+  {
+    tablePreferences,
+    initialFetcherParams,
+    clientSort,
+    paginationAttributes,
+    sortHandlerFunction,
+  }: TableSortProps<Header, Data, Offset>,
+  {
+    tableHeaders,
+    page,
+    offsets,
+    tableData,
+    debouncedRevalidate,
+  }: {
+    tableHeaders: ComputedRef<readonly Header[]>
+    page: Ref<number>
+    offsets: Ref<Array<Offset | null>>
+    tableData: Ref<Array<Data[number]>>
+    debouncedRevalidate: () => void
+  },
+) => {
+
+  type ColumnKey = TableColumnKey<Header>
+
+  const sortColumnKey = ref(toValue(tablePreferences)?.sortColumnKey || toValue(initialFetcherParams)?.sortColumnKey || '') as Ref<ColumnKey>
+  const sortColumnOrder = ref(toValue(tablePreferences)?.sortColumnOrder || toValue(initialFetcherParams)?.sortColumnOrder || DEFAULT_SORT_ORDER) as Ref<SortColumnOrder>
+  const initialSortHandled = ref<boolean>(!(sortColumnKey.value && toValue(clientSort))) // For clientSort tables, if sortColumnKey is set, that means we need to handle initial sort
+  const sortParams = computed(() => ({
+    sortColumnKey: sortColumnKey.value,
+    sortColumnOrder: sortColumnOrder.value,
+  })) as Ref<SortParams<Header>>
+
+  const { clientSideSorter: defaultClientSideSorter } = useUtilities()
+
+  const sortHandler = ({ sortColumnKey: columnKey, prevKey, sortColumnOrder: sortOrder }: TableSortPayload<ColumnKey>, sortEvtEmitter?: (params: TableSortPayload<ColumnKey>) => void): void => {
+    initialSortHandled.value = true
+
+    const header = tableHeaders.value.find((header) => header.key === columnKey) || {} as UnwrapRef<typeof tableHeaders>[number]
+    const { useSortHandlerFunction } = header
+
+    sortEvtEmitter?.({
+      prevKey,
+      sortColumnKey: columnKey,
+      sortColumnOrder: sortOrder,
+    })
+
+    page.value = 1
+
+    if (!sortColumnKey.value || columnKey !== sortColumnKey.value) {
+      offsets.value = [null]
+    }
+
+    sortColumnKey.value = columnKey
+    sortColumnOrder.value = sortOrder as SortColumnOrder
+    const sortHandler = toValue(sortHandlerFunction)
+    if (toValue(clientSort)) {
+      if (useSortHandlerFunction && sortHandler) {
+        const sorted = sortHandler({
+          key: columnKey,
+          prevKey,
+          sortColumnOrder: sortColumnOrder.value,
+          data: tableData.value,
+        })
+
+        // As `sortHandlerFunction` was marked as returning an array but we didn't use the return value
+        // before, we can keep the old behavior when nothing is returned but use the returned value if it exists.
+        if (sorted) {
+          tableData.value = [...sorted]
+        }
+      } else {
+        defaultClientSideSorter(columnKey, prevKey, sortColumnOrder.value, tableData.value)
+      }
+    } else if (!toValue(paginationAttributes)?.offset) {
+      debouncedRevalidate()
+    }
+  }
+
+  return {
+    sortColumnKey,
+    sortColumnOrder,
+    sortParams,
+    initialSortHandled,
+
+    sortHandler,
+  }
+}
+
+export type TablePaginationProps<
+  Header extends TableDataHeader,
+  Data extends TableDataRecord,
+  Offset extends OffsetType,
+> = MaybeRefOrGetterProps<Pick<
+  TableDataProps<Header, Data, Offset>,
+  | 'fetcher' | 'paginationAttributes' | 'hidePaginationWhenOptional' | 'hidePagination' | 'tablePreferences'
+>>
+
+export const useTablePagination = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
+  props: TablePaginationProps<Header, Data, Offset>,
+  tableData: Ref<Array<Data[number]>>,
+  response: Ref<Awaited<ReturnType<TableDataProps<Header, Data, Offset>['fetcher']>>>,
+) => {
+  const page = ref<number>(1)
+  const pageSize = ref<number>(getInitialPageSize(toValue(props.tablePreferences) ?? {}, toValue(props.paginationAttributes) ?? {}))
+  const offset = ref(null) as Ref<Offset | null>
+  const offsets = ref([]) as Ref<Array<Offset | null>>
+  const hasNextPage = computed(() => {
+    const res = response.value
+    return (res?.pagination && 'hasNextPage' in res.pagination) ? res.pagination.hasNextPage || false : true
+  })
+
+  const previousOffset = computed((): Offset | null => offsets.value[page.value - 1] || null)
+  const nextOffset = computed(() => {
+    const res = response.value
+    const paginationAttrs = toValue(props.paginationAttributes)
+
+    if (paginationAttrs?.offset) {
+      if (!res?.pagination?.offset) {
+        return null
+      } else {
+        return res?.pagination.offset
+      }
+    }
+
+    return null
+  })
+
+  const total = computed(() => {
+    const res = response.value
+    const paginationAttrs = toValue(props.paginationAttributes)
+    return paginationAttrs?.totalCount || res?.total || res?.data?.length || 0
+  })
+
+  const showPagination = computed((): boolean => {
+    const fetcherValue = toValue(props.fetcher)
+    const hidePaginationValue = toValue(props.hidePagination)
+    const paginationAttrs = toValue(props.paginationAttributes)
+    const hidePaginationWhenOptionalValue = toValue(props.hidePaginationWhenOptional)
+
+    // if fetcher is not defined or hidePagination is true, don't show pagination
+    if (!fetcherValue || hidePaginationValue) {
+      return false
+    }
+
+    const minPageSize = paginationAttrs?.pageSizes?.[0] ?? DEFAULT_PAGE_SIZE
+
+    // this logic is built around min page size so that pagination doesn't disappear when a higher value is selected and hidePaginationWhenOptional is true
+    if (hidePaginationWhenOptionalValue && page.value === 1) {
+      if (!paginationAttrs?.offset) {
+        // if using cursor-based pagination, hide pagination when number of items is less than min page size
+        return total.value > minPageSize
+      } else {
+        // if using offset-based pagination, hide pagination when neither previous nor next offset is available and total items is less than min page size
+        return !!previousOffset.value || !!nextOffset.value || tableData.value.length >= minPageSize
+      }
+    }
+
+    return true
+  })
+
+  const tablePaginationAttributes = computed((): TablePaginationAttributes => ({
+    totalCount: total.value,
+    initialPageSize: pageSize.value,
+    currentPage: page.value,
+    offsetPreviousButtonDisabled: !previousOffset.value,
+    offsetNextButtonDisabled: !nextOffset.value || !hasNextPage.value,
+    ...toValue(props.paginationAttributes),
+  }))
+
+  const toNextPageOffset = () => {
+    page.value++
+    offset.value = nextOffset.value
+  }
+
+  const toPreviousPageOffset = () => {
+    page.value--
+    offset.value = previousOffset.value
+  }
+
+  return {
+    total,
+    page,
+    offset,
+    offsets,
+    nextOffset,
+    showPagination,
+    pageSize,
+    tablePaginationAttributes,
+    hasNextPage,
+
+    toNextPageOffset,
+    toPreviousPageOffset,
+  }
+}
+
+export type TablePreferencesProps<
+  Header extends TableDataHeader,
+  Data extends TableDataRecord,
+  Offset extends OffsetType,
+> = MaybeRefOrGetterProps<Pick<
+  TableDataProps<Header, Data, Offset>,
+  | 'tablePreferences'
+>>
+
+export const useTablePreferences = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
+  {
+    tablePreferences,
+  }: TablePreferencesProps<Header, Data, Offset>,
+  {
+    emitTablePreferences,
+    pageSize,
+    sortColumnKey,
+    sortColumnOrder,
+  }: {
+    emitTablePreferences: (tablePreferences: TablePreferences) => void
+  }
+  & Pick<ReturnType<typeof useTablePagination<Header, Data, Offset>>, 'pageSize'>
+  & Pick<ReturnType<typeof useTableSort<Header, Data, Offset>>, 'sortColumnKey' | 'sortColumnOrder'>,
+) => {
+  type ColumnKey = TableColumnKey<Header>
+  type ColumnVisibility = TableColumnVisibility<Header>
+  type ColumnWidths = TableColumnWidths<Header>
+
+  const tableViewColumnWidths = ref(toValue(tablePreferences)?.columnWidths || {}) as Ref<ColumnWidths>
+  const tableViewColumnVisibility = ref(toValue(tablePreferences)?.columnVisibility || {}) as Ref<ColumnVisibility>
+
+  const tablePreferencesUpdateHandler = ({ columnWidths: newColumnWidth, columnVisibility: newColumnVisibility }: TablePreferences<ColumnKey>) => {
+  // Update the column width and visibility overriding but keeping the existing properties (in case the new objects are empty)
+    tableViewColumnWidths.value = {
+      ...tableViewColumnWidths.value,
+      ...newColumnWidth,
+    }
+    tableViewColumnVisibility.value = {
+      ...tableViewColumnVisibility.value,
+      ...newColumnVisibility,
+    }
+
+    // Emit an event whenever one of the tablePreferences are updated
+    emitTablePreferences(tableDataPreferences.value)
+  }
+
+  const tableDataPreferences = computed<TablePreferences<Header['key']>>(() => ({
+    pageSize: pageSize.value,
+    sortColumnKey: sortColumnKey.value,
+    sortColumnOrder: sortColumnOrder.value,
+    ...(tableViewColumnWidths.value ? { columnWidths: tableViewColumnWidths.value } : {}),
+    ...(tableViewColumnVisibility.value ? { columnVisibility: tableViewColumnVisibility.value } : {}),
+  }))
+
+  return {
+    tablePreferencesUpdateHandler,
+    tableDataPreferences,
+
+    tableViewColumnVisibility,
+    tableViewColumnWidths,
+  }
+}
+
+export type TableCacheProps<
+  Header extends TableDataHeader,
+  Data extends TableDataRecord,
+  Offset extends OffsetType,
+> = Pick<
+  TableDataProps<Header, Data, Offset>,
+  | 'searchInput' | 'cacheIdentifier' | 'fetcherCacheKey'
+>
+
+export type TableFetcherProps<
+  Header extends TableDataHeader,
+  Data extends TableDataRecord,
+  Offset extends OffsetType,
+> = MaybeRefOrGetterProps<TableDataProps<Header, Data, Offset>>
+
+export const useTableData = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
+  {
+    headers,
+    sortable,
+    searchInput,
+    fetcher,
+    cacheIdentifier,
+    fetcherCacheKey,
+    clientSort,
+    paginationAttributes,
+    sortHandlerFunction,
+    initialFetcherParams,
+    tablePreferences,
+    hidePagination,
+    hidePaginationWhenOptional,
+  }: TableFetcherProps<Header, Data, Offset>,
+  handlers: {
+    emitTablePreferences: (tablePreferences: TablePreferences) => void
+  },
+) => {
+  const { useSwrvState, useDebounce, useRequest, clientSideSorter: defaultClientSideSorter } = useUtilities()
+  const tableHeaders = computed(() => {
+    const headersVal = toValue(headers) ?? []
+    return toValue(sortable) ? headersVal : headersVal.map((header) => ({ ...header, sortable: false }))
+  })
+
+  const hasInitialized = ref(false)
+  const tableId = useId()
+
+  const filterQuery = ref(toValue(searchInput) ?? '')
+  const isInitialFetch = ref(false)
+  // Cannot use `ref<Data[number][]>([])` as the items will be inferred incorrectly inside the template.
+  const tableData = ref<Array<Data[number]>>([]) as Ref<Array<Data[number]>>
+
+  // once initData() finishes, setting tableFetcherCacheKey to non-falsey value triggers fetch of data
+  const tableFetcherCacheKey = computed((): string => {
+    if (!toValue(fetcher) || !hasInitialized.value) {
+      return ''
+    }
+
+    // Set the default identifier to a random string
+    let identifierKey: string = tableId
+    if (toValue(cacheIdentifier)) {
+      identifierKey = toValue(cacheIdentifier)!
+    }
+
+    identifierKey += `-${JSON.stringify(cacheKeyParams.value)}`
+
+    if (toValue(fetcherCacheKey)) {
+      identifierKey += `-${toValue(fetcherCacheKey)}`
+    }
+
+    return `k-table_${identifierKey}`
+  })
+
+  // ALL fetching is done through this useRequest / _revalidate
+  // don't fire until tableFetcherCacheKey is set
+  const fetchData = async () => {
+    const res = await toValue(fetcher)!(toValue(fetcherParams))
+
+    isInitialFetch.value = false
+
+    return res
+  }
+
+  const {
+    data,
+    response,
+    error,
+    revalidate,
+    isValidating,
+    isLoading,
+  } = useRequest(
+    () => tableFetcherCacheKey.value,
+    () => fetchData(),
+    { revalidateOnFocus: false, revalidateDebounce: 0 },
+  )
+
+  const {
+    page,
+    offset,
+    offsets,
+    pageSize,
+    showPagination,
+    tablePaginationAttributes,
+
+    toNextPageOffset,
+    toPreviousPageOffset,
+  } = useTablePagination({
+    fetcher: fetcher,
+    paginationAttributes: paginationAttributes,
+    hidePaginationWhenOptional: hidePaginationWhenOptional,
+    hidePagination: hidePagination,
+    tablePreferences: tablePreferences,
+  }, tableData, response)
+
+  const { state, hasData } = useSwrvState(data, error, isValidating)
+  const stateData = computed((): SwrvStateData => ({
+    hasData: hasData.value,
+    state: state.value,
+  }))
+
+  const tableState = computed((): TableState => isLoading.value ? 'loading' : error.value ? 'error' : 'success')
+  const { debouncedFn: debouncedRevalidate } = useDebounce(revalidate, 500)
+
+  const {
+    sortColumnKey,
+    sortColumnOrder,
+    sortParams,
+    initialSortHandled,
+
+    sortHandler,
+  } = useTableSort({
+    initialFetcherParams,
+    clientSort,
+    tablePreferences,
+    paginationAttributes,
+    sortHandlerFunction,
+    sortable,
+    headers,
+  }, {
+    tableHeaders,
+    page,
+    offsets,
+    tableData,
+    debouncedRevalidate,
+  })
+
+  const {
+    tablePreferencesUpdateHandler,
+    tableDataPreferences,
+    tableViewColumnVisibility,
+    tableViewColumnWidths,
+  } = useTablePreferences({
+    tablePreferences,
+  }, { emitTablePreferences: handlers.emitTablePreferences, pageSize, sortColumnKey, sortColumnOrder })
+
+  // Params that are used in the cache key for the fetcher.
+  // For client-side sorting, we don't need to include the sort params in the cache key otherwise the cache key will change on every sort,
+  // which will cause the table to re-fetch data on every sort even though we don't need to fetch new data.
+  const cacheKeyParams = computed(() => ({
+    pageSize: pageSize.value,
+    page: page.value,
+    query: filterQuery.value,
+    offset: offset.value,
+    ...(toValue(clientSort) ? {} : sortParams.value),
+  }))
+
+  // We still need all params for the fetcher
+  const fetcherParams = computed(() => ({
+    ...cacheKeyParams.value,
+    ...sortParams.value,
+  }))
+
+  const defaultFetcherProps = {
+    pageSize: pageSize.value,
+    page: page.value,
+    query: filterQuery.value,
+    sortColumnKey: sortColumnKey.value,
+    sortColumnOrder: sortColumnOrder.value,
+    offset: offset.value,
+  }
+
+  /**
+   * Initialize the table with the initial data
+   */
+  const initData = () => {
+    const fetcherParams = {
+      ...defaultFetcherProps,
+      ...(toValue(initialFetcherParams) ?? {}),
+    }
+    // don't allow overriding default settings with undefined values
+    page.value = fetcherParams.page ?? defaultFetcherProps.page
+    pageSize.value = fetcherParams.pageSize ?? defaultFetcherProps.pageSize
+    filterQuery.value = fetcherParams.query ?? defaultFetcherProps.query
+    sortColumnKey.value = fetcherParams.sortColumnKey ?? defaultFetcherProps.sortColumnKey
+    sortColumnOrder.value = fetcherParams.sortColumnOrder ?? defaultFetcherProps.sortColumnOrder
+
+    if (toValue(clientSort) && sortColumnKey.value && sortColumnOrder.value) {
+      const header = tableHeaders.value.find((header) => header.key === sortColumnKey.value) || {} as UnwrapRef<typeof tableHeaders>[number]
+      const { useSortHandlerFunction } = header
+
+      const sortHandler = toValue(sortHandlerFunction)
+      // If a custom sort function is provided, use it. Otherwise, use the default client-side sorter.
+      if (useSortHandlerFunction && sortHandler) {
+        const sorted = sortHandler({
+          key: sortColumnKey.value,
+          prevKey: '',
+          sortColumnOrder: sortColumnOrder.value,
+          data: tableData.value,
+        })
+
+        if (sorted) {
+          tableData.value = [...sorted]
+        }
+      } else {
+        defaultClientSideSorter(sortColumnKey.value, '', sortColumnOrder.value, tableData.value)
+      }
+    }
+
+    if (toValue(paginationAttributes)?.offset) {
+      offset.value = fetcherParams.offset
+      offsets.value.push(fetcherParams.offset)
+    }
+
+    // trigger setting of tableFetcherCacheKey
+    hasInitialized.value = true
+  }
+
+
+  return {
+    tableHeaders,
+
+    // data props
+    filterQuery,
+    data,
+    response,
+    error,
+    isValidating,
+    isLoading,
+    tableState,
+    stateData,
+    tableData,
+    revalidate,
+    initData,
+    debouncedRevalidate,
+
+    // sort props
+    sortColumnKey,
+    sortColumnOrder,
+    sortParams,
+    initialSortHandled,
+    sortHandler,
+    // pagination props
+    page,
+    pageSize,
+    offsets,
+    offset,
+    showPagination,
+    tablePaginationAttributes,
+    toPreviousPageOffset,
+    toNextPageOffset,
+
+    // preferences props
+    tableViewColumnVisibility,
+    tableViewColumnWidths,
+    tableDataPreferences,
+    tablePreferencesUpdateHandler,
+  }
+}

--- a/src/components/KTableData/useTableFetcher.ts
+++ b/src/components/KTableData/useTableFetcher.ts
@@ -1,4 +1,14 @@
-import { computed, ref, useId, toValue, watch } from 'vue'
+/**
+ * Composables that back KTableData.vue.
+ *
+ * - `useTableSort`, `useTablePagination`, `useTablePreferences` are internal building blocks,
+ *   each owning a coherent slice of state. They are not (currently) used independently — they
+ *   are split out so each one's inputs and outputs are explicit and the file reads as a set of
+ *   small, single-purpose pieces.
+ * - `useTableData` is the public entry point KTableData consumes. It wires the three sub-composables
+ *   together, manages the swrv cache key, and gates fetching behind `hasInitialized`.
+ */
+import { computed, ref, useId, toValue, watch, onMounted } from 'vue'
 import { getInitialPageSize, DEFAULT_PAGE_SIZE } from '@/utilities'
 import useUtilities from '@/composables/useUtilities'
 
@@ -33,6 +43,12 @@ export type SortParams<T extends TableDataHeader> = {
 
 const DEFAULT_SORT_ORDER: SortColumnOrder = 'desc'
 
+/**
+ * Owns sort state (column key + order) and chooses between client-side and server-side
+ * sort paths. `initialSortHandled` exists so client-sort tables can defer their first
+ * sort until the initial response arrives — at composable construction `tableData` is
+ * empty, so there's nothing to sort yet.
+ */
 export const useTableSort = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
   {
     tablePreferences,
@@ -60,7 +76,11 @@ export const useTableSort = <Header extends TableDataHeader, Data extends TableD
 
   const sortColumnKey = ref(toValue(tablePreferences)?.sortColumnKey || toValue(initialFetcherParams)?.sortColumnKey || '') as Ref<ColumnKey>
   const sortColumnOrder = ref(toValue(tablePreferences)?.sortColumnOrder || toValue(initialFetcherParams)?.sortColumnOrder || DEFAULT_SORT_ORDER) as Ref<SortColumnOrder>
-  const initialSortHandled = ref<boolean>(!(sortColumnKey.value && toValue(clientSort))) // For clientSort tables, if sortColumnKey is set, that means we need to handle initial sort
+  // Starts `true` for the common case (no preset sort key, OR server-sort table where the
+  // server already applied the initial sort). Flips to `false` only when client-sort is on
+  // AND a sort key is preset — in that case the consumer's response watcher must run the
+  // first sort against the freshly-arrived data and then set this back to true.
+  const initialSortHandled = ref<boolean>(!(sortColumnKey.value && toValue(clientSort)))
   const sortParams = computed(() => ({
     sortColumnKey: sortColumnKey.value,
     sortColumnOrder: sortColumnOrder.value,
@@ -68,6 +88,19 @@ export const useTableSort = <Header extends TableDataHeader, Data extends TableD
 
   const { clientSideSorter: defaultClientSideSorter } = useUtilities()
 
+  /**
+   * Branches on (clientSort × custom-sort-handler × pagination-style):
+   *   1. Always reset page to 1 and clear `offsets` if the column actually changed —
+   *      cursor offsets are column-scoped on the server and meaningless under a new sort.
+   *   2. clientSort + header opts in via `useSortHandlerFunction` + caller passed
+   *      `sortHandlerFunction` → call user fn; accept either in-place mutation or a
+   *      returned array (see legacy-compat note below).
+   *   3. clientSort without a custom fn → `defaultClientSideSorter` mutates `tableData` in place.
+   *   4. server-sort:
+   *        - cursor pagination → bail. We can't refetch without a cursor; the consumer must
+   *          let pagination round-trip back to page 1 first.
+   *        - offset/page pagination → `debouncedRevalidate()` to refetch page 1 with new sort.
+   */
   const sortHandler = ({ sortColumnKey: columnKey, prevKey, sortColumnOrder: sortOrder }: TableSortPayload<ColumnKey>, sortEvtEmitter?: (params: TableSortPayload<ColumnKey>) => void): void => {
     initialSortHandled.value = true
 
@@ -130,6 +163,18 @@ export type TablePaginationProps<
   | 'fetcher' | 'paginationAttributes' | 'hidePaginationWhenOptional' | 'hidePagination' | 'tablePreferences'
 >>
 
+/**
+ * Owns pagination state. Supports two pagination styles, selected by
+ * `paginationAttributes.offset` (boolean):
+ *
+ *   - cursor-based (default, when `offset` is falsy): `page` is just a counter. The fetcher
+ *     decides hasNextPage/hasPreviousPage; we don't track cursors.
+ *   - offset-based (when `offset` is truthy): we maintain `offsets` as a *cursor history*.
+ *     `offsets[i]` is the cursor that was used to fetch page `i`, with `offsets[0] = null`
+ *     meaning "first page, no cursor." This indexing convention is load-bearing — see the
+ *     `watch(response)` block below; commit `e5a4258b6` fixed an off-by-one that broke
+ *     backward navigation past page 2 specifically because of it.
+ */
 export const useTablePagination = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
   props: TablePaginationProps<Header, Data, Offset>,
   tableData: Ref<Array<Data[number]>>,
@@ -160,32 +205,45 @@ export const useTablePagination = <Header extends TableDataHeader, Data extends 
     return null
   })
 
+  // Three fallbacks, in priority order:
+  //   1. `paginationAttributes.totalCount` — caller knows the count out-of-band.
+  //   2. `response.total` — fetcher reported it.
+  //   3. `response.data.length` — degrade to "at least the visible rows" so cursor APIs that
+  //      don't return a count still render a sensible "showing N of N" rather than "N of 0".
   const total = computed(() => {
     const res = response.value
     const paginationAttrs = toValue(props.paginationAttributes)
     return paginationAttrs?.totalCount || res?.total || res?.data?.length || 0
   })
 
+  // Three exit conditions, in priority order:
+  //   1. No fetcher, or `hidePagination` explicit → never show.
+  //   2. `hidePaginationWhenOptional` + page 1 + cursor pagination → only show if total exceeds
+  //      the smallest configured page size.
+  //   3. `hidePaginationWhenOptional` + page 1 + offset pagination → show if either neighbor
+  //      cursor exists, or the current page is at least full. (We can't trust `total` here:
+  //      cursor APIs commonly omit a count, so we fall back to "did we get a full page?")
+  //
+  // The min-page-size anchor is intentional: pagination must NOT disappear when the user
+  // *chooses* a larger page size for a list that has more rows than the smallest size but
+  // fewer than the chosen size. Anchoring to `pageSizes[0]` keeps the control visible as
+  // soon as the row count justifies any pagination at all.
   const showPagination = computed((): boolean => {
     const fetcherValue = toValue(props.fetcher)
     const hidePaginationValue = toValue(props.hidePagination)
     const paginationAttrs = toValue(props.paginationAttributes)
     const hidePaginationWhenOptionalValue = toValue(props.hidePaginationWhenOptional)
 
-    // if fetcher is not defined or hidePagination is true, don't show pagination
     if (!fetcherValue || hidePaginationValue) {
       return false
     }
 
     const minPageSize = paginationAttrs?.pageSizes?.[0] ?? DEFAULT_PAGE_SIZE
 
-    // this logic is built around min page size so that pagination doesn't disappear when a higher value is selected and hidePaginationWhenOptional is true
     if (hidePaginationWhenOptionalValue && page.value === 1) {
       if (!paginationAttrs?.offset) {
-        // if using cursor-based pagination, hide pagination when number of items is less than min page size
         return total.value > minPageSize
       } else {
-        // if using offset-based pagination, hide pagination when neither previous nor next offset is available and total items is less than min page size
         return !!previousOffset.value || !!nextOffset.value || tableData.value.length >= minPageSize
       }
     }
@@ -212,6 +270,38 @@ export const useTablePagination = <Header extends TableDataHeader, Data extends 
     offset.value = previousOffset.value
   }
 
+  // Resets all three pagination refs to first-page state. Called from several places
+  // (pageSize change, search query change, empty-page-after-delete) — centralized here so
+  // the "back to page 1" semantics stay consistent.
+  const resetPagination = () => {
+    offsets.value = [null]
+    offset.value = null
+    page.value = 1
+  }
+
+  const pageChangeHandler = ({ page: newPage }: { page: number }) => {
+    page.value = newPage
+  }
+
+  const pageSizeChangeHandler = ({ pageSize: newPageSize }: { pageSize: number }) => {
+    resetPagination()
+    pageSize.value = newPageSize
+  }
+
+  // ⚠️ Regression-prone — both `bd2b2a77c` and `e5a4258b6` patched this block. Read carefully
+  // before changing.
+  //
+  //   - The early return guards cursor-style pagination: those tables don't use the `offsets`
+  //     history at all (they read `pagination.hasNextPage` from each response instead).
+  //   - We `push` rather than assign to `offsets[page.value]` because each new response
+  //     represents the *next* page that was just fetched — we extend the history forward.
+  //   - The check is `!offsets.value[page.value]`, NOT `[page.value - 1]`. Following the
+  //     indexing convention from `useTablePagination`'s docblock (`offsets[i]` = cursor used
+  //     to fetch page `i`, with `offsets[0] = null` for the seeded first page), the cursor
+  //     for the page that just arrived lives at index `page.value`. When the user navigates
+  //     *backward*, the response watcher fires again but `offsets[page.value]` is already
+  //     filled — pushing again would corrupt the history. Off-by-one here breaks any
+  //     backward navigation past page 2 (this was the e5a4258b6 fix).
   watch(response, (newResponse) => {
     const paginationAttrs = toValue(props.paginationAttributes)
     if (!paginationAttrs?.offset) return
@@ -236,6 +326,9 @@ export const useTablePagination = <Header extends TableDataHeader, Data extends 
 
     toNextPageOffset,
     toPreviousPageOffset,
+    resetPagination,
+    pageChangeHandler,
+    pageSizeChangeHandler,
   }
 }
 
@@ -270,8 +363,11 @@ export const useTablePreferences = <Header extends TableDataHeader, Data extends
   const tableViewColumnWidths = ref(toValue(tablePreferences)?.columnWidths || {}) as Ref<ColumnWidths>
   const tableViewColumnVisibility = ref(toValue(tablePreferences)?.columnVisibility || {}) as Ref<ColumnVisibility>
 
+  // The spread-merge (`{...existing, ...new}`) is intentional and load-bearing: callers may
+  // emit a *partial* preferences object (e.g. just the column they resized) and we must not
+  // wipe other columns' state. Easy to "simplify" into a plain assignment and silently drop
+  // every other column's width/visibility.
   const tablePreferencesUpdateHandler = ({ columnWidths: newColumnWidth, columnVisibility: newColumnVisibility }: TablePreferences<ColumnKey>) => {
-  // Update the column width and visibility overriding but keeping the existing properties (in case the new objects are empty)
     tableViewColumnWidths.value = {
       ...tableViewColumnWidths.value,
       ...newColumnWidth,
@@ -281,7 +377,6 @@ export const useTablePreferences = <Header extends TableDataHeader, Data extends
       ...newColumnVisibility,
     }
 
-    // Emit an event whenever one of the tablePreferences are updated
     emitTablePreferences(tableDataPreferences.value)
   }
 
@@ -317,6 +412,14 @@ export type TableFetcherProps<
   Offset extends OffsetType,
 > = MaybeRefOrGetterProps<TableDataProps<Header, Data, Offset>>
 
+/**
+ * Orchestrator. Wires the three sub-composables together, owns the swrv-backed `useRequest`,
+ * and gates fetching behind `hasInitialized` so we don't fire one fetch with default params
+ * and a second fetch immediately after `initData()` populates the real ones.
+ *
+ * Public surface (returned object) is consumed by KTableData.vue's template; everything
+ * else here is internal coordination.
+ */
 export const useTableData = <Header extends TableDataHeader, Data extends TableDataRecord, Offset extends OffsetType>(
   {
     headers,
@@ -343,21 +446,37 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     return toValue(sortable) ? headersVal : headersVal.map((header) => ({ ...header, sortable: false }))
   })
 
+  // Fetch gate. `tableFetcherCacheKey` returns '' (which suppresses `useRequest`) until this
+  // flips to true at the end of `initData()`. Without the gate, swrv would fire one fetch
+  // with the constructor-time defaults and a second fetch right after `initData()` overwrites
+  // page/pageSize/sort/etc — wasted requests and a flicker.
   const hasInitialized = ref(false)
   const tableId = useId()
 
   const filterQuery = ref(toValue(searchInput) ?? '')
+  // ⚠️ Default must be `true`. The flag distinguishes "never fetched" from "between fetches"
+  // and flips to `false` after the first `fetchData()` resolves. The original extraction
+  // defaulted to `false` and broke that distinction (fixed in `bd2b2a77c`).
   const isInitialFetch = ref(true)
   // Cannot use `ref<Data[number][]>([])` as the items will be inferred incorrectly inside the template.
   const tableData = ref<Array<Data[number]>>([]) as Ref<Array<Data[number]>>
 
-  // once initData() finishes, setting tableFetcherCacheKey to non-falsey value triggers fetch of data
+  // The swrv cache key. Two roles in one value:
+  //   1. Empty string is a sentinel — `useRequest` does not fire when the key is falsy. We
+  //      return '' until `initData()` flips `hasInitialized` (see fetch-gate comment above).
+  //   2. When non-empty, the key is composed of three parts so distinct table instances on
+  //      the same page don't share a swrv cache entry:
+  //        - identifier   : caller-supplied `cacheIdentifier`, or a random `tableId` so
+  //                         unidentified tables are still isolated from each other
+  //        - params JSON  : serialized `cacheKeyParams` (note: omits sort for client-sort
+  //                         tables — see `cacheKeyParams` vs `fetcherParams` below)
+  //        - extra suffix : optional `fetcherCacheKey` lets callers force a refetch by
+  //                         changing it (e.g. when an out-of-band create/delete happens)
   const tableFetcherCacheKey = computed((): string => {
     if (!toValue(fetcher) || !hasInitialized.value) {
       return ''
     }
 
-    // Set the default identifier to a random string
     let identifierKey: string = tableId
     if (toValue(cacheIdentifier)) {
       identifierKey = toValue(cacheIdentifier)!
@@ -372,8 +491,9 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     return `k-table_${identifierKey}`
   })
 
-  // ALL fetching is done through this useRequest / _revalidate
-  // don't fire until tableFetcherCacheKey is set
+  // Single fetch entry point. Every refetch — whether triggered by a key change, a manual
+  // `revalidate()`, or `debouncedRevalidate()` — funnels through here, which keeps the
+  // `isInitialFetch` flag and the fetcher invocation in lockstep.
   const fetchData = async () => {
     const res = await toValue(fetcher)!(toValue(fetcherParams))
 
@@ -405,6 +525,9 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
 
     toNextPageOffset,
     toPreviousPageOffset,
+    resetPagination,
+    pageChangeHandler,
+    pageSizeChangeHandler,
   } = useTablePagination({
     fetcher: fetcher,
     paginationAttributes: paginationAttributes,
@@ -454,9 +577,15 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     tablePreferences,
   }, { emitTablePreferences: handlers.emitTablePreferences, pageSize, sortColumnKey, sortColumnOrder })
 
-  // Params that are used in the cache key for the fetcher.
-  // For client-side sorting, we don't need to include the sort params in the cache key otherwise the cache key will change on every sort,
-  // which will cause the table to re-fetch data on every sort even though we don't need to fetch new data.
+  // Asymmetric on purpose — this is a correctness/perf split:
+  //
+  //   - `fetcherParams` ALWAYS contains sort params. The fetcher needs them: even a
+  //     client-sort table may pre-sort on the server for the *initial* page, and a
+  //     server-sort table needs them for every request.
+  //   - `cacheKeyParams` OMITS sort params under client-sort. The wire response is the same
+  //     regardless of sort order under client-sort, so including the sort key in the cache
+  //     key would cause every header click to invalidate the cache and refetch identical
+  //     data — visible as a loading flicker on every sort.
   const cacheKeyParams = computed(() => ({
     pageSize: pageSize.value,
     page: page.value,
@@ -465,7 +594,6 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     ...(toValue(clientSort) ? {} : sortParams.value),
   }))
 
-  // We still need all params for the fetcher
   const fetcherParams = computed(() => ({
     ...cacheKeyParams.value,
     ...sortParams.value,
@@ -481,7 +609,21 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
   }
 
   /**
-   * Initialize the table with the initial data
+   * One-shot initialization, called by the consumer in `onMounted`. Executes in this order:
+   *
+   *   1. Merge `defaultFetcherProps` with `initialFetcherParams`. The `??` fallbacks below
+   *      treat `undefined` in the merged params as "use default" — a caller passing
+   *      `{ page: undefined }` should not blank out the page.
+   *   2. If client-sort + an initial sort key is set, run the sort *now* against
+   *      `tableData.value`. At this exact moment `tableData` is empty for the typical
+   *      fetcher-driven flow — this branch is defensive for callers that pre-seed the
+   *      array (some consumers populate it from a different source before mount).
+   *   3. If offset-pagination, seed `offset` and push it as `offsets[0]`. This matches
+   *      the indexing convention documented on `useTablePagination` — `offsets[i]` is the
+   *      cursor for page `i`, and the response watcher relies on `offsets[0]` already
+   *      being populated when the first response arrives.
+   *   4. Flip `hasInitialized` last. This is the gate release — `tableFetcherCacheKey`
+   *      goes non-empty and `useRequest` fires the first fetch.
    */
   const initData = () => {
     const fetcherParams = {
@@ -526,6 +668,77 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     hasInitialized.value = true
   }
 
+  // Bridges the consumer's `searchInput` prop into `filterQuery`. Two debounce instances:
+  //   - `search` (zero delay) — used when the user clears the input. Clearing should feel
+  //     instant; debouncing a clear leaves stale results on screen.
+  //   - `debouncedSearch` (350ms) — used while the user is typing. Avoids one fetch per
+  //     keystroke.
+  const { debouncedFn: debouncedSearch, generateDebouncedFn: generateDebouncedSearch } = useDebounce((q: string) => {
+    filterQuery.value = q
+  }, 350)
+  const search = generateDebouncedSearch(0)
+
+  watch(() => toValue(searchInput) ?? '', (newSearchInput) => {
+    if (newSearchInput === '') {
+      search(newSearchInput)
+    } else {
+      debouncedSearch(newSearchInput)
+    }
+  }, { immediate: true })
+
+  // Search-query change must reset to page 1 — page-N can be empty under a new query, and
+  // cursor offsets from the previous query are meaningless.
+  watch(filterQuery, (newQuery, oldQuery) => {
+    if (newQuery !== oldQuery && page.value !== 1) {
+      resetPagination()
+    }
+  }, { immediate: true })
+
+  // Response → tableData bridge. Three responsibilities, in order:
+  //   1. Copy `response.data` into `tableData` (the template binds to `tableData`, not
+  //      `response`, so client-sort can mutate it without round-tripping).
+  //   2. If we landed on an empty page > 1 (e.g. user just deleted the last row of the
+  //      last page), step back to page 1.
+  //   3. Fire the deferred initial sort for client-sort tables — see `initialSortHandled`
+  //      docblock above. We pass no event emitter since this is a synthetic, internal sort.
+  watch(response, (res) => {
+    if (!res?.data) {
+      return
+    }
+
+    tableData.value = [...res.data]
+
+    if (tableData.value.length === 0 && page.value > 1) {
+      resetPagination()
+    }
+
+    if (toValue(sortable) && !initialSortHandled.value) {
+      sortHandler({ sortColumnKey: sortColumnKey.value, prevKey: '', sortColumnOrder: sortColumnOrder.value })
+    }
+  }, { deep: true, immediate: true })
+
+  // Sync external `tablePreferences` prop changes back into local state. Each branch is
+  // truthy-guarded so partial preference objects don't blank out the unmentioned slots.
+  // The sort branch fires `sortHandler` directly (no emitter) because this is a state
+  // sync, not a user-driven sort event — we don't want to round-trip a `sort` event back
+  // out to the parent.
+  watch(() => toValue(tablePreferences), (newVal) => {
+    pageSize.value = newVal?.pageSize ? newVal.pageSize : pageSize.value
+    tableViewColumnWidths.value = newVal?.columnWidths ? newVal.columnWidths : tableViewColumnWidths.value
+    tableViewColumnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : tableViewColumnVisibility.value
+    if ((newVal?.sortColumnKey || newVal?.sortColumnOrder) && (sortColumnKey.value !== newVal.sortColumnKey || sortColumnOrder.value !== newVal.sortColumnOrder)) {
+      sortHandler({
+        sortColumnKey: newVal.sortColumnKey!,
+        prevKey: sortColumnKey.value,
+        sortColumnOrder: newVal.sortColumnOrder!,
+      })
+    }
+  })
+
+  onMounted(() => {
+    initData()
+  })
+
 
   return {
     tableHeaders,
@@ -559,6 +772,9 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     tablePaginationAttributes,
     toPreviousPageOffset,
     toNextPageOffset,
+    resetPagination,
+    pageChangeHandler,
+    pageSizeChangeHandler,
 
     // preferences props
     tableViewColumnVisibility,

--- a/src/components/KTableData/useTableFetcher.ts
+++ b/src/components/KTableData/useTableFetcher.ts
@@ -1,4 +1,4 @@
-import { computed, ref, useId, toValue } from 'vue'
+import { computed, ref, useId, toValue, watch } from 'vue'
 import { getInitialPageSize, DEFAULT_PAGE_SIZE } from '@/utilities'
 import useUtilities from '@/composables/useUtilities'
 
@@ -212,6 +212,14 @@ export const useTablePagination = <Header extends TableDataHeader, Data extends 
     offset.value = previousOffset.value
   }
 
+  watch(response, (newResponse) => {
+    const { offset = null } = newResponse?.pagination || {}
+
+    if (!offsets.value[page.value - 1]) {
+      offsets.value.push(offset)
+    }
+  })
+
   return {
     total,
     page,
@@ -336,7 +344,7 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
   const tableId = useId()
 
   const filterQuery = ref(toValue(searchInput) ?? '')
-  const isInitialFetch = ref(false)
+  const isInitialFetch = ref(true)
   // Cannot use `ref<Data[number][]>([])` as the items will be inferred incorrectly inside the template.
   const tableData = ref<Array<Data[number]>>([]) as Ref<Array<Data[number]>>
 

--- a/src/components/KTableData/useTableFetcher.ts
+++ b/src/components/KTableData/useTableFetcher.ts
@@ -213,9 +213,12 @@ export const useTablePagination = <Header extends TableDataHeader, Data extends 
   }
 
   watch(response, (newResponse) => {
+    const paginationAttrs = toValue(props.paginationAttributes)
+    if (!paginationAttrs?.offset) return
+
     const { offset = null } = newResponse?.pagination || {}
 
-    if (!offsets.value[page.value - 1]) {
+    if (!offsets.value[page.value]) {
       offsets.value.push(offset)
     }
   })

--- a/src/components/KTableData/useTableFetcher.ts
+++ b/src/components/KTableData/useTableFetcher.ts
@@ -189,16 +189,17 @@ export const useTablePagination = <Header extends TableDataHeader, Data extends 
     return (res?.pagination && 'hasNextPage' in res.pagination) ? res.pagination.hasNextPage || false : true
   })
 
-  const previousOffset = computed((): Offset | null => offsets.value[page.value - 1] || null)
+  const previousOffset = computed((): Offset | null => offsets.value[page.value - 1] ?? null)
   const nextOffset = computed(() => {
     const res = response.value
     const paginationAttrs = toValue(props.paginationAttributes)
 
     if (paginationAttrs?.offset) {
-      if (!res?.pagination?.offset) {
+      // Nullish (not falsy) — `Offset` permits `number`, so `0` is a valid cursor.
+      if (res?.pagination?.offset == null) {
         return null
       } else {
-        return res?.pagination.offset
+        return res.pagination.offset
       }
     }
 
@@ -609,7 +610,11 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
   }
 
   /**
-   * One-shot initialization, called by the consumer in `onMounted`. Executes in this order:
+   * One-shot initialization. Run automatically by `useTableData`'s own `onMounted`
+   * (see below) — consumers do *not* need to call this in their own `onMounted` and
+   * doing so would double-init. It's still exposed on the return value so callers
+   * that pre-seed `tableData` from a non-fetcher source can re-trigger init manually.
+   * Executes in this order:
    *
    *   1. Merge `defaultFetcherProps` with `initialFetcherParams`. The `??` fallbacks below
    *      treat `undefined` in the merged params as "use default" — a caller passing
@@ -660,8 +665,9 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     }
 
     if (toValue(paginationAttributes)?.offset) {
-      offset.value = fetcherParams.offset
-      offsets.value.push(fetcherParams.offset)
+      const resolvedOffset = fetcherParams.offset ?? defaultFetcherProps.offset
+      offset.value = resolvedOffset
+      offsets.value.push(resolvedOffset)
     }
 
     // trigger setting of tableFetcherCacheKey
@@ -726,12 +732,18 @@ export const useTableData = <Header extends TableDataHeader, Data extends TableD
     pageSize.value = newVal?.pageSize ? newVal.pageSize : pageSize.value
     tableViewColumnWidths.value = newVal?.columnWidths ? newVal.columnWidths : tableViewColumnWidths.value
     tableViewColumnVisibility.value = newVal?.columnVisibility ? newVal.columnVisibility : tableViewColumnVisibility.value
-    if ((newVal?.sortColumnKey || newVal?.sortColumnOrder) && (sortColumnKey.value !== newVal.sortColumnKey || sortColumnOrder.value !== newVal.sortColumnOrder)) {
-      sortHandler({
-        sortColumnKey: newVal.sortColumnKey!,
-        prevKey: sortColumnKey.value,
-        sortColumnOrder: newVal.sortColumnOrder!,
-      })
+    if (newVal?.sortColumnKey || newVal?.sortColumnOrder) {
+      // Fall back to current local state for whichever slot the parent didn't set —
+      // a partial update like `{ sortColumnOrder: 'desc' }` must not blank out the key.
+      const nextKey = newVal.sortColumnKey ?? sortColumnKey.value
+      const nextOrder = newVal.sortColumnOrder ?? sortColumnOrder.value
+      if (sortColumnKey.value !== nextKey || sortColumnOrder.value !== nextOrder) {
+        sortHandler({
+          sortColumnKey: nextKey,
+          prevKey: sortColumnKey.value,
+          sortColumnOrder: nextOrder,
+        })
+      }
     }
   })
 


### PR DESCRIPTION
# Summary

- Extract logics related to fetching data out of `KTableData.vue` to a dedicated file.
- Organize sort and filter logics into the same file to make the code cleaner.

## The goal

This PR is made for exporting the data fetching logics to be reused and not reinventing the wheels.

### Why

Right now for components that renders a list of data with `KTableData`, when the component wants to:

- Get a hold of the list of data fetched from the remote server, `KTableData` will need be rendered into the DOM (maybe without being seen) no matter the data is empty or not. 
- Or when we need to switch the table view to another type of list view, `KTableData` will need to be there in the DOM to provide fetching abilities.

### What this PR does

Extracting the logics for sorting, pagination, fetching, into a sharable composable that can be called outside the component itself, so that we could use the composable with `KTableView` to render the table view and still be able to get a hold of the fetched data, pagination properties, sort logics with other type of view for instance a catalog view.

This can also benefit `KCatalog` because `KCatalog` and `KTableData` share the same API for fetching data.

### Furthermore

Since we want to keep the scope of this PR to be small, when this gets merged to the main branch, we will start to extracting data fetching common logics from `KCatalog` to build a view only component like `KCatalogView` for the business components to encapsulate a switchable list/catalog view component for sharing.

### Potential benefited counterparts

When you need the flexibility to do certain operation and you need to manage the state on your own.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
