### PR TITLE
fix(ktabs): minimal appearance spacing

### DIFF
--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -222,7 +222,7 @@ watch(() => modelValue, (newTabHash) => {
     ul {
       gap: var(--kui-space-70, $kui-space-70);
       margin-bottom: var(--kui-space-40, $kui-space-40);
-      padding: var(--kui-space-30, $kui-space-30) var(--kui-space-0, $kui-space-0);
+      padding-top: var(--kui-space-30, $kui-space-30);
 
       .tab-item {
         .tab-link {


### PR DESCRIPTION
# Summary

Remove `padding-bottom` in KTabs minimal appearance

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
