### PR TITLE
fix(kselect, kmultiselect): new dropdown footer slot [KHCP-21063]

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -247,7 +247,7 @@ When the function passed through `itemCreationValidator` returns `false`, the "A
 >
   <template
     v-if="showNewItemValidationError"
-    #dropdown-footer-text
+    #dropdown-footer
   >
     <span class="item-creation-validation-error-message">
       New item should be at least 3 characters long.
@@ -266,7 +266,7 @@ When the function passed through `itemCreationValidator` returns `false`, the "A
   >
     <template
       v-if="showNewItemValidationError"
-      #dropdown-footer-text
+      #dropdown-footer
     >
       <span class="item-creation-validation-error-message">
         New item should be at least 3 characters long.
@@ -399,7 +399,27 @@ Adds informational text to the bottom of the dropdown options which remains visi
 <KMultiselect dropdown-footer-text="Sticky dropdown footer text" :items="items" />
 ```
 
+### dropdownFooterPosition
+
+By default, the dropdown footer will be stuck to the bottom of the dropdown and will always be visible even if the dropdown content is scrolled.
+
+If you want to override the behaviour and have the footer at the end of the dropdown list, use the value `static`. This ensures the footer is visible only when the user scrolls to view the bottom of the list.
+
+Accepted values: `sticky` (default) and `static`.
+
+<ClientOnly>
+  <KMultiselect dropdown-footer-position="static" dropdown-footer-text="Static dropdown footer text" :items="deepClone(defaultItemsLongList)" />
+</ClientOnly>
+
+```html
+<KMultiselect dropdown-footer-position="static" dropdown-footer-text="Static dropdown footer text" :items="items" />
+```
+
 ### dropdownFooterTextPosition
+
+::: warning DEPRECATED
+This prop is deprecated. Use the [`dropdownFooterPosition` prop](#dropdownfooterposition) instead.
+:::
 
 By default, the dropdown footer text will be stuck to the bottom of the dropdown and will always be visible even if the dropdown content is scrolled.
 
@@ -811,7 +831,37 @@ Slot for passing a custom icon to be displayed in front of item label in selecte
 
 You can use the `empty` slot to customize the look of the dropdown list when there is no options. See [autosuggest](#autosuggest) for an example of this slot.
 
+### dropdown-footer
+
+Use this slot to render custom content at the bottom of the dropdown container. Unlike the [`dropdownFooterText` prop](#dropdownfootertext), this slot supports interactive content (for example, buttons or links).
+
+This slot takes precedence over the `dropdownFooterText` prop and the deprecated [`dropdown-footer-text` slot](#dropdown-footer-text) when provided.
+
+<ClientOnly>
+  <KMultiselect dropdown-footer-text="Dropdown footer text" :items="deepClone(defaultItemsLongList)">
+    <template #dropdown-footer>
+      <KButton appearance="tertiary" size="small">
+        Interactive footer action
+      </KButton>
+    </template>
+  </KMultiselect>
+</ClientOnly>
+
+```html
+<KMultiselect :items="items">
+  <template #dropdown-footer>
+    <KButton appearance="tertiary" size="small">
+      Interactive footer action
+    </KButton>
+  </template>
+</KMultiselect>
+```
+
 ### dropdown-footer-text
+
+::: warning DEPRECATED
+This slot is deprecated. Use the [`dropdown-footer` slot](#dropdown-footer) instead, which also supports interactive content.
+:::
 
 Slot the content of the dropdown footer text. This slot will override the `dropdownFooterText` prop if provided.
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -245,7 +245,23 @@ Text to be displayed at the bottom of the dropdown container. Can also be [slott
 <KSelect dropdown-footer-text="Helpful text in the dropdown." :items="selectItems" />
 ```
 
+### dropdownFooterPosition
+
+Defaults to `sticky`, but also accepts `static` value should you want the dropdown footer to be displayed at the bottom of dropdown container after all items.
+
+<ClientOnly>
+  <KSelect dropdown-footer-position="static" dropdown-footer-text="Helpful text in the dropdown." :items="selectItems" />
+</ClientOnly>
+
+```html
+<KSelect dropdown-footer-position="static" dropdown-footer-text="Helpful text in the dropdown." :items="selectItems" />
+```
+
 ### dropdownFooterTextPosition
+
+::: warning DEPRECATED
+This prop is deprecated. Use the [`dropdownFooterPosition` prop](#dropdownfooterposition) instead.
+:::
 
 Defaults to `sticky`, but also accepts `static` value should you want text passed through `dropdownFooterText` prop to be displayed at the bottom of dropdown container after all items.
 
@@ -421,7 +437,7 @@ When the function passed through `itemCreationValidator` returns `false`, the "A
 >
   <template
     v-if="showNewItemValidationError"
-    #dropdown-footer-text
+    #dropdown-footer
   >
     <span class="item-creation-validation-error-message">
       New item should be at least 3 characters long.
@@ -440,7 +456,7 @@ When the function passed through `itemCreationValidator` returns `false`, the "A
   >
     <template
       v-if="showNewItemValidationError"
-      #dropdown-footer-text
+      #dropdown-footer
     >
       <span class="item-creation-validation-error-message">
         New item should be at least 3 characters long.
@@ -690,7 +706,39 @@ Use this slot to provide custom content to the selected item. The slot exposes `
 </KSelect>
 ```
 
+### dropdown-footer
+
+Use this slot to render custom content at the bottom of the dropdown container. Unlike the [`dropdownFooterText` prop](#dropdownfootertext), this slot supports interactive content (for example, buttons or links).
+
+This slot takes precedence over the `dropdownFooterText` prop and the deprecated [`dropdown-footer-text` slot](#dropdown-footer-text) when provided.
+
+<ClientOnly>
+  <KSelect :items="selectItems">
+    <template #dropdown-footer>
+      <KButton appearance="tertiary" size="small">
+        <KongIcon />
+        Interactive footer action
+      </KButton>
+    </template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect :items="selectItems">
+  <template #dropdown-footer>
+    <KButton appearance="tertiary" size="small">
+      <KongIcon />
+      Interactive footer action
+    </KButton>
+  </template>
+</KSelect>
+```
+
 ### dropdown-footer-text
+
+::: warning DEPRECATED
+This slot is deprecated. Use the [`dropdown-footer` slot](#dropdown-footer) instead, which also supports interactive content.
+:::
 
 A slot alternative for [`dropdownFooterText` prop](#dropdownfootertext).
 
@@ -701,7 +749,7 @@ A slot alternative for [`dropdownFooterText` prop](#dropdownfootertext).
       Dropdown footer content.
     </template>
   </KSelect>
-</CLientOnly>
+</ClientOnly>
 
 ```html
 <KSelect :items="selectItems">

--- a/sandbox/pages/SandboxMultiselect.vue
+++ b/sandbox/pages/SandboxMultiselect.vue
@@ -106,11 +106,11 @@
         />
       </SandboxSectionComponent>
       <SandboxSectionComponent
-        title="dropdownFooterTextPosition"
+        title="dropdownFooterPosition"
       >
         <KMultiselect
+          dropdown-footer-position="static"
           dropdown-footer-text="You've reached the bottom."
-          dropdown-footer-text-position="static"
           :items="multiselectItems"
         />
       </SandboxSectionComponent>
@@ -139,7 +139,7 @@
         >
           <template
             v-if="showNewItemValidationError"
-            #dropdown-footer-text
+            #dropdown-footer
           >
             <span class="item-creation-validation-error-message">New item should be at least 3 characters long.</span>
           </template>
@@ -236,14 +236,21 @@
         </KMultiselect>
       </SandboxSectionComponent>
       <SandboxSectionComponent
-        title="dropdownFooterText"
+        title="dropdown-footer"
       >
         <KMultiselect
           dropdown-footer-text="Keep scrolling to reach the bottom."
           :items="multiselectItems"
         >
-          <template #dropdown-footer-text>
-            I am slotted.
+          <template #dropdown-footer>
+            <KButton
+              appearance="tertiary"
+              size="small"
+              @click="onDropdownFooterAction"
+            >
+              <AddIcon />
+              Interactive footer action
+            </KButton>
           </template>
         </KMultiselect>
       </SandboxSectionComponent>
@@ -318,7 +325,7 @@ import { computed, ref, inject } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
 import type { MultiselectEntry, MultiselectItem } from '@/types'
-import { KongIcon, DisabledIcon } from '@kong/icons'
+import { KongIcon, DisabledIcon, AddIcon } from '@kong/icons'
 
 const multiselectItems: MultiselectEntry[] = [
   {
@@ -402,6 +409,10 @@ const onItemCreationQueryChange = (query: string): void => {
   showNewItemValidationError.value = query ? !itemCreationValidator(query) : false
 }
 
+const onDropdownFooterAction = (): void => {
+  window.alert('Interactive dropdown footer action clicked!')
+}
+
 // Example using old group property approach
 const multiselectItemsWithGroupProperty: MultiselectItem[] = [
   {
@@ -448,7 +459,7 @@ const multiselectItemsWithGroupProperty: MultiselectItem[] = [
   .custom-item {
     display: flex;
     flex-direction: row;
-    gap: $kui-space-30;
+    gap: var(--kui-space-30, $kui-space-30);
 
     &-title-container {
       flex: 1;
@@ -459,20 +470,20 @@ const multiselectItemsWithGroupProperty: MultiselectItem[] = [
     }
 
     &-description {
-      color: $kui-color-text-neutral;
+      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
       display: block;
-      font-size: $kui-font-size-20;
+      font-size: var(--kui-font-size-20, $kui-font-size-20);
     }
   }
 
   .select-multiselect-row {
     display: flex;
     flex-direction: row;
-    gap: $kui-space-30;
+    gap: var(--kui-space-30, $kui-space-30);
   }
 
   .item-creation-validation-error-message {
-    color: $kui-color-text-danger;
+    color: var(--kui-color-text-danger, $kui-color-text-danger);
   }
 }
 </style>

--- a/sandbox/pages/SandboxSelect.vue
+++ b/sandbox/pages/SandboxSelect.vue
@@ -115,11 +115,11 @@
         />
       </SandboxSectionComponent>
       <SandboxSectionComponent
-        title="dropdownFooterTextPosition"
+        title="dropdownFooterPosition"
       >
         <KSelect
+          dropdown-footer-position="static"
           dropdown-footer-text="You've reached the bottom."
-          dropdown-footer-text-position="static"
           :items="selectItems"
         />
       </SandboxSectionComponent>
@@ -166,7 +166,7 @@
         >
           <template
             v-if="showNewItemValidationError"
-            #dropdown-footer-text
+            #dropdown-footer
           >
             <span class="item-creation-validation-error-message">New item should be at least 3 characters long.</span>
           </template>
@@ -276,14 +276,21 @@
         </KSelect>
       </SandboxSectionComponent>
       <SandboxSectionComponent
-        title="dropdownFooterText"
+        title="dropdown-footer"
       >
         <KSelect
           dropdown-footer-text="Keep scrolling to reach the bottom."
           :items="selectItems"
         >
-          <template #dropdown-footer-text>
-            I am slotted.
+          <template #dropdown-footer>
+            <KButton
+              appearance="tertiary"
+              size="small"
+              @click="onDropdownFooterAction"
+            >
+              <AddIcon />
+              Interactive footer action
+            </KButton>
           </template>
         </KSelect>
       </SandboxSectionComponent>
@@ -337,7 +344,7 @@
 import { inject, onMounted, ref } from 'vue'
 import SandboxTitleComponent from '../components/SandboxTitleComponent.vue'
 import SandboxSectionComponent from '../components/SandboxSectionComponent.vue'
-import { KongIcon } from '@kong/icons'
+import { KongIcon, AddIcon } from '@kong/icons'
 import type { SelectEntry, SelectItem } from '@/types'
 
 const selectItems: SelectEntry[] = [
@@ -481,6 +488,10 @@ const onItemCreationQueryChange = (query: string): void => {
   showNewItemValidationError.value = query ? !itemCreationValidator(query) : false
 }
 
+const onDropdownFooterAction = (): void => {
+  window.alert('Interactive dropdown footer action clicked!')
+}
+
 // Example using old group property approach
 const selectItemsWithGroupProperty: SelectItem[] = [
   {
@@ -530,7 +541,7 @@ onMounted(() => {
     align-items: flex-end;
     display: flex;
     flex-wrap: wrap;
-    gap: $kui-space-50;
+    gap: var(--kui-space-50, $kui-space-50);
   }
 
   .long-item-title {
@@ -543,7 +554,7 @@ onMounted(() => {
   .custom-item {
     display: flex;
     flex-direction: row;
-    gap: $kui-space-30;
+    gap: var(--kui-space-30, $kui-space-30);
 
     &-title-container {
       flex: 1;
@@ -554,9 +565,9 @@ onMounted(() => {
     }
 
     &-description {
-      color: $kui-color-text-neutral;
+      color: var(--kui-color-text-neutral, $kui-color-text-neutral);
       display: block;
-      font-size: $kui-font-size-20;
+      font-size: var(--kui-font-size-20, $kui-font-size-20);
     }
   }
 
@@ -567,12 +578,12 @@ onMounted(() => {
 
     .title {
       display: flex;
-      gap: $kui-space-30;
+      gap: var(--kui-space-30, $kui-space-30);
     }
   }
 
   .item-creation-validation-error-message {
-    color: $kui-color-text-danger;
+    color: var(--kui-color-text-danger, $kui-color-text-danger);
   }
 }
 </style>

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -605,6 +605,114 @@ describe('KMultiselect', () => {
     cy.get('.dropdown-footer').should('be.visible').should('contain.text', dropdownFooterText)
   })
 
+  it('renders interactive content in the dropdown-footer slot', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+    const buttonText = 'Footer action'
+
+    cy.mount(KMultiselect, {
+      props: {
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+      },
+      slots: {
+        'dropdown-footer': `<button data-testid="footer-button">${buttonText}</button>`,
+      },
+    })
+
+    cy.get('.multiselect-trigger').trigger('click')
+
+    cy.get('.dropdown-footer')
+      .should('be.visible')
+      .should('have.css', 'pointer-events', 'auto')
+    // the interactive content should be clickable
+    cy.getTestId('footer-button').should('be.visible').click()
+  })
+
+  it('dropdown-footer slot takes precedence over dropdownFooterText prop and dropdown-footer-text slot', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+
+    cy.mount(KMultiselect, {
+      props: {
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+        dropdownFooterText: 'Footer text prop',
+      },
+      slots: {
+        'dropdown-footer-text': 'Deprecated footer slot',
+        'dropdown-footer': 'New footer slot',
+      },
+    })
+
+    cy.get('.multiselect-trigger').trigger('click')
+
+    cy.get('.dropdown-footer')
+      .should('be.visible')
+      .should('contain.text', 'New footer slot')
+      .should('not.contain.text', 'Deprecated footer slot')
+      .should('not.contain.text', 'Footer text prop')
+  })
+
+  it('positions the dropdown footer via the dropdownFooterPosition prop', () => {
+    cy.mount(KMultiselect, {
+      props: {
+        items: [{ label: 'Label 1', value: 'val1' }],
+        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterPosition: 'static',
+      },
+    })
+
+    cy.get('.multiselect-trigger').trigger('click')
+
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+  })
+
+  it('supports the deprecated dropdownFooterTextPosition prop, with dropdownFooterPosition taking precedence', () => {
+    cy.mount(KMultiselect, {
+      props: {
+        items: [{ label: 'Label 1', value: 'val1' }],
+        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterTextPosition: 'static',
+      },
+    })
+
+    cy.get('.multiselect-trigger').trigger('click')
+
+    // deprecated prop still works
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+
+    // new prop takes precedence over the deprecated one
+    cy.mount(KMultiselect, {
+      props: {
+        items: [{ label: 'Label 1', value: 'val1' }],
+        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterTextPosition: 'static',
+        dropdownFooterPosition: 'sticky',
+      },
+    })
+
+    cy.get('.multiselect-trigger').trigger('click')
+
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-sticky')
+  })
+
   it('renders group titles and groups items in correct order', () => {
     const group1Title = 'Group 1'
     const group2Title = 'Group 2'

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -640,6 +640,9 @@ describe('KMultiselect', () => {
   it('dropdown-footer slot takes precedence over dropdownFooterText prop and dropdown-footer-text slot', () => {
     const labels = ['Label 1', 'Label 2', 'Label 3']
     const vals = ['label1', 'label2', 'label3']
+    const footerTextProp = 'Footer text prop'
+    const deprecatedFooterSlot = 'Deprecated footer slot'
+    const newFooterSlot = 'New footer slot'
 
     cy.mount(KMultiselect, {
       props: {
@@ -653,11 +656,11 @@ describe('KMultiselect', () => {
           label: labels[2],
           value: vals[2],
         }],
-        dropdownFooterText: 'Footer text prop',
+        dropdownFooterText: footerTextProp,
       },
       slots: {
-        'dropdown-footer-text': 'Deprecated footer slot',
-        'dropdown-footer': 'New footer slot',
+        'dropdown-footer-text': deprecatedFooterSlot,
+        'dropdown-footer': newFooterSlot,
       },
     })
 
@@ -665,30 +668,37 @@ describe('KMultiselect', () => {
 
     cy.get('.dropdown-footer')
       .should('be.visible')
-      .should('contain.text', 'New footer slot')
-      .should('not.contain.text', 'Deprecated footer slot')
-      .should('not.contain.text', 'Footer text prop')
+      .should('contain.text', newFooterSlot)
+      .should('not.contain.text', deprecatedFooterSlot)
+      .should('not.contain.text', footerTextProp)
   })
 
   it('positions the dropdown footer via the dropdownFooterPosition prop', () => {
+    const dropdownFooterText = 'Dropdown footer text'
+    const staticFooterClass = 'dropdown-footer-static'
+
     cy.mount(KMultiselect, {
       props: {
         items: [{ label: 'Label 1', value: 'val1' }],
-        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterText,
         dropdownFooterPosition: 'static',
       },
     })
 
     cy.get('.multiselect-trigger').trigger('click')
 
-    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', staticFooterClass)
   })
 
   it('supports the deprecated dropdownFooterTextPosition prop, with dropdownFooterPosition taking precedence', () => {
+    const dropdownFooterText = 'Dropdown footer text'
+    const staticFooterClass = 'dropdown-footer-static'
+    const stickyFooterClass = 'dropdown-footer-sticky'
+
     cy.mount(KMultiselect, {
       props: {
         items: [{ label: 'Label 1', value: 'val1' }],
-        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterText,
         dropdownFooterTextPosition: 'static',
       },
     })
@@ -696,13 +706,13 @@ describe('KMultiselect', () => {
     cy.get('.multiselect-trigger').trigger('click')
 
     // deprecated prop still works
-    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', staticFooterClass)
 
     // new prop takes precedence over the deprecated one
     cy.mount(KMultiselect, {
       props: {
         items: [{ label: 'Label 1', value: 'val1' }],
-        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterText,
         dropdownFooterTextPosition: 'static',
         dropdownFooterPosition: 'sticky',
       },
@@ -710,7 +720,7 @@ describe('KMultiselect', () => {
 
     cy.get('.multiselect-trigger').trigger('click')
 
-    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-sticky')
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', stickyFooterClass)
   })
 
   it('renders group titles and groups items in correct order', () => {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -222,7 +222,7 @@
               </div>
             </div>
             <div
-              v-if="hasDropdownFooter"
+              v-if="hasDropdownFooter()"
               class="dropdown-footer"
               :class="`dropdown-footer-${resolvedDropdownFooterPosition}`"
               data-testid="dropdown-footer"
@@ -552,7 +552,9 @@ const modifiedAttrs = computed(() => {
   return $attrs
 })
 
-const hasDropdownFooter = computed((): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'] || slots['dropdown-footer']))
+// Do not cache slot presence checks in a computed - `computed()` does not track raw property
+// access on the `slots` object, so slots added by a parent after mount would never be detected.
+const hasDropdownFooter = (): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'] || slots['dropdown-footer'])
 
 // `dropdownFooterPosition` takes precedence over the deprecated `dropdownFooterTextPosition` prop
 const resolvedDropdownFooterPosition = computed((): DropdownFooterPosition => dropdownFooterPosition ?? dropdownFooterTextPosition ?? 'sticky')
@@ -561,7 +563,7 @@ const createKPopAttributes = (): PopoverAttributes => {
   return {
     ...defaultKPopAttributes,
     ...kpopAttributes,
-    popoverClasses: `${defaultKPopAttributes.popoverClasses} ${kpopAttributes?.popoverClasses ?? ''} ${hasDropdownFooter.value ? 'has-dropdown-footer' : ''}`,
+    popoverClasses: `${defaultKPopAttributes.popoverClasses} ${kpopAttributes?.popoverClasses ?? ''} ${hasDropdownFooter() ? 'has-dropdown-footer' : ''}`,
     width: numericWidth.value + 'px',
     maxWidth: numericWidth.value + 'px',
     disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -222,12 +222,19 @@
               </div>
             </div>
             <div
-              v-if="dropdownFooterText || $slots['dropdown-footer-text']"
+              v-if="hasDropdownFooter"
               class="dropdown-footer"
-              :class="`dropdown-footer-${dropdownFooterTextPosition}`"
+              :class="`dropdown-footer-${resolvedDropdownFooterPosition}`"
               data-testid="dropdown-footer"
             >
-              <slot name="dropdown-footer-text">
+              <slot
+                v-if="$slots['dropdown-footer']"
+                name="dropdown-footer"
+              />
+              <slot
+                v-else
+                name="dropdown-footer-text"
+              >
                 {{ dropdownFooterText }}
               </slot>
             </div>
@@ -309,6 +316,7 @@ import type {
   MultiselectProps,
   MultiselectEmits,
   MultiselectSlots,
+  DropdownFooterPosition,
   PopoverAttributes,
 } from '@/types'
 import { CloseIcon, ChevronDownIcon, ProgressIcon } from '@kong/icons'
@@ -399,7 +407,8 @@ const {
   enableItemCreation,
   loading,
   dropdownFooterText = '',
-  dropdownFooterTextPosition = 'sticky',
+  dropdownFooterTextPosition,
+  dropdownFooterPosition,
   itemCreationValidator = () => true,
 } = defineProps<MultiselectProps<T, U>>()
 
@@ -543,13 +552,16 @@ const modifiedAttrs = computed(() => {
   return $attrs
 })
 
-const hasDropdownFooterTextSlot = (): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'])
+const hasDropdownFooter = computed((): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'] || slots['dropdown-footer']))
+
+// `dropdownFooterPosition` takes precedence over the deprecated `dropdownFooterTextPosition` prop
+const resolvedDropdownFooterPosition = computed((): DropdownFooterPosition => dropdownFooterPosition ?? dropdownFooterTextPosition ?? 'sticky')
 
 const createKPopAttributes = (): PopoverAttributes => {
   return {
     ...defaultKPopAttributes,
     ...kpopAttributes,
-    popoverClasses: `${defaultKPopAttributes.popoverClasses} ${kpopAttributes?.popoverClasses ?? ''} ${hasDropdownFooterTextSlot() ? 'has-dropdown-footer' : ''}`,
+    popoverClasses: `${defaultKPopAttributes.popoverClasses} ${kpopAttributes?.popoverClasses ?? ''} ${hasDropdownFooter.value ? 'has-dropdown-footer' : ''}`,
     width: numericWidth.value + 'px',
     maxWidth: numericWidth.value + 'px',
     disabled: (attrs.disabled !== undefined && String(attrs.disabled) !== 'false') || (attrs.readonly !== undefined && String(attrs.readonly) !== 'false'),
@@ -1431,7 +1443,6 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
     gap: var(--kui-space-30, $kui-space-30);
     line-height: var(--kui-line-height-20, $kui-line-height-20);
     padding: var(--kui-space-50, $kui-space-50);
-    pointer-events: none;
   }
 
   .help-text {
@@ -1492,32 +1503,36 @@ $kMultiselectInputHelpTextHeight: var(--kui-line-height-20, $kui-line-height-20)
     top: 0;
   }
 
-  &.multiselect-popover .popover-container {
-    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-input-color-border, var(--kui-color-border, $kui-color-border));
-    border-radius: var(--kui-input-border-radius, var(--kui-border-radius-30, $kui-border-radius-30));
-    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
+  &.multiselect-popover {
+    .popover-container {
+      border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-input-color-border, var(--kui-color-border, $kui-color-border));
+      border-radius: var(--kui-input-border-radius, var(--kui-border-radius-30, $kui-border-radius-30));
+      padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
 
-    &.has-dropdown-footer {
-      padding-bottom: var(--kui-space-0, $kui-space-0);
-    }
+      .popover-content {
+        @include kMultiselectPopoverMaxHeight;
 
-    .popover-content {
-      @include kMultiselectPopoverMaxHeight;
+        // when dropdown footer text position is sticky
+        &:has(.dropdown-footer.dropdown-footer-sticky) {
+          max-height: none;
 
-      // when dropdown footer text position is sticky
-      &:has(.dropdown-footer.dropdown-footer-sticky) {
-        max-height: none;
+          .multiselect-list {
+            @include kMultiselectPopoverMaxHeight;
+          }
+        }
 
-        .multiselect-list {
-          @include kMultiselectPopoverMaxHeight;
+        // Firefox workaround
+        // since :has() selector isn't supported in Firefox be default
+        .multiselect-list ~ .dropdown-footer-sticky {
+          bottom: 0;
+          position: sticky;
         }
       }
+    }
 
-      // Firefox workaround
-      // since :has() selector isn't supported in Firefox be default
-      .multiselect-list ~ .dropdown-footer-sticky {
-        bottom: 0;
-        position: sticky;
+    &.has-dropdown-footer {
+      .popover-container {
+        padding-bottom: var(--kui-space-0, $kui-space-0);
       }
     }
   }

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -383,6 +383,114 @@ describe('KSelect', () => {
     cy.get('.dropdown-footer').should('be.visible').should('contain.text', dropdownFooterText)
   })
 
+  it('renders interactive content in the dropdown-footer slot', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+    const buttonText = 'Footer action'
+
+    cy.mount(KSelect, {
+      props: {
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+      },
+      slots: {
+        'dropdown-footer': `<button data-testid="footer-button">${buttonText}</button>`,
+      },
+    })
+
+    cy.getTestId('select-input').trigger('click')
+
+    cy.get('.dropdown-footer')
+      .should('be.visible')
+      .should('have.css', 'pointer-events', 'auto')
+    // the interactive content should be clickable
+    cy.getTestId('footer-button').should('be.visible').click()
+  })
+
+  it('dropdown-footer slot takes precedence over dropdownFooterText prop and dropdown-footer-text slot', () => {
+    const labels = ['Label 1', 'Label 2', 'Label 3']
+    const vals = ['label1', 'label2', 'label3']
+
+    cy.mount(KSelect, {
+      props: {
+        items: [{
+          label: labels[0],
+          value: vals[0],
+        }, {
+          label: labels[1],
+          value: vals[1],
+        }, {
+          label: labels[2],
+          value: vals[2],
+        }],
+        dropdownFooterText: 'Footer text prop',
+      },
+      slots: {
+        'dropdown-footer-text': 'Deprecated footer slot',
+        'dropdown-footer': 'New footer slot',
+      },
+    })
+
+    cy.getTestId('select-input').trigger('click')
+
+    cy.get('.dropdown-footer')
+      .should('be.visible')
+      .should('contain.text', 'New footer slot')
+      .should('not.contain.text', 'Deprecated footer slot')
+      .should('not.contain.text', 'Footer text prop')
+  })
+
+  it('positions the dropdown footer via the dropdownFooterPosition prop', () => {
+    cy.mount(KSelect, {
+      props: {
+        items: [{ label: 'Label 1', value: 'val1' }],
+        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterPosition: 'static',
+      },
+    })
+
+    cy.getTestId('select-input').trigger('click')
+
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+  })
+
+  it('supports the deprecated dropdownFooterTextPosition prop, with dropdownFooterPosition taking precedence', () => {
+    cy.mount(KSelect, {
+      props: {
+        items: [{ label: 'Label 1', value: 'val1' }],
+        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterTextPosition: 'static',
+      },
+    })
+
+    cy.getTestId('select-input').trigger('click')
+
+    // deprecated prop still works
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+
+    // new prop takes precedence over the deprecated one
+    cy.mount(KSelect, {
+      props: {
+        items: [{ label: 'Label 1', value: 'val1' }],
+        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterTextPosition: 'static',
+        dropdownFooterPosition: 'sticky',
+      },
+    })
+
+    cy.getTestId('select-input').trigger('click')
+
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-sticky')
+  })
+
   it('renders group titles and groups items in correct order (backwards compatible)', () => {
     const group1Title = 'Group 1'
     const group2Title = 'Group 2'

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -418,6 +418,9 @@ describe('KSelect', () => {
   it('dropdown-footer slot takes precedence over dropdownFooterText prop and dropdown-footer-text slot', () => {
     const labels = ['Label 1', 'Label 2', 'Label 3']
     const vals = ['label1', 'label2', 'label3']
+    const footerTextProp = 'Footer text prop'
+    const deprecatedFooterSlot = 'Deprecated footer slot'
+    const newFooterSlot = 'New footer slot'
 
     cy.mount(KSelect, {
       props: {
@@ -431,11 +434,11 @@ describe('KSelect', () => {
           label: labels[2],
           value: vals[2],
         }],
-        dropdownFooterText: 'Footer text prop',
+        dropdownFooterText: footerTextProp,
       },
       slots: {
-        'dropdown-footer-text': 'Deprecated footer slot',
-        'dropdown-footer': 'New footer slot',
+        'dropdown-footer-text': deprecatedFooterSlot,
+        'dropdown-footer': newFooterSlot,
       },
     })
 
@@ -443,30 +446,37 @@ describe('KSelect', () => {
 
     cy.get('.dropdown-footer')
       .should('be.visible')
-      .should('contain.text', 'New footer slot')
-      .should('not.contain.text', 'Deprecated footer slot')
-      .should('not.contain.text', 'Footer text prop')
+      .should('contain.text', newFooterSlot)
+      .should('not.contain.text', deprecatedFooterSlot)
+      .should('not.contain.text', footerTextProp)
   })
 
   it('positions the dropdown footer via the dropdownFooterPosition prop', () => {
+    const dropdownFooterText = 'Dropdown footer text'
+    const staticFooterClass = 'dropdown-footer-static'
+
     cy.mount(KSelect, {
       props: {
         items: [{ label: 'Label 1', value: 'val1' }],
-        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterText,
         dropdownFooterPosition: 'static',
       },
     })
 
     cy.getTestId('select-input').trigger('click')
 
-    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', staticFooterClass)
   })
 
   it('supports the deprecated dropdownFooterTextPosition prop, with dropdownFooterPosition taking precedence', () => {
+    const dropdownFooterText = 'Dropdown footer text'
+    const staticFooterClass = 'dropdown-footer-static'
+    const stickyFooterClass = 'dropdown-footer-sticky'
+
     cy.mount(KSelect, {
       props: {
         items: [{ label: 'Label 1', value: 'val1' }],
-        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterText,
         dropdownFooterTextPosition: 'static',
       },
     })
@@ -474,13 +484,13 @@ describe('KSelect', () => {
     cy.getTestId('select-input').trigger('click')
 
     // deprecated prop still works
-    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-static')
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', staticFooterClass)
 
     // new prop takes precedence over the deprecated one
     cy.mount(KSelect, {
       props: {
         items: [{ label: 'Label 1', value: 'val1' }],
-        dropdownFooterText: 'Dropdown footer text',
+        dropdownFooterText,
         dropdownFooterTextPosition: 'static',
         dropdownFooterPosition: 'sticky',
       },
@@ -488,7 +498,7 @@ describe('KSelect', () => {
 
     cy.getTestId('select-input').trigger('click')
 
-    cy.get('.dropdown-footer').should('be.visible').should('have.class', 'dropdown-footer-sticky')
+    cy.get('.dropdown-footer').should('be.visible').should('have.class', stickyFooterClass)
   })
 
   it('renders group titles and groups items in correct order (backwards compatible)', () => {

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -156,7 +156,7 @@
                 :item="{ label: 'No results', value: 'no_results', disabled: true }"
               />
               <div
-                v-if="hasDropdownFooter && resolvedDropdownFooterPosition === 'static'"
+                v-if="hasDropdownFooter() && resolvedDropdownFooterPosition === 'static'"
                 class="dropdown-footer dropdown-footer-static"
               >
                 <slot
@@ -180,7 +180,7 @@
             </div>
           </div>
           <div
-            v-if="hasDropdownFooter && resolvedDropdownFooterPosition === 'sticky'"
+            v-if="hasDropdownFooter() && resolvedDropdownFooterPosition === 'sticky'"
             class="dropdown-footer dropdown-footer-sticky"
           >
             <slot
@@ -291,7 +291,9 @@ const defaultKPopAttributes: Omit<PopoverAttributes, 'popoverClasses'> = {
   hideCaret: true,
 }
 
-const hasDropdownFooter = computed((): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'] || slots['dropdown-footer']))
+// Do not cache slot presence checks in a computed - `computed()` does not track raw property
+// access on the `slots` object, so slots added by a parent after mount would never be detected.
+const hasDropdownFooter = (): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'] || slots['dropdown-footer'])
 
 // `dropdownFooterPosition` takes precedence over the deprecated `dropdownFooterTextPosition` prop
 const resolvedDropdownFooterPosition = computed((): SelectDropdownFooterPosition => dropdownFooterPosition ?? dropdownFooterTextPosition ?? 'sticky')
@@ -378,7 +380,7 @@ const createKPopAttributes = (): PopoverAttributes => {
   return {
     ...defaultKPopAttributes,
     ...kpopAttributes,
-    popoverClasses: `k-select-popover select-popover ${hasDropdownFooter.value ? `has-${resolvedDropdownFooterPosition.value}-dropdown-footer` : ''} ${kpopAttributes?.popoverClasses ?? ''}`,
+    popoverClasses: `k-select-popover select-popover ${hasDropdownFooter() ? `has-${resolvedDropdownFooterPosition.value}-dropdown-footer` : ''} ${kpopAttributes?.popoverClasses ?? ''}`,
     width: String(actualElementWidth.value),
     maxWidth: String(actualElementWidth.value),
     disabled: isDisabled.value || isReadonly.value,

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -156,10 +156,17 @@
                 :item="{ label: 'No results', value: 'no_results', disabled: true }"
               />
               <div
-                v-if="(dropdownFooterText || $slots['dropdown-footer-text']) && dropdownFooterTextPosition === 'static'"
+                v-if="hasDropdownFooter && resolvedDropdownFooterPosition === 'static'"
                 class="dropdown-footer dropdown-footer-static"
               >
-                <slot name="dropdown-footer-text">
+                <slot
+                  v-if="$slots['dropdown-footer']"
+                  name="dropdown-footer"
+                />
+                <slot
+                  v-else
+                  name="dropdown-footer-text"
+                >
                   {{ dropdownFooterText }}
                 </slot>
               </div>
@@ -173,10 +180,17 @@
             </div>
           </div>
           <div
-            v-if="(dropdownFooterText || $slots['dropdown-footer-text']) && dropdownFooterTextPosition === 'sticky'"
+            v-if="hasDropdownFooter && resolvedDropdownFooterPosition === 'sticky'"
             class="dropdown-footer dropdown-footer-sticky"
           >
-            <slot name="dropdown-footer-text">
+            <slot
+              v-if="$slots['dropdown-footer']"
+              name="dropdown-footer"
+            />
+            <slot
+              v-else
+              name="dropdown-footer-text"
+            >
               {{ dropdownFooterText }}
             </slot>
           </div>
@@ -211,6 +225,7 @@ import type {
   SelectProps,
   SelectEmits,
   SelectSlots,
+  SelectDropdownFooterPosition,
   PopoverAttributes,
 } from '@/types'
 import { ChevronDownIcon, CloseIcon, ProgressIcon } from '@kong/icons'
@@ -244,7 +259,8 @@ const {
   loading,
   clearable,
   dropdownFooterText = '',
-  dropdownFooterTextPosition = 'sticky',
+  dropdownFooterTextPosition,
+  dropdownFooterPosition,
   reuseItemTemplate,
   enableItemCreation,
   itemCreationValidator = () => true,
@@ -275,7 +291,10 @@ const defaultKPopAttributes: Omit<PopoverAttributes, 'popoverClasses'> = {
   hideCaret: true,
 }
 
-const hasDropdownFooterTextSlot = (): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'])
+const hasDropdownFooter = computed((): boolean => !!(dropdownFooterText || slots['dropdown-footer-text'] || slots['dropdown-footer']))
+
+// `dropdownFooterPosition` takes precedence over the deprecated `dropdownFooterTextPosition` prop
+const resolvedDropdownFooterPosition = computed((): SelectDropdownFooterPosition => dropdownFooterPosition ?? dropdownFooterTextPosition ?? 'sticky')
 
 const inputKey = ref<number>(0)
 const inputRef = useTemplateRef('inputElement')
@@ -359,7 +378,7 @@ const createKPopAttributes = (): PopoverAttributes => {
   return {
     ...defaultKPopAttributes,
     ...kpopAttributes,
-    popoverClasses: `k-select-popover select-popover ${hasDropdownFooterTextSlot() ? `has-${dropdownFooterTextPosition}-dropdown-footer` : ''} ${kpopAttributes?.popoverClasses ?? ''}`,
+    popoverClasses: `k-select-popover select-popover ${hasDropdownFooter.value ? `has-${resolvedDropdownFooterPosition.value}-dropdown-footer` : ''} ${kpopAttributes?.popoverClasses ?? ''}`,
     width: String(actualElementWidth.value),
     maxWidth: String(actualElementWidth.value),
     disabled: isDisabled.value || isReadonly.value,
@@ -920,7 +939,6 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
     gap: var(--kui-space-30, $kui-space-30);
     line-height: var(--kui-line-height-20, $kui-line-height-20);
     padding: var(--kui-space-50, $kui-space-50);
-    pointer-events: none;
     position: sticky;
 
     &-static {
@@ -953,13 +971,17 @@ $kSelectInputHelpTextHeight: calc(var(--kui-line-height-20, $kui-line-height-20)
     overflow-y: auto;
   }
 
-  &.popover .popover-container {
-    border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-input-color-border, var(--kui-color-border, $kui-color-border));
-    border-radius: var(--kui-input-border-radius, var(--kui-border-radius-30, $kui-border-radius-30));
-    padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
+  &.popover {
+    .popover-container {
+      border: var(--kui-border-width-10, $kui-border-width-10) solid var(--kui-input-color-border, var(--kui-color-border, $kui-color-border));
+      border-radius: var(--kui-input-border-radius, var(--kui-border-radius-30, $kui-border-radius-30));
+      padding: var(--kui-space-20, $kui-space-20) var(--kui-space-0, $kui-space-0);
+    }
 
     &.has-sticky-dropdown-footer, &.has-static-dropdown-footer {
-      padding-bottom: var(--kui-space-0, $kui-space-0);
+      .popover-container {
+        padding-bottom: var(--kui-space-0, $kui-space-0);
+      }
     }
   }
 }

--- a/src/types/multi-select.ts
+++ b/src/types/multi-select.ts
@@ -33,7 +33,12 @@ export interface MultiselectFilterFunctionParams<T extends string = string> {
   query: string
 }
 
-export type DropdownFooterTextPosition = 'sticky' | 'static'
+export type DropdownFooterPosition = 'sticky' | 'static'
+
+/**
+ * @deprecated Use `DropdownFooterPosition` instead.
+ */
+export type DropdownFooterTextPosition = DropdownFooterPosition
 
 /**
  * @internal
@@ -192,11 +197,21 @@ export interface MultiselectProps<T extends string, U extends boolean = false> {
   dropdownFooterText?: string
 
   /**
+   * @deprecated Use `dropdownFooterPosition` instead.
+   *
    * The position of the dropdown footer text.
    * Accepted values: 'sticky' and 'static'.
    * @default 'sticky'
    */
   dropdownFooterTextPosition?: DropdownFooterTextPosition
+
+  /**
+   * The position of the dropdown footer.
+   * Accepted values: 'sticky' and 'static'.
+   * Takes precedence over the deprecated `dropdownFooterTextPosition` prop.
+   * @default 'sticky'
+   */
+  dropdownFooterPosition?: DropdownFooterPosition
 
   /**
    * Validator function for item creation.
@@ -232,9 +247,17 @@ export interface MultiselectSlots<T extends string = string> {
   empty?: () => any
 
   /**
+   * @deprecated Use the `dropdown-footer` slot instead, which also supports interactive content.
+   *
    * Slot for dropdown footer in multiselect.
    */
   'dropdown-footer-text'?: () => any
+
+  /**
+   * A slot for custom dropdown footer content. Supports interactive content.
+   * Takes precedence over the `dropdownFooterText` prop and the deprecated `dropdown-footer-text` slot.
+   */
+  'dropdown-footer'?: () => any
 
   /**
    * Slot for icon in the selected item badge.

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -85,7 +85,12 @@ export interface SelectFilterFunctionParams<T extends string | number> {
   items: Array<SelectItem<T>>
 }
 
-export type SelectDropdownFooterTextPosition = 'sticky' | 'static'
+export type SelectDropdownFooterPosition = 'sticky' | 'static'
+
+/**
+ * @deprecated Use `SelectDropdownFooterPosition` instead.
+ */
+export type SelectDropdownFooterTextPosition = SelectDropdownFooterPosition
 
 export interface SelectProps<T extends string | number, U extends boolean = false> {
   /**
@@ -179,11 +184,21 @@ export interface SelectProps<T extends string | number, U extends boolean = fals
   dropdownFooterText?: string
 
   /**
+   * @deprecated Use `dropdownFooterPosition` instead.
+   *
    * Dropdown footer text position.
    * Accepted values: 'sticky' and 'static'.
    * @default 'sticky'
    */
   dropdownFooterTextPosition?: SelectDropdownFooterTextPosition
+
+  /**
+   * Dropdown footer position.
+   * Accepted values: 'sticky' and 'static'.
+   * Takes precedence over the deprecated `dropdownFooterTextPosition` prop.
+   * @default 'sticky'
+   */
+  dropdownFooterPosition?: SelectDropdownFooterPosition
 
   /**
    * If true and item-template is passed, will display item-template content inside selected-slot-template.
@@ -265,9 +280,17 @@ export interface SelectSlots<T extends string | number> {
   'selected-item-template'?: NoInfer<(props: { item: SelectItem<T> }) => any>
 
   /**
+   * @deprecated Use the `dropdown-footer` slot instead, which also supports interactive content.
+   *
    * A slot alternative for the `dropdownFooterText` prop.
    */
   'dropdown-footer-text'?(): any
+
+  /**
+   * A slot for custom dropdown footer content. Supports interactive content.
+   * Takes precedence over the `dropdownFooterText` prop and the deprecated `dropdown-footer-text` slot.
+   */
+  'dropdown-footer'?(): any
 
   /**
    * Content to be displayed when `loading` prop is true.


### PR DESCRIPTION
# Summary

Addresses: https://konghq.atlassian.net/browse/KHCP-21063

Changes:

- Added a new `dropdown-footer` slot to KSelect and KMultiselect that supports interactive content (buttons, links), replacing the `pointer-events: none;` restriction on the footer
- In both components deprecated the `dropdown-footer-text` slot in favour of `dropdown-footer` (the new slot takes precedence over both the deprecated slot and the `dropdownFooterText` prop)
- In both components renamed the `dropdownFooterTextPosition` prop to `dropdownFooterPosition`, keeping the old prop working as a deprecated alias (new prop wins when both are set)
- Updated types, docs, sandbox examples, and component tests to cover the new slot / prop, precedence, and backwards compatibility

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
