### PR TITLE
fix: stabilize v-bind() css variable names across releases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// TEMP: trigger preview package build for PR #3311 (no-op, revert before merge)
 import type { App } from 'vue'
 // Import all components
 import * as components from './components'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,17 @@ const buildFormats: Array<'es' | 'cjs' | 'umd'> = isUMDBuild ? ['umd'] : ['es', 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    vue(),
+    vue({
+      features: {
+        // By default the scope id used to generate v-bind() css variable names (e.g.
+        // KMultiselect's popover max-height) is hashed from the file's path AND content,
+        // so any edit anywhere in the file changes the variable name on the next release.
+        // Apps on different Kongponents versions can then disagree on the variable name
+        // for the same rule, and the style silently stops applying. 'filepath' drops
+        // content from the hash so the name stays stable across releases.
+        componentIdGenerator: 'filepath',
+      },
+    }),
     ...(process.env.DISABLE_VUE_DEVTOOLS === 'true' ? [] : [VueDevTools()]), // Cypress 14+ introduces an issue with VueDevTools when running tests so we need to disable it in the test environment only
   ],
   resolve: {


### PR DESCRIPTION
## Summary

By default, `@vitejs/plugin-vue` derives a component's scope id from its file path **and full source content** in production builds. That scope id feeds into the hashed CSS variable name Vue generates for any `v-bind()` used inside `<style>` (KMultiselect and KSelect both do this for popover `max-height`). So any edit anywhere in the file changes that variable name on the next release, even when the bound style itself is untouched.

### The problem this causes

When two consumer apps within a multi-workspace or multi-app monorepo end up running different Kongponents versions at the same time (e.g. due to a partial/incomplete rollout), the app that injects the "winning" CSS can define a rule under one variable name, while the app rendering the component looks up that rule under a different one. The names don't match, so the rule is never found and the style silently stops applying.

This has broken a consuming app's KMultiselect popover sizing on two separate occasions.

### The fix

Set `componentIdGenerator: 'filepath'` on the `vue()` plugin. This drops file content from the scope-id hash, so the generated variable name stays stable across releases as long as the file isn't renamed — fixing the pattern library-wide, not just for KMultiselect.

## Verified

- `pnpm lint` / `vue-tsc --noEmit` — clean.
- `vite build` — clean.
- KMultiselect's own component test suite (`KMultiselect.cy.ts`) — 32/32 passing.
- Empirically confirmed the fix: built the library, noted the generated `max-height` variable name (`--v3a3cf6aa`), made an unrelated one-line content edit to `KMultiselect.vue`, rebuilt from scratch, and got the identical variable name back. Reverted that verification-only edit before committing.

## Trade-off to flag

This changes the `data-v-xxxxxxx` scope-id hash for every scoped component in the library once, on the release that adopts this. That's an internal, opaque identifier not meant to be depended on externally, so it shouldn't be user-visible — but worth a release-notes callout in case anything unsupported hardcodes a specific `data-v-` selector.