### PR TITLE
docs: clarify when KDropdown change event fires

### DIFF
--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -327,6 +327,7 @@ We also recommend setting the icon style `color` property to a value of `current
 Fires when dropdown is opened/closed. Returns state of the dropdown (boolean).
 
 ### change
+
 Fires when items are clicked if the [`selectionMenu` prop](#selectionmenu) is `true`. Returns the selected menu item object.
 
 ## KDropdownItem


### PR DESCRIPTION
# Summary

The `change` event in `KDropdown` doesn't actually fire unless a condition is met. This updates the docs to reflect that.

### Screenshots

**Before**

<img width="735" height="120" alt="Screenshot 2026-02-06 at 12 57 30 PM" src="https://github.com/user-attachments/assets/8ba0cf82-1168-43f3-95b0-9ad947d5aaf2" />

**After**

<img width="704" height="135" alt="Screenshot 2026-02-06 at 12 57 02 PM" src="https://github.com/user-attachments/assets/3c9e782a-8bcf-4d86-8874-3983166076ab" />
