### PR TITLE
feat: add a readonly prop to filters [MA-5080]

### DIFF
--- a/docs/components/filter-group.md
+++ b/docs/components/filter-group.md
@@ -163,6 +163,10 @@ If `true` the filter will always be rendered as a pill regardless of whether it 
 
 Where the filter's popover will be placed, defaults to `bottom-start`. See [popover placement](../components/popover#placement)
 
+### filter.readonly
+
+If `true` the filter will only be rendered as a pill if it has a value and will never appear in the "Add filter" dropdown as the user can't change it. See [example](#readonly-filter)
+
 ### filter.maxWidth
 
 The max width of the filter's popover, defaults to `400px`. See [popover maxWidth](../components/popover#maxwidth)
@@ -497,6 +501,53 @@ A custom filter is rendered when content is provided in the [filter-\*](#filter-
 </KFilterGroup>
 ```
 
+### Readonly Filter
+
+A readonly filter is rendered as a pill only when it has a value.
+
+<ClientOnly>
+  <KFilterGroup
+    v-model="readonlySelection"
+    :filters="readonlyFilters"
+  />
+</ClientOnly>
+
+```html
+<template>
+  <KFilterGroup
+    v-model="selection"
+    :filters="{
+      environment: {
+        label: 'Environment',
+        operators: ['eq'],
+        readonly: true,
+      },
+      notVisibleWhenNotSet: {
+        label: 'Not visible when has no value',
+        readonly: true,
+      },
+      name: {
+        label: 'Name',
+      },
+    }"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue'
+
+  const selection = ref({
+    environment: {
+      operator: 'eq',
+      value: 'prod',
+      text: 'Prod',
+    }
+  })
+</script>
+```
+
+
+
 ### Operator Usage
 
 For any filter other than a [Custom Filter](#custom-filter), when more than one operator is set for a filter, an operator selection is rendered in the popover.
@@ -602,6 +653,29 @@ const operatorFilters: FilterGroupFilters = {
     ...deepClone(inputFilter),
     operators: ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte'],
     pinned: true
+  },
+}
+
+const readonlySelection = ref<FilterGroupSelection>({
+  environment: {
+    operator: 'eq',
+    value: 'prod',
+    text: 'Prod',
+  },
+})
+
+const readonlyFilters: FilterGroupFilters = {
+  environment: {
+    label: 'Environment',
+    operators: ['eq'],
+    readonly: true,
+  },
+  notVisibleWhenNotSet: {
+    label: 'Not visible when has no value',
+    readonly: true,
+  },
+  name: {
+    label: 'Name',
   },
 }
 

--- a/sandbox/pages/SandboxFilterGroup.vue
+++ b/sandbox/pages/SandboxFilterGroup.vue
@@ -29,10 +29,11 @@
     pinned: true,
   },
   defaultMultiSelect: {
-    label: 'Default multiselect',
+    label: 'Readonly, pinned, multi',
     multiple: true,
     options: [{ value: 'a', label: 'Ayy' }, { value: 'b', label: 'Bee' }, { value: 'c', label: 'See' }],
     pinned: true,
+    readonly: true,
   },
   inputOperators: {
     label: 'Input with operators',
@@ -49,6 +50,10 @@
     operators: ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte'],
     options: [{ value: 'a', label: 'Ayy' }, { value: 'b', label: 'Bee' }, { value: 'c', label: 'See' }],
   },
+  readonlyWithoutValue: {
+    label: 'Readonly without a value does not appear in the list',
+    readonly: true,
+  }
 })`"
         language="javascript"
       />
@@ -206,10 +211,11 @@ const filters: FilterGroupFilters = {
     pinned: true,
   },
   defaultMultiSelect: {
-    label: 'Default multiselect',
+    label: 'Readonly, pinned, multi',
     multiple: true,
     options: [{ value: 'a', label: 'Ayy' }, { value: 'b', label: 'Bee' }, { value: 'c', label: 'See' }],
     pinned: true,
+    readonly: true,
   },
   inputOperators: {
     label: 'Input with operators',
@@ -226,6 +232,10 @@ const filters: FilterGroupFilters = {
     operators: ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte'],
     options: [{ value: 'a', label: 'Ayy' }, { value: 'b', label: 'Bee' }, { value: 'c', label: 'See' }],
   },
+  readonlyWithoutValue: {
+    label: 'Readonly without a value does not appear in the list',
+    readonly: true,
+  },
 }
 
 const selection = ref<FilterGroupSelection>({
@@ -233,6 +243,11 @@ const selection = ref<FilterGroupSelection>({
     operator: 'eq',
     value: 'Pinned default value',
     text: 'Pinned default value',
+  },
+  defaultMultiSelect: {
+    operator: 'eq',
+    value: ['a', 'b'],
+    text: 'Ayy, Bee',
   },
 })
 

--- a/src/components/KFilterGroup/FilterPill.vue
+++ b/src/components/KFilterGroup/FilterPill.vue
@@ -14,6 +14,7 @@
         :delimiter="delimiter"
         :label="filter.label"
         :pill-focus="isOpen"
+        :readonly="filter.readonly"
         v-bind="attrs"
         @clear="onClear"
         @click.prevent.stop

--- a/src/components/KFilterGroup/FilterSelector.cy.ts
+++ b/src/components/KFilterGroup/FilterSelector.cy.ts
@@ -41,6 +41,23 @@ describe('KFilterGroup - FilterSelector', () => {
       })
   })
 
+  it('readonly filters do not render in the dropdown', () => {
+    const expectedText = ['Ayy', 'Zee', 'Jay']
+    render({ filters: {
+      a: { label: expectedText[0]! },
+      z: { label: expectedText[1]! },
+      j: { label: expectedText[2]!, readonly: true },
+    } })
+
+    cy.getTestId(SELECTOR_ID).should('exist').click()
+    cy.getTestId('dropdown-item-trigger')
+      .should('have.length', 2)
+      .each((el, index) => {
+        // we set readonly on the last item just to make this loop easier
+        expect(el).to.have.text(expectedText[index]!)
+      })
+  })
+
   it('emits @select with filter key on item click', () => {
     render({ filters: {
       a: { label: 'Ayy' },

--- a/src/components/KFilterGroup/FilterSelector.vue
+++ b/src/components/KFilterGroup/FilterSelector.vue
@@ -95,6 +95,7 @@ const items = computed((): Array<{ label: string, value: string, onClick: () => 
       || filter.label.toLocaleLowerCase().includes(lowerSearch.value)
 
     return matchesSearch // if the lowercase label includes the search string
+      && !filter.readonly // readonly filters don't appear in the FilterSelector
   })
   .map(([key, filter]) => ({
     label: filter.label,

--- a/src/components/KFilterGroup/InteractivePill.cy.ts
+++ b/src/components/KFilterGroup/InteractivePill.cy.ts
@@ -18,6 +18,7 @@ describe('KFilterGroup - InteractivePill', () => {
     contentLabel,
     delimiter,
     pillFocus,
+    readonly,
     tooltipText,
   }: {
     label: string
@@ -25,6 +26,7 @@ describe('KFilterGroup - InteractivePill', () => {
     contentLabel?: string
     delimiter?: string
     pillFocus?: boolean
+    readonly?: boolean
     tooltipText?: string
   }) => {
     cy.mount(InteractivePill as any, {
@@ -34,6 +36,7 @@ describe('KFilterGroup - InteractivePill', () => {
         ...(contentLabel !== undefined && { contentLabel }),
         ...(delimiter !== undefined && { delimiter }),
         ...(pillFocus !== undefined && { pillFocus }),
+        ...(readonly !== undefined && { readonly }),
         ...(tooltipText !== undefined && { tooltipText }),
         onTrigger: cy.spy().as('trigger'),
         onClear: cy.spy().as('clear'),
@@ -115,6 +118,29 @@ describe('KFilterGroup - InteractivePill', () => {
 
     cy.get('@clear').should('have.callCount', 0)
     cy.get('@trigger').should('have.callCount', 1)
+  })
+
+  it('while readonly does not fire trigger when clicked', () => {
+    render({ label: 'test', readonly: true })
+    cy.get('@clear').should('have.callCount', 0)
+    cy.get('@trigger').should('have.callCount', 0)
+
+    cy.getTestId(PILL_ID).click()
+
+    cy.get('@clear').should('have.callCount', 0)
+    cy.get('@trigger').should('have.callCount', 0)
+  })
+
+  it('when readonly without content, the control icons do not appear', () => {
+    render({ label: 'test', contentLabel: undefined, readonly: true })
+    cy.getTestId(CLEAR_ICON_ID).should('not.exist')
+    cy.getTestId(OPEN_ICON_ID).should('not.exist')
+  })
+
+  it('when readonly with content, the control icons do not appear', () => {
+    render({ label: 'test', contentLabel: 'foo', readonly: true })
+    cy.getTestId(CLEAR_ICON_ID).should('not.exist')
+    cy.getTestId(OPEN_ICON_ID).should('not.exist')
   })
 
   it('fires trigger when enter is pressed on the pill', () => {

--- a/src/components/KFilterGroup/InteractivePill.vue
+++ b/src/components/KFilterGroup/InteractivePill.vue
@@ -15,6 +15,7 @@
           ref="trigger"
           class="interactive-pill-trigger"
           data-testid="interactive-pill-trigger"
+          :disabled="readonly"
           type="button"
           @blur="onPillBlur"
           @click="onPillTrigger"
@@ -40,7 +41,7 @@
           </div>
 
           <div
-            v-if="!hasContent"
+            v-if="!hasContent && !readonly"
             class="pill-icon open-icon"
             data-testid="interactive-pill-open-icon"
           >
@@ -54,7 +55,7 @@
         </button>
 
         <button
-          v-if="hasContent"
+          v-if="hasContent && !readonly"
           ref="clear"
           class="pill-icon clear-icon"
           data-testid="interactive-pill-clear-icon"
@@ -96,6 +97,7 @@ const {
   contentLabel = undefined,
   delimiter = ': ',
   pillFocus = false,
+  readonly = false,
   tooltipText = undefined,
 } = defineProps<{
   label: string
@@ -103,6 +105,7 @@ const {
   contentLabel?: string
   delimiter?: string
   pillFocus?: boolean
+  readonly?: boolean
   tooltipText?: string
 }>()
 
@@ -164,7 +167,10 @@ const pillState = computed((): string => {
   const clearFocusClass = clearFocus || browserClearFocus.value
     ? 'clear-focused'
     : 'clear-unfocused'
-  return `${contentClass} ${pillFocusClass} ${clearFocusClass}`
+
+  const readonlyClass = readonly ? 'readonly' : 'writeable'
+
+  return `${contentClass} ${pillFocusClass} ${clearFocusClass} ${readonlyClass}`
 })
 
 const onPillFocus = () => {
@@ -311,6 +317,23 @@ $shadowFocusNarrow: 0 0 0 2px rgba(
   :deep(#{$kongponentsKongIconSelector}) {
     height: var(--kui-icon-size-30, $kui-icon-size-30) !important;
     width: var(--kui-icon-size-30, $kui-icon-size-30) !important;
+  }
+
+  &.readonly {
+    padding-right: var(--kui-space-20, $kui-space-20);
+
+    .interactive-pill-trigger {
+      cursor: not-allowed;
+    }
+
+    &.unfocused.has-content {
+      .interactive-pill-trigger:hover,
+      .interactive-pill-trigger:hover + .clear-icon,
+      .clear-icon:hover {
+        background-color: inherit;
+        color: inherit;
+      }
+    }
   }
 }
 </style>

--- a/src/types/filter-group.ts
+++ b/src/types/filter-group.ts
@@ -65,6 +65,14 @@ export interface Filter {
    * @default '400px'
    */
   maxWidth?: number | string
+
+  /**
+   * When true, will only be visible to the user when a value for this filter
+   * exists. Additionally, they won't be able to open the filter content while
+   * true.
+   * @default false
+   */
+  readonly?: boolean
 }
 
 export interface FilterSelection {


### PR DESCRIPTION
Satisfies [MA-5080](https://konghq.atlassian.net/browse/MA-5080)

# Summary

* Updates KFilterGroup to support `readonly` filters.

### Demo

https://github.com/user-attachments/assets/acbde729-c05b-4073-8da4-95118dc2822e

[MA-5080]: https://konghq.atlassian.net/browse/MA-5080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ