### PR TITLE
fix(ktreelist): tree item font-family

### DIFF
--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -140,6 +140,7 @@ defineExpose({ setExpandedValue, id: item.id })
   border-width: var(--kui-tree-list-border-width, var(--kui-border-width-10, $kui-border-width-10));
   color: var(--kui-tree-list-color-text, var(--kui-color-text, $kui-color-text));
   display: flex;
+  font-family: var(--kui-font-family-text, $kui-font-family-text);
   font-size: var(--kui-font-size-30, $kui-font-size-30);
   font-weight: var(--kui-tree-list-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
   gap: var(--kui-space-20, $kui-space-20);

--- a/src/components/KTreeList/KTreeItem.vue
+++ b/src/components/KTreeList/KTreeItem.vue
@@ -140,7 +140,7 @@ defineExpose({ setExpandedValue, id: item.id })
   border-width: var(--kui-tree-list-border-width, var(--kui-border-width-10, $kui-border-width-10));
   color: var(--kui-tree-list-color-text, var(--kui-color-text, $kui-color-text));
   display: flex;
-  font-family: var(--kui-font-family-text, $kui-font-family-text);
+  font-family: var(--kui-tree-list-font-family, var(--kui-font-family-text, $kui-font-family-text));
   font-size: var(--kui-font-size-30, $kui-font-size-30);
   font-weight: var(--kui-tree-list-font-weight, var(--kui-font-weight-regular, $kui-font-weight-regular));
   gap: var(--kui-space-20, $kui-space-20);


### PR DESCRIPTION
# Summary

Set `font-family` in tree list item. Previously it was unset (see screenshots)

Before (Arial)

<img width="2008" height="959" alt="Screenshot 2026-08-07 at 2 54 42 PM" src="https://github.com/user-attachments/assets/be8f00e0-47d8-483a-828b-4062c69ca2d9" />

After

<img width="2011" height="972" alt="Screenshot 2026-08-07 at 2 55 34 PM" src="https://github.com/user-attachments/assets/09ca0cdc-c28f-4dcc-97a8-84eb66628f15" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
