### PR TITLE
fix(ktableview): resize handle NaN height on mount [KM-2845]

### DIFF
--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -252,8 +252,11 @@ describe('KTableView', () => {
         cy.get('.resize-handle').first().should(([handle]) => {
           const row = handle.closest('tr')
 
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(row).to.exist
+
           expect(parseFloat(window.getComputedStyle(handle).height))
-            .to.be.closeTo(row?.getBoundingClientRect().height ?? NaN, 1)
+            .to.be.closeTo(row!.getBoundingClientRect().height, 1)
         })
       }
 

--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -252,9 +252,6 @@ describe('KTableView', () => {
         cy.get('.resize-handle').first().should(([handle]) => {
           const row = handle.closest('tr')
 
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(row).to.exist
-
           expect(parseFloat(window.getComputedStyle(handle).height))
             .to.be.closeTo(row!.getBoundingClientRect().height, 1)
         })

--- a/src/components/KTableView/KTableView.cy.ts
+++ b/src/components/KTableView/KTableView.cy.ts
@@ -239,6 +239,31 @@ describe('KTableView', () => {
       cy.get('.resize-handle').should('exist')
     })
 
+    it('keeps the resize handle height in sync when the header row height changes', () => {
+      cy.mount(KTableView, {
+        props: {
+          headers: options.headers,
+          data: options.data,
+          resizeColumns: true,
+        },
+      })
+
+      const expectHandleHeightMatchesRow = () => {
+        cy.get('.resize-handle').first().should(([handle]) => {
+          const row = handle.closest('tr')
+
+          expect(parseFloat(window.getComputedStyle(handle).height))
+            .to.be.closeTo(row?.getBoundingClientRect().height ?? NaN, 1)
+        })
+      }
+
+      expectHandleHeightMatchesRow()
+
+      cy.get('th.table-headers').invoke('css', 'padding-top', '60px')
+
+      expectHandleHeightMatchesRow()
+    })
+
     it('renders column show/hide when headers.hidable is set', () => {
       // make ID column hidable
       options.headers[1].hidable = true

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -491,7 +491,7 @@ import KCheckbox from '@/components/KCheckbox/KCheckbox.vue'
 import BulkActionsDropdown from './BulkActionsDropdown.vue'
 import { getInitialPageSize, getUniqueStringId } from '@/utilities'
 import { getScrollbarSize } from '@/utilities/browser'
-import { useResizeObserver } from '@vueuse/core'
+import { useElementSize, useResizeObserver } from '@vueuse/core'
 import type { CSSProperties, Ref } from 'vue'
 import { mapValues } from 'lodash-es'
 import { normalizeSize } from '@/utilities/css'
@@ -877,16 +877,8 @@ const resizeHoverColumn = computed(() => {
 // get the resizable header divs to be used for the resize observers
 // eslint-disable-next-line no-undef
 const headerElems = computed((): NodeListOf<Element> | undefined => headerRowRef.value?.querySelectorAll('th.resizable'))
-const headerHeight = computed((): string => {
-  const elem = headerElems.value?.item(0)
-  if (elem) {
-    const styles = window?.getComputedStyle(elem)
-    if (styles?.height) {
-      return `${parseInt(styles.height, 10)}px`
-    }
-  }
-  return 'auto'
-})
+const { height: headerRowHeight } = useElementSize(headerRowRef)
+const headerHeight = computed((): string => headerRowHeight.value ? `${headerRowHeight.value}px` : 'auto')
 
 const startResize = (evt: MouseEvent, colKey: ColumnKey) => {
   // right clicks should be ignored

--- a/src/components/KTableView/KTableView.vue
+++ b/src/components/KTableView/KTableView.vue
@@ -877,7 +877,10 @@ const resizeHoverColumn = computed(() => {
 // get the resizable header divs to be used for the resize observers
 // eslint-disable-next-line no-undef
 const headerElems = computed((): NodeListOf<Element> | undefined => headerRowRef.value?.querySelectorAll('th.resizable'))
-const { height: headerRowHeight } = useElementSize(headerRowRef)
+// resize handles are only ever rendered when this is true (see showResizeHandle) - avoid
+// observing the header row's size when there's nothing that needs its height
+const isResizable = computed((): boolean => resizeColumns && !nested)
+const { height: headerRowHeight } = useElementSize(computed(() => isResizable.value ? headerRowRef.value : null))
 const headerHeight = computed((): string => headerRowHeight.value ? `${headerRowHeight.value}px` : 'auto')
 
 const startResize = (evt: MouseEvent, colKey: ColumnKey) => {


### PR DESCRIPTION
# Summary

[KM-2845]

Preview: https://github.com/kong-konnect/konnect-ui-apps/pull/12557

`KTableView`'s resize handle height (`headerHeight`) was computed once from `getComputedStyle(th).height` inside a Vue `computed`, with no reactive dependency on actual DOM layout. Two compounding issues:

1. `getComputedStyle().height` can still return `"auto"` right when the table mounts, before layout has settled. `"auto"` is truthy, so it passed the guard and got `parseInt`'d into `NaN`, rendering `.resize-handle { height: NaNpx }` (handle invisible/undraggable).
2. Even with an `isNaN` guard, the `computed` has no reactive dependency on layout — it only reruns when the header row's template ref changes, not when the browser finishes laying out the row. So once it settled on a bad value, it would never recompute.

Replaced the one-shot `getComputedStyle` read with `useElementSize(headerRowRef)` from `@vueuse/core`, which is backed by a `ResizeObserver` and returns a reactive numeric height — no string parsing, no `NaN` path, and it stays in sync with the header row's real height for the lifetime of the component (window resizes, column resizing, content changes, etc).

[KM-2845]: https://konghq.atlassian.net/browse/KM-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ