### PR TITLE
fix: kselect hover color and theme tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^2.1.9",
     "@kong-ui-public/sandbox-layout": "^2.3.26",
-    "@kong/design-tokens": "3.0.0",
+    "@kong/design-tokens": "3.0.2-pr.690.cb1af82.0",
     "@kong/eslint-config-kong-ui": "1.7.1",
     "@kong/stylelint-plugin-design-tokens": "2.0.0",
     "@nuxt/kit": "^4.4.7",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^2.1.9",
     "@kong-ui-public/sandbox-layout": "^2.3.26",
-    "@kong/design-tokens": "3.0.2-pr.690.cb1af82.0",
+    "@kong/design-tokens": "3.0.2",
     "@kong/eslint-config-kong-ui": "1.7.1",
     "@kong/stylelint-plugin-design-tokens": "2.0.0",
     "@nuxt/kit": "^4.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^2.3.26
         version: 2.4.14(vue@3.5.38(typescript@5.9.3))
       '@kong/design-tokens':
-        specifier: 3.0.2-pr.690.cb1af82.0
-        version: 3.0.2-pr.690.cb1af82.0
+        specifier: 3.0.2
+        version: 3.0.2
       '@kong/eslint-config-kong-ui':
         specifier: 1.7.1
         version: 1.7.1(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -1136,8 +1136,8 @@ packages:
     peerDependencies:
       vue: '>= 3.3.13 < 4'
 
-  '@kong/design-tokens@3.0.2-pr.690.cb1af82.0':
-    resolution: {integrity: sha512-5wZjYUpRTVdlelZZ2uMDDf/N8+NmSTr7+26782b9q7b56m5ztrCN6xZviKclGH5rJ4aYTqk4TebM3mu5trB1ag==}
+  '@kong/design-tokens@3.0.2':
+    resolution: {integrity: sha512-WHg9MfnvqHOIrQCwuwWWv9LHml5FRaZxXN5tN81mk/Yk8017a5duZzwnoZsMCCUkLfgp71Lj+vP5/JH37oVBdg==}
     engines: {node: '>=20.19.5', pnpm: '>=10.28.2'}
 
   '@kong/eslint-config-kong-ui@1.7.1':
@@ -8246,7 +8246,7 @@ snapshots:
       '@kong/icons': 1.55.1(vue@3.5.38(typescript@5.9.3))
       vue: 3.5.38(typescript@5.9.3)
 
-  '@kong/design-tokens@3.0.2-pr.690.cb1af82.0': {}
+  '@kong/design-tokens@3.0.2': {}
 
   '@kong/eslint-config-kong-ui@1.7.1(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^2.3.26
         version: 2.4.14(vue@3.5.38(typescript@5.9.3))
       '@kong/design-tokens':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 3.0.2-pr.690.cb1af82.0
+        version: 3.0.2-pr.690.cb1af82.0
       '@kong/eslint-config-kong-ui':
         specifier: 1.7.1
         version: 1.7.1(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -1136,8 +1136,8 @@ packages:
     peerDependencies:
       vue: '>= 3.3.13 < 4'
 
-  '@kong/design-tokens@3.0.0':
-    resolution: {integrity: sha512-13ngJWY1hS5zxS5kTO5RksLjE0abjG47gzpEAr3xK1wpwuTAfyR9d9fi1fZh1fssFsylfuV1okcegSDLODyw9g==}
+  '@kong/design-tokens@3.0.2-pr.690.cb1af82.0':
+    resolution: {integrity: sha512-5wZjYUpRTVdlelZZ2uMDDf/N8+NmSTr7+26782b9q7b56m5ztrCN6xZviKclGH5rJ4aYTqk4TebM3mu5trB1ag==}
     engines: {node: '>=20.19.5', pnpm: '>=10.28.2'}
 
   '@kong/eslint-config-kong-ui@1.7.1':
@@ -8246,7 +8246,7 @@ snapshots:
       '@kong/icons': 1.55.1(vue@3.5.38(typescript@5.9.3))
       vue: 3.5.38(typescript@5.9.3)
 
-  '@kong/design-tokens@3.0.0': {}
+  '@kong/design-tokens@3.0.2-pr.690.cb1af82.0': {}
 
   '@kong/eslint-config-kong-ui@1.7.1(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:

--- a/src/components/KSelect/KSelectItem.vue
+++ b/src/components/KSelect/KSelectItem.vue
@@ -73,6 +73,7 @@ const handleClick = (e: MouseEvent): void => {
       &:hover {
         .select-item-label {
           background-color: var(--kui-select-item-color-background-hover, var(--kui-color-background-primary-weakest, $kui-color-background-primary-weakest));
+          color: var(--kui-select-item-color-text-selected, var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest));
         }
       }
     }


### PR DESCRIPTION
# Summary

Pulls in https://github.com/Kong/design-tokens/pull/690 to fix `color-text-disabled` and `color-background-disabled` colors for the `classic-night` theme.

Also fixes a missing `color` token for KSelect