### PR TITLE
Security research PoC -- do not merge (HackerOne report by aks-builds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ This will trigger the Commitizen interactive prompt for building your commit mes
   - There is an exception for automated pull request approvals originating from generated dependency updates that satisfy status checks and other requirements.
 - Protected branches require at least one approval from code owners.
 - All status checks must pass before a pull request may be merged.
+


### PR DESCRIPTION
Opened solely to test whether `.github/workflows/agentic-reviewer.yaml`'s `issue_comment` trigger fires for a first-time, no-association contributor, per Kong's bug bounty program (GitHub Actions in Public Repositories is an eligible asset). No injection payload will be sent -- only the bare `/muthur` trigger phrase, to confirm reachability, per the program's own 'stop at first proof, do not exploit/escalate/pivot' rule. This PR will be closed immediately after confirming. Reported via HackerOne, handle: aks-builds.