### PR TITLE
Revert "fix(ktabs): use kbutton for ktabs (#2707)"

### DIFF
--- a/src/components/KTabs/KTabs.cy.ts
+++ b/src/components/KTabs/KTabs.cy.ts
@@ -1,6 +1,16 @@
 import { h } from 'vue'
 import type { TabsAppearance } from '@/types'
 import KTabs from '@/components/KTabs/KTabs.vue'
+import { createRouter, createWebHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [{
+    name: 'home',
+    path: '/',
+    component: { template: '<div />' },
+  }],
+})
 
 const TABS = [
   { hash: '#pictures', title: 'Pictures' },
@@ -19,6 +29,9 @@ describe('KTabs', () => {
             tabs: TABS,
             appearance,
           },
+          global: {
+            plugins: [router],
+          },
         })
         cy.get('.k-tabs').should('have.class', appearance)
       })
@@ -28,6 +41,9 @@ describe('KTabs', () => {
           props: {
             tabs: TABS,
             appearance,
+          },
+          global: {
+            plugins: [router],
           },
         })
 
@@ -41,6 +57,9 @@ describe('KTabs', () => {
             modelValue: '#books',
             appearance,
           },
+          global: {
+            plugins: [router],
+          },
         })
 
         cy.get('.tab-item').eq(2).should('have.class', 'active')
@@ -51,6 +70,9 @@ describe('KTabs', () => {
           props: {
             tabs: TABS,
             appearance,
+          },
+          global: {
+            plugins: [router],
           },
         })
 
@@ -70,6 +92,9 @@ describe('KTabs', () => {
             tabs: TABS,
             hidePanels: true,
             appearance,
+          },
+          global: {
+            plugins: [router],
           },
           slots: {
             pictures: h('div', {}, picturesSlot),
@@ -104,6 +129,9 @@ describe('KTabs', () => {
             tabs,
             appearance,
           },
+          global: {
+            plugins: [router],
+          },
         })
 
         cy.get('.tab-item .tab-link').eq(1).should('have.class', 'disabled')
@@ -124,6 +152,9 @@ describe('KTabs', () => {
             tabs,
             appearance,
           },
+          global: {
+            plugins: [router],
+          },
         })
 
         cy.get('.tab-item .tab-link').eq(1).should('have.attr', 'href', '/movies')
@@ -131,15 +162,18 @@ describe('KTabs', () => {
 
       it('renders the tab as a link with no href attribute if tab.to is present and tab.disabled is true', () => {
         const tabs = [
-          { hash: '#pictures', title: 'Pictures' },
-          { hash: '#movies', title: 'Movies', to: '/movies', disabled: true },
-          { hash: '#books', title: 'Books' },
+          { hash: '#pictures', title: 'Enabled' },
+          { hash: '#movies', title: 'String to, disabled', to: '/movies', disabled: true },
+          { hash: '#books', title: 'Object to, disabled', to: { name: 'home' }, disabled: true },
         ]
 
         cy.mount(KTabs, {
           props: {
             tabs,
             appearance,
+          },
+          global: {
+            plugins: [router],
           },
         })
 
@@ -152,6 +186,9 @@ describe('KTabs', () => {
             tabs: TABS,
             beforeChange: () => false,
             appearance,
+          },
+          global: {
+            plugins: [router],
           },
         })
 
@@ -170,6 +207,9 @@ describe('KTabs', () => {
             props: {
               tabs: TABS,
               appearance,
+            },
+            global: {
+              plugins: [router],
             },
             slots: {
               pictures: h('div', {}, picturesSlot),
@@ -198,6 +238,9 @@ describe('KTabs', () => {
             props: {
               tabs: TABS,
               appearance,
+            },
+            global: {
+              plugins: [router],
             },
             slots: {
               'pictures-anchor': h('div', {}, picturesSlot),

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -15,16 +15,15 @@
         :class="{ active: activeTab === tab.hash }"
         :data-testid="`${tab.hash.replace('#', '')}-tab`"
       >
-        <KButton
-          appearance="none"
+        <component
+          :is="tabComponent(tab).tag"
           :aria-controls="hidePanels ? undefined : `panel-${tab.hash}`"
           :aria-selected="hidePanels ? undefined : (activeTab === tab.hash ? 'true' : 'false')"
           class="tab-link"
           :class="{ disabled: tab.disabled }"
-          :disabled="tab.disabled"
           role="tab"
           :tabindex="getAnchorTabindex(tab)"
-          :to="tab.to"
+          v-bind="tabComponent(tab).attributes"
           @click="!tab.disabled ? handleTabChange(tab.hash) : undefined"
           @click.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
           @keydown.enter.prevent="!tab.disabled ? handleTabChange(tab.hash) : undefined"
@@ -33,7 +32,7 @@
           <slot :name="`${getTabSlotName(tab.hash)}-anchor`">
             <span>{{ tab.title }}</span>
           </slot>
-        </KButton>
+        </component>
       </li>
     </ul>
 
@@ -57,7 +56,6 @@
 
 <script lang="ts" setup generic="const Hash extends string = string">
 import { ref, watch } from 'vue'
-import KButton from '@/components/KButton/KButton.vue'
 import type { StripHash, Tab, TabsEmits, TabsProps, TabsSlots } from '@/types'
 
 const {
@@ -92,6 +90,18 @@ const getAnchorTabindex = (tab: Tab): string => {
   }
 
   return typeof anchorTabindex === 'number' && anchorTabindex >= -1 && anchorTabindex <= 32767 ? String(anchorTabindex) : '0'
+}
+
+const tabComponent = (tab: Tab) => {
+  if (tab.to) {
+    if (typeof tab.to === 'string') {
+      return { tag: 'a', attributes: { href: tab.disabled ? undefined : tab.to } }
+    } else if (typeof tab.to === 'object') {
+      return { tag: 'router-link', attributes: { to: tab.disabled ? undefined : tab.to } }
+    }
+  }
+
+  return { tag: 'div', attributes: {} }
 }
 
 watch(() => modelValue, (newTabHash) => {

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -93,11 +93,11 @@ const getAnchorTabindex = (tab: Tab): string => {
 }
 
 const tabComponent = (tab: Tab) => {
-  if (tab.to) {
+  if (tab.to && !tab.disabled) {
     if (typeof tab.to === 'string') {
-      return { tag: 'a', attributes: { href: tab.disabled ? undefined : tab.to } }
+      return { tag: 'a', attributes: { href: tab.to } }
     } else if (typeof tab.to === 'object') {
-      return { tag: 'router-link', attributes: { to: tab.disabled ? undefined : tab.to } }
+      return { tag: 'router-link', attributes: { to: tab.to } }
     }
   }
 


### PR DESCRIPTION
This reverts commit fdd17e25ff11678fff15ee7552c5f15556afdc8a.

The current behaviour results in an anchor element inside of a button element. I'm not sure why a KButton was added for something that looks like a Tab as there isn't much info in the PR (nor the JIRA) that caused this. cc @Justineo 

https://github.com/Kong/kongponents/pull/2707

<img width="1498" height="267" alt="Screenshot 2026-04-24 at 10 22 59" src="https://github.com/user-attachments/assets/490d7d1f-5801-420c-976d-9e893b822da5" />

FYI: I ws hoping to do a fully clean revert, but there were some tiny conflicts in the revert due to https://github.com/Kong/kongponents/pull/2781 coming in just after the PR that caused the issue. I thin kI've resolved those correctly and I checked the sandbox. But please let me know if you spot anything amiss.




# Summary

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
