### PR TITLE
feat(kfiltergroup): add selectAttributes/multiselectAttributes/inputAttributes

### DIFF
--- a/docs/components/filter-group.md
+++ b/docs/components/filter-group.md
@@ -144,6 +144,10 @@ export interface Filter {
   pinned?: boolean
   placement?: PopPlacement
   maxWidth?: number | string
+  readonly?: boolean
+  selectAttributes?: SelectFilterAttributes
+  multiselectAttributes?: MultiselectFilterAttributes
+  inputAttributes?: InputFilterAttributes
 }
 ```
 
@@ -189,6 +193,109 @@ If `true` the filter will only be rendered as a pill if it has a value and will 
 ### filter.maxWidth
 
 The max width of the filter's popover, defaults to `400px`. See [popover maxWidth](../components/popover#maxwidth)
+
+### filter.selectAttributes
+
+> [!IMPORTANT]
+> RFC — proposed API, feedback welcome before this ships. See the [pull request](#) for context and discussion.
+
+Passthrough props for the built-in [KSelect](../components/select) value control, used when the filter renders a [select filter](#select-filter) (`options` is set, `multiple` is `false`/unset). Only `label`, `placeholder`, `labelAttributes`, `kpopAttributes`, `dropdownMaxHeight`, `enableFiltering`, `clearable`, `help`, `error`, and `loading` may be overridden — see [KSelect's props](../components/select#props) for details. Anything not specified falls back to the filter's built-in default (`label: 'Value'`, `placeholder: 'Select a value'`).
+
+<ClientOnly>
+  <KFilterGroup
+    v-model="selectAttributesSelection"
+    :filters="selectAttributesFilters"
+  />
+</ClientOnly>
+
+```html
+<KFilterGroup
+  v-model="selection"
+  :filters="{
+    status: {
+      label: 'Status',
+      options: [
+        { value: 'todo', label: 'Todo' },
+        { value: 'inprogress', label: 'In Progress' },
+        { value: 'done', label: 'Done' },
+      ],
+      pinned: true,
+      selectAttributes: {
+        label: 'Status is',
+        placeholder: 'Choose a status',
+      },
+    },
+  }"
+/>
+```
+
+### filter.multiselectAttributes
+
+> [!IMPORTANT]
+> RFC — proposed API, feedback welcome before this ships. See the [pull request](#) for context and discussion.
+
+Passthrough props for the built-in [KMultiselect](../components/multiselect) value control, used when the filter renders a [multiselect filter](#multiselect-filter) (`options` is set, `multiple` is `true`). Only `label`, `placeholder`, `searchPlaceholder`, `labelAttributes`, `kpopAttributes`, `dropdownMaxHeight`, `selectedRowCount`, `collapsedContext`, `autosuggest`, `help`, `error`, and `loading` may be overridden — see [KMultiselect's props](../components/multiselect#props) for details. Anything not specified falls back to the filter's built-in default (`label: 'Value'`, `placeholder: 'Select values'`).
+
+<ClientOnly>
+  <KFilterGroup
+    v-model="multiselectAttributesSelection"
+    :filters="multiselectAttributesFilters"
+  />
+</ClientOnly>
+
+```html
+<KFilterGroup
+  v-model="selection"
+  :filters="{
+    tag: {
+      label: 'Tag',
+      operators: ['contains'],
+      multiple: true,
+      options: [
+        { value: 'foo', label: 'Foo' },
+        { value: 'bar', label: 'Bar' },
+        { value: 'baz', label: 'Baz' },
+      ],
+      pinned: true,
+      multiselectAttributes: {
+        label: 'Tags include',
+        placeholder: 'Choose tags',
+      },
+    },
+  }"
+/>
+```
+
+### filter.inputAttributes
+
+> [!IMPORTANT]
+> RFC — proposed API, feedback welcome before this ships. See the [pull request](#) for context and discussion.
+
+Passthrough props for the built-in [KInput](../components/input) value control, used when the filter renders a [text filter](#text-filter) (`options` is not set). Only `label`, `labelAttributes`, `help`, `error`, `errorMessage`, `characterLimit`, `type`, and `showPasswordMaskToggle` may be overridden — see [KInput's props](../components/input#props) for details. Anything not specified falls back to the filter's built-in default (`label: 'Value'`, `placeholder: 'Enter a value'`).
+
+<ClientOnly>
+  <KFilterGroup
+    v-model="inputAttributesSelection"
+    :filters="inputAttributesFilters"
+  />
+</ClientOnly>
+
+```html
+<KFilterGroup
+  v-model="selection"
+  :filters="{
+    name: {
+      label: 'Name',
+      pinned: true,
+      inputAttributes: {
+        label: 'Name contains',
+      },
+    },
+  }"
+/>
+```
+
+> Note: these three props only affect the built-in select/multiselect/input value controls. If you need to change anything else about the popover's content — including the operator control — use the [filter content slot](#filter-content) instead.
 
 ### selectorLabel
 
@@ -664,6 +771,41 @@ const multiselectFilters: FilterGroupFilters = {
 const textSelection = ref<FilterGroupSelection>({})
 const textFilters: FilterGroupFilters = {
   status: { ...deepClone(inputFilter), pinned: true },
+}
+
+const selectAttributesSelection = ref<FilterGroupSelection>({})
+const selectAttributesFilters: FilterGroupFilters = {
+  status: {
+    ...deepClone(selectFilter),
+    pinned: true,
+    selectAttributes: {
+      label: 'Status is',
+      placeholder: 'Choose a status',
+    },
+  },
+}
+
+const multiselectAttributesSelection = ref<FilterGroupSelection>({})
+const multiselectAttributesFilters: FilterGroupFilters = {
+  tag: {
+    ...deepClone(multiselectFilter),
+    pinned: true,
+    multiselectAttributes: {
+      label: 'Tags include',
+      placeholder: 'Choose tags',
+    },
+  },
+}
+
+const inputAttributesSelection = ref<FilterGroupSelection>({})
+const inputAttributesFilters: FilterGroupFilters = {
+  name: {
+    ...deepClone(inputFilter),
+    pinned: true,
+    inputAttributes: {
+      label: 'Name contains',
+    },
+  },
 }
 
 const operatorSelection = ref<FilterGroupSelection>({})

--- a/sandbox/pages/SandboxFilterGroup.vue
+++ b/sandbox/pages/SandboxFilterGroup.vue
@@ -53,6 +53,14 @@
   readonlyWithoutValue: {
     label: 'Readonly without a value does not appear in the list',
     readonly: true,
+  },
+  customSelectAttributes: {
+    label: 'Select with custom value label/placeholder',
+    options: [{ value: 'a', label: 'Ayy' }, { value: 'b', label: 'Bee' }, { value: 'c', label: 'See' }],
+    selectAttributes: {
+      label: 'Custom label',
+      placeholder: 'Pick one',
+    },
   }
 })`"
         language="javascript"
@@ -251,6 +259,14 @@ const filters: FilterGroupFilters = {
   readonlyWithoutValue: {
     label: 'Readonly without a value does not appear in the list',
     readonly: true,
+  },
+  customSelectAttributes: {
+    label: 'Select with custom value label/placeholder',
+    options: [{ value: 'a', label: 'Ayy' }, { value: 'b', label: 'Bee' }, { value: 'c', label: 'See' }],
+    selectAttributes: {
+      label: 'Custom label',
+      placeholder: 'Pick one',
+    },
   },
 }
 

--- a/src/components/KFilterGroup/FilterPill.cy.ts
+++ b/src/components/KFilterGroup/FilterPill.cy.ts
@@ -145,6 +145,67 @@ describe('KFilterGroup - FilterPill', () => {
     cy.get('@clear').should('have.callCount', 1)
   })
 
+  describe('value control attributes passthrough', () => {
+    it('input: uses "Value" as the default label/placeholder', () => {
+      render({ filter: { label: 'Foo' }, initOpen: true })
+      cy.getTestId(INPUT_ID).should('have.attr', 'placeholder', 'Enter a value')
+      cy.getTestId(INPUT_ID).parents('.k-input').find('.k-label').should('contain.text', 'Value')
+    })
+
+    it('input: inputAttributes overrides the default label', () => {
+      render({
+        filter: { label: 'Foo', inputAttributes: { label: 'Custom label' } },
+        initOpen: true,
+      })
+      cy.getTestId(INPUT_ID).parents('.k-input').find('.k-label').should('contain.text', 'Custom label')
+    })
+
+    it('select: uses "Value" as the default label/placeholder', () => {
+      render({
+        filter: { label: 'Foo', options: [{ label: 'Bar', value: 'bar' }] },
+        initOpen: true,
+      })
+      cy.getTestId('select-label').should('contain.text', 'Value')
+      cy.getTestId(SELECT_ID).should('have.attr', 'placeholder', 'Select a value')
+    })
+
+    it('select: selectAttributes overrides the default label/placeholder', () => {
+      render({
+        filter: {
+          label: 'Foo',
+          options: [{ label: 'Bar', value: 'bar' }],
+          selectAttributes: { label: 'Custom label', placeholder: 'Pick one' },
+        },
+        initOpen: true,
+      })
+      cy.getTestId('select-label').should('contain.text', 'Custom label')
+      cy.getTestId(SELECT_ID).should('have.attr', 'placeholder', 'Pick one')
+    })
+
+    it('multiselect: uses "Value" as the default label/placeholder', () => {
+      render({
+        filter: { label: 'Foo', multiple: true, options: [{ label: 'Bar', value: 'bar' }] },
+        initOpen: true,
+      })
+      cy.getTestId('multiselect-label').should('contain.text', 'Value')
+      cy.getTestId(MULTISELECT_ID).should('contain.text', 'Select values')
+    })
+
+    it('multiselect: multiselectAttributes overrides the default label/placeholder', () => {
+      render({
+        filter: {
+          label: 'Foo',
+          multiple: true,
+          options: [{ label: 'Bar', value: 'bar' }],
+          multiselectAttributes: { label: 'Custom label', placeholder: 'Pick some' },
+        },
+        initOpen: true,
+      })
+      cy.getTestId('multiselect-label').should('contain.text', 'Custom label')
+      cy.getTestId(MULTISELECT_ID).should('contain.text', 'Pick some')
+    })
+  })
+
   describe('popover content interactions', () => {
     it('emits @close when cancel button is clicked', () => {
       cy.get('@close').should('have.callCount', 0)

--- a/src/components/KFilterGroup/FilterPill.vue
+++ b/src/components/KFilterGroup/FilterPill.vue
@@ -56,6 +56,7 @@
                 :items="filter.options"
                 label="Value"
                 placeholder="Select a value"
+                v-bind="filter.selectAttributes"
               />
               <KMultiselect
                 v-else-if="filterType === 'multiselect'"
@@ -64,6 +65,7 @@
                 :items="filter.options"
                 label="Value"
                 placeholder="Select values"
+                v-bind="filter.multiselectAttributes"
               />
               <KInput
                 v-else
@@ -72,6 +74,7 @@
                 data-testid="filter-pill-input"
                 label="Value"
                 placeholder="Enter a value"
+                v-bind="filter.inputAttributes"
               />
             </div>
           </div>

--- a/src/types/filter-group.ts
+++ b/src/types/filter-group.ts
@@ -1,4 +1,7 @@
 import type { PopPlacement } from './popover'
+import type { SelectProps } from './select'
+import type { MultiselectProps } from './multi-select'
+import type { InputProps } from './input'
 
 /**
  * The filter's operator:
@@ -20,6 +23,57 @@ export interface FilterOption {
   /** value for the item to be displayed in the (multi)select dropdown. */
   value: string
 }
+
+/**
+ * Passthrough props for the built-in `KSelect` value control rendered for
+ * single-select filters (`options` set, `multiple` unset/false).
+ */
+export type SelectFilterAttributes = Pick<SelectProps<any>,
+  | 'label'
+  | 'placeholder'
+  | 'labelAttributes'
+  | 'kpopAttributes'
+  | 'dropdownMaxHeight'
+  | 'enableFiltering'
+  | 'clearable'
+  | 'help'
+  | 'error'
+  | 'loading'
+>
+
+/**
+ * Passthrough props for the built-in `KMultiselect` value control rendered for
+ * multi-select filters (`options` set, `multiple: true`).
+ */
+export type MultiselectFilterAttributes = Pick<MultiselectProps<any>,
+  | 'label'
+  | 'placeholder'
+  | 'searchPlaceholder'
+  | 'labelAttributes'
+  | 'kpopAttributes'
+  | 'dropdownMaxHeight'
+  | 'selectedRowCount'
+  | 'collapsedContext'
+  | 'autosuggest'
+  | 'help'
+  | 'error'
+  | 'loading'
+>
+
+/**
+ * Passthrough props for the built-in `KInput` value control rendered for text
+ * filters (no `options`).
+ */
+export type InputFilterAttributes = Pick<InputProps,
+  | 'label'
+  | 'labelAttributes'
+  | 'help'
+  | 'error'
+  | 'errorMessage'
+  | 'characterLimit'
+  | 'type'
+  | 'showPasswordMaskToggle'
+>
 
 export interface Filter {
   /**
@@ -73,6 +127,27 @@ export interface Filter {
    * @default false
    */
   readonly?: boolean
+
+  /**
+   * Passthrough props for the built-in `KSelect` value control. Only applies
+   * to single-select filters (`options` set, `multiple` unset/false).
+   * @default undefined
+   */
+  selectAttributes?: SelectFilterAttributes
+
+  /**
+   * Passthrough props for the built-in `KMultiselect` value control. Only
+   * applies to multi-select filters (`options` set, `multiple: true`).
+   * @default undefined
+   */
+  multiselectAttributes?: MultiselectFilterAttributes
+
+  /**
+   * Passthrough props for the built-in `KInput` value control. Only applies
+   * to text filters (no `options`).
+   * @default undefined
+   */
+  inputAttributes?: InputFilterAttributes
 }
 
 export interface FilterSelection {


### PR DESCRIPTION
[KM-2887]

## RFC

This is a **draft/RFC PR** — I'd like feedback on the API shape before finalizing.

### Problem

`KFilterGroup`'s built-in select/multiselect/input filter types hardcode `label="Value"` and their placeholder text in `FilterPill.vue`, with no way to override them short of overriding the entire `#filter-<key>` slot — which throws away the built-in operator+value layout and forces the host app to reimplement the apply/cancel flow itself.

### Proposal

Add three new optional per-filter passthrough props, one per built-in value control type:

- `selectAttributes` — passed to the built-in `KSelect` (single-select filters)
- `multiselectAttributes` — passed to the built-in `KMultiselect` (multi-select filters)
- `inputAttributes` — passed to the built-in `KInput` (text filters)

Each is a typed `Pick<...>` of the target component's props (e.g. `label`, `placeholder`, `help`, `error`, `kpopAttributes`, etc.), following the existing `*Attributes` passthrough convention already used elsewhere in this library (`kpopAttributes`, `labelAttributes`). Only one is ever relevant per filter (determined the same way `filterType` already is), so there's no ambiguity about which to use, and each gets full type safety/autocomplete for its specific target component.

An alternative considered was a single merged prop (e.g. just `inputAttributes` for all three), since the types are mutually exclusive — happy to discuss if reviewers prefer that tradeoff (simpler surface vs. less precise typing/naming).

### Changes

- `src/types/filter-group.ts` — new `SelectFilterAttributes`/`MultiselectFilterAttributes`/`InputFilterAttributes` types and matching optional `Filter` fields
- `src/components/KFilterGroup/FilterPill.vue` — spreads each attributes object onto its value control after the hardcoded defaults, so overrides win when supplied
- `src/components/KFilterGroup/FilterPill.cy.ts` — new tests for default + override behavior on all three control types
- `sandbox/pages/SandboxFilterGroup.vue` / `docs/components/filter-group.md` — new usage examples and prop docs (docs sections flagged as RFC pending this PR's outcome)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm eslint` clean on changed files
- [x] `FilterPill.cy.ts` (21/21) and `KFilterGroup.cy.ts` (14/14) pass
- [x] `pnpm docs:build` succeeds
- [ ] Reviewer sign-off on API shape (three props vs. one merged prop)

[KM-2887]: https://konghq.atlassian.net/browse/KM-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ