### PR TITLE
feat(kpop): implement popover delay prop

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -179,6 +179,32 @@ When [`trigger` prop](#trigger) is `hover`, you can provide a timeout for popove
 </KPop>
 ```
 
+### popoverDelay
+
+When [`trigger` prop](#trigger) is `hover`, you can provide a delay before the popover opens. Default value is 0 milliseconds (open immediately). If the user moves off the trigger before the delay elapses, the popover does not open.
+
+<KPop
+  :popover-delay="2000"
+  trigger="hover"
+  button-text="Open popover"
+>
+  <template #content>
+    Popover content.
+  </template>
+</KPop>
+
+```html
+<KPop
+  :popover-delay="2000"
+  trigger="hover"
+  button-text="Open popover"
+>
+  <template #content>
+    Popover content.
+  </template>
+</KPop>
+```
+
 ### disabled
 
 Boolean to control whether popover should be disabled. Defaults to `false`.

--- a/sandbox/pages/SandboxPop.vue
+++ b/sandbox/pages/SandboxPop.vue
@@ -91,6 +91,17 @@
           </template>
         </KPop>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="popoverDelay">
+        <KPop
+          button-text="Button"
+          :popover-delay="2000"
+          trigger="hover"
+        >
+          <template #content>
+            Popover content.
+          </template>
+        </KPop>
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="disabled">
         <KPop
           button-text="Button"

--- a/sandbox/pages/SandboxPop.vue
+++ b/sandbox/pages/SandboxPop.vue
@@ -388,6 +388,6 @@ const onEvent = (message: string): void => {
 .horizontal-container {
   display: flex;
   flex-wrap: wrap;
-  gap: $kui-space-50;
+  gap: var(--kui-space-50, $kui-space-50);
 }
 </style>

--- a/src/components/KPop/KPop.cy.ts
+++ b/src/components/KPop/KPop.cy.ts
@@ -100,6 +100,42 @@ describe('KPop', () => {
     cy.get('.popover').should('be.visible')
   })
 
+  it('delays showing popover on hover when popoverDelay is set', () => {
+    cy.mount(KPop, {
+      props: {
+        title: 'Popover Title',
+        trigger: 'hover',
+        popoverDelay: 500,
+      },
+      slots: {
+        default: () => h('div', { class: ['slottedEl'] }, 'Slotted element'),
+      },
+    })
+
+    cy.get('.popover').should('not.be.visible')
+    cy.get('.slottedEl').trigger('mouseenter')
+    cy.get('.popover').should('not.be.visible')
+    cy.get('.popover', { timeout: 1000 }).should('be.visible')
+  })
+
+  it('cancels pending show when mouseleave occurs during popoverDelay', () => {
+    cy.mount(KPop, {
+      props: {
+        title: 'Popover Title',
+        trigger: 'hover',
+        popoverDelay: 500,
+      },
+      slots: {
+        default: () => h('div', { class: ['slottedEl'] }, 'Slotted element'),
+      },
+    })
+
+    cy.get('.slottedEl').trigger('mouseenter')
+    cy.get('.slottedEl').trigger('mouseleave')
+    cy.wait(800)
+    cy.get('.popover').should('not.be.visible')
+  })
+
   it('renders with correct default zIndex', () => {
     cy.mount(KPop)
 

--- a/src/components/KPop/KPop.cy.ts
+++ b/src/components/KPop/KPop.cy.ts
@@ -132,6 +132,7 @@ describe('KPop', () => {
 
     cy.get('.slottedEl').trigger('mouseenter')
     cy.get('.slottedEl').trigger('mouseleave')
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(800)
     cy.get('.popover').should('not.be.visible')
   })

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -107,6 +107,7 @@ const {
   placement = 'auto',
   trigger = 'click',
   popoverTimeout = 300,
+  popoverDelay = 0,
   hideCloseIcon,
   hideCaret,
   closeOnPopoverClick,
@@ -134,6 +135,7 @@ const isVisible = ref<boolean>(false)
 const popoverTrigger = computed((): HTMLElement | null => triggerWrapperElement.value && triggerWrapperElement.value?.children[0] ? triggerWrapperElement.value?.children[0] as HTMLElement : null)
 
 const timer = ref<number | null>(null)
+const showTimer = ref<number | null>(null)
 
 const togglePopover = () => {
   if (!isVisible.value) {
@@ -165,14 +167,30 @@ const showPopover = async () => {
   if (!disabled) {
     if (timer.value) {
       clearTimeout(timer.value)
+      timer.value = null
     }
 
-    startFloatingUpdates()
-    isVisible.value = true
+    const reveal = () => {
+      startFloatingUpdates()
+      isVisible.value = true
+    }
+
+    if (trigger === 'hover' && popoverDelay > 0) {
+      if (showTimer.value) {
+        clearTimeout(showTimer.value)
+      }
+      showTimer.value = setTimeout(reveal, popoverDelay)
+    } else {
+      reveal()
+    }
   }
 }
 
 const hidePopover = () => {
+  if (showTimer.value) {
+    clearTimeout(showTimer.value)
+    showTimer.value = null
+  }
   timer.value = setTimeout(() => {
     cancelFloatingUpdates()
     isVisible.value = false
@@ -303,6 +321,12 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  if (showTimer.value) {
+    clearTimeout(showTimer.value)
+  }
+  if (timer.value) {
+    clearTimeout(timer.value)
+  }
   cancelFloatingUpdates()
 })
 

--- a/src/types/popover.ts
+++ b/src/types/popover.ts
@@ -80,6 +80,12 @@ export interface PopProps {
   popoverTimeout?: number
 
   /**
+   * The delay in milliseconds before the popover opens when trigger prop is hover.
+   * @default 0
+   */
+  popoverDelay?: number
+
+  /**
    * Whether to hide close button in popover content.
    * @default false
    */
@@ -204,6 +210,7 @@ export type PopoverAttributes = Pick<PopProps,
   | 'popoverClasses'
   | 'popoverElementAttributes'
   | 'popoverTimeout'
+  | 'popoverDelay'
   | 'offset'
   | 'width'
   | 'hideCaret'


### PR DESCRIPTION
# Summary

Implement `popoverDelay` prop in KPop: when `trigger` prop is `hover`, you can provide a delay before the popover opens. Default value is 0 milliseconds (open immediately). If the user moves off the trigger before the delay elapses, the popover does not open.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
