### PR TITLE
fix(ktableview): slotted link default styles

### DIFF
--- a/sandbox/pages/SandboxTableData.vue
+++ b/sandbox/pages/SandboxTableData.vue
@@ -135,7 +135,7 @@
           <template #username="{ rowValue }">
             <KExternalLink
               class="username-link"
-              href="https://kongponents.konghq.com/components/alert.html"
+              href="https://kongponents.konghq.com/components/table-data.html"
             >
               @{{ rowValue }}
             </KExternalLink>
@@ -578,7 +578,7 @@ const getRowOneTwoLink = (row: Record<string, any>): RowLink => {
   .horizontal-container {
     display: flex;
     flex-wrap: wrap;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .username-link {

--- a/sandbox/pages/SandboxTableData.vue
+++ b/sandbox/pages/SandboxTableData.vue
@@ -113,7 +113,7 @@
           <template #username="{ rowValue }">
             <KExternalLink
               class="username-link"
-              href="https://kongponents.konghq.com/components/alert.html"
+              href="https://kongponents.konghq.com/components/table-data.html"
             >
               @{{ rowValue }}
             </KExternalLink>

--- a/sandbox/pages/SandboxTableView/SandboxTableView.vue
+++ b/sandbox/pages/SandboxTableView/SandboxTableView.vue
@@ -106,7 +106,7 @@
           <template #username="{ rowValue }">
             <KExternalLink
               class="username-link"
-              href="https://kongponents.konghq.com/components/alert.html"
+              href="https://kongponents.konghq.com/components/table-view.html"
             >
               @{{ rowValue }}
             </KExternalLink>
@@ -129,7 +129,7 @@
           <template #username="{ rowValue }">
             <KExternalLink
               class="username-link"
-              href="https://kongponents.konghq.com/components/alert.html"
+              href="https://kongponents.konghq.com/components/table-view.html"
             >
               @{{ rowValue }}
             </KExternalLink>
@@ -183,6 +183,14 @@
           </template>
           <template #tooltip-email>
             Id: <code>8576925e-d7e0-4ecd-8f14-15db1765e69a</code>
+          </template>
+          <template #username="{ rowValue }">
+            <a
+              href="https://kongponents.konghq.com/components/table-view.html"
+              target="_blank"
+            >
+              @{{ rowValue }}
+            </a>
           </template>
           <template #email="{ rowValue }">
             <KCopy :text="rowValue" />
@@ -683,7 +691,7 @@ onBeforeMount(() => {
   .horizontal-container {
     display: flex;
     flex-wrap: wrap;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .username-link {

--- a/sandbox/pages/SandboxTableView/SandboxTableView.vue
+++ b/sandbox/pages/SandboxTableView/SandboxTableView.vue
@@ -184,6 +184,11 @@
           <template #tooltip-email>
             Id: <code>8576925e-d7e0-4ecd-8f14-15db1765e69a</code>
           </template>
+          <template #name="{ rowValue }">
+            <KExternalLink href="https://kongponents.konghq.com/components/table-view.html">
+              {{ rowValue }}
+            </KExternalLink>
+          </template>
           <template #username="{ rowValue }">
             <a
               href="https://kongponents.konghq.com/components/table-view.html"

--- a/src/components/KExternalLink/KExternalLink.vue
+++ b/src/components/KExternalLink/KExternalLink.vue
@@ -39,29 +39,10 @@ const isHrefValid = computed((): boolean => !!isValidUrl(href))
 
 <style lang="scss" scoped>
 .k-external-link {
+  @include link;
+
   align-items: center;
-  color: var(--kui-link-color-text, var(--kui-color-text-primary, $kui-color-text-primary));
   display: inline-flex;
-  font-size: inherit;
-  font-weight: var(--kui-link-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
   gap: var(--kui-space-20, $kui-space-20);
-  list-style: inherit;
-  outline: none;
-  text-decoration: var(--kui-link-text-decoration, none);
-
-  &:hover {
-    color: var(--kui-link-color-text-hover, var(--kui-color-text-primary-strong, $kui-color-text-primary-strong));
-    text-decoration: var(--kui-link-text-decoration-hover, none);
-  }
-
-  &:focus-visible {
-    box-shadow: var(--kui-link-shadow-focus, var(--kui-shadow-focus, $kui-shadow-focus));
-    color: var(--kui-link-color-text-hover, var(--kui-color-text-primary-strong, $kui-color-text-primary-strong));
-    text-decoration: var(--kui-link-text-decoration-hover, none);
-  }
-
-  &:active {
-    color: var(--kui-link-color-text-active, var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest));
-  }
 }
 </style>

--- a/src/components/KExternalLink/KExternalLink.vue
+++ b/src/components/KExternalLink/KExternalLink.vue
@@ -43,6 +43,8 @@ const isHrefValid = computed((): boolean => !!isValidUrl(href))
 
   align-items: center;
   display: inline-flex;
+  font-weight: var(--kui-link-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
   gap: var(--kui-space-20, $kui-space-20);
+  list-style: inherit;
 }
 </style>

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -6,4 +6,5 @@
 @forward "@/styles/mixins/loaders";
 @forward "@/styles/mixins/buttons";
 @forward "@/styles/mixins/tables";
+@forward "@/styles/mixins/links";
 @forward "@/styles/mixins/common";

--- a/src/styles/mixins/_links.scss
+++ b/src/styles/mixins/_links.scss
@@ -1,0 +1,25 @@
+@use "@kong/design-tokens/tokens/scss/variables" as *;
+
+@mixin link {
+  color: var(--kui-link-color-text, var(--kui-color-text-primary, $kui-color-text-primary));
+  font-size: inherit;
+  font-weight: var(--kui-link-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
+  list-style: inherit;
+  outline: none;
+  text-decoration: var(--kui-link-text-decoration, none);
+
+  &:hover {
+    color: var(--kui-link-color-text-hover, var(--kui-color-text-primary-strong, $kui-color-text-primary-strong));
+    text-decoration: var(--kui-link-text-decoration-hover, none);
+  }
+
+  &:focus-visible {
+    box-shadow: var(--kui-link-shadow-focus, var(--kui-shadow-focus, $kui-shadow-focus));
+    color: var(--kui-link-color-text-hover, var(--kui-color-text-primary-strong, $kui-color-text-primary-strong));
+    text-decoration: var(--kui-link-text-decoration-hover, none);
+  }
+
+  &:active {
+    color: var(--kui-link-color-text-active, var(--kui-color-text-primary-strongest, $kui-color-text-primary-strongest));
+  }
+}

--- a/src/styles/mixins/_links.scss
+++ b/src/styles/mixins/_links.scss
@@ -3,8 +3,6 @@
 @mixin link {
   color: var(--kui-link-color-text, var(--kui-color-text-primary, $kui-color-text-primary));
   font-size: inherit;
-  font-weight: var(--kui-link-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
-  list-style: inherit;
   outline: none;
   text-decoration: var(--kui-link-text-decoration, none);
 

--- a/src/styles/mixins/_tables.scss
+++ b/src/styles/mixins/_tables.scss
@@ -1,5 +1,6 @@
 @use "@kong/design-tokens/tokens/scss/variables" as *;
 @use "@/styles/vars" as *;
+@use "@/styles/mixins/links" as *;
 @use "@/styles/mixins/common" as *;
 
 @mixin table {
@@ -229,6 +230,10 @@
               font-weight: var(--kui-table-cell-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
               line-height: var(--kui-table-cell-line-height, var(--kui-line-height-30, $kui-line-height-30));
               white-space: nowrap;
+
+              :deep(a) {
+                @include link;
+              }
 
               &.resize-hover {
                 // creates a 2px "border" on the right - can't use the border because it will "jump"


### PR DESCRIPTION
# Summary

Apply default link styles to slotted links in KTableVIew table cells

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
