### PR TITLE
fix(kpop, kmodal, kslideout): teleported kpop z-index [KHCP-20474]

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -415,6 +415,8 @@ Attributes to be applied to `.popover` element.
 
 Pass a number to use for the `z-index` property. Default value is `1000`.
 
+When `KPop` is nested inside a `KModal`, `KPrompt`, or `KSlideout` and no explicit `zIndex` is provided, the popover automatically resolves to one above its parent container's `z-index`, so it always renders on top. An explicit `zIndex` prop always takes precedence.
+
 ### offset
 
 Prop for specifying popover offset (string). Default value is `16px`.
@@ -441,7 +443,11 @@ Prop for specifying popover offset (string). Default value is `16px`.
 
 ### target
 
-In certain scenarios, you may want to attach the popover to other target elements. To achieve this, use the `target` prop to specify a selector for the element where the popover will be teleported. When falsy value us passed, the teleport will be disabled, therefore popover won't be [teleported](https://vuejs.org/guide/built-ins/teleport). Defaults to `null`.
+In certain scenarios, you may want to attach the popover to other target elements. To achieve this, use the `target` prop to specify a selector for the element where the popover will be teleported. When falsy value is passed, the teleport will be disabled, therefore popover won't be [teleported](https://vuejs.org/guide/built-ins/teleport). Defaults to `null`.
+
+:::tip NOTE
+When a teleported popover is nested inside a `KSlideout`, `KModal`, or `KPrompt`, it automatically elevates its `z-index` above the parent container so it renders on top — even though teleporting moves it out of the parent's DOM subtree (`provide`/`inject` follows the component tree, not the DOM). If you set an explicit [`zIndex`](#zindex) prop, that value is used as-is, so make sure it is higher than the parent's `z-index` (`KSlideout` defaults to `9999`, `KModal`/`KPrompt` to `1100`).
+:::
 
 <KPop
   target="body"

--- a/sandbox/pages/SandboxModals.vue
+++ b/sandbox/pages/SandboxModals.vue
@@ -502,6 +502,14 @@
             @proceed="data.modalVisible = false"
           >
             Slotted KModel content
+
+            <KPop target="body">
+              <KButton>Popover</KButton>
+
+              <template #content>
+                Lorem ipsum.
+              </template>
+            </KPop>
           </KModal>
           <KPrompt
             :visible="data.promptVisible"
@@ -509,6 +517,14 @@
             @proceed="data.promptVisible = false"
           >
             Slotted KPrompt content
+
+            <KPop target="body">
+              <KButton>Popover</KButton>
+
+              <template #content>
+                Lorem ipsum.
+              </template>
+            </KPop>
           </KPrompt>
         </KComponent>
       </SandboxSectionComponent>
@@ -686,13 +702,13 @@ watch(inputAutofocusModalVisible, (newValue): void => {
   .horizontal-container {
     display: flex;
     flex-wrap: wrap;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .vertical-container {
     display: flex;
     flex-direction: column;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .loading-container {

--- a/sandbox/pages/SandboxModals.vue
+++ b/sandbox/pages/SandboxModals.vue
@@ -502,14 +502,6 @@
             @proceed="data.modalVisible = false"
           >
             Slotted KModel content
-
-            <KPop target="body">
-              <KButton>Popover</KButton>
-
-              <template #content>
-                Lorem ipsum.
-              </template>
-            </KPop>
           </KModal>
           <KPrompt
             :visible="data.promptVisible"
@@ -517,14 +509,6 @@
             @proceed="data.promptVisible = false"
           >
             Slotted KPrompt content
-
-            <KPop target="body">
-              <KButton>Popover</KButton>
-
-              <template #content>
-                Lorem ipsum.
-              </template>
-            </KPop>
           </KPrompt>
         </KComponent>
       </SandboxSectionComponent>

--- a/sandbox/pages/SandboxSlideout.vue
+++ b/sandbox/pages/SandboxSlideout.vue
@@ -138,6 +138,14 @@
             :visible="data.slideoutVisible"
             @close="data.slideoutVisible = false"
           >
+            <KPop target="body">
+              <KButton>Popover</KButton>
+
+              <template #content>
+                Lorem ipsum.
+              </template>
+            </KPop>
+
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus viverra vitae congue eu consequat ac felis. Netus et malesuada fames ac turpis. Donec massa sapien faucibus et molestie ac feugiat. Cursus turpis massa tincidunt dui. Eget nullam non nisi est sit amet facilisis magna. Porttitor eget dolor morbi non arcu risus quis. Tempus urna et pharetra pharetra massa massa ultricies mi. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet non. Elit eget gravida cum sociis natoque penatibus et. Lobortis mattis aliquam faucibus purus in massa tempor nec. Aliquet eget sit amet tellus cras adipiscing enim eu. Diam vulputate ut pharetra sit amet aliquam. Ultricies mi quis hendrerit dolor magna eget est lorem. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Pellentesque habitant morbi tristique senectus et netus et. Aliquam ultrices sagittis orci a scelerisque purus.</p>
             <p>Tincidunt dui ut ornare lectus sit amet. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Egestas erat imperdiet sed euismod nisi porta lorem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed. Sit amet cursus sit amet dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum. Tristique risus nec feugiat in. Purus viverra accumsan in nisl. Massa sapien faucibus et molestie ac feugiat. Pharetra magna ac placerat vestibulum. Consequat mauris nunc congue nisi vitae.</p>
             <p>Turpis tincidunt id aliquet risus feugiat in ante. Congue nisi vitae suscipit tellus. Tincidunt id aliquet risus feugiat in ante. Tincidunt ornare massa eget egestas purus. Velit dignissim sodales ut eu sem. Suspendisse sed nisi lacus sed. At lectus urna duis convallis convallis tellus id interdum velit. Dignissim diam quis enim lobortis. Ullamcorper sit amet risus nullam eget. Id volutpat lacus laoreet non curabitur gravida arcu ac tortor.</p>

--- a/sandbox/pages/SandboxSlideout.vue
+++ b/sandbox/pages/SandboxSlideout.vue
@@ -138,7 +138,10 @@
             :visible="data.slideoutVisible"
             @close="data.slideoutVisible = false"
           >
-            <KPop target="body">
+            <KPop
+              placement="left"
+              target="body"
+            >
               <KButton>Popover</KButton>
 
               <template #content>

--- a/sandbox/pages/SandboxSlideout.vue
+++ b/sandbox/pages/SandboxSlideout.vue
@@ -138,17 +138,6 @@
             :visible="data.slideoutVisible"
             @close="data.slideoutVisible = false"
           >
-            <KPop
-              placement="left"
-              target="body"
-            >
-              <KButton>Popover</KButton>
-
-              <template #content>
-                Lorem ipsum.
-              </template>
-            </KPop>
-
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lacus viverra vitae congue eu consequat ac felis. Netus et malesuada fames ac turpis. Donec massa sapien faucibus et molestie ac feugiat. Cursus turpis massa tincidunt dui. Eget nullam non nisi est sit amet facilisis magna. Porttitor eget dolor morbi non arcu risus quis. Tempus urna et pharetra pharetra massa massa ultricies mi. Facilisi morbi tempus iaculis urna id volutpat lacus laoreet non. Elit eget gravida cum sociis natoque penatibus et. Lobortis mattis aliquam faucibus purus in massa tempor nec. Aliquet eget sit amet tellus cras adipiscing enim eu. Diam vulputate ut pharetra sit amet aliquam. Ultricies mi quis hendrerit dolor magna eget est lorem. Diam sollicitudin tempor id eu nisl nunc mi ipsum. Pellentesque habitant morbi tristique senectus et netus et. Aliquam ultrices sagittis orci a scelerisque purus.</p>
             <p>Tincidunt dui ut ornare lectus sit amet. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Egestas erat imperdiet sed euismod nisi porta lorem. Potenti nullam ac tortor vitae purus faucibus ornare suspendisse sed. Sit amet cursus sit amet dictum sit amet justo donec. Augue mauris augue neque gravida in fermentum. Tristique risus nec feugiat in. Purus viverra accumsan in nisl. Massa sapien faucibus et molestie ac feugiat. Pharetra magna ac placerat vestibulum. Consequat mauris nunc congue nisi vitae.</p>
             <p>Turpis tincidunt id aliquet risus feugiat in ante. Congue nisi vitae suscipit tellus. Tincidunt id aliquet risus feugiat in ante. Tincidunt ornare massa eget egestas purus. Velit dignissim sodales ut eu sem. Suspendisse sed nisi lacus sed. At lectus urna duis convallis convallis tellus id interdum velit. Dignissim diam quis enim lobortis. Ullamcorper sit amet risus nullam eget. Id volutpat lacus laoreet non curabitur gravida arcu ac tortor.</p>

--- a/src/components/KModal/KModal.cy.ts
+++ b/src/components/KModal/KModal.cy.ts
@@ -1,4 +1,6 @@
 import KModal from '@/components/KModal/KModal.vue'
+import KPop from '@/components/KPop/KPop.vue'
+import { h } from 'vue'
 
 describe('KModal', () => {
   it('renders closed when visible is false', () => {
@@ -245,6 +247,22 @@ describe('KModal', () => {
     })
 
     cy.get('.k-modal .modal-backdrop').should('have.css', 'z-index', '1100') // default z-index
+  })
+
+  it('provides its z-index so a nested KPop elevates above it', () => {
+    cy.mount(KModal, {
+      props: {
+        visible: true,
+        zIndex: 1100,
+      },
+      slots: {
+        default: () => h(KPop, { target: 'body' }, {
+          content: () => 'Popover content',
+        }),
+      },
+    })
+
+    cy.get('.popover').should('have.css', 'z-index', '1101')
   })
 
   it('emits proceed event when action button is clicked', () => {

--- a/src/components/KModal/KModal.vue
+++ b/src/components/KModal/KModal.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref, useAttrs, useId, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, provide, ref, useAttrs, useId, watch } from 'vue'
 import { FocusTrap } from 'focus-trap-vue'
 import { useTextSelection } from '@vueuse/core'
 import KButton from '@/components/KButton/KButton.vue'
@@ -99,6 +99,7 @@ import type { ModalProps, ModalEmits, ModalSlots } from '@/types'
 import { CloseIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
 import { normalizeSize } from '@/utilities/css'
+import { POPOVER_PARENT_ZINDEX_KEY } from '@/utilities/injection-keys'
 
 defineOptions({
   inheritAttrs: false,
@@ -127,6 +128,9 @@ const {
 
 const emit = defineEmits<ModalEmits>()
 const slots = defineSlots<ModalSlots>()
+
+// Provide the modal's z-index so a nested (teleported) KPop can elevate its popover above the modal.
+provide(POPOVER_PARENT_ZINDEX_KEY, computed(() => zIndex))
 
 const attrs = useAttrs()
 

--- a/src/components/KPop/KPop.cy.ts
+++ b/src/components/KPop/KPop.cy.ts
@@ -1,5 +1,6 @@
 import KPop from '@/components/KPop/KPop.vue'
-import { h } from 'vue'
+import { computed, h } from 'vue'
+import { POPOVER_PARENT_ZINDEX_KEY } from '@/utilities/injection-keys'
 
 describe('KPop', () => {
   it('renders props when passed', () => {
@@ -151,6 +152,33 @@ describe('KPop', () => {
     })
 
     cy.get('.popover').should('have.css', 'z-index', '2200')
+  })
+
+  it('elevates zIndex above a parent-provided z-index when not explicitly set', () => {
+    cy.mount(KPop, {
+      global: {
+        provide: {
+          [POPOVER_PARENT_ZINDEX_KEY as symbol]: computed(() => 9999),
+        },
+      },
+    })
+
+    cy.get('.popover').should('have.css', 'z-index', '10000')
+  })
+
+  it('prefers an explicit zIndex over a parent-provided z-index', () => {
+    cy.mount(KPop, {
+      props: {
+        zIndex: 500,
+      },
+      global: {
+        provide: {
+          [POPOVER_PARENT_ZINDEX_KEY as symbol]: computed(() => 9999),
+        },
+      },
+    })
+
+    cy.get('.popover').should('have.css', 'z-index', '500')
   })
 
   it('does not render close icon when prop is false', () => {

--- a/src/components/KPop/KPop.vue
+++ b/src/components/KPop/KPop.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, computed, watch, useId } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, inject, provide, watch, useId } from 'vue'
 import { useFloating, autoUpdate, autoPlacement, flip, shift } from '@floating-ui/vue'
 import type { PopProps, PopEmits, PopSlots, PopPlacement } from '@/types'
 import KButton from '@/components/KButton/KButton.vue'
@@ -100,6 +100,7 @@ import { KUI_ICON_SIZE_30, KUI_SPACE_60 } from '@kong/design-tokens'
 import KPopTeleportWrapper from './KPopTeleportWrapper.vue'
 import { useEventListener } from '@vueuse/core'
 import { normalizeSize } from '@/utilities/css'
+import { POPOVER_PARENT_ZINDEX_KEY } from '@/utilities/injection-keys'
 
 const {
   buttonText = '',
@@ -118,13 +119,20 @@ const {
   popoverClasses = '',
   popoverElementAttributes = {},
   tag = 'div',
-  zIndex = 1000,
+  zIndex,
   offset = KUI_SPACE_60,
   target = null,
 } = defineProps<PopProps>()
 
 const emit = defineEmits<PopEmits>()
 const slots = defineSlots<PopSlots>()
+
+// A container (KModal, KSlideout) or an ancestor KPop may provide its z-index. When `zIndex` is not
+// explicitly set, resolve to just above the parent so a teleported popover renders above it; otherwise
+// fall back to the default of 1000. Provide the resolved value so nested popovers keep stacking above.
+const parentZIndex = inject(POPOVER_PARENT_ZINDEX_KEY, null)
+const resolvedZIndex = computed<number>(() => zIndex ?? (parentZIndex?.value != null ? parentZIndex.value + 1 : 1000))
+provide(POPOVER_PARENT_ZINDEX_KEY, resolvedZIndex)
 
 const popoverId = useId()
 const titleId = useId()
@@ -273,7 +281,7 @@ const marginStyles = computed(() => {
 const popoverStyles = computed(() => {
   return {
     ...floatingStyles.value,
-    zIndex,
+    zIndex: resolvedZIndex.value,
   }
 })
 

--- a/src/components/KSlideout/KSlideout.cy.ts
+++ b/src/components/KSlideout/KSlideout.cy.ts
@@ -1,4 +1,5 @@
 import KSlideout from '@/components/KSlideout/KSlideout.vue'
+import KPop from '@/components/KPop/KPop.vue'
 import { h } from 'vue'
 
 describe('KSlideout', () => {
@@ -58,6 +59,22 @@ describe('KSlideout', () => {
 
     cy.get('.k-slideout .slideout-container').should('have.css', 'z-index', '92929')
     cy.get('.k-slideout .slideout-backdrop').should('have.css', 'z-index', '92929')
+  })
+
+  it('provides its z-index so a nested KPop elevates above it', () => {
+    cy.mount(KSlideout, {
+      props: {
+        visible: true,
+        zIndex: 9999,
+      },
+      slots: {
+        default: () => h(KPop, { target: 'body' }, {
+          content: () => 'Popover content',
+        }),
+      },
+    })
+
+    cy.get('.popover').should('have.css', 'z-index', '10000')
   })
 
   it('renders close icon on right', () => {

--- a/src/components/KSlideout/KSlideout.vue
+++ b/src/components/KSlideout/KSlideout.vue
@@ -46,12 +46,13 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, useTemplateRef, onUnmounted, watch } from 'vue'
+import { computed, provide, useTemplateRef, onUnmounted, watch } from 'vue'
 import { onClickOutside } from '@vueuse/core'
 import { CloseIcon } from '@kong/icons'
 import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
 import type { KSlideoutEmits, KSlideoutProps, KSlideoutSlots } from '@/types/slideout'
 import { normalizeSize } from '@/utilities/css'
+import { POPOVER_PARENT_ZINDEX_KEY } from '@/utilities/injection-keys'
 
 const {
   visible,
@@ -67,6 +68,9 @@ const {
 const emit = defineEmits<KSlideoutEmits>()
 
 defineSlots<KSlideoutSlots>()
+
+// Provide the slideout's z-index so a nested (teleported) KPop can elevate its popover above the slideout.
+provide(POPOVER_PARENT_ZINDEX_KEY, computed(() => zIndex))
 
 const slideoutContainerElementRef = useTemplateRef('slideoutContainerElement')
 

--- a/src/utilities/injection-keys.ts
+++ b/src/utilities/injection-keys.ts
@@ -1,0 +1,9 @@
+import type { ComputedRef, InjectionKey } from 'vue'
+
+/**
+ * Provided by container components (KModal, KSlideout) with their `zIndex` so a nested KPop can
+ * elevate its popover above them. Necessary because a teleported popover leaves the parent's DOM
+ * subtree, so it can't be raised via CSS — but `provide`/`inject` follows the component tree
+ * (unaffected by `<Teleport>`), letting KPop resolve a z-index above its logical parent.
+ */
+export const POPOVER_PARENT_ZINDEX_KEY: InjectionKey<ComputedRef<number>> = Symbol('popover-parent-zindex')


### PR DESCRIPTION
# Summary

Addressing: https://konghq.atlassian.net/browse/KHCP-20474

When a KPop was used with a teleported popover (via the `target` prop) inside a KModal, KPrompt, or KSlideout, the popover rendered _underneath_ the container because its default `z-index` (`1000`) was lower than the modal's (`1100`) or slideout's (`9999`), and a CSS fix was impossible since teleporting removes the popover from the parent's DOM subtree. To solve this cleanly, KModal and KSlideout now provide their `z-index` through a shared injection key, and KPop injects it to automatically resolve to one above its parent when no explicit `zIndex` is set — leveraging the fact that Vue's `provide` / `inject` follows the component tree rather than the DOM, so it works through `<Teleport>`. An explicit `zIndex` prop still takes precedence, and KPop re-provides its resolved value so nested popovers continue stacking correctly.

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
