### PR TITLE
test(kalert, kinput): convert cypress to vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
     "test:open": "cross-env DISABLE_VUE_DEVTOOLS=true cypress open --component -b chrome",
     "test:spec": "cross-env DISABLE_VUE_DEVTOOLS=true cypress run --component -b chrome --spec",
     "test:unit": "vitest run --project unit",
-    "test:unit:watch": "vitest --project unit",
+    "test:unit:open": "vitest --project unit",
     "test:browser:install": "playwright install --with-deps chromium firefox webkit",
     "test:browser": "vitest run --project browser",
-    "test:browser:watch": "vitest --project browser --browser.headless=false",
+    "test:browser:open": "vitest --project browser --browser.headless=false",
     "semantic-release": "semantic-release"
   },
   "dependencies": {

--- a/src/components/KAlert/KAlert.browser.spec.ts
+++ b/src/components/KAlert/KAlert.browser.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { page } from 'vitest/browser'
+import { h } from 'vue'
+import { render } from 'vitest-browser-vue'
+import KAlert from '@/components/KAlert/KAlert.vue'
+import { AlertAppearances } from '@/types'
+import type { AlertAppearance } from '@/types'
+
+const rendersCorrectVariant = (variant: AlertAppearance) => {
+  it(`renders ${variant} variant`, async () => {
+    await render(KAlert, {
+      props: {
+        appearance: variant,
+        alertMessage: `I am ${variant}`,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-alert')).toHaveClass(variant)
+  })
+}
+
+describe('KAlert', () => {
+  // Loop through AlertAppearances
+  Object.keys(AlertAppearances).map(v => rendersCorrectVariant(v as AlertAppearance))
+
+  it('renders info variant when no appearance prop', async () => {
+    await render(KAlert, {
+      props: {
+        alertMessage: 'I should be info!',
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-alert')).toHaveClass('info')
+  })
+
+  it('renders all elements correctly when props are not passed', async () => {
+    await render(KAlert)
+
+    await expect.element(page.getByCSS('.k-alert')).toBeInTheDocument()
+    await expect.element(page.getByCSS('.alert-icon-container')).not.toBeInTheDocument()
+    await expect.element(page.getByCSS('.alert-content')).toBeInTheDocument()
+    await expect.element(page.getByCSS('.alert-title')).not.toBeInTheDocument()
+    await expect.element(page.getByCSS('.alert-message')).not.toBeInTheDocument()
+    await expect.element(page.getByCSS('.alert-dismiss-icon')).not.toBeInTheDocument()
+  })
+
+  it('renders title when passed as a prop', async () => {
+    const title = 'I am a title'
+
+    await render(KAlert, {
+      props: {
+        title,
+      },
+    })
+
+    await expect.element(page.getByCSS('.alert-title')).toBeVisible()
+    await expect.element(page.getByCSS('.alert-title')).toHaveTextContent(new RegExp(`^${title}$`))
+  })
+
+  it('renders message when passed as a prop', async () => {
+    const message = 'I am a message'
+
+    await render(KAlert, {
+      props: {
+        message,
+      },
+    })
+
+    await expect.element(page.getByCSS('.alert-message')).toBeVisible()
+    await expect.element(page.getByCSS('.alert-message')).toHaveTextContent(new RegExp(`^${message}$`))
+  })
+
+  it('renders icon and dismiss button when props are passed', async () => {
+    await render(KAlert, {
+      props: {
+        showIcon: true,
+        dismissible: true,
+      },
+    })
+
+    await expect.element(page.getByCSS('.alert-icon-container')).toBeInTheDocument()
+    await expect.element(page.getByCSS('.alert-dismiss-icon')).toBeInTheDocument()
+  })
+
+  it('renders default slot correctly', async () => {
+    const message = 'I am a message'
+    const defaultSlotContent = 'Default'
+
+    await render(KAlert, {
+      props: {
+        message,
+      },
+      slots: {
+        default: h('span', {}, defaultSlotContent),
+      },
+    })
+
+    await expect.element(page.getByCSS('.alert-message')).toBeVisible()
+    await expect.element(page.getByCSS('.alert-message')).toHaveTextContent(new RegExp(`^${defaultSlotContent}$`))
+  })
+
+  it('displays icon passed through icon slot', async () => {
+    const iconSlotContent = 'icon slot content'
+    const testId = 'slotted-icon'
+
+    await render(KAlert, {
+      slots: {
+        icon: h('div', { 'data-testid': testId }, iconSlotContent),
+      },
+    })
+
+    await expect.element(page.getByCSS('.alert-icon-container').getByTestId(testId)).toBeVisible()
+    await expect.element(page.getByCSS('.alert-icon-container').getByTestId(testId)).toHaveTextContent(iconSlotContent)
+  })
+
+  it('emits dismiss event when dismiss button is clicked', async () => {
+    const screen = await render(KAlert, {
+      props: {
+        dismissible: true,
+      },
+    })
+
+    await page.getByCSS('.alert-dismiss-icon').click()
+
+    await expect.poll(() => screen.emitted()).toHaveProperty('dismiss')
+  })
+})

--- a/src/components/KInput/KInput.browser.spec.ts
+++ b/src/components/KInput/KInput.browser.spec.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { defineComponent, h, ref } from 'vue'
+import { render } from 'vitest-browser-vue'
+import KInput from '@/components/KInput/KInput.vue'
+
+describe('KInput', () => {
+  it('renders text when value is passed', async () => {
+    const text = 'Hello'
+
+    await render(KInput, {
+      props: {
+        modelValue: text, // e.g. v-model
+      },
+    })
+
+    await expect.element(page.getByCSS('input')).toHaveValue(text)
+  })
+
+  it('renders `null` modelValue as empty string', async () => {
+    await render(KInput, {
+      props: {
+        // @ts-expect-error - to allow passing an invalid modelValue
+        modelValue: null, // e.g. v-model
+      },
+    })
+
+    await expect.element(page.getByCSS('input')).not.toHaveValue('null')
+    await expect.element(page.getByCSS('input')).toHaveValue('')
+  })
+
+  it('renders `undefined` modelValue as empty string', async () => {
+    await render(KInput, {
+      props: {
+        modelValue: undefined, // e.g. v-model
+      },
+    })
+
+    await expect.element(page.getByCSS('input')).not.toHaveValue('undefined')
+    await expect.element(page.getByCSS('input')).toHaveValue('')
+  })
+
+  it('renders label when value is passed', async () => {
+    const label = 'A label'
+
+    await render(KInput, {
+      props: {
+        label,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-label')).toHaveTextContent(label)
+  })
+
+  it('renders label with labelAttributes applied', async () => {
+    const label = 'A label'
+
+    await render(KInput, {
+      props: {
+        label,
+        labelAttributes: {
+          info: 'some info text',
+        },
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-label')).toHaveTextContent(label)
+    await expect.element(page.getByCSS('.k-label .tooltip-trigger-icon')).toBeVisible()
+  })
+
+  it('renders label and tooltip with `label-tooltip` slot applied', async () => {
+    const label = 'A label'
+
+    await render(KInput, {
+      props: {
+        label,
+      },
+      slots: {
+        'label-tooltip': () => h('div', {}, 'This is a tooltip'),
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-label')).toHaveTextContent(label)
+    await expect.element(page.getByCSS('.k-label .tooltip-trigger-icon')).toBeVisible()
+  })
+
+  it('renders a label-tooltip slot that is added after mount', async () => {
+    const ready = ref(false)
+
+    await render(defineComponent({
+      setup: () => () => h(
+        KInput,
+        { label: 'A label' },
+        ready.value ? { 'label-tooltip': () => 'Tooltip content' } : {},
+      ),
+    }))
+
+    await expect.element(page.getByCSS('.k-label .tooltip-trigger-icon')).not.toBeInTheDocument()
+
+    ready.value = true
+
+    await expect.element(page.getByCSS('.k-label .tooltip-trigger-icon')).toBeVisible()
+  })
+
+  it('handles `required` attribute correctly', async () => {
+    await render(KInput, {
+      props: {
+        label: 'A label',
+        required: true,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-label')).toHaveClass('required')
+  })
+
+  it('renders help when value is passed', async () => {
+    const helpText = 'I am helpful'
+
+    await render(KInput, {
+      props: {
+        help: helpText,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input .help-text')).toHaveTextContent(helpText)
+  })
+
+  it('renders error message when `error` and `errorMessage` are passed', async () => {
+    const helpText = 'I am helpful'
+    const errorMessage = 'This is an error message'
+
+    await render(KInput, {
+      props: {
+        help: helpText,
+        error: true,
+        errorMessage,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input .help-text')).toHaveTextContent(errorMessage)
+    await expect.element(page.getByCSS('.k-input .help-text')).not.toHaveTextContent(helpText)
+  })
+
+  it('renders help with `help` slot applied', async () => {
+    const helpText = 'This is help text'
+
+    await render(KInput, {
+      slots: {
+        help: () => h('div', {}, helpText),
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input .help-text')).toHaveTextContent(helpText)
+  })
+
+  it('renders a help slot that is added after mount', async () => {
+    const helpText = 'This is help text'
+    const ready = ref(false)
+
+    await render(defineComponent({
+      setup: () => () => h(
+        KInput,
+        null,
+        ready.value ? { help: () => helpText } : {},
+      ),
+    }))
+
+    await expect.element(page.getByCSS('.k-input .help-text')).not.toBeInTheDocument()
+
+    ready.value = true
+
+    await expect.element(page.getByCSS('.k-input .help-text')).toHaveTextContent(helpText)
+  })
+
+  it('renders the error message with `error` and `error-message` props and `help` slot applied', async () => {
+    const helpText = 'This is help text'
+    const errorMessage = 'This is an error message'
+
+    await render(KInput, {
+      props: {
+        error: true,
+        errorMessage,
+      },
+      slots: {
+        help: () => h('div', {}, helpText),
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input .help-text')).toHaveTextContent(errorMessage)
+  })
+
+  it('shows character count when characterLimit prop is set and exceeded', async () => {
+    const textCharCount = 28
+    const charLimit = 5
+
+    await render(KInput, {
+      props: {
+        characterLimit: charLimit,
+      },
+    })
+
+    await page.getByCSS('.k-input input.input').fill(`This input has ${textCharCount} characters`)
+
+    await expect.element(page.getByCSS('.k-input.input-error .help-text')).toHaveTextContent(`${textCharCount} / ${charLimit}`)
+  })
+
+  it('reacts to text changes', async () => {
+    const inputValue = 'hey'
+    const newValue = 'hey, dude'
+
+    const screen = await render(KInput, {
+      props: {
+        modelValue: inputValue,
+      },
+    })
+
+    await expect.element(page.getByCSS('.input')).toHaveValue(inputValue)
+
+    await page.getByCSS('.input').clear()
+    await page.getByCSS('.input').fill(newValue)
+
+    // Check for emitted event
+    await expect.poll(() => screen.emitted()).toHaveProperty('input')
+    await expect.element(page.getByCSS('.input')).toHaveValue(newValue)
+  })
+
+  it('renders before slot when passed', async () => {
+    const beforeSlot = 'before-slot'
+
+    await render(KInput, {
+      slots: {
+        before: `<span data-testid="${beforeSlot}">Before slot</span>`,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input').getByTestId(beforeSlot)).toBeVisible()
+  })
+
+  it('renders after slot when passed', async () => {
+    const afterSlot = 'after-slot'
+
+    await render(KInput, {
+      slots: {
+        after: `<span data-testid="${afterSlot}">After slot</span>`,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input').getByTestId(afterSlot)).toBeVisible()
+  })
+
+  it('toggle masking button is not rendered when showPasswordMaskToggle is true but type is not password', async () => {
+    await render(KInput, {
+      props: {
+        type: 'text',
+        showPasswordMaskToggle: true,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input .mask-value-toggle-button')).not.toBeInTheDocument()
+  })
+
+  it('toggle masking functionality behaves correctly when showPasswordMaskToggle is true and input type is password', async () => {
+    const afterSlot = 'after-slot'
+
+    await render(KInput, {
+      props: {
+        type: 'password',
+        showPasswordMaskToggle: true,
+      },
+      slots: {
+        after: `<span data-testid="${afterSlot}">After slot</span>`,
+      },
+    })
+
+    await expect.element(page.getByCSS('.k-input .mask-value-toggle-button')).toBeVisible()
+    await expect.element(page.getByCSS('.k-input input')).toHaveAttribute('type', 'password')
+
+    await userEvent.click(page.getByCSS('.k-input input'))
+    await page.getByCSS('.k-input .mask-value-toggle-button').click()
+
+    await expect.element(page.getByCSS('.k-input input')).toHaveAttribute('type', 'text')
+
+    await page.getByCSS('.k-input .mask-value-toggle-button').click()
+
+    await expect.element(page.getByCSS('.k-input input')).toHaveAttribute('type', 'password')
+    await expect.element(page.getByCSS('.k-input input')).toHaveFocus()
+
+    // user-provided after slot should be rendered
+    await expect.element(page.getByCSS('.k-input').getByTestId(afterSlot)).not.toBeInTheDocument()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,10 +21,13 @@ export default defineConfig({
      * `vitest-browser-vue` is only referenced from `setupFiles`, so Vite doesn't discover it
      * during its initial dependency crawl and pre-bundles it on demand instead. On a cold
      * cache (every CI run) that on-demand optimization races the browser instances starting
-     * up concurrently, and whichever one loses throws "Vitest failed to find the runner".
-     * Listing it here folds it into the eager pre-bundle, done before any instance connects.
+     * up concurrently, and whichever one loses throws "Vitest failed to find the runner" —
+     * or, for a dependency first pulled in partway through the run (e.g. `swrv`, only
+     * imported transitively via `useUtilities`), hangs a browser instance outright instead
+     * of erroring. Listing deps here folds them into the eager pre-bundle, done before any
+     * instance connects.
      */
-    include: ['vitest-browser-vue', '@kong/design-tokens/tokens/themeable-tokens'],
+    include: ['vitest-browser-vue', '@kong/design-tokens/tokens/themeable-tokens', 'swrv'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# Summary

Convert Cypress component tests to vitest for KAlert and KInput

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->
