### PR TITLE
feat: expose label slot on KInput, KTextArea, KSelect, KMultiselect, KFileUpload, KSlider

### DIFF
--- a/docs/components/file-upload.md
+++ b/docs/components/file-upload.md
@@ -244,6 +244,24 @@ By default KFileUpload will display the error state with a generic error message
 
 ## Slots
 
+### label
+
+Provide slotted content for the file upload label. This slot takes precedence over the `label` prop if both are provided.
+
+<KFileUpload :accept="['.jpg', '.png']">
+  <template #label>
+    Slotted label
+  </template>
+</KFileUpload>
+
+```html
+<KFileUpload :accept="['.jpg', '.png']">
+  <template #label>
+    Slotted label
+  </template>
+</KFileUpload>
+```
+
 ### icon
 
 Slot for an icon in front of the input field.

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -273,6 +273,24 @@ Should you decide to use your own custom icons, you can use design tokens export
 We also recommend setting the icon style `color` property to a value of `currentColor` to utilize default KInput styling for slotted content.
 :::
 
+### label
+
+Provide slotted content for the input label. This slot takes precedence over the `label` prop if both are provided.
+
+<KInput>
+  <template #label>
+    Slotted label
+  </template>
+</KInput>
+
+```html
+<KInput>
+  <template #label>
+    Slotted label
+  </template>
+</KInput>
+```
+
 ### label-tooltip
 
 If you want to utilize HTML in the input label's tooltip, use the slot.

--- a/docs/components/multiselect.md
+++ b/docs/components/multiselect.md
@@ -824,6 +824,26 @@ Text passed in for the `label` will automatically strip any trailing `*` when us
 
 ## Slots
 
+### label
+
+Provide slotted content for the multiselect label. This slot takes precedence over the `label` prop if both are provided.
+
+<ClientOnly>
+  <KMultiselect :items="[]">
+    <template #label>
+      Slotted label
+    </template>
+  </KMultiselect>
+</ClientOnly>
+
+```html
+<KMultiselect :items="items">
+  <template #label>
+    Slotted label
+  </template>
+</KMultiselect>
+```
+
 ### label-tooltip
 
 If you want to utilize HTML in the multiselect label's tooltip, use the slot.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -628,6 +628,26 @@ Use the `readonly` attribute to indicate the element is not editable.
 
 ## Slots
 
+### label
+
+Provide slotted content for the select label. This slot takes precedence over the `label` prop if both are provided.
+
+<ClientOnly>
+  <KSelect :items="[]">
+    <template #label>
+      Slotted label
+    </template>
+  </KSelect>
+</ClientOnly>
+
+```html
+<KSelect :items="items">
+  <template #label>
+    Slotted label
+  </template>
+</KSelect>
+```
+
 ### item-template
 
 Use this slot to pass custom content to the items. The slot exposes `item` slot prop.

--- a/docs/components/slider.md
+++ b/docs/components/slider.md
@@ -212,6 +212,26 @@ Boolean to control whether or not the input should be disabled.
 
 Use the `labelAttributes` prop to configure the KLabel's [props](/components/label) when using the `label` prop.
 
+## Slots
+
+### label
+
+Provide slotted content for the slider label. This slot takes precedence over the `label` prop if both are provided.
+
+<KSlider :model-value="5">
+  <template #label>
+    Slotted label
+  </template>
+</KSlider>
+
+```html
+<KSlider v-model="value">
+  <template #label>
+    Slotted label
+  </template>
+</KSlider>
+```
+
 ## Events
 
 ### update:modelValue

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -148,6 +148,24 @@ KTextArea works with `v-model` for two-way data binding:
 
 ## Slots
 
+### label
+
+Provide slotted content for the textarea label. This slot takes precedence over the `label` prop if both are provided.
+
+<KTextArea>
+  <template #label>
+    Slotted label
+  </template>
+</KTextArea>
+
+```html
+<KTextArea>
+  <template #label>
+    Slotted label
+  </template>
+</KTextArea>
+```
+
 ### label-tooltip
 
 Slot for tooltip content if textarea has a label and label has tooltip (note: this slot overrides `info` content specified in `labelAttributes`)

--- a/src/components/KFileUpload/KFileUpload.cy.ts
+++ b/src/components/KFileUpload/KFileUpload.cy.ts
@@ -1,3 +1,4 @@
+import { h } from 'vue'
 import KFileUpload from '@/components/KFileUpload/KFileUpload.vue'
 
 describe('KFileUpload', () => {
@@ -54,6 +55,32 @@ describe('KFileUpload', () => {
       cy.get('.k-label .tooltip-trigger-icon').should('not.exist')
       cy.then(() => Cypress.vueWrapper.setData({ ready: true }))
       cy.get('.k-label .tooltip-trigger-icon').should('exist').and('be.visible')
+    })
+
+    it('renders label slot content, overriding label prop', () => {
+      cy.mount(KFileUpload, {
+        props: {
+          label: 'Prop label',
+          accept: ['.md'],
+        },
+        slots: {
+          label: () => h('span', {}, 'Slotted label'),
+        },
+      })
+
+      cy.get('.k-label').should('contain.text', 'Slotted label')
+      cy.get('.k-label').should('not.contain.text', 'Prop label')
+    })
+
+    it('renders label slot without label prop', () => {
+      cy.mount(KFileUpload, {
+        props: { accept: ['.md'] },
+        slots: {
+          label: () => h('span', {}, 'Slotted label'),
+        },
+      })
+
+      cy.get('.k-label').should('contain.text', 'Slotted label')
     })
 
     it('should emit correct event when a file is selected, removed', () => {

--- a/src/components/KFileUpload/KFileUpload.vue
+++ b/src/components/KFileUpload/KFileUpload.vue
@@ -8,13 +8,15 @@
     @drop.prevent="onDrop"
   >
     <KLabel
-      v-if="label"
+      v-if="label || $slots.label"
       v-bind="labelAttributes"
       :id="isAppearanceDropzone ? `file-upload-dropzone-label-${fileInputId}` : undefined"
       :for="fileInputId"
       :required="isRequired"
     >
-      {{ strippedLabel }}
+      <slot name="label">
+        {{ strippedLabel }}
+      </slot>
 
       <template
         v-if="hasLabelTooltip()"

--- a/src/components/KInput/KInput.cy.ts
+++ b/src/components/KInput/KInput.cy.ts
@@ -104,6 +104,30 @@ describe('KInput', () => {
     cy.get('.k-label .tooltip-trigger-icon').should('exist').and('be.visible')
   })
 
+  it('renders label slot content, overriding label prop', () => {
+    cy.mount(KInput, {
+      props: {
+        label: 'Prop label',
+      },
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+    cy.get('.k-label').should('not.contain.text', 'Prop label')
+  })
+
+  it('renders label slot without label prop', () => {
+    cy.mount(KInput, {
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+  })
+
   it('handles `required` attribute correctly', () => {
     cy.mount(KInput, {
       props: {

--- a/src/components/KInput/KInput.vue
+++ b/src/components/KInput/KInput.vue
@@ -4,12 +4,14 @@
     :class="[attrs.class, { 'input-error': charLimitExceeded || error || hasError }]"
   >
     <KLabel
-      v-if="label"
+      v-if="label || $slots.label"
       :for="inputId"
       v-bind="labelAttributes"
       :required="isRequired"
     >
-      {{ strippedLabel }}
+      <slot name="label">
+        {{ strippedLabel }}
+      </slot>
 
       <template
         v-if="hasLabelTooltip()"

--- a/src/components/KMultiselect/KMultiselect.cy.ts
+++ b/src/components/KMultiselect/KMultiselect.cy.ts
@@ -148,6 +148,32 @@ describe('KMultiselect', () => {
     cy.get('.k-label .tooltip-trigger-icon').should('exist').and('be.visible')
   })
 
+  it('renders label slot content, overriding label prop', () => {
+    cy.mount(KMultiselect, {
+      props: {
+        label: 'Prop label',
+        items: [],
+      },
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+    cy.get('.k-label').should('not.contain.text', 'Prop label')
+  })
+
+  it('renders label slot without label prop', () => {
+    cy.mount(KMultiselect, {
+      props: { items: [] },
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+  })
+
   it('reacts to text change and select', () => {
     const labels = ['Label 1', 'Label 2']
     const vals = ['label1', 'label2']

--- a/src/components/KMultiselect/KMultiselect.vue
+++ b/src/components/KMultiselect/KMultiselect.vue
@@ -5,13 +5,15 @@
     :style="widthStyle"
   >
     <KLabel
-      v-if="label"
+      v-if="label || $slots.label"
       v-bind="labelAttributes"
       :data-testid="labelAttributes['data-testid'] ? labelAttributes['data-testid'] : 'multiselect-label'"
       :for="multiselectWrapperId"
       :required="isRequired"
     >
-      {{ strippedLabel }}
+      <slot name="label">
+        {{ strippedLabel }}
+      </slot>
 
       <template
         v-if="hasLabelTooltip()"

--- a/src/components/KSelect/KSelect.cy.ts
+++ b/src/components/KSelect/KSelect.cy.ts
@@ -667,6 +667,32 @@ describe('KSelect', () => {
     cy.get('.k-label .tooltip-trigger-icon').should('exist').and('be.visible')
   })
 
+  it('renders label slot content, overriding label prop', () => {
+    cy.mount(KSelect, {
+      props: {
+        label: 'Prop label',
+        items: [],
+      },
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+    cy.get('.k-label').should('not.contain.text', 'Prop label')
+  })
+
+  it('renders label slot without label prop', () => {
+    cy.mount(KSelect, {
+      props: { items: [] },
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+  })
+
   it('displays placeholder correctly when selected item slot is present', () => {
     const selectedItemContent = 'I am slotted!'
     const placeholderText = 'Placeholder text'

--- a/src/components/KSelect/KSelect.vue
+++ b/src/components/KSelect/KSelect.vue
@@ -4,13 +4,15 @@
     :class="[$attrs.class]"
   >
     <KLabel
-      v-if="label"
+      v-if="label || $slots.label"
       data-testid="select-label"
       v-bind="labelAttributes"
       :for="selectInputId"
       :required="isRequired"
     >
-      {{ strippedLabel }}
+      <slot name="label">
+        {{ strippedLabel }}
+      </slot>
 
       <template
         v-if="hasLabelTooltip()"

--- a/src/components/KSlider/KSlider.cy.ts
+++ b/src/components/KSlider/KSlider.cy.ts
@@ -30,6 +30,33 @@ describe('KSlider', () => {
     cy.get('datalist option').last().should('have.attr', 'value', '20')
   })
 
+  it('renders label slot content, overriding label prop', () => {
+    cy.mount({
+      components: { KSlider },
+      template: `
+        <KSlider label="Prop label" :model-value="5">
+          <template #label>Slotted label</template>
+        </KSlider>
+      `,
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+    cy.get('.k-label').should('not.contain.text', 'Prop label')
+  })
+
+  it('renders label slot without label prop', () => {
+    cy.mount({
+      components: { KSlider },
+      template: `
+        <KSlider :model-value="5">
+          <template #label>Slotted label</template>
+        </KSlider>
+      `,
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+  })
+
   it('renders marks correctly when showMarks is true', () => {
     mount(KSlider, {
       props: {

--- a/src/components/KSlider/KSlider.vue
+++ b/src/components/KSlider/KSlider.vue
@@ -4,11 +4,13 @@
     data-testid="k-slider"
   >
     <KLabel
-      v-if="label"
+      v-if="label || $slots.label"
       v-bind="labelAttributes"
       :for="`${inputId}-input`"
     >
-      {{ label }}
+      <slot name="label">
+        {{ label }}
+      </slot>
     </KLabel>
 
     <div class="slider-container">
@@ -95,7 +97,7 @@
 
 <script setup lang="ts">
 import { computed, useId, useTemplateRef, watch } from 'vue'
-import type { SliderProps, SliderEmits } from '@/types'
+import type { SliderProps, SliderEmits, SliderSlots } from '@/types'
 import KLabel from '@/components/KLabel/KLabel.vue'
 import KPop from '@/components/KPop/KPop.vue'
 
@@ -117,6 +119,7 @@ const {
 } = defineProps<SliderProps>()
 
 const emit = defineEmits<SliderEmits>()
+defineSlots<SliderSlots>()
 
 const inputId = useId()
 

--- a/src/components/KTextArea/KTextArea.cy.ts
+++ b/src/components/KTextArea/KTextArea.cy.ts
@@ -121,6 +121,30 @@ describe('KTextArea', () => {
     cy.get('.k-label .tooltip-trigger-icon').should('exist').and('be.visible')
   })
 
+  it('renders label slot content, overriding label prop', () => {
+    cy.mount(KTextArea, {
+      props: {
+        label: 'Prop label',
+      },
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+    cy.get('.k-label').should('not.contain.text', 'Prop label')
+  })
+
+  it('renders label slot without label prop', () => {
+    cy.mount(KTextArea, {
+      slots: {
+        label: () => h('span', {}, 'Slotted label'),
+      },
+    })
+
+    cy.get('.k-label').should('contain.text', 'Slotted label')
+  })
+
   it('handles `required` attribute correctly', () => {
     cy.mount(KTextArea, {
       props: {

--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -4,12 +4,14 @@
     :class="[$attrs.class, { 'input-error': error || hasError || charLimitExceeded }]"
   >
     <KLabel
-      v-if="label"
+      v-if="label || $slots.label"
       :for="textAreaId"
       v-bind="labelAttributes"
       :required="isRequired"
     >
-      {{ strippedLabel }}
+      <slot name="label">
+        {{ strippedLabel }}
+      </slot>
       <template
         v-if="hasLabelTooltip()"
         #tooltip

--- a/src/types/file-upload.ts
+++ b/src/types/file-upload.ts
@@ -90,6 +90,11 @@ export interface FileUploadEmits {
 
 export interface FileUploadSlots {
   /**
+   * Slot for custom label content. Takes precedence over the `label` prop if both are provided.
+   */
+  label?(): any
+
+  /**
    * Slot for an icon in front of the input field.
    */
   icon?(): any

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -85,6 +85,11 @@ export interface InputEmits {
 
 export interface InputSlots {
   /**
+   * Slot for custom label content. Takes precedence over the `label` prop if both are provided.
+   */
+  label?(): any
+
+  /**
    * Inserting icons before the input field.
    */
   before?(): any

--- a/src/types/multi-select.ts
+++ b/src/types/multi-select.ts
@@ -232,6 +232,11 @@ export interface MultiselectEmits<T extends string = string> {
 
 export interface MultiselectSlots<T extends string = string> {
   /**
+   * Slot for custom label content. Takes precedence over the `label` prop if both are provided.
+   */
+  label?: () => any
+
+  /**
    * Slot for customizing multiselect label's tooltip.
    */
   'label-tooltip'?: () => any

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -270,6 +270,11 @@ export interface SelectEmits<T extends string | number> {
 
 export interface SelectSlots<T extends string | number> {
   /**
+   * Slot for custom label content. Takes precedence over the `label` prop if both are provided.
+   */
+  label?(): any
+
+  /**
    * Use this slot to pass custom content to the items.
    */
   'item-template'?: NoInfer<(props: { item: SelectItem<T> }) => any>

--- a/src/types/slider.ts
+++ b/src/types/slider.ts
@@ -74,4 +74,11 @@ export interface SliderEmits {
   'update:modelValue': [modelValue: number]
 }
 
+export interface SliderSlots {
+  /**
+   * Slot for custom label content. Takes precedence over the `label` prop if both are provided.
+   */
+  label?(): any
+}
+
 

--- a/src/types/text-area.ts
+++ b/src/types/text-area.ts
@@ -96,6 +96,11 @@ export interface TextAreaEmits {
 
 export interface TextAreaSlots {
   /**
+   * Slot for custom label content. Takes precedence over the `label` prop if both are provided.
+   */
+  label?(): any
+
+  /**
    * Slot for tooltip content if textarea has a label and label has tooltip.
    */
   'label-tooltip'?: () => any


### PR DESCRIPTION
## Summary

- Add a `label` slot to 6 input-style components that internally use `KLabel` but previously had no way to customize label content
- The slot follows the same pattern as `KInputSwitch` (which already had a `label` slot): takes precedence over the `label` prop when both are provided, and triggers label rendering even without the prop
- No breaking changes — purely additive

## Components updated

| Component | Change |
|---|---|
| `KInput` | Added `label` slot |
| `KTextArea` | Added `label` slot |
| `KSelect` | Added `label` slot |
| `KMultiselect` | Added `label` slot |
| `KFileUpload` | Added `label` slot |
| `KSlider` | Added `label` slot + new `SliderSlots` type + `defineSlots` |

## Implementation pattern

```vue
<KLabel v-if="label || $slots.label" ...>
  <slot name="label">
    {{ strippedLabel }}
  </slot>
  ...
</KLabel>
```
