### PR TITLE
fix: failing test ci

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
      * of erroring. Listing deps here folds them into the eager pre-bundle, done before any
      * instance connects.
      */
-    include: ['vitest-browser-vue', '@kong/design-tokens/tokens/themeable-tokens', 'swrv'],
+    include: ['vitest-browser-vue', '@kong/design-tokens/tokens/themeable-tokens', 'swrv', 'virtua/vue', 'lodash-es'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# Summary

The tests would sometimes fail because it can get to a point where one session would trigger a rebuild on the dependencies since these were not already added in the optimize list and other sessions would lose the old dependencies.