### PR TITLE
fix(kradio): reset card label margin

### DIFF
--- a/src/components/KRadio/KRadio.vue
+++ b/src/components/KRadio/KRadio.vue
@@ -347,6 +347,7 @@ $kRadioDotSize: 6px;
       box-shadow: var(--kui-shadow-border, $kui-shadow-border);
       cursor: pointer;
       height: 100%;
+      margin-bottom: 0;
       outline: none;
       padding: var(--kui-space-70, $kui-space-70);
       transition: box-shadow $kongponentsTransitionDurTimingFunc, background-color $kongponentsTransitionDurTimingFunc;


### PR DESCRIPTION
# Summary

Reset the KRadio card label's `margin-bottom` to `0` so host normalize styles cannot add unintended spacing.

<img width="725" height="191" alt="image" src="https://github.com/user-attachments/assets/bce49dfb-c952-46b3-9227-fb195b02c1cf" />

<img width="363" height="103" alt="image" src="https://github.com/user-attachments/assets/a406dd45-6b0a-45bb-b310-e7de4d27fc6d" />
