### PR TITLE
fix(kbadge): max-width remove important

### DIFF
--- a/src/components/KBadge/KBadge.vue
+++ b/src/components/KBadge/KBadge.vue
@@ -157,7 +157,7 @@ $kBadgeMethodWidth: 85px;
   &.method {
     .badge-content {
       justify-content: center;
-      min-width: $kBadgeMethodWidth !important;
+      min-width: $kBadgeMethodWidth;
       text-align: center;
       text-transform: uppercase;
     }


### PR DESCRIPTION
# Summary

Remove `!important` from the `min-width` rule to avoid specificity issues when applying custom styling

.k-badge.method .badge-content {
  min-width: $kBadgeMethodWidth ~!important~;
}

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
