### PR TITLE
fix(ktextarea): remove baseline gap below textarea wrapper

### DIFF
--- a/src/components/KTextArea/KTextArea.vue
+++ b/src/components/KTextArea/KTextArea.vue
@@ -320,6 +320,10 @@ $kTextAreaPaddingY: var(--kui-space-40, $kui-space-40); // corresponds to mixin,
   }
 
   .input-textarea {
+    // textarea defaults to `inline-block`, which leaves room for the line's descender below it and makes
+    // the wrapper taller than the textarea itself. Setting it to `block` removes that baseline gap.
+    display: block;
+
     @include inputDefaults {
       // A fallback max-height. Referenced GitHub’s implementation for the current value.
       // It’s highly unlikely that we would need an input box taller than the viewport—this isn’t a document editor.


### PR DESCRIPTION
[KM-3121]

## Summary

`KTextArea`'s `.input-textarea-wrapper` div renders a few pixels taller than the `<textarea>` inside it, leaving a visible gap below the field.

`<textarea>` defaults to `display: inline-block`, and nothing in `KTextArea`'s styles overrode it. An inline-block element inside a block-level wrapper sits on the line's baseline, leaving room below it for the font's descender — that reserved space is the extra gap under the wrapper.

<img width="461" height="287" alt="Screenshot 2026-08-19 140558" src="https://github.com/user-attachments/assets/9e2d0f2f-b672-4b3b-b54f-3b5d65aa8a4a" />

## Fix

Set `display: block` on `.input-textarea` to remove the baseline gap.

Uploading Screen Recording 2026-08-19 141456.mp4…

[TEST_COVERAGE_EXEMPT_REASON] one-liner style change

[KM-3121]: https://konghq.atlassian.net/browse/KM-3121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ