### PR TITLE
fix(deps): vue-router semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "peerDependencies": {
     "vue": ">= 3.5.0 < 4",
-    "vue-router": ">4 || >5"
+    "vue-router": "4 || 5"
   },
   "devDependencies": {
     "@babel/types": "^7.29.0",


### PR DESCRIPTION
Unfortunately I didn't check back the correction of peer range in https://github.com/Kong/kongponents/pull/3175 well enough. The range `>4 || >5` is the same as `>=5` which means that versions of major 4 and below are excluded and all version from 5 upwards are included (`v5`, `v6`, `v7`, ...). I've changed it now to `4 || 5` which should include all versions of 4 and 5.