### PR TITLE
fix(kcopy): truncate when the root cannot shrink [parked]

### DIFF
--- a/src/components/KCopy/KCopy.cy.ts
+++ b/src/components/KCopy/KCopy.cy.ts
@@ -122,6 +122,98 @@ describe('KCopy', () => {
     cy.get(container).find('.text-icon').should('be.visible')
   })
 
+  describe('truncation', () => {
+    // `truncationLimit: 'auto'` renders the full text and truncates only when it measures an
+    // overflow on `.copy-text`, so the component has to be given less room than the text needs.
+    const longText = 'https://example.konghq.com/a-very-long-path-that-does-not-fit/1234567890ABCDEFG'
+    const column = '[data-testid="column"]'
+
+    const expectTruncated = () => {
+      cy.get(container).find('.copy-text').should(($text) => {
+        expect($text[0].scrollWidth).to.be.greaterThan($text[0].offsetWidth)
+      })
+    }
+
+    const expectWithinColumn = () => {
+      cy.get(column).then(($column) => {
+        const columnRight = $column[0].getBoundingClientRect().right
+
+        cy.get(container).should(($root) => {
+          expect($root[0].getBoundingClientRect().right).to.be.at.most(columnRight)
+        })
+
+        cy.getTestId('copy-to-clipboard').should(($button) => {
+          expect($button[0].getBoundingClientRect().right).to.be.at.most(columnRight)
+        })
+      })
+    }
+
+    it('truncates when it is a grid item narrower than its text', () => {
+      cy.mount({
+        components: { KCopy },
+        data: () => ({ longText }),
+        template: `
+          <div
+            data-testid="column"
+            style="display: grid; grid-template-columns: 1fr; width: 200px"
+          >
+            <KCopy
+              badge
+              truncate
+              truncation-limit="auto"
+              :text="longText"
+            />
+          </div>
+        `,
+      })
+
+      expectTruncated()
+      expectWithinColumn()
+    })
+
+    // Consumers laying the badge out in a column commonly make the root a block so it fills the
+    // column. The badge box is inline-flex sized to its content, so it needs capping separately.
+    it('truncates when a consumer makes the root a block', () => {
+      cy.mount({
+        components: { KCopy },
+        data: () => ({ longText }),
+        template: `
+          <div
+            data-testid="column"
+            style="overflow: hidden; width: 200px"
+          >
+            <component is="style">.k-copy.block-root { display: block; width: 100%; }</component>
+            <KCopy
+              badge
+              class="block-root"
+              truncate
+              truncation-limit="auto"
+              :text="longText"
+            />
+          </div>
+        `,
+      })
+
+      expectTruncated()
+      expectWithinColumn()
+    })
+
+    it('does not truncate when the text fits', () => {
+      cy.mount(KCopy, {
+        props: {
+          text,
+          truncate: true,
+          truncationLimit: 'auto',
+        },
+      })
+
+      cy.get(container).find('.truncate-content').should('not.exist')
+      cy.get(container).find('.copy-text').should(($text) => {
+        expect($text[0].scrollWidth).to.equal($text[0].offsetWidth)
+      })
+    })
+  })
+
   describe('tooltips', () => {
     it('renders with `copyTooltip` prop set', () => {
       const tooltipText = 'Click to copy!'

--- a/src/components/KCopy/KCopy.vue
+++ b/src/components/KCopy/KCopy.vue
@@ -187,13 +187,25 @@ onBeforeUnmount(() => {
   display: flex;
   font-variant-ligatures: no-contextual;
   max-width: 100%; /** necessary for truncation */
+  // grid and flex items default to min-width: auto, which pins this to its content width
+  min-width: 0;
 
   .copy-element {
     align-items: center;
+    box-sizing: border-box; // the badge appearance adds padding that max-width must cover
     display: inline-flex;
+    max-width: 100%; // the badge appearance sizes this box to its content
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    // `truncationLimit: 'auto'` truncates only when .copy-text measures an overflow, so
+    // everything down to it has to be able to shrink
+    .copy-tooltip-wrapper,
+    .copy-text {
+      min-width: 0;
+    }
 
     .copy-text {
       @include truncate;


### PR DESCRIPTION
# Summary

`KCopy` with `truncate` + `truncation-limit="auto"` renders the full text and truncates only when it measures `offsetWidth < scrollWidth` on the inner `.copy-text`. Where the component can't shrink to the width it was given, that measurement never trips — so the text renders full width, overflows its container (typically clipped mid-character by an ancestor's `overflow: hidden`), and the copy button is pushed out of view.

Measured against a long URL in a 200px column. `overflow` is how far the copy button lands past the column's right edge:

| Shape | truncates? | overflow | |
|---|---|---|---|
| `.k-copy` is a grid item | no | **+315px** | ✗ |
| Consumer sets `display: block` on `.k-copy` | no | **+351px** | ✗ |
| Plain block parent | yes | none | ✓ |
| Flex parent | yes | none | ✓ |

So it isn't universal — it's specific to shapes where the root box is held at its content width:

- **`.k-copy` as a grid item.** `.k-copy` is `overflow: visible`, so its `min-width: auto` resolves to a content-based minimum and the box won't shrink into its track. The flex case already works, because `.copy-element` is `overflow: hidden` and its automatic minimum resolves small.
- **Consumer makes the root a block.** The badge box (`.copy-container.badge-styles`) is `inline-flex; width: fit-content`, which sizes to its content and won't shrink to fit a block parent.

## What changed

All in `KCopy.vue` styles — no template or script changes, no API change:

- `min-width: 0` on `.k-copy`, so it can shrink as a grid or flex item
- `max-width: 100%` and `box-sizing: border-box` on `.copy-element`, so the fit-content badge box is capped at the width it was given, padding included
- `min-width: 0` on `.copy-tooltip-wrapper` and `.copy-text`, since flex children default to `min-width: auto` and the measured element has to be able to shrink

Each is load-bearing — reverting any one of them fails the new tests.

That last one also closes a latent feedback loop: `KTooltip` renders no wrapper element until it has text, and it only gets text once `isTruncated` flips. Without `min-width: 0` on the wrapper, the wrapper appearing can stop `.copy-text` shrinking, which unsets `isTruncated`, which removes the wrapper again.

## Tests

Three added to `KCopy.cy.ts`, covering both broken shapes plus a negative control that the component still leaves text alone when it fits. The two positive tests were each confirmed to fail without the fix (the second in isolation, since `cypress-fail-fast` masks it behind the first).

An earlier draft of these tests mounted into a plain narrow block parent — everything passed with the fix fully reverted, because that shape was never broken. Worth knowing if you go to extend them: the parent's display type is the whole ballgame.

## Verification

- `pnpm test` — 747 passing. One `KFileUpload` spec fails in full-suite runs, but it fails identically on a clean `main` and passes in isolation; it's pre-existing and unrelated.
- `pnpm stylelint`, `pnpm typecheck`, `pnpm test:unit` (87) — clean. `pnpm lint` has 2 warnings, both pre-existing in `KComponent`/`KTable`.
- Docs page checked in a browser: all 15 `KCopy` instances render with zero overflow past their parent and a visible copy button; the two `auto` demos truncate.
