### PR TITLE
fix(kmultiselect): reflect modelValue order in selectedItem badges

### DIFF
--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -21,6 +21,8 @@ KMultiselect - A select component that allows for choosing multiple items and cr
 
 KMultiselect works as regular inputs do using `v-model` for data binding:
 
+When the parent updates `modelValue`, selected badges follow the order of values in the updated model.
+
 <ClientOnly>
   <KLabel>Value:</KLabel> <pre class="json">{{ JSON.stringify(myVal) }}</pre>
   <KMultiselect v-model="myVal" :items="deepClone(defaultItems)" />
@@ -52,6 +54,71 @@ const items: MultiselectItem[] = [
 
 const clearIt = () => {
   myVal.value = []
+}
+</script>
+```
+
+#### Programmatic selection order
+
+Each click adds an option and places its badge at the same position in `modelValue`.
+
+<ClientOnly>
+  <div class="programmatic-selection-example">
+    <KMultiselect
+      v-model="selectedFields"
+      :items="orderedFields"
+    />
+    <div class="programmatic-selection-actions">
+      <KButton @click="insertOrderedItem">
+        Insert Item
+      </KButton>
+    </div>
+    <div>
+      <KLabel>Current modelValue:</KLabel>
+      <pre class="json">{{ JSON.stringify(selectedFields, null, 2) }}</pre>
+    </div>
+  </div>
+</ClientOnly>
+
+```vue
+<template>
+  <KMultiselect
+    v-model="selectedFields"
+    :items="fields"
+  />
+  <KButton @click="insertOrderedItem">
+    Insert Item
+  </KButton>
+  <pre>{{ selectedFields }}</pre>
+</template>
+
+<script setup lang="ts">
+import type { MultiselectItem } from '@kong/kongponents'
+import { ref } from 'vue'
+
+const fields = ref<MultiselectItem[]>([
+  { label: 'Name', value: 'name' },
+  { label: 'Environment', value: 'env' },
+  { label: 'Team', value: 'team' },
+  { label: 'Region', value: 'region' },
+])
+const selectedFields = ref(fields.value.map(item => item.value))
+let itemCount = 0
+
+const insertOrderedItem = (): void => {
+  itemCount++
+  const item = { label: `Item ${itemCount}`, value: `item${itemCount}` }
+
+  fields.value = [
+    ...fields.value.slice(0, 1),
+    item,
+    ...fields.value.slice(1),
+  ]
+  selectedFields.value = [
+    ...selectedFields.value.slice(0, 1),
+    item.value,
+    ...selectedFields.value.slice(1),
+  ]
 }
 </script>
 ```
@@ -1022,6 +1089,14 @@ export default defineComponent({
       mySelections: ['cats', 'bunnies'],
       addedItems: [],
       myVal: ['cats', 'dogs', 'bunnies'],
+      orderedFields: [
+        { label: 'Name', value: 'name' },
+        { label: 'Environment', value: 'env' },
+        { label: 'Team', value: 'team' },
+        { label: 'Region', value: 'region' },
+      ],
+      selectedFields: ['name', 'env', 'team', 'region'],
+      orderedItemCount: 0,
       myAutoVal: [],
       myDebounceAutoVal: [],
       defaultItems: [{
@@ -1229,6 +1304,24 @@ export default defineComponent({
     clearIt () {
       this.myVal = []
     },
+    insertOrderedItem () {
+      this.orderedItemCount++
+      const item = {
+        label: `Item ${this.orderedItemCount}`,
+        value: `item${this.orderedItemCount}`
+      }
+
+      this.orderedFields = [
+        ...this.orderedFields.slice(0, 1),
+        item,
+        ...this.orderedFields.slice(1),
+      ]
+      this.selectedFields = [
+        ...this.selectedFields.slice(0, 1),
+        item.value,
+        ...this.selectedFields.slice(1),
+      ]
+    },
     customFilter ({items, query}) {
       return items.filter(item => item.label.toLowerCase().includes(query.toLowerCase()) || item.description.toLowerCase().includes(query.toLowerCase()))
     },
@@ -1364,6 +1457,17 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   gap: $kui-space-50;
+}
+
+.programmatic-selection-example {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-40;
+}
+
+.programmatic-selection-actions {
+  display: flex;
+  gap: $kui-space-30;
 }
 
 .item-creation-validation-error-message {

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -84,7 +84,7 @@ Each click adds an option and places its badge at the same position in `modelVal
 <template>
   <KMultiselect
     v-model="selectedFields"
-    :items="fields"
+    :items="orderedFields"
   />
   <KButton @click="insertOrderedItem">
     Insert Item
@@ -96,23 +96,23 @@ Each click adds an option and places its badge at the same position in `modelVal
 import type { MultiselectItem } from '@kong/kongponents'
 import { ref } from 'vue'
 
-const fields = ref<MultiselectItem[]>([
+const orderedFields = ref<MultiselectItem[]>([
   { label: 'Name', value: 'name' },
   { label: 'Environment', value: 'env' },
   { label: 'Team', value: 'team' },
   { label: 'Region', value: 'region' },
 ])
-const selectedFields = ref(fields.value.map(item => item.value))
+const selectedFields = ref(orderedFields.value.map(item => item.value))
 let itemCount = 0
 
 const insertOrderedItem = (): void => {
   itemCount++
   const item = { label: `Item ${itemCount}`, value: `item${itemCount}` }
 
-  fields.value = [
-    ...fields.value.slice(0, 1),
+  orderedFields.value = [
+    ...orderedFields.value.slice(0, 1),
     item,
-    ...fields.value.slice(1),
+    ...orderedFields.value.slice(1),
   ]
   selectedFields.value = [
     ...selectedFields.value.slice(0, 1),

--- a/sandbox/pages/SandboxMultiselect.vue
+++ b/sandbox/pages/SandboxMultiselect.vue
@@ -300,6 +300,34 @@
           Deselect Item
         </KButton>
       </SandboxSectionComponent>
+      <SandboxSectionComponent title="programmatic selection order">
+        <div class="ordered-model-example">
+          <div class="ordered-model-controls">
+            <KMultiselect
+              v-model="orderedSelection"
+              :items="orderedItems"
+            />
+            <div class="ordered-model-actions">
+              <KButton
+                size="small"
+                @click="randomizeOrderedSelection"
+              >
+                Randomize selection order
+              </KButton>
+              <KButton
+                size="small"
+                @click="insertOrderedItem"
+              >
+                Insert Item
+              </KButton>
+            </div>
+          </div>
+          <div>
+            <strong>Current modelValue</strong>
+            <pre>{{ orderedSelectionJson }}</pre>
+          </div>
+        </div>
+      </SandboxSectionComponent>
       <SandboxSectionComponent title="Respecting siblings on resize">
         <div class="select-multiselect-row">
           <KSelect
@@ -402,6 +430,46 @@ const example1DeselectItem = () => {
 
 const example1ModelJson = computed(() => JSON.stringify(example1Selected.value, undefined, 2))
 
+const orderedItems = ref<MultiselectItem[]>([
+  { label: 'Name', value: 'name' },
+  { label: 'Environment', value: 'env' },
+  { label: 'Team', value: 'team' },
+  { label: 'Region', value: 'region' },
+])
+const orderedSelection = ref(orderedItems.value.map(item => item.value))
+const orderedSelectionJson = computed(() => JSON.stringify(orderedSelection.value, undefined, 2))
+let orderedItemCount = 0
+
+const randomizeOrderedSelection = (): void => {
+  const randomizedSelection = [...orderedSelection.value].sort(() => Math.random() - 0.5)
+
+  if (JSON.stringify(randomizedSelection) === JSON.stringify(orderedSelection.value)) {
+    const firstValue = randomizedSelection.shift()
+
+    if (firstValue) {
+      randomizedSelection.push(firstValue)
+    }
+  }
+
+  orderedSelection.value = randomizedSelection
+}
+
+const insertOrderedItem = (): void => {
+  orderedItemCount++
+  const item = { label: `Item ${orderedItemCount}`, value: `item${orderedItemCount}` }
+
+  orderedItems.value = [
+    ...orderedItems.value.slice(0, 1),
+    item,
+    ...orderedItems.value.slice(1),
+  ]
+  orderedSelection.value = [
+    ...orderedSelection.value.slice(0, 1),
+    item.value,
+    ...orderedSelection.value.slice(1),
+  ]
+}
+
 const showNewItemValidationError = ref<boolean>(false)
 const itemCreationValidator = (value: string) => value.length >= 3
 
@@ -479,6 +547,25 @@ const multiselectItemsWithGroupProperty: MultiselectItem[] = [
   .select-multiselect-row {
     display: flex;
     flex-direction: row;
+    gap: var(--kui-space-30, $kui-space-30);
+  }
+
+  .ordered-model-example {
+    align-items: flex-start;
+    display: grid;
+    gap: var(--kui-space-50, $kui-space-50);
+    grid-template-columns: minmax(0, 1fr) minmax(180px, auto);
+  }
+
+  .ordered-model-controls {
+    display: grid;
+    gap: var(--kui-space-40, $kui-space-40);
+  }
+
+  .ordered-model-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
     gap: var(--kui-space-30, $kui-space-30);
   }
 

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -889,6 +889,96 @@ describe('KMultiselect', () => {
     })
   })
 
+  it('orders selected badges by programmatic modelValue changes', () => {
+    const initialItems = [
+      { label: 'Name', value: 'name' },
+      { label: 'Environment', value: 'env' },
+      { label: 'Team', value: 'team' },
+      { label: 'Region', value: 'region' },
+    ]
+    const initialModelValue = initialItems.map(item => item.value)
+    const updatedItems = [
+      initialItems[0],
+      { label: 'Control plane', value: 'control_plane' },
+      ...initialItems.slice(1),
+    ]
+    const updatedModelValue = updatedItems.map(item => item.value)
+    const badgeLabels = () => cy.getTestId('selection-badges-container')
+      .find('.multiselect-selection-badge-label')
+    const assertBadgeOrder = (expectedLabels: string[]) => {
+      badgeLabels().should($labels => {
+        expect([...$labels].map(label => label.textContent?.trim())).to.deep.equal(expectedLabels)
+      })
+    }
+
+    cy.mount(KMultiselect, {
+      props: {
+        items: initialItems,
+        modelValue: initialModelValue,
+        selectedRowCount: 5,
+      },
+    })
+
+    assertBadgeOrder(['Name', 'Environment', 'Team', 'Region'])
+
+    cy.then(() => Cypress.vueWrapper.setProps({
+      items: updatedItems,
+      modelValue: updatedModelValue,
+    }))
+
+    assertBadgeOrder(['Name', 'Control plane', 'Environment', 'Team', 'Region'])
+
+    cy.then(() => Cypress.vueWrapper.setProps({
+      modelValue: ['region', 'name', 'env', 'team', 'control_plane'],
+    }))
+
+    assertBadgeOrder(['Region', 'Name', 'Environment', 'Team', 'Control plane'])
+  })
+
+  it('keeps the open dropdown order stable while selecting and removing items', () => {
+    const items = [
+      { label: 'Name', value: 'name' },
+      { label: 'Environment', value: 'env' },
+      { label: 'Team', value: 'team' },
+      { label: 'Region', value: 'region' },
+    ]
+    const optionLabels = () => cy.get('.multiselect-items-container')
+      .find('.multiselect-item-label')
+    const assertOptionOrder = () => {
+      optionLabels().should($labels => {
+        expect([...$labels].map(label => label.textContent?.trim())).to.deep.equal([
+          'Name',
+          'Environment',
+          'Team',
+          'Region',
+        ])
+      })
+    }
+
+    cy.mount({
+      components: { KMultiselect },
+      data: () => ({
+        items,
+        selectedItems: [],
+      }),
+      template: '<KMultiselect v-model="selectedItems" :items="items" />',
+    })
+
+    cy.getTestId('multiselect-trigger').click()
+    cy.get('.multiselect-popover').should('be.visible')
+    assertOptionOrder()
+
+    cy.getTestId('multiselect-item-env').click()
+    cy.getTestId('multiselect-item-team').click()
+    cy.get('.multiselect-popover').should('be.visible')
+    assertOptionOrder()
+
+    cy.getTestId('multiselect-item-env').click()
+    cy.getTestId('multiselect-item-team').click()
+    cy.get('.multiselect-popover').should('be.visible')
+    assertOptionOrder()
+  })
+
   it('should not cause form submission when enter key is pressed while filtering', () => {
     const onSubmit = cy.spy().as('onSubmit')
 

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -1101,8 +1101,11 @@ watch(value, (newVal, oldVal) => {
 
     const previouslySelectedItems = new Set<string>(oldVal)
     const currentlySelectedItems = new Set<string>(newVal)
+    const internallySelectedItems = new Set(currentSelectedValues)
 
-    const selectedAndPresentItems = unfilteredItems.value.filter((item: Item) => currentlySelectedItems.has(item.value))
+    const selectedAndPresentItems = unfilteredItems.value.filter((item: Item) =>
+      currentlySelectedItems.has(item.value) && !internallySelectedItems.has(item.value),
+    )
     const deselectedItems = selectedItems.value.filter((item: Item) => !currentlySelectedItems.has(item.value) && previouslySelectedItems.has(item.value))
 
     if (deselectedItems.length) {

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -722,6 +722,18 @@ const stageSelections = () => {
   }, 0)
 }
 
+const reorderSelectedItems = (orderedValues: Value[]) => {
+  const selectedItemsByValue = new Map(selectedItems.value.map(item => [item.value, item]))
+
+  selectedItems.value = orderedValues
+    .map(itemValue => selectedItemsByValue.get(itemValue))
+    .filter((item): item is Item => item !== undefined)
+  visibleSelectedItemsStaging.value = [...selectedItems.value]
+  invisibleSelectedItemsStaging.value = []
+  invisibleSelectedItemsStagingSet.clear()
+  stageSelections()
+}
+
 // handles programmatic selections
 const handleMultipleItemsSelect = (items: Item[]) => {
   items.forEach(itemToSelect => {
@@ -1076,6 +1088,12 @@ watch(filteredNormalizedItems, () => {
 // watch for programmatic changes to model
 watch(value, (newVal, oldVal) => {
   if (JSON.stringify(newVal) !== JSON.stringify(oldVal)) {
+    const currentSelectedValues = selectedItems.value.map(item => item.value)
+
+    if (JSON.stringify(currentSelectedValues) === JSON.stringify(newVal)) {
+      return
+    }
+
     if (!newVal.length) {
       clearSelection()
       return
@@ -1094,7 +1112,13 @@ watch(value, (newVal, oldVal) => {
     if (selectedAndPresentItems.length) {
       handleMultipleItemsSelect(selectedAndPresentItems)
     }
+
+    reorderSelectedItems(newVal)
   }
+}, {
+  // When items and modelValue change together, let the items watcher add new options
+  // before ordering the selected badges.
+  flush: 'post',
 })
 
 watch(() => items, (newValue, oldValue) => {


### PR DESCRIPTION
closes: https://konghq.atlassian.net/browse/MA-5270

# Summary

Fixes `KMultiselect` so selected badges follow the value order in programmatic `modelValue` updates.

# Changes

- Rebuild internal selected items and badge overflow state in `modelValue` order.
- Wait for updated items before reconciling simultaneous `items` and `modelValue` changes.
- Skip reconciliation when a user selection already matches `modelValue`.
- Add focused tests for badge ordering and stable dropdown option order.
- Add interactive sandbox and documentation examples.
