### PR TITLE
feat(k-badge): add status code variant [KHCP-20495]

### DIFF
--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -14,18 +14,18 @@ KBadge is a visual text label that presents small amount of information.
 
 KBadge component takes one of the following appearance values:
 
-| Standard     | Methods   |
-| ------------ | --------- |
-| `info` (default)       | `connect` |
-| `success`    | `custom`  |
-| `warning`    | `delete`  |
-| `danger`     | `get`     |
-| `decorative` | `head`    |
-| `neutral`    | `options` |
-|              | `patch`   |
-|              | `post`    |
-|              | `put`     |
-|              | `trace`   |
+| Standard         | Methods   | Status Codes |
+| ---------------- | --------- | ------------ |
+| `info` (default) | `connect` | `status-1xx` |
+| `success`        | `custom`  | `status-2XX` |
+| `warning`        | `delete`  | `status-3XX` |
+| `danger`         | `get`     | `status-4XX` |
+| `decorative`     | `head`    | `status-5XX` |
+| `neutral`        | `options` |              |
+|                  | `patch`   |              |
+|                  | `post`    |              |
+|                  | `put`     |              |
+|                  | `trace`   |              |
 
 :::tip TIP
 Passing one of the methods appearances will apply `text-transform: uppercase` and set the `min-width` on the badge container. You may pass `custom` to apply method badge styling should you need a badge for your custom method.
@@ -84,6 +84,23 @@ Passing one of the methods appearances will apply `text-transform: uppercase` an
       Trace
     </KBadge>
   </div>
+  <div class="horizontal-spacing-container">
+    <KBadge appearance="status-1xx">
+      1XX
+    </KBadge>
+    <KBadge appearance="status-2XX">
+      2XX
+    </KBadge>
+    <KBadge appearance="status-3XX">
+      3XX
+    </KBadge>
+    <KBadge appearance="status-4XX">
+      4XX
+    </KBadge>
+    <KBadge appearance="status-5XX">
+      5XX
+    </KBadge>
+  </div>
 </div>
 
 ```html
@@ -103,6 +120,11 @@ Passing one of the methods appearances will apply `text-transform: uppercase` an
 <KBadge appearance="post">Post</KBadge>
 <KBadge appearance="put">Put</KBadge>
 <KBadge appearance="trace">Trace</KBadge>
+<KBadge appearance="status-1xx">1XX</KBadge>
+<KBadge appearance="status-2XX">2XX</KBadge>
+<KBadge appearance="status-3XX">3XX</KBadge>
+<KBadge appearance="status-4XX">4XX</KBadge>
+<KBadge appearance="status-5XX">5XX</KBadge>
 ```
 
 ### size

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -16,11 +16,11 @@ KBadge component takes one of the following appearance values:
 
 | Standard         | Methods   | Status Codes |
 | ---------------- | --------- | ------------ |
-| `info` (default) | `connect` | `status-1XX` |
-| `success`        | `custom`  | `status-2XX` |
-| `warning`        | `delete`  | `status-3XX` |
-| `danger`         | `get`     | `status-4XX` |
-| `decorative`     | `head`    | `status-5XX` |
+| `info` (default) | `connect` | `status-1xx` |
+| `success`        | `custom`  | `status-2xx` |
+| `warning`        | `delete`  | `status-3xx` |
+| `danger`         | `get`     | `status-4xx` |
+| `decorative`     | `head`    | `status-5xx` |
 | `neutral`        | `options` |              |
 |                  | `patch`   |              |
 |                  | `post`    |              |
@@ -85,19 +85,19 @@ Passing one of the methods appearances will apply `text-transform: uppercase` an
     </KBadge>
   </div>
   <div class="horizontal-spacing-container">
-    <KBadge appearance="status-1XX">
+    <KBadge appearance="status-1xx">
       1XX
     </KBadge>
-    <KBadge appearance="status-2XX">
+    <KBadge appearance="status-2xx">
       2XX
     </KBadge>
-    <KBadge appearance="status-3XX">
+    <KBadge appearance="status-3xx">
       3XX
     </KBadge>
-    <KBadge appearance="status-4XX">
+    <KBadge appearance="status-4xx">
       4XX
     </KBadge>
-    <KBadge appearance="status-5XX">
+    <KBadge appearance="status-5xx">
       5XX
     </KBadge>
   </div>
@@ -120,11 +120,11 @@ Passing one of the methods appearances will apply `text-transform: uppercase` an
 <KBadge appearance="post">Post</KBadge>
 <KBadge appearance="put">Put</KBadge>
 <KBadge appearance="trace">Trace</KBadge>
-<KBadge appearance="status-1XX">1XX</KBadge>
-<KBadge appearance="status-2XX">2XX</KBadge>
-<KBadge appearance="status-3XX">3XX</KBadge>
-<KBadge appearance="status-4XX">4XX</KBadge>
-<KBadge appearance="status-5XX">5XX</KBadge>
+<KBadge appearance="status-1xx">1XX</KBadge>
+<KBadge appearance="status-2xx">2XX</KBadge>
+<KBadge appearance="status-3xx">3XX</KBadge>
+<KBadge appearance="status-4xx">4XX</KBadge>
+<KBadge appearance="status-5xx">5XX</KBadge>
 ```
 
 ### size

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -16,7 +16,7 @@ KBadge component takes one of the following appearance values:
 
 | Standard         | Methods   | Status Codes |
 | ---------------- | --------- | ------------ |
-| `info` (default) | `connect` | `status-1xx` |
+| `info` (default) | `connect` | `status-1XX` |
 | `success`        | `custom`  | `status-2XX` |
 | `warning`        | `delete`  | `status-3XX` |
 | `danger`         | `get`     | `status-4XX` |
@@ -85,7 +85,7 @@ Passing one of the methods appearances will apply `text-transform: uppercase` an
     </KBadge>
   </div>
   <div class="horizontal-spacing-container">
-    <KBadge appearance="status-1xx">
+    <KBadge appearance="status-1XX">
       1XX
     </KBadge>
     <KBadge appearance="status-2XX">
@@ -120,7 +120,7 @@ Passing one of the methods appearances will apply `text-transform: uppercase` an
 <KBadge appearance="post">Post</KBadge>
 <KBadge appearance="put">Put</KBadge>
 <KBadge appearance="trace">Trace</KBadge>
-<KBadge appearance="status-1xx">1XX</KBadge>
+<KBadge appearance="status-1XX">1XX</KBadge>
 <KBadge appearance="status-2XX">2XX</KBadge>
 <KBadge appearance="status-3XX">3XX</KBadge>
 <KBadge appearance="status-4XX">4XX</KBadge>

--- a/sandbox/pages/SandboxBadge.vue
+++ b/sandbox/pages/SandboxBadge.vue
@@ -63,7 +63,7 @@
           </KBadge>
         </div>
         <div class="horizontal-spacing">
-          <KBadge appearance="status-1xx">
+          <KBadge appearance="status-1XX">
             1XX
           </KBadge>
           <KBadge appearance="status-2XX">

--- a/sandbox/pages/SandboxBadge.vue
+++ b/sandbox/pages/SandboxBadge.vue
@@ -62,6 +62,23 @@
             Trace
           </KBadge>
         </div>
+        <div class="horizontal-spacing">
+          <KBadge appearance="status-1xx">
+            1XX
+          </KBadge>
+          <KBadge appearance="status-2XX">
+            2XX
+          </KBadge>
+          <KBadge appearance="status-3XX">
+            3XX
+          </KBadge>
+          <KBadge appearance="status-4XX">
+            4XX
+          </KBadge>
+          <KBadge appearance="status-5XX">
+            5XX
+          </KBadge>
+        </div>
         <KBadge appearance="connect">
           Long truncating method badge
         </KBadge>
@@ -494,13 +511,13 @@ const handleIconClick = (): void => {
     align-items: flex-end;
     display: flex;
     flex-wrap: wrap;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .resizable-container {
     max-width: 900px;
     overflow-x: auto;
-    padding-bottom: $kui-space-60;
+    padding-bottom: var(--kui-space-60, $kui-space-60);
     resize: horizontal;
   }
 }

--- a/sandbox/pages/SandboxBadge.vue
+++ b/sandbox/pages/SandboxBadge.vue
@@ -63,19 +63,19 @@
           </KBadge>
         </div>
         <div class="horizontal-spacing">
-          <KBadge appearance="status-1XX">
+          <KBadge appearance="status-1xx">
             1XX
           </KBadge>
-          <KBadge appearance="status-2XX">
+          <KBadge appearance="status-2xx">
             2XX
           </KBadge>
-          <KBadge appearance="status-3XX">
+          <KBadge appearance="status-3xx">
             3XX
           </KBadge>
-          <KBadge appearance="status-4XX">
+          <KBadge appearance="status-4xx">
             4XX
           </KBadge>
-          <KBadge appearance="status-5XX">
+          <KBadge appearance="status-5xx">
             5XX
           </KBadge>
         </div>

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -190,7 +190,7 @@ $kBadgeMethodWidth: 85px;
   }
 
   // status codes
-  &.status-1xx {
+  &.status-1XX {
     @include badgeAppearance(var(--kui-status-color-background-100, $kui-status-color-background-100), var(--kui-status-color-text-100, $kui-status-color-text-100), var(--kui-status-color-text-100, $kui-status-color-100s));
   }
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -190,23 +190,23 @@ $kBadgeMethodWidth: 85px;
   }
 
   // status codes
-  &.status-1XX {
+  &.status-1xx {
     @include badgeAppearance(var(--kui-status-color-background-100, $kui-status-color-background-100), var(--kui-status-color-text-100, $kui-status-color-text-100), var(--kui-status-color-text-100, $kui-status-color-100s));
   }
 
-  &.status-2XX {
+  &.status-2xx {
     @include badgeAppearance(var(--kui-status-color-background-200, $kui-status-color-background-200), var(--kui-status-color-text-200, $kui-status-color-text-200), var(--kui-status-color-text-200, $kui-status-color-200s));
   }
 
-  &.status-3XX {
+  &.status-3xx {
     @include badgeAppearance(var(--kui-status-color-background-300, $kui-status-color-background-300), var(--kui-status-color-text-300, $kui-status-color-text-300), var(--kui-status-color-text-300, $kui-status-color-300s));
   }
 
-  &.status-4XX {
+  &.status-4xx {
     @include badgeAppearance(var(--kui-status-color-background-400, $kui-status-color-background-400), var(--kui-status-color-text-400, $kui-status-color-text-400), var(--kui-status-color-text-400, $kui-status-color-400s));
   }
 
-  &.status-5XX {
+  &.status-5xx {
     @include badgeAppearance(var(--kui-status-color-background-500, $kui-status-color-background-500), var(--kui-status-color-text-500, $kui-status-color-text-500), var(--kui-status-color-text-500, $kui-status-color-500s));
   }
 

--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -189,6 +189,27 @@ $kBadgeMethodWidth: 85px;
     @include badgeAppearance(var(--kui-color-background-neutral-weaker, $kui-color-background-neutral-weaker), var(--kui-color-text-neutral-strong, $kui-color-text-neutral-strong), var(--kui-color-text-neutral-stronger, $kui-color-text-neutral-stronger));
   }
 
+  // status codes
+  &.status-1xx {
+    @include badgeAppearance(var(--kui-status-color-background-100, $kui-status-color-background-100), var(--kui-status-color-text-100, $kui-status-color-text-100), var(--kui-status-color-text-100, $kui-status-color-100s));
+  }
+
+  &.status-2XX {
+    @include badgeAppearance(var(--kui-status-color-background-200, $kui-status-color-background-200), var(--kui-status-color-text-200, $kui-status-color-text-200), var(--kui-status-color-text-200, $kui-status-color-200s));
+  }
+
+  &.status-3XX {
+    @include badgeAppearance(var(--kui-status-color-background-300, $kui-status-color-background-300), var(--kui-status-color-text-300, $kui-status-color-text-300), var(--kui-status-color-text-300, $kui-status-color-300s));
+  }
+
+  &.status-4XX {
+    @include badgeAppearance(var(--kui-status-color-background-400, $kui-status-color-background-400), var(--kui-status-color-text-400, $kui-status-color-text-400), var(--kui-status-color-text-400, $kui-status-color-400s));
+  }
+
+  &.status-5XX {
+    @include badgeAppearance(var(--kui-status-color-background-500, $kui-status-color-background-500), var(--kui-status-color-text-500, $kui-status-color-text-500), var(--kui-status-color-text-500, $kui-status-color-500s));
+  }
+
   // methods
   &.connect {
     @include badgeAppearance(var(--kui-method-color-background-connect, $kui-method-color-background-connect), var(--kui-method-color-text-connect, $kui-method-color-text-connect), var(--kui-method-color-text-connect-strong, $kui-method-color-text-connect-strong));

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,7 +1,7 @@
 import type { TooltipAttributes } from './tooltip'
 
 export type BadgeMethodAppearance = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' | 'connect' | 'trace' | 'custom'
-export type BadgeStatusAppearance = 'status-1xx' | 'status-2XX' | 'status-3XX' | 'status-4XX' | 'status-5XX'
+export type BadgeStatusAppearance = 'status-1XX' | 'status-2XX' | 'status-3XX' | 'status-4XX' | 'status-5XX'
 export type BadgeAppearance = 'info' | 'success' | 'warning' | 'danger' | 'neutral' | 'decorative' | BadgeMethodAppearance | BadgeStatusAppearance
 export type BadgeMethodAppearanceRecord = Record<BadgeMethodAppearance, BadgeMethodAppearance>
 export type BadgeStatusAppearanceRecord = Record<BadgeStatusAppearance, BadgeStatusAppearance>
@@ -23,7 +23,7 @@ export const BadgeMethodAppearances: BadgeMethodAppearanceRecord = {
 } as const
 
 export const BadgeStatusAppearances: BadgeStatusAppearanceRecord = {
-  'status-1xx': 'status-1xx',
+  'status-1XX': 'status-1XX',
   'status-2XX': 'status-2XX',
   'status-3XX': 'status-3XX',
   'status-4XX': 'status-4XX',

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,7 +1,7 @@
 import type { TooltipAttributes } from './tooltip'
 
 export type BadgeMethodAppearance = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' | 'connect' | 'trace' | 'custom'
-export type BadgeStatusAppearance = 'status-1XX' | 'status-2XX' | 'status-3XX' | 'status-4XX' | 'status-5XX'
+export type BadgeStatusAppearance = 'status-1xx' | 'status-2xx' | 'status-3xx' | 'status-4xx' | 'status-5xx'
 export type BadgeAppearance = 'info' | 'success' | 'warning' | 'danger' | 'neutral' | 'decorative' | BadgeMethodAppearance | BadgeStatusAppearance
 export type BadgeMethodAppearanceRecord = Record<BadgeMethodAppearance, BadgeMethodAppearance>
 export type BadgeStatusAppearanceRecord = Record<BadgeStatusAppearance, BadgeStatusAppearance>
@@ -23,11 +23,11 @@ export const BadgeMethodAppearances: BadgeMethodAppearanceRecord = {
 } as const
 
 export const BadgeStatusAppearances: BadgeStatusAppearanceRecord = {
-  'status-1XX': 'status-1XX',
-  'status-2XX': 'status-2XX',
-  'status-3XX': 'status-3XX',
-  'status-4XX': 'status-4XX',
-  'status-5XX': 'status-5XX',
+  'status-1xx': 'status-1xx',
+  'status-2xx': 'status-2xx',
+  'status-3xx': 'status-3xx',
+  'status-4xx': 'status-4xx',
+  'status-5xx': 'status-5xx',
 } as const
 
 export const BadgeAppearances: BadgeAppearanceRecord = {

--- a/src/types/badge.ts
+++ b/src/types/badge.ts
@@ -1,8 +1,10 @@
 import type { TooltipAttributes } from './tooltip'
 
 export type BadgeMethodAppearance = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'options' | 'head' | 'connect' | 'trace' | 'custom'
-export type BadgeAppearance = 'info' | 'success' | 'warning' | 'danger' | 'neutral' | 'decorative' | BadgeMethodAppearance
+export type BadgeStatusAppearance = 'status-1xx' | 'status-2XX' | 'status-3XX' | 'status-4XX' | 'status-5XX'
+export type BadgeAppearance = 'info' | 'success' | 'warning' | 'danger' | 'neutral' | 'decorative' | BadgeMethodAppearance | BadgeStatusAppearance
 export type BadgeMethodAppearanceRecord = Record<BadgeMethodAppearance, BadgeMethodAppearance>
+export type BadgeStatusAppearanceRecord = Record<BadgeStatusAppearance, BadgeStatusAppearance>
 export type BadgeAppearanceRecord = Record<BadgeAppearance, BadgeAppearance>
 export type BadgeSize = 'medium' | 'small'
 export type BadgeSizeRecord = Record<BadgeSize, BadgeSize>
@@ -20,6 +22,14 @@ export const BadgeMethodAppearances: BadgeMethodAppearanceRecord = {
   custom: 'custom',
 } as const
 
+export const BadgeStatusAppearances: BadgeStatusAppearanceRecord = {
+  'status-1xx': 'status-1xx',
+  'status-2XX': 'status-2XX',
+  'status-3XX': 'status-3XX',
+  'status-4XX': 'status-4XX',
+  'status-5XX': 'status-5XX',
+} as const
+
 export const BadgeAppearances: BadgeAppearanceRecord = {
   info: 'info',
   success: 'success',
@@ -28,6 +38,7 @@ export const BadgeAppearances: BadgeAppearanceRecord = {
   decorative: 'decorative',
   neutral: 'neutral',
   ...BadgeMethodAppearances,
+  ...BadgeStatusAppearances,
 } as const
 
 export const BadgeSizes: BadgeSizeRecord = {
@@ -38,7 +49,7 @@ export const BadgeSizes: BadgeSizeRecord = {
 export interface BadgeProps {
   /**
    * Base style of the badge.
-   * One of ['info', 'success', 'warning', 'danger', 'neutral', 'decorative', BadgeMethodAppearance].
+   * One of ['info', 'success', 'warning', 'danger', 'neutral', 'decorative', BadgeMethodAppearance, BadgeStatusAppearance].
    * @default 'info'
    */
   appearance?: BadgeAppearance


### PR DESCRIPTION
# Summary

Add HTTP status codes as KBadge variants
```ts
type BadgeStatusAppearance = 'status-1xx' | 'status-2xx' | 'status-3xx' | 'status-4xx' | 'status-5xx'
```
<br/>

<img width="269" height="49" alt="image" src="https://github.com/user-attachments/assets/9bc0fb9b-5f22-4edf-be79-f7133756f98d" />

<br/><br/>

Component brief: https://docs.google.com/document/d/11UaliGkfmJ4QVd1edevoAr6QjJBUr4IKr11vOiK6Rtg/edit?usp=sharing
Figma: https://www.figma.com/design/71ZGNi6DQT2eFIE0qikR2b/Status-Code-update-identification?node-id=405-18218&t=EPqaPvBqm79xacQ0-4
Resolves: https://konghq.atlassian.net/browse/KHCP-20495