### PR TITLE
fix(ktableview): actions dropdown popover attributes prop [KHCP-20535]

### DIFF
--- a/docs/components/table-view.md
+++ b/docs/components/table-view.md
@@ -808,6 +808,18 @@ A boolean to disable some of the table features like column visibility, column r
 
 Prop for hiding toolbar. Useful when elements provided in the toolbar are not actionable (for example, when toolbar contains filter controls, however the fetcher returns no results as there are no records to filter by).
 
+### actionsDropdownPopoverAttributes
+
+Attributes (of type [`PopoverAttributes`](/components/popover#popoverattributes)) to be applied to the row actions dropdown popover. Useful for overriding things like `zIndex` or `maxHeight` on the actions popover. Defaults to `{}`.
+
+```html
+<KTableView
+  :data="tableData"
+  :headers="headers"
+  :actions-dropdown-popover-attributes="{ zIndex: 9999 }"
+/>
+```
+
 ### tooltipTarget
 
 Teleport target element selector for tooltips rendered by KTableView (e.g. column header tooltip, disabled row bulk action checkbox tooltip). Defaults to `body`.

--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -316,6 +316,22 @@ describe('KTableView', () => {
       cy.get('th').eq(options.headers.indexOf(options.headers.find((header => header.key === 'actions'))!)).find('.table-header-label').should('have.class', 'sr-only')
     })
 
+    it('applies actionsDropdownPopoverAttributes to the actions dropdown popover', () => {
+      cy.mount(KTableView, {
+        props: {
+          headers: options.headers,
+          data: options.data,
+          actionsDropdownPopoverAttributes: { zIndex: 9999 },
+        },
+        slots: {
+          'action-items': () => h('span', {}, 'Action item'),
+        },
+      })
+
+      cy.getTestId('actions-dropdown').eq(0).find('[data-testid="row-actions-dropdown-trigger"]').click()
+      cy.get('.k-popover .popover').should('have.attr', 'style').and('include', 'z-index: 9999')
+    })
+
     it('bulk actions in not enabled when rowKey prop is not provided', () => {
       cy.mount(KTableView, {
         props: {

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -333,7 +333,7 @@
                         ref="actionsDropdown"
                         class="actions-dropdown"
                         data-testid="actions-dropdown"
-                        :kpop-attributes="{ placement: 'bottom-end', target: 'body', popoverElementAttributes: getActionsDropdownPopoverAttributes(row, rowIndex) }"
+                        :kpop-attributes="{ ...actionsDropdownPopoverAttributes, placement: 'bottom-end', target: 'body', popoverElementAttributes: getActionsDropdownPopoverAttributes(row, rowIndex) }"
                         @toggle-dropdown="($event: boolean) => onRowActionsToggle(row, $event, cellHelperData)"
                       >
                         <KButton
@@ -535,6 +535,7 @@ const {
   tooltipTarget = 'body',
   data = [],
   headers = [],
+  actionsDropdownPopoverAttributes = {},
   ...restProps
 } = defineProps<TableViewProps<Header, Data>>()
 

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -210,6 +210,7 @@ export type PopoverAttributes = Pick<PopProps,
   | 'maxWidth'
   | 'disabled'
   | 'target'
+  | 'zIndex'
   | 'trigger' // Not supported in KDropdown, KSelect and KMultiselect
 > & {
   'data-testid'?: string

--- a/src/types/table.ts
+++ b/src/types/table.ts
@@ -1,5 +1,13 @@
 import type { RouterLinkProps } from 'vue-router'
-import type { ButtonAppearance, EmptyStateIconVariant, PageChangeData, PageSizeChangeData, PaginationProps, SwrvStateData } from '@/types'
+import type {
+  ButtonAppearance,
+  EmptyStateIconVariant,
+  PageChangeData,
+  PageSizeChangeData,
+  PaginationProps,
+  SwrvStateData,
+  PopoverAttributes,
+} from '@/types'
 
 /**
  * @internal
@@ -413,6 +421,12 @@ type TablePropsShared<
    * @default 'body'
    */
   tooltipTarget?: string | null
+
+  /**
+   * Attributes to be applied to the actions dropdown popover.
+   * @default {}
+   */
+  actionsDropdownPopoverAttributes?: PopoverAttributes
 } & {
   /**
    * Emitted when the user clicks on a table row.


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-20535

Adding `actionsDropdownPopoverAttributes` prop in KTableView which aims to solve this problem:

When using KTableView / KTableData inside of KModal / KPrompt, the modal element `z-index` is higher than default KPop `z-index`. That means actions dropdown (which is teleported to `body`) will appear underneath the modal. There is no easy way to override it - targeting the `.popover` with global CSS overrides may result in other dropdown elements being affected and potentially causing other `z-index` related issues.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
