### PR TITLE
fix(kcatalog, ktableview): render dynamic toolbar slots [KM-2835]

### DIFF
--- a/src/components/KCatalog/KCatalog.cy.ts
+++ b/src/components/KCatalog/KCatalog.cy.ts
@@ -183,6 +183,39 @@ describe('KCatalog', () => {
       cy.get('.k-catalog .catalog-toolbar button').should('contain.text', 'Toolbar button')
     })
 
+    it('renders a toolbar slot that is added after mount', () => {
+      cy.mount({
+        components: { KCatalog },
+        data: () => ({
+          ready: false,
+        }),
+        methods: {
+          fetcher() {
+            return { data: getItems(1), total: 1 }
+          },
+        },
+        template: `
+          <KCatalog
+            cache-identifier="dynamic-toolbar-catalog"
+            disable-pagination
+            :fetcher="fetcher"
+          >
+            <template
+              v-if="ready"
+              #toolbar
+            >
+              <div data-testid="toolbar-content">Toolbar</div>
+            </template>
+          </KCatalog>
+        `,
+      })
+
+      cy.getTestId('catalog-toolbar').should('not.exist')
+      cy.then(() => Cypress.vueWrapper.setData({ ready: true }))
+      cy.getTestId('catalog-toolbar').should('exist')
+      cy.getTestId('toolbar-content').should('exist')
+    })
+
     it('can change card sizes - small', () => {
       const total = 5
 

--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -10,7 +10,7 @@
     </component>
 
     <div
-      v-if="hasToolbarSlot"
+      v-if="slots.toolbar"
       class="catalog-toolbar"
       data-testid="catalog-toolbar"
     >
@@ -231,7 +231,6 @@ const previousOffset = computed((): string | null => offsets.value[page.value - 
 const nextOffset = ref<string | null>(null)
 const hasNextPage = ref<boolean>(true)
 const hasInitialized = ref<boolean>(false)
-const hasToolbarSlot = computed((): boolean => !!slots.toolbar)
 
 const defaultFetcherProps = {
   page: 1,

--- a/src/components/KTableData/KTableData.cy.ts
+++ b/src/components/KTableData/KTableData.cy.ts
@@ -237,6 +237,41 @@ describe('KTableData', () => {
       cy.get('.k-table-data .table-toolbar button').should('contain.text', 'Toolbar button')
     })
 
+    it('forwards a toolbar slot that is added after mount', () => {
+      cy.mount({
+        components: { KTableData },
+        data: () => ({
+          headers: options.headers.map(header => ({ ...header, hidable: false })),
+          ready: false,
+        }),
+        methods: {
+          fetcher() {
+            return { data: options.data }
+          },
+        },
+        template: `
+          <KTableData
+            cache-identifier="dynamic-toolbar-table-data"
+            :fetcher="fetcher"
+            :headers="headers"
+            hide-pagination
+          >
+            <template
+              v-if="ready"
+              #toolbar
+            >
+              <div data-testid="toolbar-content">Toolbar</div>
+            </template>
+          </KTableData>
+        `,
+      })
+
+      cy.getTestId('table-toolbar').should('not.exist')
+      cy.then(() => Cypress.vueWrapper.setData({ ready: true }))
+      cy.getTestId('table-toolbar').should('exist')
+      cy.getTestId('toolbar-content').should('exist')
+    })
+
     it('has hover class when passed', () => {
       cy.mount(KTableData, {
         props: {

--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -185,6 +185,33 @@ describe('KTableView', () => {
   })
 
   describe('default', () => {
+    const mountDynamicToolbar = ({
+      headers = options.headers.map(header => ({ ...header, hidable: false })),
+      ready = false,
+    }: { headers?: TableViewHeader[], ready?: boolean } = {}) => {
+      cy.mount({
+        components: { KTableView },
+        data: () => ({
+          headers,
+          ready,
+          rows: options.data,
+        }),
+        template: `
+          <KTableView
+            :data="rows"
+            :headers="headers"
+          >
+            <template
+              v-if="ready"
+              #toolbar
+            >
+              <div data-testid="toolbar-content">Toolbar</div>
+            </template>
+          </KTableView>
+        `,
+      })
+    }
+
     it('renders link in action slot', () => {
       cy.mount(KTableView, {
         props: {
@@ -212,6 +239,39 @@ describe('KTableView', () => {
 
       cy.get('.k-table-view .table-toolbar').find('button').should('be.visible')
       cy.get('.k-table-view .table-toolbar button').should('contain.text', 'Toolbar button')
+    })
+
+    it('renders a toolbar slot that is added after mount', () => {
+      mountDynamicToolbar()
+
+      cy.getTestId('table-toolbar').should('not.exist')
+      cy.then(() => Cypress.vueWrapper.setData({ ready: true }))
+      cy.getTestId('table-toolbar').should('exist')
+      cy.getTestId('toolbar-content').should('exist')
+    })
+
+    it('removes a toolbar slot after mount when no default toolbar controls are active', () => {
+      mountDynamicToolbar({ ready: true })
+
+      cy.getTestId('table-toolbar').should('exist')
+      cy.getTestId('toolbar-content').should('exist')
+      cy.then(() => Cypress.vueWrapper.setData({ ready: false }))
+      cy.getTestId('toolbar-content').should('not.exist')
+      cy.getTestId('table-toolbar').should('not.exist')
+    })
+
+    it('removes a toolbar slot after mount while keeping active default toolbar controls', () => {
+      mountDynamicToolbar({
+        headers: options.headers.map((header, index) => ({ ...header, hidable: index === 1 })),
+        ready: true,
+      })
+
+      cy.getTestId('table-toolbar').should('exist')
+      cy.getTestId('toolbar-content').should('exist')
+      cy.then(() => Cypress.vueWrapper.setData({ ready: false }))
+      cy.getTestId('toolbar-content').should('not.exist')
+      cy.getTestId('table-toolbar').should('exist')
+      cy.getTestId('column-visibility-menu-button').should('exist')
     })
 
     it('has hover class when passed', () => {

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -4,23 +4,23 @@
     :class="{ 'hide-headers': hideHeaders }"
   >
     <div
-      v-if="hasToolbarSlot"
+      v-if="hasToolbar()"
       class="table-toolbar"
       data-testid="table-toolbar"
     >
       <slot name="toolbar" />
 
       <div
-        v-if="showBulkActionsToolbar || hasColumnVisibilityMenu"
+        v-if="showBulkActionsToolbar() || hasColumnVisibilityMenu()"
         class="toolbar-default-items-container"
       >
         <slot
-          v-if="showBulkActionsToolbar"
+          v-if="showBulkActionsToolbar()"
           name="bulk-actions"
           :selected-rows="bulkActionsSelectedRows"
         >
           <BulkActionsDropdown
-            v-if="!$slots['bulk-actions']"
+            v-if="!slots['bulk-actions']"
             :button-label="tableHeaders.find((header: TableViewHeader) => header.key === TableViewHeaderKeys.BULK_ACTIONS)!.label"
             :count="bulkActionsSelectedRowsCount"
             :disabled="!bulkActionsSelectedRowsCount || loading || !data.length"
@@ -35,7 +35,7 @@
         </slot>
 
         <ColumnVisibilityMenu
-          v-if="hasColumnVisibilityMenu"
+          v-if="hasColumnVisibilityMenu()"
           :columns="visibilityColumns"
           :disabled="columnVisibilityDisabled"
           :table-id="tableId"
@@ -190,7 +190,7 @@
                   </div>
 
                   <KTooltip
-                    v-if="column.tooltip || $slots[getColumnTooltipSlotName(column.key)]"
+                    v-if="column.tooltip || slots[getColumnTooltipSlotName(column.key)]"
                     :data-testid="getColumnTooltipSlotName(column.key)"
                     :kpop-attributes="{ target: tooltipTarget }"
                     max-width="300"
@@ -592,26 +592,24 @@ const resizerHoveredColumn = ref('') as Ref<ColumnKey | ''>
 const currentHoveredColumn = ref('') as Ref<ColumnKey | ''>
 const hasRowActions = computed((): boolean => (tableHeaders.value.some((header) => header.key === TableViewHeaderKeys.ACTIONS)))
 const hasHidableColumns = computed((): boolean => tableHeaders.value.filter((header) => header.hidable).length > 0)
-const hasColumnVisibilityMenu = computed((): boolean => {
+const hasColumnVisibilityMenu = (): boolean => {
   if (nested || !hasHidableColumns.value || error) {
     return false
   }
 
   if (slots.toolbar) {
-    // when toolbar slot is present, we want to disable column visibility menu rather than hide it in certain states
     return true
   }
 
-  // show when not loading and there is data
   return !loading && !!data && !!data.length
-})
+}
 const columnVisibilityDisabled = computed((): boolean => loading || !(data && data.length))
 // columns whose visibility can be toggled
 const visibilityColumns = computed(() => tableHeaders.value.filter((header) => header.hidable && !isSpecialColumn(header.key)))
 // visibility preferences from the host app (initialized by app)
-const visibilityPreferences = computed(() => (hasColumnVisibilityMenu.value ? tablePreferences.columnVisibility || {} : {})) as Ref<ColumnVisibility>
+const visibilityPreferences = computed(() => (nested || !hasHidableColumns.value || error ? {} : tablePreferences.columnVisibility || {})) as Ref<ColumnVisibility>
 // current column visibility state
-const columnVisibility = ref(hasColumnVisibilityMenu.value ? tablePreferences.columnVisibility || {} : {}) as Ref<ColumnVisibility>
+const columnVisibility = ref(hasColumnVisibilityMenu() ? tablePreferences.columnVisibility || {} : {}) as Ref<ColumnVisibility>
 
 const tableWrapperHeight = ref<string>('100%')
 const isScrollableVertically = ref<boolean>(false)
@@ -622,7 +620,6 @@ const sortColumnKey = ref(tablePreferences.sortColumnKey || '') as Ref<ColumnKey
 const DEFAULT_INITIAL_SORT_ORDER: SortColumnOrder = 'desc'
 const sortColumnOrder = ref<SortColumnOrder>(tablePreferences.sortColumnOrder || DEFAULT_INITIAL_SORT_ORDER)
 const isClickable = ref(false)
-const hasToolbarSlot = computed((): boolean => !hideToolbar && !nested && (!!slots.toolbar || hasColumnVisibilityMenu.value || showBulkActionsToolbar.value))
 const actionsDropdownRef = useTemplateRef('actionsDropdown')
 const isActionsDropdownHovered = ref<boolean>(false)
 const tableWrapperStyles = computed((): CSSProperties => ({
@@ -633,19 +630,19 @@ const scrollbarWidth = computed((): string => `${getScrollbarSize()}px`)
 const bulkActionsSelectedRows = ref([]) as Ref<Row[]>
 const hasBulkActions = computed((): boolean => !nested && !error && tableHeaders.value.some((header) => header.key === TableViewHeaderKeys.BULK_ACTIONS) && !!(slots['bulk-action-items'] || slots['bulk-actions']) && !!data.every((row) => getRowKey(row)))
 const dataSelectState = ref([]) as Ref<Array<TableViewSelectState<Row>>>
-const showBulkActionsToolbar = computed((): boolean => {
+const showBulkActionsToolbar = (): boolean => {
   if (nested || !hasBulkActions.value || error) {
     return false
   }
 
   if (slots.toolbar) {
-    // when toolbar slot is present, we want to disable bulk actions dropdown rather than hide it in certain states
     return true
   }
 
-  // show when not loading and there is data
   return !loading && !!data && !!data.length
-})
+}
+
+const hasToolbar = (): boolean => !hideToolbar && !nested && (!!slots.toolbar || hasColumnVisibilityMenu() || showBulkActionsToolbar())
 const bulkActionsSelectedRowsCount = computed((): string => {
   const selectedRowsCount = bulkActionsSelectedRows.value.length
 
@@ -1290,7 +1287,7 @@ watch([columnVisibility, tableHeaders, hasExpandableRows], (newVals) => {
 }, { deep: true, immediate: true })
 
 // because hasColumnVisibilityMenu also accounts for error/loading/empty state, we need to watch it
-watch(hasColumnVisibilityMenu, (newVal) => {
+watch(() => hasColumnVisibilityMenu(), (newVal) => {
   if (newVal) {
     columnVisibility.value = tablePreferences.columnVisibility || {}
   }


### PR DESCRIPTION
# Summary

[KM-2835]

Fixes toolbar rendering when consumers conditionally add the `#toolbar` slot after `KCatalog` or `KTableView` has already mounted.

The toolbar wrappers now read slot presence during render instead of caching slot keys in computed state. `KTableView` keeps the existing default toolbar controls behavior, and `KTableData` is covered through forwarding regression tests.

[KM-2835]: https://konghq.atlassian.net/browse/KM-2835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ