### PR TITLE
feat(kbutton): button component tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ docs/.vitepress/.temp
 docs/.vitepress/.cache
 docs/.vitepress/cache
 docs/.vitepress/dist
+
+.claude/

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -190,19 +190,33 @@ In order to prevent component styles from leaking out into the consuming applica
 
 2. All component styles must be wrapped in a unique wrapper class so that styles do not leak out into the consuming application.
 
-  TODO: update class naming guidelines
+The class name should follow the syntax `.k-{component-name}-*`
 
-    The class name should follow the syntax `.k-{component-name}-*`
+This is a good practice even if you go with option one outlined above.
 
-   This is a good practice even if you go with option one outlined above.
+```html
+<style lang="scss">
+.k-button {
+  /* All other styles must go inside the wrapper */
+}
+</style>
+```
 
-    ```html
-    <style lang="scss">
-    .k-button {
-      /* All other styles must go inside the wrapper */
-    }
-    </style>
-    ```
+#### Design tokens
+
+All values in component styles **must** come from tokens defined in the [`@kong/design-tokens`](https://github.com/Kong/design-tokens) package. Do not use hardcoded values or invent custom token names.
+
+Components should reference tokens using the three-level fallback pattern: component token → global CSS custom property → SCSS variable.
+
+```sass
+background-color: var(--kui-button-color-background-primary, var(--kui-color-background-primary, $kui-color-background-primary));
+```
+
+**Component tokens** (namespaced like `--kui-{component}-*`) are a targeted customization surface for consumers. They let downstream applications override a single component's styles without affecting the global design system.
+
+::: warning IMPORTANT
+Component tokens must be **defined and exported from the `@kong/design-tokens` repository first** before they can be used in any component file. Do not reference a component token that does not yet exist in `@kong/design-tokens`.
+:::
 
 #### Relative units
 

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -19,3 +19,23 @@ table .my-table-row {
 ```
 
 See the [Kong Design Tokens](https://github.com/Kong/design-tokens) repository for more examples and [the list of available tokens](https://github.com/Kong/design-tokens/blob/main/TOKENS.md).
+
+## Component Tokens
+
+In addition to global design tokens, some components expose **component tokens** — CSS custom properties scoped to that specific component (e.g., `--kui-button-color-background-primary`). Component tokens let you customize a single component's appearance without affecting the rest of your application.
+
+Component tokens take priority over global tokens. When you set a component token, it overrides the global token fallback for that property in that component only.
+
+```html
+<style>
+/* Apply to every KButton in your app */
+:root {
+  --kui-button-color-background-primary: hotpink;
+}
+
+/* Or scope the override to a specific container */
+.my-sidebar {
+  --kui-button-color-background-primary: purple;
+}
+</style>
+```

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^2.1.2",
     "@kong-ui-public/sandbox-layout": "^2.3.26",
-    "@kong/design-tokens": "1.20.0",
+    "@kong/design-tokens": "1.21.1-pr.645.624f3ce.0",
     "@kong/eslint-config-kong-ui": "1.6.1",
     "@nuxt/kit": "^4.4.2",
     "@semantic-release/changelog": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^2.1.2",
     "@kong-ui-public/sandbox-layout": "^2.3.26",
-    "@kong/design-tokens": "1.21.1-pr.645.624f3ce.0",
+    "@kong/design-tokens": "1.22.0",
     "@kong/eslint-config-kong-ui": "1.6.1",
     "@nuxt/kit": "^4.4.2",
     "@semantic-release/changelog": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^2.3.26
         version: 2.3.26(vue@3.5.29(typescript@5.9.3))
       '@kong/design-tokens':
-        specifier: 1.20.0
-        version: 1.20.0
+        specifier: 1.21.1-pr.645.624f3ce.0
+        version: 1.21.1-pr.645.624f3ce.0
       '@kong/eslint-config-kong-ui':
         specifier: 1.6.1
         version: 1.6.1(@typescript-eslint/parser@8.47.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
@@ -548,8 +548,8 @@ packages:
       commander:
         optional: true
 
-  '@bufbuild/protobuf@2.11.0':
-    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+  '@bufbuild/protobuf@2.12.0':
+    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
 
   '@cacheable/memory@2.0.6':
     resolution: {integrity: sha512-7e8SScMocHxcAb8YhtkbMhGG+EKLRIficb1F5sjvhSYsWTZGxvg4KIDp8kgxnV2PUJ3ddPe6J9QESjKvBWRDkg==}
@@ -1236,8 +1236,8 @@ packages:
     peerDependencies:
       vue: '>= 3.3.13 < 4'
 
-  '@kong/design-tokens@1.20.0':
-    resolution: {integrity: sha512-6j7A/+gxz8pY4xqUTPtqXhi5zGvEowQ1FikWR0nni13QbiOvHsNaJbXGHTG4x2+VOQt3amDs6jGpppHP9Pv95Q==}
+  '@kong/design-tokens@1.21.1-pr.645.624f3ce.0':
+    resolution: {integrity: sha512-Ox026sAsv5luoIbGogN+5RCPsddKGZ1Lslk1taSLS7MHToGzm9OqGCWzk+cKZ+cEDN09PD6Kpl8S/5WVxKVk8Q==}
     engines: {node: '>=20.19.5', pnpm: '>=10.28.2'}
 
   '@kong/eslint-config-kong-ui@1.6.1':
@@ -2145,6 +2145,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -7945,7 +7948,7 @@ snapshots:
       cac: 6.7.14
       citty: 0.2.1
 
-  '@bufbuild/protobuf@2.11.0':
+  '@bufbuild/protobuf@2.12.0':
     optional: true
 
   '@cacheable/memory@2.0.6':
@@ -8583,7 +8586,7 @@ snapshots:
       '@kong/icons': 1.45.0(vue@3.5.29(typescript@5.9.3))
       vue: 3.5.29(typescript@5.9.3)
 
-  '@kong/design-tokens@1.20.0': {}
+  '@kong/design-tokens@1.21.1-pr.645.624f3ce.0': {}
 
   '@kong/eslint-config-kong-ui@1.6.1(@typescript-eslint/parser@8.47.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -9361,7 +9364,7 @@ snapshots:
 
   '@rollup/pluginutils@5.2.0(@rollup/wasm-node@4.60.3)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -9598,6 +9601,8 @@ snapshots:
     optional: true
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -12446,7 +12451,7 @@ snapshots:
 
   is-reference@1.2.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-regex@1.1.4:
     dependencies:
@@ -14165,7 +14170,7 @@ snapshots:
 
   sass-embedded@1.79.5:
     dependencies:
-      '@bufbuild/protobuf': 2.11.0
+      '@bufbuild/protobuf': 2.12.0
       buffer-builder: 0.2.0
       colorjs.io: 0.5.2
       immutable: 4.3.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^2.3.26
         version: 2.3.26(vue@3.5.29(typescript@5.9.3))
       '@kong/design-tokens':
-        specifier: 1.21.1-pr.645.624f3ce.0
-        version: 1.21.1-pr.645.624f3ce.0
+        specifier: 1.22.0
+        version: 1.22.0
       '@kong/eslint-config-kong-ui':
         specifier: 1.6.1
         version: 1.6.1(@typescript-eslint/parser@8.47.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
@@ -1236,8 +1236,8 @@ packages:
     peerDependencies:
       vue: '>= 3.3.13 < 4'
 
-  '@kong/design-tokens@1.21.1-pr.645.624f3ce.0':
-    resolution: {integrity: sha512-Ox026sAsv5luoIbGogN+5RCPsddKGZ1Lslk1taSLS7MHToGzm9OqGCWzk+cKZ+cEDN09PD6Kpl8S/5WVxKVk8Q==}
+  '@kong/design-tokens@1.22.0':
+    resolution: {integrity: sha512-wtgv89fXqTYjB6kq18YUNn1k37LY8YQoVAn64JrZjubiI5Cwi6dS6e3igMqkvZVuJVgEjL1RKMmKpyKjot6vlA==}
     engines: {node: '>=20.19.5', pnpm: '>=10.28.2'}
 
   '@kong/eslint-config-kong-ui@1.6.1':
@@ -8586,7 +8586,7 @@ snapshots:
       '@kong/icons': 1.45.0(vue@3.5.29(typescript@5.9.3))
       vue: 3.5.29(typescript@5.9.3)
 
-  '@kong/design-tokens@1.21.1-pr.645.624f3ce.0': {}
+  '@kong/design-tokens@1.22.0': {}
 
   '@kong/eslint-config-kong-ui@1.6.1(@typescript-eslint/parser@8.47.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -146,7 +146,7 @@ export default {
   // stylelint-disable-next-line no-duplicate-selectors
   & {
     align-items: center;
-    border-radius: var(--kui-border-radius-30, $kui-border-radius-30);
+    border-radius: var(--kui-button-border-radius, var(--kui-border-radius-30, $kui-border-radius-30));
     cursor: pointer;
     display: inline-flex;
     font-family: var(--kui-font-family-text, $kui-font-family-text);
@@ -166,6 +166,7 @@ export default {
     outline: none;
   }
 
+  // TODO: Need button component token for this?
   &:focus-visible {
     box-shadow: var(--kui-shadow-focus, $kui-shadow-focus);
   }
@@ -178,104 +179,122 @@ export default {
   /* Appearances */
 
   &.primary {
-    background-color: var(--kui-color-background-primary, $kui-color-background-primary);
-    border: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-transparent, $kui-color-border-transparent);
-    color: var(--kui-color-text-inverse, $kui-color-text-inverse);
+    background-color: var(--kui-button-color-background-primary, var(--kui-color-background-primary, $kui-color-background-primary));
+    border: var(--kui-button-border-width, var(--kui-border-width-20, $kui-border-width-20)) solid var(--kui-button-color-border-primary, var(--kui-color-border-transparent, $kui-color-border-transparent));
+    color: var(--kui-button-color-text-primary, var(--kui-color-text-inverse, $kui-color-text-inverse));
 
     &:hover:not(:disabled):not([disabled]):not(:focus):not(:active) {
-      background-color: var(--kui-color-background-primary-strong, $kui-color-background-primary-strong);
+      background-color: var(--kui-button-color-background-primary-hover, var(--kui-color-background-primary-strong, $kui-color-background-primary-strong));
+      border-color: var(--kui-button-color-border-primary-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:focus-visible {
-      background-color: var(--kui-color-background-primary-stronger, $kui-color-background-primary-stronger);
+      background-color: var(--kui-button-color-background-primary-hover, var(--kui-color-background-primary-stronger, $kui-color-background-primary-stronger));
+      border-color: var(--kui-button-color-border-primary-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:active {
-      background-color: var(--kui-color-background-primary-strongest, $kui-color-background-primary-strongest);
+      background-color: var(--kui-button-color-background-primary-active, var(--kui-color-background-primary-strongest, $kui-color-background-primary-strongest));
+      border-color: var(--kui-button-color-border-primary-active, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-active, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:disabled, &[disabled] {
-      background-color: var(--kui-color-background-disabled, $kui-color-background-disabled);
-      color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+      background-color: var(--kui-button-color-background-primary-disabled, var(--kui-color-background-disabled, $kui-color-background-disabled));
+      border-color: var(--kui-button-color-border-primary-disabled, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-primary-disabled, var(--kui-color-text-disabled, $kui-color-text-disabled));
     }
   }
 
   &.secondary {
-    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-    border: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-primary, $kui-color-border-primary);
-    color: var(--kui-color-text-primary, $kui-color-text-primary);
+    background-color: var(--kui-button-color-background-secondary, var(--kui-color-background-transparent, $kui-color-background-transparent));
+    border: var(--kui-button-border-width, var(--kui-border-width-20, $kui-border-width-20)) solid var(--kui-button-color-border-secondary, var(--kui-color-border-primary, $kui-color-border-primary));
+    color: var(--kui-button-color-text-secondary, var(--kui-color-text-primary, $kui-color-text-primary));
 
     &:hover:not(:disabled):not([disabled]):not(:focus):not(:active) {
-      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-      border-color: var(--kui-color-border-primary-strong, $kui-color-border-primary-strong);
-      color: var(--kui-color-text-primary-strong, $kui-color-text-primary-strong);
+      background-color: var(--kui-button-color-background-secondary-hover, var(--kui-color-background-transparent, $kui-color-background-transparent));
+      border-color: var(--kui-button-color-border-secondary-hover, var(--kui-color-border-primary-strong, $kui-color-border-primary-strong));
+      color: var(--kui-button-color-text-secondary-hover, var(--kui-color-text-primary-strong, $kui-color-text-primary-strong));
     }
 
     &:focus-visible {
-      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-      border-color: var(--kui-color-border-primary-stronger, $kui-color-border-primary-stronger);
-      color: var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger);
+      background-color: var(--kui-button-color-background-secondary-hover, var(--kui-color-background-transparent, $kui-color-background-transparent));
+      border-color: var(--kui-button-color-border-secondary-hover, var(--kui-color-border-primary-stronger, $kui-color-border-primary-stronger));
+      color: var(--kui-button-color-text-secondary-hover, var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger));
     }
 
     &:active {
-      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-      border-color: var(--kui-color-border-primary-strongest, $kui-color-border-primary-strongest);
-      color: var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest);
+      background-color: var(--kui-button-color-background-secondary-active, var(--kui-color-background-transparent, $kui-color-background-transparent));
+      border-color: var(--kui-button-color-border-secondary-active, var(--kui-color-border-primary-strongest, $kui-color-border-primary-strongest));
+      color: var(--kui-button-color-text-secondary-active, var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest));
     }
 
     &:disabled, &[disabled] {
-      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-      border-color: var(--kui-color-border-disabled, $kui-color-border-disabled);
-      color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+      background-color: var(--kui-button-color-background-secondary-disabled, var(--kui-color-background-transparent, $kui-color-background-transparent));
+      border-color: var(--kui-button-color-border-secondary-disabled, var(--kui-color-border-disabled, $kui-color-border-disabled));
+      color: var(--kui-button-color-text-secondary-disabled, var(--kui-color-text-disabled, $kui-color-text-disabled));
     }
   }
 
   &.tertiary {
-    background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-    border: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-transparent, $kui-color-border-transparent);
-    color: var(--kui-color-text-primary, $kui-color-text-primary);
+    background-color: var(--kui-button-color-background-tertiary, var(--kui-color-background-transparent, $kui-color-background-transparent));
+    border: var(--kui-button-border-width, var(--kui-border-width-20, $kui-border-width-20)) solid var(--kui-button-color-border-tertiary, var(--kui-color-border-transparent, $kui-color-border-transparent));
+    color: var(--kui-button-color-text-tertiary, var(--kui-color-text-primary, $kui-color-text-primary));
 
     &:hover:not(:disabled):not([disabled]):not(:focus):not(:active) {
-      background-color: var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest);
-      color: var(--kui-color-text-primary-strong, $kui-color-text-primary-strong);
+      background-color: var(--kui-button-color-background-tertiary-hover, var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest));
+      border-color: var(--kui-button-color-border-tertiary-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-tertiary-hover, var(--kui-color-text-primary-strong, $kui-color-text-primary-strong));
     }
 
     &:focus-visible {
-      background-color: var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest);
-      color: var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger);
+      background-color: var(--kui-button-color-background-tertiary-hover, var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest));
+      border-color: var(--kui-button-color-border-tertiary-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-tertiary-hover, var(--kui-color-text-primary-stronger, $kui-color-text-primary-stronger));
     }
 
     &:active {
-      background-color: var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker);
-      color: var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest);
+      background-color: var(--kui-button-color-background-tertiary-active, var(--kui-color-background-primary-weaker, $kui-color-background-primary-weaker));
+      border-color: var(--kui-button-color-border-tertiary-active, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-tertiary-active, var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest));
     }
 
     &:disabled, &[disabled] {
-      background-color: var(--kui-color-background-transparent, $kui-color-background-transparent);
-      color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+      background-color: var(--kui-button-color-background-tertiary-disabled, var(--kui-color-background-transparent, $kui-color-background-transparent));
+      border-color: var(--kui-button-color-border-tertiary-disabled, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-tertiary-disabled, var(--kui-color-text-disabled, $kui-color-text-disabled));
     }
   }
 
   &.danger {
-    background-color: var(--kui-color-background-danger, $kui-color-background-danger);
-    border: var(--kui-border-width-20, $kui-border-width-20) solid var(--kui-color-border-transparent, $kui-color-border-transparent);
-    color: var(--kui-color-text-inverse, $kui-color-text-inverse);
+    background-color: var(--kui-button-color-background-danger, var(--kui-color-background-danger, $kui-color-background-danger));
+    border: var(--kui-button-border-width, var(--kui-border-width-20, $kui-border-width-20)) solid var(--kui-button-color-border-danger, var(--kui-color-border-transparent, $kui-color-border-transparent));
+    color: var(--kui-button-color-text-danger, var(--kui-color-text-inverse, $kui-color-text-inverse));
 
     &:hover:not(:disabled):not([disabled]):not(:focus):not(:active) {
-      background-color: var(--kui-color-background-danger-strong, $kui-color-background-danger-strong);
+      background-color: var(--kui-button-color-background-danger-hover, var(--kui-color-background-danger-strong, $kui-color-background-danger-strong));
+      border-color: var(--kui-button-color-border-danger-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-danger-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:focus-visible {
-      background-color: var(--kui-color-background-danger-stronger, $kui-color-background-danger-stronger);
+      background-color: var(--kui-button-color-background-danger-hover, var(--kui-color-background-danger-stronger, $kui-color-background-danger-stronger));
+      border-color: var(--kui-button-color-border-danger-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-danger-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:active {
-      background-color: var(--kui-color-background-danger-strongest, $kui-color-background-danger-strongest);
+      background-color: var(--kui-button-color-background-danger-active, var(--kui-color-background-danger-strongest, $kui-color-background-danger-strongest));
+      border-color: var(--kui-button-color-border-danger-active, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-danger-active, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:disabled, &[disabled] {
-      background-color: var(--kui-color-background-disabled, $kui-color-background-disabled);
-      color: var(--kui-color-text-disabled, $kui-color-text-disabled);
+      background-color: var(--kui-button-color-background-danger-disabled, var(--kui-color-background-disabled, $kui-color-background-disabled));
+      border-color: var(--kui-button-color-border-danger-disabled, var(--kui-color-border-transparent, $kui-color-border-transparent));
+      color: var(--kui-button-color-text-danger-disabled, var(--kui-color-text-disabled, $kui-color-text-disabled));
     }
   }
 

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -149,8 +149,8 @@ export default {
     border-radius: var(--kui-button-border-radius, var(--kui-border-radius-30, $kui-border-radius-30));
     cursor: pointer;
     display: inline-flex;
-    font-family: var(--kui-font-family-text, $kui-font-family-text);
-    font-weight: var(--kui-font-weight-semibold, $kui-font-weight-semibold);
+    font-family: var(--kui-button-font-family, var(--kui-font-family-text, $kui-font-family-text));
+    font-weight: var(--kui-button-font-weight, var(--kui-font-weight-semibold, $kui-font-weight-semibold));
     justify-content: center;
     // Remove tap color highlight on mobile Safari
     -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -326,13 +326,13 @@ export default {
   /* Sizes */
 
   &.large {
-    font-size: var(--kui-font-size-40, $kui-font-size-40);
+    font-size: var(--kui-button-font-size-large, var(--kui-font-size-40, $kui-font-size-40));
     gap: var(--kui-space-40, $kui-space-40);
-    line-height: var(--kui-line-height-40, $kui-line-height-40);
-    padding: var(--kui-space-30, $kui-space-30) var(--kui-space-50, $kui-space-50);
+    line-height: var(--kui-button-line-height-large, var(--kui-line-height-40, $kui-line-height-40));
+    padding: var(--kui-button-padding-large-y, var(--kui-space-30, $kui-space-30)) var(--kui-button-padding-large-x, var(--kui-space-50, $kui-space-50));
 
     &.icon-button {
-      padding: var(--kui-space-30, $kui-space-30);
+      padding: var(--kui-button-padding-large-y, var(--kui-space-30, $kui-space-30));
     }
 
     // enforce icon size exported by @kong/icons because it's defined by the design system
@@ -347,15 +347,15 @@ export default {
   }
 
   &.small {
-    border-radius: var(--kui-border-radius-20, $kui-border-radius-20);
-    border-width: var(--kui-border-width-10, $kui-border-width-10);
-    font-size: var(--kui-font-size-20, $kui-font-size-20);
+    border-radius: var(--kui-button-border-radius, var(--kui-border-radius-20, $kui-border-radius-20));
+    border-width: var(--kui-button-border-width, var(--kui-border-width-10, $kui-border-width-10));
+    font-size: var(--kui-button-font-size-small, var(--kui-font-size-20, $kui-font-size-20));
     gap: var(--kui-space-20, $kui-space-20);
-    line-height: var(--kui-line-height-20, $kui-line-height-20);
-    padding: var(--kui-space-10, $kui-space-10) var(--kui-space-30, $kui-space-30);
+    line-height: var(--kui-button-line-height-medium, var(--kui-line-height-20, $kui-line-height-20));
+    padding: var(--kui-button-padding-small-y, var(--kui-space-10, $kui-space-10)) var(--kui-button-padding-small-x, var(--kui-space-30, $kui-space-30));
 
     &.icon-button {
-      padding: var(--kui-space-10, $kui-space-10);
+      padding: var(--kui-button-padding-small-y, var(--kui-space-10, $kui-space-10));
     }
 
     // enforce icon size exported by @kong/icons because it's defined by the design system

--- a/src/components/KButton/KButton.vue
+++ b/src/components/KButton/KButton.vue
@@ -186,19 +186,19 @@ export default {
     &:hover:not(:disabled):not([disabled]):not(:focus):not(:active) {
       background-color: var(--kui-button-color-background-primary-hover, var(--kui-color-background-primary-strong, $kui-color-background-primary-strong));
       border-color: var(--kui-button-color-border-primary-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
-      color: var(--kui-button-color-text-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
+      color: var(--kui-button-color-text-primary-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:focus-visible {
       background-color: var(--kui-button-color-background-primary-hover, var(--kui-color-background-primary-stronger, $kui-color-background-primary-stronger));
       border-color: var(--kui-button-color-border-primary-hover, var(--kui-color-border-transparent, $kui-color-border-transparent));
-      color: var(--kui-button-color-text-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
+      color: var(--kui-button-color-text-primary-hover, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:active {
       background-color: var(--kui-button-color-background-primary-active, var(--kui-color-background-primary-strongest, $kui-color-background-primary-strongest));
       border-color: var(--kui-button-color-border-primary-active, var(--kui-color-border-transparent, $kui-color-border-transparent));
-      color: var(--kui-button-color-text-active, var(--kui-color-text-inverse, $kui-color-text-inverse));
+      color: var(--kui-button-color-text-primary-active, var(--kui-color-text-inverse, $kui-color-text-inverse));
     }
 
     &:disabled, &[disabled] {

--- a/src/styles/mixins/_buttons.scss
+++ b/src/styles/mixins/_buttons.scss
@@ -4,13 +4,14 @@
 /* Buttons mixins */
 
 @mixin kButtonMediumSize {
-  font-size: var(--kui-font-size-30, $kui-font-size-30);
+  font-size: var(--kui-button-font-size-medium, var(--kui-font-size-30, $kui-font-size-30));
   gap: var(--kui-space-30, $kui-space-30);
-  line-height: var(--kui-line-height-30, $kui-line-height-30);
-  padding: var(--kui-space-20, $kui-space-20) var(--kui-space-40, $kui-space-40);
+  line-height: var(--kui-button-line-height-medium, var(--kui-line-height-30, $kui-line-height-30));
+  padding: var(--kui-button-padding-medium-y, var(--kui-space-20, $kui-space-20))
+    var(--kui-button-padding-medium-x, var(--kui-space-40, $kui-space-40));
 
   &.icon-button {
-    padding: var(--kui-space-20, $kui-space-20);
+    padding: var(--kui-button-padding-medium-y, var(--kui-space-20, $kui-space-20));
   }
 
   // enforce icon size exported by @kong/icons because it's defined by the design system


### PR DESCRIPTION
# Summary

Implement `button` component tokens from https://github.com/Kong/design-tokens/pull/645

Since these are additive:

- Non-breaking for v9 of Kongponents utilized in Konnect and Dev Portal
- Dev Portal gains the ability to enable customers to customize their `primary`, `secondary`, `tertiary`, and `danger` buttons globally, rather than per-button.