### PR TITLE
fix(kpagination): remove 15 default page size option

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -16,7 +16,7 @@ A total number of items inside the paginated data source. This prop is **require
 
 ### pageSizes
 
-An array of numbers of page sizes that the user can choose from. The default page sizes are: `[15, 30, 50, 75, 100]`.
+An array of numbers of page sizes that the user can choose from. The default page sizes are: `[30, 50, 75, 100]`.
 
 You can provide custom page sizes. The first number in the array will be the initial page size unless otherwise specified through the [`initialPageSize` prop](#initialpagesize).
 

--- a/src/components/KCatalog/KCatalog.vue
+++ b/src/components/KCatalog/KCatalog.vue
@@ -197,7 +197,7 @@ const {
   fetcherCacheKey = '',
   searchInput = '',
   paginationNeighbors = 1,
-  paginationPageSizes = [15, 30, 50, 75, 100],
+  paginationPageSizes = [30, 50, 75, 100],
   paginationTotalItems = null,
   disablePaginationPageJump,
   disablePagination,

--- a/src/components/KPagination/KPagination.browser.spec.ts
+++ b/src/components/KPagination/KPagination.browser.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-vue'
+import KPagination from '@/components/KPagination/KPagination.vue'
+
+describe('KPagination', () => {
+  const myItems = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+  const pageSizes = [2, 4, 6]
+
+  /**
+   * `data-testid="visible-items"` is rendered twice — once for the large-screen breakpoint
+   * and once for the small-screen one — so a bare `getByTestId` is ambiguous under Vitest's
+   * strict locators. The 1366px test viewport shows the large-screen copy.
+   */
+  const visibleItems = () => page.getByCSS('.pagination-text.large-screen[data-testid="visible-items"]')
+
+  it('correctly renders props', async () => {
+    const currPage = 2
+    await render(KPagination, {
+      props: {
+        totalCount: 9,
+        pageSizes,
+        currentPage: currPage,
+        items: myItems,
+      },
+    })
+
+    await expect.element(visibleItems()).toHaveTextContent('3 to 4')
+    await expect.element(visibleItems()).toHaveTextContent('of 9')
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(currPage + '')
+
+    for (let i = 0; i < pageSizes.length; i++) {
+      await expect.element(page.getByCSS(`[data-testid="dropdown-item-trigger"][value="${pageSizes[i]}"]`)).toBeInTheDocument()
+    }
+  })
+
+  it('goes to first page', async () => {
+    await render(KPagination, {
+      props: {
+        totalCount: 9,
+        pageSizes: [2, 4, 6],
+        items: myItems,
+      },
+    })
+
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(1 + '')
+    await page.getByTestId('next-button').click()
+    await page.getByTestId('next-button').click()
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(3 + '')
+    await page.getByTestId('page-1-button').click()
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(1 + '')
+  })
+
+  it('goes to previous page', async () => {
+    await render(KPagination, {
+      props: {
+        totalCount: 9,
+        pageSizes: [2, 4, 6],
+        items: myItems,
+      },
+    })
+
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(1 + '')
+    await page.getByTestId('next-button').click()
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(2 + '')
+    await page.getByTestId('previous-button').click()
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent(1 + '')
+  })
+
+  it('can change page size', async () => {
+    await render(KPagination, {
+      props: {
+        totalCount: 9,
+        pageSizes: [2, 4, 6],
+        items: myItems,
+      },
+    })
+
+    await expect.element(page.getByTestId('page-size-dropdown-trigger')).toHaveTextContent('2 items per page')
+    await page.getByTestId('page-size-dropdown-trigger').click()
+    await page.getByCSS('[data-testid="dropdown-item-trigger"][value="4"]').click()
+    await expect.element(page.getByTestId('page-size-dropdown-trigger')).toHaveTextContent('4 items per page')
+  })
+
+  it('does not render the detached last-page button when mounted on the last page', async () => {
+    // Reproduces a bug where mounting at the last page rendered "1 ... 7 8 ... 8"
+    // (the last page number appeared both inside pagesVisible and as the detached last-page button)
+    await render(KPagination, {
+      props: {
+        totalCount: 116,
+        pageSizes: [15, 30, 50],
+        initialPageSize: 15,
+        currentPage: 8,
+      },
+    })
+
+    await expect.element(page.getByTestId('last-button')).not.toBeInTheDocument()
+    await expect.poll(() => page.getByCSS('[data-testid="page-8-button"]').all().length).toBe(1)
+    await expect.element(page.getByCSS('.pagination-button.active')).toHaveTextContent('8')
+  })
+})

--- a/src/components/KPagination/KPagination.vue
+++ b/src/components/KPagination/KPagination.vue
@@ -166,7 +166,7 @@ const kpopAttrs = {
 const {
   items = [],
   totalCount = 0,
-  pageSizes = [15, 30, 50, 75, 100],
+  pageSizes = [30, 50, 75, 100],
   initialPageSize = null,
   neighbors = 1,
   currentPage = null,

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -216,7 +216,7 @@ export interface CatalogProps<T extends readonly CatalogItem[] = readonly Catalo
 
   /**
    * A prop to pass in an array of page sizes used by the pagination component.
-   * @default [15, 30, 50, 75, 100]
+   * @default [30, 50, 75, 100]
    */
   paginationPageSizes?: number[]
 

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -27,7 +27,7 @@ export interface PaginationProps<T> {
 
   /**
    * The available page size options.
-   * @default [15, 30, 50, 75, 100]
+   * @default [30, 50, 75, 100]
    */
   pageSizes?: number[]
 


### PR DESCRIPTION
# Summary

Remove `15` - default page size option in KPagination. The default page size options are: `[30, 50, 75, 100]`

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->

<!--
## Test Coverage Exemption (Optional)
If your PR doesn't need test coverage, uncomment this section and provide the exemption reason on the next line.

[TEST_COVERAGE_EXEMPT_REASON] give it a reason
-->
