### PR TITLE
fix(k-button): link button styling issue under KAlert slots

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -200,6 +200,29 @@ Slot for passing alert message content. When provided, takes precedence over the
 </KAlert>
 ```
 
+<KAlert class="divided-group">
+  <div class="space-between">
+    <strong>With KButton</strong>
+    <div class="button-group">
+      <KButton to="/components/button">To KButton</KButton>
+      <KButton to="/components/button" disabled>disabled Link KButton</KButton>
+    </div>   
+  </div>
+</KAlert>
+
+```html
+<KAlert class="divided-group">
+  <div class="space-between">
+    <strong>With KButton</strong>
+
+    <div class="button-group">
+      <KButton to="/components/button">To KButton</KButton>
+      <KButton to="/components/button" disabled>disabled Link KButton</KButton>
+    </div>   
+  </div>
+</KAlert>
+```
+
 ### icon
 
 Slot for providing a custom icon to the left of the alert message.
@@ -272,5 +295,16 @@ const showAlert = ref<boolean>(true)
   display: flex;
   flex-direction: column;
   gap: $kui-space-50;
+}
+
+.space-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .button-group {
+    display: flex;
+    gap: $kui-space-20;
+  }
 }
 </style>

--- a/sandbox/pages/SandboxAlert.vue
+++ b/sandbox/pages/SandboxAlert.vue
@@ -188,6 +188,22 @@
         <KAlert>
           <strong>Custom</strong> content
         </KAlert>
+
+        <KAlert class="divided-group">
+          <strong>With button</strong>
+
+          <div>
+            <KButton to="/kongponents/#/button">
+              To KButton
+            </KButton>
+            <KButton
+              disabled
+              to="/kongponents/#/button"
+            >
+              To KButton
+            </KButton>
+          </div>
+        </KAlert>
       </SandboxSectionComponent>
     </div>
   </SandboxLayout>
@@ -204,7 +220,13 @@ import { KongIcon } from '@kong/icons'
 .kalert-sandbox {
   .appearance-content {
     display: flex;
-    gap: $kui-space-40;
+    gap: var(--kui-space-40, $kui-space-40);
+  }
+
+  .divided-group :deep(.alert-message) {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
   }
 }
 </style>

--- a/src/components/KAlert/KAlert.vue
+++ b/src/components/KAlert/KAlert.vue
@@ -104,7 +104,7 @@ const getAlertIcon = computed((): AlertIcon => {
     .alert-message {
       :slotted(a),
       :deep(a) {
-        &:not([type='button']) {
+        &:not([type='button']):not([role='button']) {
           color: $textColor;
           text-decoration: underline;
 


### PR DESCRIPTION
* Fix the issue that style were unexpectedly applied to link KButton.
* Add docs for the changes

# Summary

This PR fixes the unexpected style applied to KButton renders as link in some places, because the `KButton` with `to` attribute attached will render as `<a role="button" />` rather than `<a type="button" />`, by adding `[role="button"]` in the same CSS group to avoid this from happening.

<img width="1738" height="1490" alt="CleanShot 2026-05-20 at 11 08 42@2x" src="https://github.com/user-attachments/assets/99eec972-f778-40b3-a5d5-30cc51e5a550" />

[KM-2603]


<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->


[KM-2603]: https://konghq.atlassian.net/browse/KM-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ