### PR TITLE
feat: add slots for filter items [ma-5062]

### DIFF
--- a/docs/components/filter-group.md
+++ b/docs/components/filter-group.md
@@ -294,6 +294,46 @@ const onOpen = (key: string) => {
 </script>
 ```
 
+### Filter Item
+
+You can customize the appearance of dropdown items in the filter selection dropdown. The corresponding filter key from the [`filters` prop](#filters) should be used to target the appropriate `filter-item-*` slot.
+
+<ClientOnly>
+  <KFilterGroup
+    v-model="customItemsSelection"
+    :filters="customItemsFilters"
+  >
+    <template #filter-item-status>
+      Status
+      <InfoIcon style="margin-left: auto" />
+    </template>
+    <template #filter-item-tag>
+      Tag
+      <KBadge>example</KBadge>
+      <ExternalLinkIcon style="margin-left: auto" />
+    </template>
+  </KFilterGroup>
+</ClientOnly>
+
+```html
+<template>
+  <KFilterGroup
+    v-model="selection"
+    :filters="filters"
+  >
+    <template #filter-item-status>
+      Status
+      <InfoIcon style="margin-left: auto" />
+    </template>
+    <template #filter-item-tag>
+      Tag
+      <KBadge>example</KBadge>
+      <ExternalLinkIcon style="margin-left: auto" />
+    </template>
+  </KFilterGroup>
+</template>
+```
+
 ## Events
 
 ### apply
@@ -468,6 +508,7 @@ For any filter other than a [Custom Filter](#custom-filter), when more than one 
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { InfoIcon, ExternalLinkIcon } from '@kong/icons'
 import { TimePeriods, TimeframeKeys } from '@mocks/KDateTimePickerMockData'
 import type { Filter, FilterGroupFilters, FilterGroupSelection, FilterSelection } from '@/types'
 import { defineComponent } from 'vue'
@@ -599,6 +640,12 @@ const customNodesFilters: FilterGroupFilters = {
   customNodes: { operators: ['eq'], label: 'Minimum nodes', pinned: true },
 }
 const customNodes = ref(0)
+
+const customItemsSelection = ref<FilterGroupSelection>({})
+const customItemsFilters: FilterGroupFilters = {
+  status: deepClone(selectFilter),
+  tag: deepClone(multiselectFilter),
+}
 
 const resetModelSelection = () => {
   modelSelection.value = { name: defaultNameSelection }

--- a/src/components/KFilterGroup/FilterSelector.cy.ts
+++ b/src/components/KFilterGroup/FilterSelector.cy.ts
@@ -6,14 +6,17 @@ describe('KFilterGroup - FilterSelector', () => {
 
   const render = ({
     filters,
+    slots = {},
   }: {
     filters: FilterGroupFilters
+    slots?: any
   }) => {
     cy.mount(FilterSelector as any, {
       props: {
         filters,
         onSelect: cy.spy().as('select'),
       },
+      slots,
     })
   }
 
@@ -54,5 +57,20 @@ describe('KFilterGroup - FilterSelector', () => {
     cy.getTestId(SELECTOR_ID).should('have.class', 'focused')
     cy.getTestId(SELECTOR_ID).click()
     cy.getTestId(SELECTOR_ID).should('have.class', 'unfocused')
+  })
+
+  it('exposes a slot for each filter item', () => {
+    render({
+      filters: {
+        a: { label: 'Ayy' },
+      },
+      slots: {
+        'filter-item-a': '<div>hello</div>',
+      },
+    })
+    cy.getTestId(SELECTOR_ID).click()
+    cy.getTestId('dropdown-item-trigger')
+      .should('have.length', 1)
+      .should('have.text', 'hello')
   })
 })

--- a/src/components/KFilterGroup/FilterSelector.vue
+++ b/src/components/KFilterGroup/FilterSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <KDropdown
     ref="filterSelector"
-    :items="items"
+    width="auto"
     @toggle-dropdown="onToggle"
   >
     <template #default>
@@ -17,17 +17,41 @@
         </template>
       </InteractivePill>
     </template>
+
+    <template #items>
+      <div
+        ref="itemWrapper"
+        class="items-wrapper"
+      >
+        <KDropdownItem
+          v-for="item in items"
+          :key="item.value"
+          data-testid="dropdown-item-trigger"
+          :item="item"
+          :value="item.value"
+          @click="item.onClick"
+        >
+          <slot
+            :name="`filter-item-${item.value}`"
+          >
+            {{ item.label }}
+          </slot>
+        </KDropdownItem>
+      </div>
+    </template>
   </KDropdown>
 </template>
 
 <script setup lang="ts">
-import { computed, useTemplateRef, ref } from 'vue'
-import type { DropdownItem, FilterGroupFilters } from '@/types'
+import { computed, nextTick, useTemplateRef, ref } from 'vue'
+import type { FilterGroupFilters } from '@/types'
 import KDropdown from '@/components/KDropdown/KDropdown.vue'
+import KDropdownItem from '@/components/KDropdown/KDropdownItem.vue'
 import InteractivePill from './InteractivePill.vue'
 import { AddIcon } from '@kong/icons'
 
 const filterSelectorRef = useTemplateRef('filterSelector')
+const itemWrapperRef = useTemplateRef('itemWrapper')
 const isOpen = ref<boolean>(false)
 
 const pillFocus = ref<boolean>(false)
@@ -40,7 +64,7 @@ const {
   label?: string
 }>()
 
-const items = computed((): DropdownItem[] => Object.entries(filters)
+const items = computed((): Array<{ label: string, value: string, onClick: () => void }> => Object.entries(filters)
   .map(([key, filter]) => ({
     label: filter.label,
     value: key,
@@ -64,11 +88,25 @@ const onToggle = (open: boolean) => {
   isOpen.value = !isOpen.value
 }
 
-const onTrigger = () => {
+const onTrigger = async () => {
   if (isOpen.value) {
     filterSelectorRef.value?.closeDropdown()
   } else {
     filterSelectorRef.value?.openDropdown()
+
+    // in order to make sure we're at the top of the list every time we open it
+    // we need to scroll the item wrapper to the top.
+    await nextTick()
+    itemWrapperRef.value?.scrollTo({ top: 0 })
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.items-wrapper {
+  max-height: 50vh;
+  overflow: auto;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+</style>

--- a/src/components/KFilterGroup/FilterSelector.vue
+++ b/src/components/KFilterGroup/FilterSelector.vue
@@ -104,7 +104,7 @@ const onTrigger = async () => {
 
 <style lang="scss" scoped>
 .items-wrapper {
-  max-height: 50vh;
+  max-height: min(500px, 90vh); // usually 500px but use 90vh on screens smaller than that
   overflow: auto;
   overflow-wrap: break-word;
   word-break: break-word;

--- a/src/components/KFilterGroup/KFilterGroup.cy.ts
+++ b/src/components/KFilterGroup/KFilterGroup.cy.ts
@@ -21,10 +21,14 @@ describe('KFilterGroup', () => {
 
   const render = ({
     filters,
+    groupLabel = undefined,
     selection = {},
+    slots = {},
   }: {
     filters: FilterGroupFilters
+    groupLabel?: string
     selection?: FilterGroupSelection
+    slots?: any
   }) => {
     const onApply = cy.spy().as('apply')
     const onClose = cy.spy().as('close')
@@ -34,12 +38,14 @@ describe('KFilterGroup', () => {
     cy.mount(KFilterGroup as any, {
       props: {
         filters,
+        groupLabel,
         modelValue: selection,
         onApply,
         onClose,
         onOpen,
         onClear,
       },
+      slots,
     }).as('filterGroup')
   }
 
@@ -140,6 +146,19 @@ describe('KFilterGroup', () => {
       expect($els.eq(1)).to.have.attr('data-testid', 'filter-group-pill-basic_b')
       expect($els.eq(2)).to.have.attr('data-testid', 'filter-group-pill-basic_a')
     })
+  })
+
+  it('exposes slots for filter items', () => {
+    render({
+      filters: {
+        basic_a: BASIC_FILTER,
+      },
+      slots: {
+        'filter-item-basic_a': '<div class="slot-test">hello</div>',
+      },
+    })
+    cy.getTestId(FILTER_SELECTOR_ID).click()
+    cy.get('[data-testid="dropdown-item-trigger"] .slot-test').should('exist')
   })
 
   it('emits @open', () => {

--- a/src/components/KFilterGroup/KFilterGroup.vue
+++ b/src/components/KFilterGroup/KFilterGroup.vue
@@ -32,7 +32,15 @@
       :filters="hiddenFilters"
       :label="selectorLabel ? selectorLabel : 'Add filter'"
       @select="onSelectFilter"
-    />
+    >
+      <template
+        v-for="key in hiddenFilterKeys"
+        :key="key"
+        #[getFilterItemSlotName(key)]
+      >
+        <slot :name="getFilterItemSlotName(key)" />
+      </template>
+    </FilterSelector>
   </div>
 </template>
 
@@ -46,6 +54,7 @@ import type {
   FilterGroupFilters,
   FilterGroupSelection,
   FilterGroupSlots,
+  FilterItemSlotName,
   FilterSelection,
   FilterSlotName,
 } from '@/types'
@@ -60,6 +69,15 @@ const slots = useSlots()
  */
 const getFilterSlotName = (filterKey: string): FilterSlotName => {
   return `filter-${filterKey}`
+}
+
+/**
+ * Utilize a helper function to generate the column slot name.
+ * This helps TypeScript infer the slot name in the template section so that the slot props can be resolved.
+ * @param {string} filterKey The filter's key
+ */
+const getFilterItemSlotName = (filterKey: string): FilterItemSlotName => {
+  return `filter-item-${filterKey}`
 }
 
 defineSlots<FilterGroupSlots>()

--- a/src/types/filter-group.ts
+++ b/src/types/filter-group.ts
@@ -189,9 +189,26 @@ export interface FilterGroupEmits {
  * the slot props can be resolved.
  */
 export type FilterSlotName<Key extends string = string> = `filter-${Key}`
+/**
+ * Provide a type interface for KFilterGroup `filter-item-*` slot names.
+ *
+ * This helps TypeScript infer the slot name in the template section so that
+ * the slot props can be resolved.
+ */
+export type FilterItemSlotName<Key extends string = string> = `filter-item-${Key}`
 export type FilterGroupSlots = {
+  /**
+   * The "Filters" label
+   */
+  'group-label'?: () => any
+} & {
   /**
    * Each filter's popover content.
    */
   [K in FilterSlotName]?: () => any
+} & {
+  /**
+   * Each filter's dropdown item content.
+   */
+  [K in FilterItemSlotName]?: () => any
 }


### PR DESCRIPTION
satisfies [ma-5062](https://konghq.atlassian.net/browse/MA-5062)

# Summary

If you have too many filters, the filter selection dropdown bleeds off the edge of the screen. Additionally, in some cases you want to be able to modify the content of the filter selection dropdown items.

## Screenshots

**bleed issue, before**

<img width="513" height="972" alt="Screenshot 2026-05-22 at 4 52 57 PM" src="https://github.com/user-attachments/assets/e7eabaea-03f3-4461-999d-461b2740dc72" />

**bleed issue, after**

<img width="449" height="970" alt="Screenshot 2026-05-22 at 4 55 12 PM" src="https://github.com/user-attachments/assets/c818e654-9376-4af1-91f4-c6fe54c4e029" />

**Using the new slots to decorate the "API" item**

<img width="284" height="191" alt="Screenshot 2026-05-22 at 4 56 50 PM" src="https://github.com/user-attachments/assets/536f6664-77cc-40fe-b5eb-141569a400ad" />