### PR TITLE
fix(ktabs): minimal appearance horizontal overflow

### DIFF
--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -111,6 +111,8 @@ watch(() => modelValue, (newTabHash) => {
     gap: var(--kui-space-40, $kui-space-40);
     list-style: none;
     margin-top: var(--kui-space-0, $kui-space-0);
+    overflow-x: auto;
+    overflow-y: hidden;
     padding: var(--kui-space-0, $kui-space-0);
 
     .tab-item {

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -114,6 +114,7 @@ watch(() => modelValue, (newTabHash) => {
     overflow-x: auto;
     overflow-y: hidden;
     padding: var(--kui-space-0, $kui-space-0);
+    scrollbar-width: thin;
 
     .tab-item {
       position: relative;
@@ -167,8 +168,6 @@ watch(() => modelValue, (newTabHash) => {
       border-bottom-style: solid;
       border-bottom-width: var(--kui-tabs-border-width, var(--kui-border-width-10, $kui-border-width-10));
       margin-bottom: var(--kui-space-70, $kui-space-70);
-      overflow-x: auto;
-      overflow-y: hidden;
       padding: var(--kui-space-0, $kui-space-0) var(--kui-space-70, $kui-space-70);
       padding-top: var(--kui-space-20, $kui-space-20);
 


### PR DESCRIPTION
# Summary

Make KTabs (both `minimal` and `default` appearance) scroll horizontally when overflowing

Before

<img width="567" height="1000" alt="Screenshot 2026-08-12 at 5 09 15 PM" src="https://github.com/user-attachments/assets/d95fce75-f005-4762-b522-50f803b35156" />

After

<img width="567" height="991" alt="Screenshot 2026-08-12 at 5 15 59 PM" src="https://github.com/user-attachments/assets/3b174959-44d7-47a5-8c51-c4f82cfacb1f" />

<!-- 
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
