### PR TITLE
fix: bumping actions versions to prevent Node20 warning [KHCP-20416]

### DIFF
--- a/.github/actions/setup-pnpm-with-dependencies/action.yaml
+++ b/.github/actions/setup-pnpm-with-dependencies/action.yaml
@@ -39,7 +39,7 @@ runs:
         echo "pnpm-version=${voltaPnpmVersion}">> $GITHUB_OUTPUT
 
     - name: Setup Node
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ steps.node-version.outputs.node-version }}
         registry-url: https://registry.npmjs.org
@@ -52,7 +52,7 @@ runs:
 
     - name: Dependency Cache
       id: dependency-cache
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
       with:
         path: |
           ~/.cache/Cypress

--- a/.github/workflows/get-changed-files.yaml
+++ b/.github/workflows/get-changed-files.yaml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 2
 
       - name: Check if component (`src` directory) files have changed
-        uses: Kong/changed-files@1f31e0a3b1acd04d48dff8801048bb314c8a9e0d
+        uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
         id: component-files-changed
         # Return 'true' for any directories listed here that changed
         with:
@@ -46,7 +46,7 @@ jobs:
             nuxt/**
 
       - name: Check if docs (`docs` directory) files have changed
-        uses: Kong/changed-files@1f31e0a3b1acd04d48dff8801048bb314c8a9e0d
+        uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
         id: docs-files-changed
         # Return 'true' for any directories listed here that changed
         with:
@@ -54,7 +54,7 @@ jobs:
             docs/**
 
       - name: Check if files changed in `src/`, `docs/`, or `cypress/` directories
-        uses: Kong/changed-files@1f31e0a3b1acd04d48dff8801048bb314c8a9e0d
+        uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
         id: components-or-docs-or-cypress-files-changed
         # Return 'true' for any directories listed here that changed
         with:
@@ -64,7 +64,7 @@ jobs:
             cypress/**
 
       - name: Check if package.json or pnpm.lock files changed
-        uses: Kong/changed-files@1f31e0a3b1acd04d48dff8801048bb314c8a9e0d
+        uses: Kong/changed-files@cd69b79ca4e2a1198064c5e6564cce68920df311
         id: package-json-pnpm-lock-files-changed
         # Return 'true' for any directories listed here that changed
         with:

--- a/.github/workflows/pr-audit.yaml
+++ b/.github/workflows/pr-audit.yaml
@@ -42,6 +42,6 @@ jobs:
 
       - name: PR Audit
         if: github.actor != 'renovate[bot]'
-        uses: Kong/public-shared-actions/pr-previews/audit@main
+        uses: Kong/public-shared-actions/pr-previews/audit@8d98bc15a5143332a36f206e6699296e6cc2adac
         with:
           renovate-pr-author: renovate[bot]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
 
       # Upload artifact for `publish` workflow if this is a push event
       - name: Upload build artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kongponents-ci-build-output-artifact
           path: |
@@ -50,20 +50,20 @@ jobs:
             ./LICENSE
 
       - name: Run Cypress component tests
-        uses: cypress-io/github-action@e44ee0fa67251ab7e2d854d85b3a466577f47d14 # v7.1.3
+        uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5.8.4
         with:
           install: false
           command: pnpm test
 
       - name: Upload Cypress screenshots (on failure)
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
 
       - name: Upload Cypress videos (always)
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: cypress-videos


### PR DESCRIPTION
# Summary

Those are to prevent Node20 depiction warnings