### PR TITLE
feat: support operator delimiter overrides [MA-5120]

### DIFF
--- a/docs/components/filter-group.md
+++ b/docs/components/filter-group.md
@@ -29,6 +29,7 @@ interface FilterSelection {
   operator: FilterOperator // 'eq' | 'neq' | 'contains' | 'exists' | 'lt' | 'lte' | 'gt' | 'gte'
   value: string | string[] // the user's selection
   text: string // the display string for that selection
+  operatorDelimiter?: string // override the display string for the delimiter displayed in the pill
 }
 ```
 
@@ -46,7 +47,13 @@ interface FilterSelection {
       Add "In Progress" filter
     </KButton>
     <KButton
-      :disabled="modelSelection?.name?.value === 'My name' && Object.keys(modelSelection).length === 1"
+      :disabled="!modelSelection?.name || modelSelection?.name?.operatorDelimiter !== undefined"
+      @click="setOperatorDelimiter"
+    >
+      Set name's operatorDelimiter to '?'
+    </KButton>
+    <KButton
+      :disabled="modelSelection?.name?.value === 'My name' && Object.keys(modelSelection).length === 1 && modelSelection?.name?.operatorDelimiter === undefined"
       @click="resetModelSelection"
     >
       Reset
@@ -61,14 +68,20 @@ interface FilterSelection {
     :filters="filters"
   />
   <KButton
-    :disabled="modelSelection?.status?.value === 'inprogress'"
+    :disabled="selection?.status?.value === 'inprogress'"
     @click="filterInProgress"
   >
     Add "In Progress" filter
   </KButton>
   <KButton
-    :disabled="selection?.name?.value === 'My name' && Object.keys(selection).length === 1"
-    @click="resetModelSelection"
+    :disabled="!selection?.name || selection?.name?.operatorDelimiter !== undefined"
+    @click="setOperatorDelimiter"
+  >
+    Set name's operatorDelimiter to '?'
+  </KButton>
+  <KButton
+    :disabled="selection?.name?.value === 'My name' && Object.keys(selection).length === 1 && selection?.name?.operatorDelimiter === undefined"
+    @click="resetSelection"
   >
     Reset
   </KButton>
@@ -93,8 +106,9 @@ const selection = ref<FilterGroupSelection>({
   name: defaultNameSelection,
 })
 
-const resetModelSelection = () => {
-  selection.value.name = defaultNameSelection,
+const resetSelection = () => {
+  delete selection.value.name?.operatorDelimiter
+  selection.value = { name: defaultNameSelection }
 }
 
 const filterInProgress = () => {
@@ -108,6 +122,11 @@ const filterInProgress = () => {
   }
 }
 
+const setOperatorDelimiter = () => {
+  if (selection.value.name && selection.value.name.operatorDelimiter === undefined) {
+    selection.value.name.operatorDelimiter = ' ? '
+  }
+}
 </script>
 ```
 
@@ -748,6 +767,7 @@ const customItemsFilters: FilterGroupFilters = {
 }
 
 const resetModelSelection = () => {
+  delete modelSelection.value.name?.operatorDelimiter
   modelSelection.value = { name: defaultNameSelection }
 }
 
@@ -759,6 +779,12 @@ const filterInProgress = () => {
       value: 'inprogress',
       text: 'In Progress',
     }
+  }
+}
+
+const setOperatorDelimiter = () => {
+  if (modelSelection.value.name && modelSelection.value.name.operatorDelimiter === undefined) {
+    modelSelection.value.name.operatorDelimiter = ' ? '
   }
 }
 

--- a/sandbox/pages/SandboxFilterGroup.vue
+++ b/sandbox/pages/SandboxFilterGroup.vue
@@ -74,6 +74,22 @@
     </SandboxSectionComponent>
 
     <SandboxSectionComponent
+      description="Setting an 'operatorDelimiter' on a selection overrides the delimiter that's shown in the pill. Below we override the delimiter to be ' %%% ' in every case."
+      title="v-model - with an operatorDelimiter"
+    >
+      <KFilterGroup
+        v-model="operatorOverrideSelection"
+        :filters="operatorOverrideFilters"
+        @apply="onApply"
+      />
+      <KCodeBlock
+        id="filter-code"
+        :code="JSON.stringify(operatorOverrideSelection, null, 2)"
+        language="javascript"
+      />
+    </SandboxSectionComponent>
+
+    <SandboxSectionComponent
       description="Changes the 'Add filter' button text."
       title="selectorLabel"
     >
@@ -251,6 +267,14 @@ const selection = ref<FilterGroupSelection>({
   },
 })
 
+const operatorOverrideFilters: FilterGroupFilters = {
+  operatorOverride: {
+    label: 'Using an operatorDelimiter',
+    operators: ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte'],
+  },
+}
+const operatorOverrideSelection = ref<FilterGroupSelection>({})
+
 const customFilters: FilterGroupFilters = {
   custom: {
     label: 'Custom slotted filter',
@@ -265,6 +289,16 @@ const onApply = (key: string, applySelection: FilterGroupSelection) => {
       operator: 'eq',
       value: customValue.value ? 'true' : 'false',
       text: customValue.value ? 'True' : 'False',
+    }
+  } else if (key === 'operatorOverride') {
+    if (applySelection[key]) {
+      operatorOverrideSelection.value = {
+        ...applySelection,
+        [key]: {
+          ...applySelection[key],
+          operatorDelimiter: ' %%% ',
+        },
+      }
     }
   } else {
     alert(`@apply filter '${key}' with selection\n${JSON.stringify(applySelection, null, 2)}`)

--- a/src/components/KFilterGroup/FilterPill.cy.ts
+++ b/src/components/KFilterGroup/FilterPill.cy.ts
@@ -73,6 +73,21 @@ describe('KFilterGroup - FilterPill', () => {
     })
   })
 
+  it('renders the selection text with the operatorDelimiter if set', () => {
+    render({ filter: { label: 'Foo' } })
+    const ops = ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte']
+    const operatorDelimiter = ' !!! '
+
+    ops.forEach((op) => {
+      cy.get('@filterPill')
+        .its('wrapper')
+        .invoke('setProps', {
+          selection: { operator: op, value: 'a', text: 'Ayy', operatorDelimiter },
+        })
+      cy.getTestId(PILL_ID).should('have.text', `Foo${operatorDelimiter}Ayy`)
+    })
+  })
+
   it('renders clear icon when selection is defined', () => {
     render({
       filter: { label: 'Foo' },

--- a/src/components/KFilterGroup/FilterPill.vue
+++ b/src/components/KFilterGroup/FilterPill.vue
@@ -274,6 +274,10 @@ const userSelection = computed((): FilterSelection | undefined => {
  * The delimiter to display in the pill's label. Determined based on the `selection.operator`
  */
 const delimiter = computed((): string | undefined => {
+  if (selection?.operatorDelimiter !== undefined) {
+    return selection.operatorDelimiter
+  }
+
   switch (selection?.operator) {
     case 'eq':
       return ' = '

--- a/src/components/KFilterGroup/FilterSelector.cy.ts
+++ b/src/components/KFilterGroup/FilterSelector.cy.ts
@@ -102,6 +102,29 @@ describe('KFilterGroup - FilterSelector', () => {
     cy.getTestId(FILTERING_ID).should('be.visible').and('be.focused')
   })
 
+  it('has a search bar when itemFiltering is true, and resets it on open', () => {
+    render({
+      filters: { a: { label: 'Ayy' } },
+      itemFiltering: true,
+    })
+    cy.getTestId(SELECTOR_ID).click()
+
+    // initial state should be visible, focused, '' value
+    cy.getTestId(FILTERING_ID).should('be.visible').and('be.focused').and('have.value', '')
+
+    // after typing should have value 'hello'
+    cy.getTestId(FILTERING_ID).type('hello')
+    cy.getTestId(FILTERING_ID).should('have.value', 'hello')
+
+    // close and re-open the selector
+    cy.get('body').type('{esc}')
+    cy.getTestId(FILTERING_ID).should('not.be.visible')
+    cy.getTestId(SELECTOR_ID).click()
+
+    // should be reset to initial state
+    cy.getTestId(FILTERING_ID).should('be.visible').and('be.focused').and('have.value', '')
+  })
+
   it('filters items when you type in the itemFiltering input', () => {
     render({
       filters: {

--- a/src/components/KFilterGroup/FilterSelector.vue
+++ b/src/components/KFilterGroup/FilterSelector.vue
@@ -116,6 +116,8 @@ const onToggle = async (open: boolean) => {
     pillFocus.value = true
 
     await nextTick()
+    // always reset the item search when we open
+    itemSearch.value = ''
     // if we have an filtering ref, focus on it
     itemFilteringInputRef.value?.input?.focus()
   } else {

--- a/src/types/filter-group.ts
+++ b/src/types/filter-group.ts
@@ -82,6 +82,11 @@ export interface FilterSelection {
   operator: FilterOperator
 
   /**
+   * Override what delimiter is displayed for the selected operator. Useful for custom filters.
+   */
+  operatorDelimiter?: string
+
+  /**
    * The value input by the user
    */
   value: string | string[]


### PR DESCRIPTION
Satisfies [MA-5120](https://konghq.atlassian.net/browse/MA-5120)

# Summary

If you want to use an operator like `exists` (which generates the delimiter `': '`), you get this output:

<img width="134" height="40" alt="Screenshot 2026-06-10 at 4 19 16 PM" src="https://github.com/user-attachments/assets/4e74fe92-07c0-41b4-9ddb-f04257ec474c" />

There are cases where you want a different delimiter than the default. That's where the new `operatorDelimiter` comes in. It ONLY affects the delimiter. With `operatorDelimiter: ' in: '` you get:

<img width="145" height="34" alt="Screenshot 2026-06-10 at 4 22 39 PM" src="https://github.com/user-attachments/assets/b131bd6e-f18a-4275-afcb-8eb05cc8c778" />


[MA-5120]: https://konghq.atlassian.net/browse/MA-5120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ