### PR TITLE
chore: simple-git audit fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,7 +266,8 @@
       "lodash-es@<=4.17.23": ">=4.18.0",
       "lodash@<=4.17.23": ">=4.18.0",
       "defu@<=6.1.4": ">=6.1.5",
-      "unhead@<2.1.13": ">=2.1.13"
+      "unhead@<2.1.13": ">=2.1.13",
+      "simple-git@<3.36.0": ">=3.36.0"
     },
     "onlyBuiltDependencies": [
       "@evilmartians/lefthook",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,7 @@ overrides:
   lodash@<=4.17.23: '>=4.18.0'
   defu@<=6.1.4: '>=6.1.5'
   unhead@<2.1.13: '>=2.1.13'
+  simple-git@<3.36.0: '>=3.36.0'
 
 importers:
 
@@ -136,7 +137,7 @@ importers:
         version: 1.6.1(@typescript-eslint/parser@8.47.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@nuxt/kit':
         specifier: ^4.4.2
-        version: 4.4.2(magicast@0.5.1)
+        version: 4.4.2(magicast@0.5.2)
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.3(typescript@5.9.3))
@@ -208,7 +209,7 @@ importers:
         version: 2.2.0
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.2)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.3)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -226,7 +227,7 @@ importers:
         version: 6.1.3
       rollup-plugin-visualizer:
         specifier: ^6.0.11
-        version: 6.0.11(@rollup/wasm-node@4.60.2)
+        version: 6.0.11(@rollup/wasm-node@4.60.3)
       sass:
         specifier: ^1.98.0
         version: 1.98.0
@@ -265,7 +266,7 @@ importers:
         version: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3)
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(@nuxt/kit@4.4.2(magicast@0.5.1))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.29(typescript@5.9.3))
+        version: 8.1.1(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.29(typescript@5.9.3))
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.35.0)(@types/node@24.12.0)(fuse.js@7.1.0)(postcss@8.5.8)(sass-embedded@1.79.5)(sass@1.98.0)(search-insights@2.14.0)(sortablejs@1.15.7)(terser@5.44.0)(typescript@5.9.3)
@@ -1995,8 +1996,8 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/wasm-node@4.60.2':
-    resolution: {integrity: sha512-FOfZOg752WSyKNefpSM3WrhggSTSuKuwcSfF7tdWC9PBYYg7BLwBR267uShFAI1ZyA0gNkdqK16LL9mNOPsQ1Q==}
+  '@rollup/wasm-node@4.60.3':
+    resolution: {integrity: sha512-SVhQ4TJk0BvnJKwceVsCWHtmquucfjU0eu+Bonrjb6W3zombkA/tqw1efaqT2BONX/TJniqkzumF6Sz/sXMJ2w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2088,6 +2089,12 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -6350,8 +6357,8 @@ packages:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
 
-  simple-git@3.33.0:
-    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -8232,10 +8239,10 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
-  '@dxup/nuxt@0.4.0(magicast@0.5.1)(typescript@5.9.3)':
+  '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       chokidar: 5.0.0
       pathe: 2.0.3
       tinyglobby: 0.2.15
@@ -8624,11 +8631,11 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.5.2)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -8709,12 +8716,12 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.0
       semver: 7.7.4
-      simple-git: 3.33.0
+      simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
       vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.1))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
       vite-plugin-vue-tracer: 1.3.0(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       which: 5.0.0
       ws: 8.19.0
@@ -8723,31 +8730,6 @@ snapshots:
       - supports-color
       - utf-8-validate
       - vue
-
-  '@nuxt/kit@4.4.2(magicast@0.5.1)':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.1)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      mlly: 1.8.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rc9: 3.0.1
-      scule: 1.3.0
-      semver: 7.7.4
-      tinyglobby: 0.2.16
-      ufo: 1.6.3
-      unctx: 2.5.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
 
   '@nuxt/kit@4.4.2(magicast@0.5.2)':
     dependencies:
@@ -8774,11 +8756,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.1)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.2)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.3)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@unhead/vue': 2.1.12(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
       consola: 3.4.2
@@ -8793,7 +8775,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.2)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.3)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -8853,19 +8835,19 @@ snapshots:
       pkg-types: 2.3.0
       std-env: 4.0.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.4.2(magicast@0.5.1))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.4.2(f32a92d2686c43026f60a19e8aef32a8)':
+  '@nuxt/vite-builder@4.4.2(74bed0d77000613d8f896403f76dc524)':
     dependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
-      '@rollup/plugin-replace': 6.0.3(@rollup/wasm-node@4.60.2)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@rollup/plugin-replace': 6.0.3(@rollup/wasm-node@4.60.3)
       '@vitejs/plugin-vue': 6.0.6(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.8)
@@ -8880,7 +8862,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.2)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.3)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -8897,7 +8879,7 @@ snapshots:
     optionalDependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
-      rollup-plugin-visualizer: 6.0.11(@rollup/wasm-node@4.60.2)
+      rollup-plugin-visualizer: 6.0.11(@rollup/wasm-node@4.60.3)
     transitivePeerDependencies:
       - '@biomejs/biome'
       - '@types/node'
@@ -9279,13 +9261,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.5': {}
 
-  '@rollup/plugin-alias@6.0.0(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-alias@6.0.0(@rollup/wasm-node@4.60.3)':
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/plugin-commonjs@29.0.0(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-commonjs@29.0.0(@rollup/wasm-node@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.2)
+      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.3)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9293,56 +9275,56 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/plugin-inject@5.0.5(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-inject@5.0.5(@rollup/wasm-node@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.2)
+      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.3)
       estree-walker: 2.0.2
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/plugin-json@6.1.0(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-json@6.1.0(@rollup/wasm-node@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.2)
+      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.3)
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/plugin-node-resolve@16.0.3(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-node-resolve@16.0.3(@rollup/wasm-node@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.2)
+      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.3)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/plugin-replace@6.0.3(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-replace@6.0.3(@rollup/wasm-node@4.60.3)':
     dependencies:
-      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.2)
+      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.3)
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/plugin-terser@0.4.4(@rollup/wasm-node@4.60.2)':
+  '@rollup/plugin-terser@0.4.4(@rollup/wasm-node@4.60.3)':
     dependencies:
       serialize-javascript: 7.0.5
       smob: 1.5.0
       terser: 5.44.0
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/pluginutils@5.2.0(@rollup/wasm-node@4.60.2)':
+  '@rollup/pluginutils@5.2.0(@rollup/wasm-node@4.60.3)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
-  '@rollup/wasm-node@4.60.2':
+  '@rollup/wasm-node@4.60.3':
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
@@ -9518,6 +9500,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
@@ -9734,10 +9722,10 @@ snapshots:
     transitivePeerDependencies:
       - vite
 
-  '@vercel/nft@1.3.1(@rollup/wasm-node@4.60.2)':
+  '@vercel/nft@1.3.1(@rollup/wasm-node@4.60.3)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0
-      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.2)
+      '@rollup/pluginutils': 5.2.0(@rollup/wasm-node@4.60.3)
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
       async-sema: 3.1.1
@@ -10418,22 +10406,22 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.1
 
-  c12@3.3.4(magicast@0.5.1):
+  c12@3.3.3(magicast@0.5.2):
     dependencies:
       chokidar: 5.0.0
-      confbox: 0.2.4
+      confbox: 0.2.2
       defu: 6.1.7
-      dotenv: 17.4.2
+      dotenv: 17.2.3
       exsolve: 1.0.8
-      giget: 3.2.0
+      giget: 2.0.0
       jiti: 2.6.1
       ohash: 2.0.11
       pathe: 2.0.3
-      perfect-debounce: 2.1.0
+      perfect-debounce: 2.0.0
       pkg-types: 2.3.0
-      rc9: 3.0.1
+      rc9: 2.1.2
     optionalDependencies:
-      magicast: 0.5.1
+      magicast: 0.5.2
 
   c12@3.3.4(magicast@0.5.2):
     dependencies:
@@ -12899,14 +12887,14 @@ snapshots:
   nitropack@2.13.1:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(@rollup/wasm-node@4.60.2)
-      '@rollup/plugin-commonjs': 29.0.0(@rollup/wasm-node@4.60.2)
-      '@rollup/plugin-inject': 5.0.5(@rollup/wasm-node@4.60.2)
-      '@rollup/plugin-json': 6.1.0(@rollup/wasm-node@4.60.2)
-      '@rollup/plugin-node-resolve': 16.0.3(@rollup/wasm-node@4.60.2)
-      '@rollup/plugin-replace': 6.0.3(@rollup/wasm-node@4.60.2)
-      '@rollup/plugin-terser': 0.4.4(@rollup/wasm-node@4.60.2)
-      '@vercel/nft': 1.3.1(@rollup/wasm-node@4.60.2)
+      '@rollup/plugin-alias': 6.0.0(@rollup/wasm-node@4.60.3)
+      '@rollup/plugin-commonjs': 29.0.0(@rollup/wasm-node@4.60.3)
+      '@rollup/plugin-inject': 5.0.5(@rollup/wasm-node@4.60.3)
+      '@rollup/plugin-json': 6.1.0(@rollup/wasm-node@4.60.3)
+      '@rollup/plugin-node-resolve': 16.0.3(@rollup/wasm-node@4.60.3)
+      '@rollup/plugin-replace': 6.0.3(@rollup/wasm-node@4.60.3)
+      '@rollup/plugin-terser': 0.4.4(@rollup/wasm-node@4.60.3)
+      '@vercel/nft': 1.3.1(@rollup/wasm-node@4.60.3)
       archiver: 7.0.1
       c12: 3.3.3(magicast@0.5.1)
       chokidar: 5.0.0
@@ -12948,8 +12936,8 @@ snapshots:
       pkg-types: 2.3.0
       pretty-bytes: 7.1.0
       radix3: 1.1.2
-      rollup: '@rollup/wasm-node@4.60.2'
-      rollup-plugin-visualizer: 6.0.11(@rollup/wasm-node@4.60.2)
+      rollup: '@rollup/wasm-node@4.60.3'
+      rollup-plugin-visualizer: 6.0.11(@rollup/wasm-node@4.60.3)
       scule: 1.3.0
       semver: 7.7.4
       serve-placeholder: 2.0.2
@@ -13075,19 +13063,19 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.2)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3):
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.3)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
-      '@dxup/nuxt': 0.4.0(magicast@0.5.1)(typescript@5.9.3)
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.1)
+      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.3(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.1)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.2)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.0))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@parcel/watcher@2.5.1)(@rollup/wasm-node@4.60.3)(@types/node@24.12.0)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.3(jiti@2.6.1))(ioredis@5.9.3)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3))(sass-embedded@1.79.5)(sass@1.98.0)(stylelint@16.26.1(typescript@5.9.3))(terser@5.44.0)(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
       '@nuxt/schema': 4.4.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.1))
-      '@nuxt/vite-builder': 4.4.2(f32a92d2686c43026f60a19e8aef32a8)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.2(74bed0d77000613d8f896403f76dc524)
       '@unhead/vue': 2.1.12(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
       compatx: 0.2.0
       consola: 3.4.2
@@ -14009,14 +13997,14 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.2):
+  rollup-plugin-visualizer@6.0.11(@rollup/wasm-node@4.60.3):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.4
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
 
   rou3@0.8.1: {}
 
@@ -14346,10 +14334,12 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-git@3.33.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -15200,7 +15190,7 @@ snapshots:
       typescript: 5.9.3
       vue-tsc: 3.2.5(typescript@5.9.3)
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.1))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -15213,18 +15203,18 @@ snapshots:
       vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3)
       vite-dev-rpc: 1.1.0(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
     optionalDependencies:
-      '@nuxt/kit': 4.4.2(magicast@0.5.1)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.1.1(@nuxt/kit@4.4.2(magicast@0.5.1))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.29(typescript@5.9.3)):
+  vite-plugin-vue-devtools@8.1.1(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.29(typescript@5.9.3))
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
       sirv: 3.0.2
       vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.1))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
       vite-plugin-vue-inspector: 5.3.2(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(sass-embedded@1.79.5)(sass@1.98.0)(terser@5.44.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -15260,7 +15250,7 @@ snapshots:
     dependencies:
       esbuild: 0.27.3
       postcss: 8.5.6
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
     optionalDependencies:
       '@types/node': 24.12.0
       fsevents: 2.3.3
@@ -15274,7 +15264,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.6
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0
@@ -15291,7 +15281,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.8
-      rollup: '@rollup/wasm-node@4.60.2'
+      rollup: '@rollup/wasm-node@4.60.3'
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0


### PR DESCRIPTION
# Summary

Audit failure is because of a nuxt dependency (simple-git)
But when I tried to upgrade nuxt to latest version, it failed because `chokidar` (another nuxt dep) has a trust downgrade and pnpm blocked the nuxt version bump :melting_face: 

<img width="884" height="113" alt="image" src="https://github.com/user-attachments/assets/2cad1ae2-5f8b-4624-b899-a976ad5adecd" />

Hence had to do an override.



