### PR TITLE
fix: calendar only tries to reset times when appropriate [MA-5071]

### DIFF
--- a/src/components/KDateTimePicker/CalendarWrapper.vue
+++ b/src/components/KDateTimePicker/CalendarWrapper.vue
@@ -82,9 +82,9 @@
 <script lang="ts" setup>
 import type { DatePickerModel, DatePickerRangeObject, DateTimePickerMode, TimeGranularity } from '@/types'
 
-import { computed, nextTick, onMounted, ref, useId, watch } from 'vue'
+import { computed, onMounted, ref, useId, watch } from 'vue'
 import { DatePicker } from 'v-calendar'
-import { format, isBefore, isSameDay, startOfToday } from 'date-fns'
+import { format, isBefore, isSameSecond, isSameDay, parse, startOfToday } from 'date-fns'
 
 const {
   isRange,
@@ -118,7 +118,6 @@ const calendarVModel = defineModel<DatePickerModel>({ required: true })
 const hasError = defineModel<boolean>('error', { default: false })
 const startTimeValue = ref<string>(formatTimeForInput(new Date(), timeGranularity))
 const endTimeValue = ref<string>(formatTimeForInput(new Date(), timeGranularity))
-const isApplyingFullDayRange = ref(false)
 const originalTimeValues = ref<{ start: string, end: string }>({
   start: formatTimeForInput(new Date(), timeGranularity),
   end: formatTimeForInput(new Date(), timeGranularity),
@@ -197,7 +196,7 @@ const isValidDateRange = (
  * Automatically adjust times to create a full-day range (00:00:00 - 23:59:59)
  * @returns true if full-day range was applied, false otherwise
  */
-const applyFullDayRangeIfSameDay = async (): Promise<boolean> => {
+const applyFullDayRangeIfSameDay = (): boolean => {
   if (!sameDayFullRange || !isRange) {
     return false
   }
@@ -206,21 +205,32 @@ const applyFullDayRangeIfSameDay = async (): Promise<boolean> => {
     return false
   }
 
-  if (!isSameDay(calendarVModel.value.start, calendarVModel.value.end)) {
-    return false
+  const actualTimeStart = calendarVModel.value.start.getTime()
+  const actualTimeEnd = calendarVModel.value.end.getTime()
+
+  // due to watchers and state that is manipulated elsewhere, we need to look at
+  // the value within the time inputs themselves to calculate what time is being
+  // requested and we also need to look at what's in the model
+  const format = timeGranularity === 'secondly' ? 'HH:mm:ss' : 'HH:mm'
+  const timeStart = startTimeValue.value
+    ? parse(startTimeValue.value, format, calendarVModel.value.start).getTime()
+    : actualTimeStart
+  const timeEnd = endTimeValue.value
+    ? parse(endTimeValue.value, format, calendarVModel.value.end).getTime()
+    : actualTimeEnd
+
+  const sameDay = isSameDay(calendarVModel.value.start, calendarVModel.value.end)
+  const sameSecond = isSameSecond(calendarVModel.value.start, calendarVModel.value.end)
+
+  // if we are requesting the exact same date, or in the same day requesting a
+  // start time that's greater than the end time (either in the time picker or
+  // in the model as explained above), then set start to the beginning of the
+  // day and end to the end of the day
+  if (sameSecond || (sameDay && (timeStart >= timeEnd || actualTimeStart >= actualTimeEnd))) {
+    // this will cause the timeValues to be set via the calendarVModel watcher
+    calendarVModel.value.start.setHours(0, 0, 0, 0)
+    calendarVModel.value.end.setHours(23, 59, 59, 999)
   }
-
-  // Prevents time watchers from overwriting the calendarVModel
-  isApplyingFullDayRange.value = true
-
-  startTimeValue.value = '00:00'
-  endTimeValue.value = '23:59'
-
-  calendarVModel.value.start.setHours(0, 0, 0, 0)
-  calendarVModel.value.end.setHours(23, 59, 59, 999)
-
-  await nextTick()
-  isApplyingFullDayRange.value = false
 
   return true
 }
@@ -274,7 +284,7 @@ const calendarSelectAttributes = {
 }
 
 watch(() => startTimeValue.value, (newTime) => {
-  if (!newTime || isApplyingFullDayRange.value) {
+  if (!newTime) {
     return
   }
 
@@ -289,7 +299,7 @@ watch(() => startTimeValue.value, (newTime) => {
 })
 
 watch(() => endTimeValue.value, (newTime) => {
-  if (!newTime || isApplyingFullDayRange.value) {
+  if (!newTime) {
     return
   }
 
@@ -303,16 +313,18 @@ watch(() => endTimeValue.value, (newTime) => {
 
 watch(() => calendarVModel.value, () => {
   if (isRange && isValidDateRange(calendarVModel.value)) {
-    if (!applyFullDayRangeIfSameDay()) {
-      startTimeValue.value = formatTimeForInput(calendarVModel.value.start, timeGranularity)
-      endTimeValue.value = formatTimeForInput(calendarVModel.value.end, timeGranularity)
-    }
+    applyFullDayRangeIfSameDay()
+    startTimeValue.value = formatTimeForInput(calendarVModel.value.start, timeGranularity)
+    endTimeValue.value = formatTimeForInput(calendarVModel.value.end, timeGranularity)
 
     hasError.value = isInvalidRange(calendarVModel.value.start, calendarVModel.value.end)
   } else if (calendarVModel.value instanceof Date) {
     startTimeValue.value = formatTimeForInput(calendarVModel.value, timeGranularity)
   }
-}, { immediate: true, deep: true })
+  // we don't want to calculate this immediately, because we need to wait for
+  // initTimeInputs to execute. Otherwise it can mistakenly reset the times to
+  // midnight/midnight when a valid time had already been selected (e.g. 5-10am)
+}, { immediate: false, deep: true })
 
 // Keep track of original time values if time granularity changes
 watch(() => timeGranularity, () => {

--- a/src/components/KDateTimePicker/KDateTimePicker.cy.ts
+++ b/src/components/KDateTimePicker/KDateTimePicker.cy.ts
@@ -572,7 +572,7 @@ describe('KDateTimePicker', () => {
   })
 
   describe('sameDayFullRange', () => {
-    it('applies full-day range when same day selected with sameDayFullRange enabled', () => {
+    it('applies full-day range when exact same day selected with sameDayFullRange enabled', () => {
       const calendarTargetDateString = format(new Date(), 'yyyy-MM-dd')
       const calendarSelector = `.id-${calendarTargetDateString}`
 
@@ -593,6 +593,70 @@ describe('KDateTimePicker', () => {
 
       cy.getTestId('time-input-start').should('have.value', '00:00')
       cy.getTestId('time-input-end').should('have.value', '23:59')
+      cy.getTestId(submitButton).should('not.be.disabled')
+    })
+
+    it('applies full-day range when the end time is less than the start time on the same day selected with sameDayFullRange enabled', () => {
+      const startDay = 1
+      const endDay = 2
+      const targetDay = 3
+
+      const calendarTargetDateString = format(new Date(today.getFullYear(), today.getMonth(), targetDay), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+
+      // the dates are different, but the start hour is after the end hour, so it will reset
+      const start = new Date(today.getFullYear(), today.getMonth(), startDay, 4)
+      const end = new Date(today.getFullYear(), today.getMonth(), endDay, 1)
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start, end, timePeriodsKey: '' },
+          range: true,
+          sameDayFullRange: true,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+
+      // Select the same day twice for start and end
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      cy.getTestId('time-input-start').should('have.value', '00:00')
+      cy.getTestId('time-input-end').should('have.value', '23:59')
+      cy.getTestId(submitButton).should('not.be.disabled')
+    })
+
+    it('does NOT apply full-day range when the end time is greater than the start time on the same day selected with sameDayFullRange enabled', () => {
+      const startDay = 1
+      const endDay = 2
+      const targetDay = 3
+
+      const calendarTargetDateString = format(new Date(today.getFullYear(), today.getMonth(), targetDay), 'yyyy-MM-dd')
+      const calendarSelector = `.id-${calendarTargetDateString}`
+
+      // the dates are different, but the end hour is after the after hour, so it won't reset
+      const start = new Date(today.getFullYear(), today.getMonth(), startDay, 1)
+      const end = new Date(today.getFullYear(), today.getMonth(), endDay, 4)
+
+      cy.mount(KDateTimePicker, {
+        props: {
+          mode: 'dateTime',
+          modelValue: { start, end, timePeriodsKey: '' },
+          range: true,
+          sameDayFullRange: true,
+        },
+      })
+
+      cy.getTestId(timepickerInput).click()
+
+      // Select the same day twice for start and end
+      cy.get(calendarSelector).click()
+      cy.get(calendarSelector).click()
+
+      cy.getTestId('time-input-start').should('have.value', '01:00')
+      cy.getTestId('time-input-end').should('have.value', '04:00')
       cy.getTestId(submitButton).should('not.be.disabled')
     })
 
@@ -627,18 +691,23 @@ describe('KDateTimePicker', () => {
       // yesterday would be in the previous month and not rendered by the calendar.
       const isFirstOfMonth = today.getDate() === 1
       const startDate = isFirstOfMonth
-        ? today
+        ? new Date(today.getFullYear(), today.getMonth(), today.getDate())
         : new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1)
       const endDate = isFirstOfMonth
         ? new Date(today.getFullYear(), today.getMonth(), 2)
-        : today
+        : new Date(today.getFullYear(), today.getMonth(), today.getDate())
+
+      // force both dates to have a time set that doesn't match what we're trying to detect
+      startDate.setHours(1)
+      endDate.setHours(2)
+
       const startDateString = format(startDate, 'yyyy-MM-dd')
       const endDateString = format(endDate, 'yyyy-MM-dd')
 
       cy.mount(KDateTimePicker, {
         props: {
           mode: 'dateTime',
-          modelValue: { start: null, end: null, timePeriodsKey: '' },
+          modelValue: { start: startDate, end: endDate, timePeriodsKey: '' },
           range: true,
           sameDayFullRange: true,
         },
@@ -648,8 +717,8 @@ describe('KDateTimePicker', () => {
       cy.get(`.id-${startDateString}`).click()
       cy.get(`.id-${endDateString}`).click()
 
-      cy.getTestId('time-input-start').should('not.have.value', '00:00')
-      cy.getTestId('time-input-end').should('not.have.value', '23:59')
+      cy.getTestId('time-input-start').should('have.value', '01:00')
+      cy.getTestId('time-input-end').should('have.value', '02:00')
       cy.getTestId(submitButton).should('not.be.disabled')
     })
   })


### PR DESCRIPTION
Satisfies [MA-5071](https://konghq.atlassian.net/browse/MA-5071)

# Summary

`KDateTimePicker` tries to munge the start/end times to `00:00:00` and `23:59:59` respectively when a user picks the same date twice. It was doing that too greedily in too many cases which in some odd edge cases was causing a valid time choice of 4am - 10am on the same day to become 4am - 11:59:59pm instead.

[MA-5071]: https://konghq.atlassian.net/browse/MA-5071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ