### PR TITLE
test(kfiltergroup): convert kfiltergroup to vitest [KHCP-21676]

### DIFF
--- a/src/components/KFilterGroup/FilterPill.browser.spec.ts
+++ b/src/components/KFilterGroup/FilterPill.browser.spec.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { h } from 'vue'
+import { render } from 'vitest-browser-vue'
+import FilterPill from '@/components/KFilterGroup/FilterPill.vue'
+import KButton from '@/components/KButton/KButton.vue'
+import type { Filter, FilterPillSlotProps, FilterSelection } from '@/types'
+
+describe('KFilterGroup - FilterPill', () => {
+  const PILL_ID = 'filter-pill'
+  const CONTENT_ID = 'filter-pill-content'
+  const CLEAR_ICON_ID = 'interactive-pill-clear-icon'
+  const OPEN_ICON_ID = 'interactive-pill-open-icon'
+  const APPLY_ID = 'filter-pill-apply'
+  const CANCEL_ID = 'filter-pill-cancel'
+  const INPUT_ID = 'filter-pill-input'
+  const SELECT_ID = 'filter-pill-select'
+  const MULTISELECT_ID = 'filter-pill-multiselect'
+
+  const renderFilterPill = async ({
+    filter,
+    initOpen,
+    selection = undefined,
+    custom = false,
+    slots = undefined,
+  }: {
+    filter: Filter
+    initOpen?: boolean
+    selection?: FilterSelection
+    custom?: boolean
+    slots?: Record<string, (props: FilterPillSlotProps) => any>
+  }) => {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    const onOpen = vi.fn()
+    const onClear = vi.fn()
+
+    const screen = await render(FilterPill as any, {
+      props: {
+        filter,
+        initOpen,
+        selection,
+        custom,
+        onApply,
+        onClose,
+        onOpen,
+        onClear,
+      },
+      slots,
+    })
+
+    return { screen, onApply, onClose, onOpen, onClear }
+  }
+
+  it('renders closed by default', async () => {
+    await renderFilterPill({ filter: { label: 'Foo' } })
+    await expect.element(page.getByTestId(CONTENT_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(CONTENT_ID)).not.toBeVisible()
+  })
+
+  it('renders open when initOpen is true', async () => {
+    await renderFilterPill({ filter: { label: 'Foo' }, initOpen: true })
+    await expect.element(page.getByTestId(CONTENT_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(CONTENT_ID)).toBeVisible()
+  })
+
+  it('renders the selection text', async () => {
+    await renderFilterPill({
+      filter: { label: 'Foo' },
+      selection: { operator: 'eq', value: 'a', text: 'Ayy' },
+    })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveTextContent(/^Foo = Ayy$/)
+  })
+
+  it('renders the selection text with the correct operator text', async () => {
+    const { screen } = await renderFilterPill({ filter: { label: 'Foo' } })
+    const ops = ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte'] as const
+    const expected = [' = ', ' ≠ ', ': ', ': ', ' < ', ' ≤ ', ' > ', ' ≥ ']
+
+    for (let i = 0; i < ops.length; i++) {
+      await screen.rerender({ selection: { operator: ops[i], value: 'a', text: 'Ayy' } })
+      await expect.element(page.getByTestId(PILL_ID)).toHaveTextContent(new RegExp(`^Foo${expected[i]}Ayy$`))
+    }
+  })
+
+  it('renders the selection text with the operatorDelimiter if set', async () => {
+    const { screen } = await renderFilterPill({ filter: { label: 'Foo' } })
+    const ops = ['eq', 'neq', 'contains', 'exists', 'lt', 'lte', 'gt', 'gte'] as const
+    const operatorDelimiter = ' !!! '
+
+    for (const op of ops) {
+      await screen.rerender({ selection: { operator: op, value: 'a', text: 'Ayy', operatorDelimiter } })
+      await expect.element(page.getByTestId(PILL_ID)).toHaveTextContent(/^Foo !!! Ayy$/)
+    }
+  })
+
+  it('renders clear icon when selection is defined', async () => {
+    await renderFilterPill({
+      filter: { label: 'Foo' },
+      selection: { operator: 'eq', value: 'a', text: 'Ayy' },
+    })
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).toBeVisible()
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).not.toBeInTheDocument()
+  })
+
+  it('renders open icon when selection is undefined', async () => {
+    await renderFilterPill({ filter: { label: 'Foo' }, selection: undefined })
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).toBeVisible()
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).not.toBeInTheDocument()
+  })
+
+  it('toggles open state when clicked', async () => {
+    await renderFilterPill({ filter: { label: 'Foo' }, initOpen: true })
+    await expect.element(page.getByTestId(CONTENT_ID)).toBeVisible()
+    await page.getByTestId(PILL_ID).click()
+    await expect.element(page.getByTestId(CONTENT_ID)).not.toBeVisible()
+    await page.getByTestId(PILL_ID).click()
+    await expect.element(page.getByTestId(CONTENT_ID)).toBeVisible()
+  })
+
+  it('emits @open/@close when opened/closed', async () => {
+    const { onOpen, onClose } = await renderFilterPill({ filter: { label: 'Foo' }, initOpen: true })
+
+    // initOpen counts as an open
+    await expect.poll(() => onOpen.mock.calls.length).toBe(1)
+    expect(onClose).toHaveBeenCalledTimes(0)
+
+    await page.getByTestId(PILL_ID).click()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    await expect.poll(() => onClose.mock.calls.length).toBe(1)
+
+    await page.getByTestId(PILL_ID).click()
+
+    await expect.poll(() => onOpen.mock.calls.length).toBe(2)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits @clear when clear button is clicked', async () => {
+    const { onClear } = await renderFilterPill({
+      filter: { label: 'Foo' },
+      selection: { operator: 'eq', value: 'a', text: 'Ayy' },
+    })
+    await page.getByTestId(CLEAR_ICON_ID).click()
+    await expect.poll(() => onClear.mock.calls.length).toBe(1)
+  })
+
+  describe('popover content interactions', () => {
+    it('emits @close when cancel button is clicked', async () => {
+      const { onClose } = await renderFilterPill({ filter: { label: 'Foo' } })
+      await page.getByTestId(PILL_ID).click()
+      await page.getByTestId(CANCEL_ID).click()
+      await expect.poll(() => onClose.mock.calls.length).toBe(1)
+    })
+
+    it('emits @apply when apply button is clicked', async () => {
+      const { onApply } = await renderFilterPill({ filter: { label: 'Foo' } })
+      await page.getByTestId(PILL_ID).click()
+      await expect.element(page.getByTestId(APPLY_ID)).toHaveAttribute('disabled')
+      await page.getByTestId(INPUT_ID).fill('foo')
+      await page.getByTestId(APPLY_ID).click()
+      await expect.poll(() => onApply.mock.calls.length).toBe(1)
+    })
+
+    it('text input: focuses the input if the filter is an input type', async () => {
+      await renderFilterPill({ filter: { label: 'Foo' } })
+      await expect.element(page.getByTestId(INPUT_ID)).toBeInTheDocument()
+      await expect.element(page.getByTestId(INPUT_ID)).not.toBeVisible()
+      await expect.element(page.getByTestId(INPUT_ID)).not.toHaveFocus()
+      await page.getByTestId(PILL_ID).click()
+      await expect.element(page.getByTestId(INPUT_ID)).toBeVisible()
+      await expect.element(page.getByTestId(INPUT_ID)).toHaveFocus()
+    })
+
+    it('select input: emits apply with the selected content', async () => {
+      const { onApply } = await renderFilterPill({
+        filter: {
+          label: 'Foo',
+          multiple: false,
+          options: [
+            { label: 'Bar', value: 'bar' },
+            { label: 'Baz', value: 'baz' },
+          ],
+        },
+      })
+      await page.getByTestId(PILL_ID).click()
+      await page.getByTestId(SELECT_ID).click()
+      await page.getByTestId('select-item-baz').click()
+      await page.getByTestId(APPLY_ID).click()
+      await expect.poll(() => onApply.mock.calls.length).toBe(1)
+      expect(onApply).toHaveBeenCalledWith({ operator: 'eq', text: 'Baz', value: 'baz' })
+    })
+
+    it('multi select input: emits apply with multiple selected content', async () => {
+      const { onApply } = await renderFilterPill({
+        filter: {
+          label: 'Foo',
+          multiple: true,
+          options: [
+            { label: 'Bar', value: 'bar' },
+            { label: 'Baz', value: 'baz' },
+          ],
+        },
+      })
+      await page.getByTestId(PILL_ID).click()
+      await page.getByTestId(MULTISELECT_ID).click()
+      await page.getByTestId('multiselect-item-baz').click()
+      await page.getByTestId('multiselect-item-bar').click()
+      // Close the multiselect dropdown by focusing its search input then pressing Escape.
+      page.getByTestId('multiselect-dropdown-input').element().focus()
+      await userEvent.keyboard('{Escape}')
+      await page.getByTestId(APPLY_ID).click()
+      await expect.poll(() => onApply.mock.calls.length).toBe(1)
+      expect(onApply).toHaveBeenCalledWith({ operator: 'eq', text: 'Baz, Bar', value: ['baz', 'bar'] })
+    })
+
+    describe('custom filter slot props', () => {
+      const CUSTOM_OPTIONS = [{ label: 'Bar', value: 'bar' }, { label: 'Baz', value: 'baz' }]
+
+      it('passes filter/selection state through to the slot', async () => {
+        await renderFilterPill({
+          custom: true,
+          filter: {
+            label: 'Foo',
+            multiple: true,
+            operators: ['eq', 'neq'],
+            options: CUSTOM_OPTIONS,
+          },
+          selection: { operator: 'neq', value: 'a', text: 'Ayy' },
+          slots: {
+            default: (props: FilterPillSlotProps) => h('div', {}, [
+              h('span', { 'data-testid': 'custom-options' }, JSON.stringify(props.options)),
+              h('span', { 'data-testid': 'custom-multiple' }, String(props.multiple)),
+              h('span', { 'data-testid': 'custom-operators' }, JSON.stringify(props.operators)),
+              h('span', { 'data-testid': 'custom-value' }, JSON.stringify(props.value)),
+              h('span', { 'data-testid': 'custom-text' }, props.text),
+              h('span', { 'data-testid': 'custom-operator' }, props.operator),
+            ]),
+          },
+        })
+        await page.getByTestId(PILL_ID).click()
+        await expect.element(page.getByTestId('custom-options')).toHaveTextContent(JSON.stringify(CUSTOM_OPTIONS))
+        await expect.element(page.getByTestId('custom-multiple')).toHaveTextContent('true')
+        await expect.element(page.getByTestId('custom-operators')).toHaveTextContent(JSON.stringify(['eq', 'neq']))
+        await expect.element(page.getByTestId('custom-value')).toHaveTextContent(JSON.stringify('a'))
+        await expect.element(page.getByTestId('custom-text')).toHaveTextContent('Ayy')
+        await expect.element(page.getByTestId('custom-operator')).toHaveTextContent('neq')
+      })
+
+      it('emits @apply built from setValue/setOperator', async () => {
+        const { onApply } = await renderFilterPill({
+          custom: true,
+          filter: { label: 'Foo', operators: ['eq', 'neq'], options: CUSTOM_OPTIONS },
+          slots: {
+            default: (props: FilterPillSlotProps) => h('div', {}, [
+              h('button', {
+                'data-testid': 'custom-set-value',
+                onClick: () => props.setValue('baz', 'Baz'),
+              }, 'set value'),
+              h('button', {
+                'data-testid': 'custom-set-operator',
+                onClick: () => props.setOperator('neq'),
+              }, 'set operator'),
+            ]),
+          },
+        })
+        await page.getByTestId(PILL_ID).click()
+        await page.getByTestId('custom-set-value').click()
+        await page.getByTestId('custom-set-operator').click()
+        await page.getByTestId(APPLY_ID).click()
+        await expect.poll(() => onApply.mock.calls.length).toBe(1)
+        expect(onApply).toHaveBeenCalledWith({ operator: 'neq', text: 'Baz', value: 'baz' })
+      })
+
+      it('disables/enables apply via setApplyState', async () => {
+        // KButton registered explicitly so its `disabled` prop maps to a native
+        // button[disabled] — making toBeDisabled() reliable.
+        const onApply = vi.fn()
+        await render(FilterPill as any, {
+          props: {
+            filter: { label: 'Foo' },
+            custom: true,
+            onApply,
+          },
+          global: {
+            components: { KButton },
+          },
+          slots: {
+            default: (props: FilterPillSlotProps) => h('div', {}, [
+              h('button', {
+                'data-testid': 'custom-disable',
+                onClick: () => props.setApplyState(false),
+              }, 'disable'),
+              h('button', {
+                'data-testid': 'custom-enable',
+                onClick: () => props.setApplyState(true),
+              }, 'enable'),
+            ]),
+          },
+        })
+
+        await page.getByTestId(PILL_ID).click()
+        await expect.element(page.getByTestId(APPLY_ID)).not.toBeDisabled()
+
+        await page.getByTestId('custom-disable').click()
+        await expect.element(page.getByTestId(APPLY_ID)).toBeDisabled()
+
+        await page.getByTestId('custom-enable').click()
+        await expect.element(page.getByTestId(APPLY_ID)).not.toBeDisabled()
+        await page.getByTestId(APPLY_ID).click()
+        await expect.poll(() => onApply.mock.calls.length).toBe(1)
+      })
+
+      it('still emits @apply with undefined if setValue is never called', async () => {
+        const { onApply } = await renderFilterPill({
+          custom: true,
+          filter: { label: 'Foo' },
+          slots: {
+            default: () => h('div', { 'data-testid': 'bare-custom-slot' }, 'no destructured props used'),
+          },
+        })
+        await page.getByTestId(PILL_ID).click()
+        await page.getByTestId(APPLY_ID).click()
+        await expect.poll(() => onApply.mock.calls.length).toBe(1)
+        expect(onApply).toHaveBeenCalledWith(undefined)
+      })
+    })
+  })
+})

--- a/src/components/KFilterGroup/FilterSelector.browser.spec.ts
+++ b/src/components/KFilterGroup/FilterSelector.browser.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { render } from 'vitest-browser-vue'
+import FilterSelector from '@/components/KFilterGroup/FilterSelector.vue'
+import type { FilterGroupFilters } from '@/types'
+
+describe('KFilterGroup - FilterSelector', () => {
+  const SELECTOR_ID = 'filter-selector'
+  const FILTERING_ID = 'filter-selector-item-filtering'
+  const FILTERING_NO_ITEMS_ID = 'filter-selector-no-items'
+
+  const renderSelector = async ({
+    filters,
+    itemFiltering = false,
+    slots = {},
+  }: {
+    filters: FilterGroupFilters
+    itemFiltering?: boolean
+    slots?: any
+  }) => {
+    const onSelect = vi.fn()
+    await render(FilterSelector as any, {
+      props: { filters, itemFiltering, onSelect },
+      slots,
+    })
+    return { onSelect }
+  }
+
+  it('renders each filter in the dropdown in order', async () => {
+    const expectedText = ['Ayy', 'Zee', 'Jay']
+    await renderSelector({
+      filters: {
+        a: { label: expectedText[0]! },
+        z: { label: expectedText[1]! },
+        j: { label: expectedText[2]! },
+      },
+    })
+
+    await expect.element(page.getByTestId(SELECTOR_ID)).toBeInTheDocument()
+    await page.getByTestId(SELECTOR_ID).click()
+    const items = page.getByTestId('dropdown-item-trigger')
+    await expect.poll(() => items.all().length).toBe(expectedText.length)
+    for (let i = 0; i < expectedText.length; i++) {
+      await expect.element(items.nth(i)).toHaveTextContent(expectedText[i]!)
+    }
+  })
+
+  it('readonly filters do not render in the dropdown', async () => {
+    const expectedText = ['Ayy', 'Zee', 'Jay']
+    await renderSelector({
+      filters: {
+        a: { label: expectedText[0]! },
+        z: { label: expectedText[1]! },
+        j: { label: expectedText[2]!, readonly: true },
+      },
+    })
+
+    await page.getByTestId(SELECTOR_ID).click()
+    const items = page.getByTestId('dropdown-item-trigger')
+    await expect.poll(() => items.all().length).toBe(2)
+    for (let i = 0; i < 2; i++) {
+      await expect.element(items.nth(i)).toHaveTextContent(expectedText[i]!)
+    }
+  })
+
+  it('emits @select with filter key on item click', async () => {
+    const { onSelect } = await renderSelector({ filters: { a: { label: 'Ayy' } } })
+
+    await page.getByTestId(SELECTOR_ID).click()
+    const items = page.getByTestId('dropdown-item-trigger')
+    await expect.poll(() => items.all().length).toBe(1)
+    await expect.element(items.nth(0)).toHaveTextContent('Ayy')
+    await items.nth(0).click()
+    await expect.poll(() => onSelect.mock.calls.length).toBe(1)
+    expect(onSelect).toHaveBeenCalledWith('a')
+  })
+
+  it('is focused after click, and unfocused on blur', async () => {
+    await renderSelector({ filters: {} })
+    await expect.element(page.getByTestId(SELECTOR_ID)).toHaveClass('unfocused')
+    await page.getByTestId(SELECTOR_ID).click()
+    await expect.element(page.getByTestId(SELECTOR_ID)).toHaveClass('focused')
+    await page.getByTestId(SELECTOR_ID).click()
+    await expect.element(page.getByTestId(SELECTOR_ID)).toHaveClass('unfocused')
+  })
+
+  it('does not have a search bar when itemFiltering is false', async () => {
+    await renderSelector({ filters: { a: { label: 'Ayy' } }, itemFiltering: false })
+    await expect.element(page.getByTestId(FILTERING_ID)).not.toBeInTheDocument()
+    await page.getByTestId(SELECTOR_ID).click()
+    await expect.element(page.getByTestId(FILTERING_ID)).not.toBeInTheDocument()
+  })
+
+  it('has a search bar when itemFiltering is true, and focuses it', async () => {
+    await renderSelector({ filters: { a: { label: 'Ayy' } }, itemFiltering: true })
+    await expect.element(page.getByTestId(FILTERING_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(FILTERING_ID)).not.toBeVisible()
+    await page.getByTestId(SELECTOR_ID).click()
+    await expect.element(page.getByTestId(FILTERING_ID)).toBeVisible()
+    await expect.element(page.getByTestId(FILTERING_ID)).toHaveFocus()
+  })
+
+  it('has a search bar when itemFiltering is true, and resets it on open', async () => {
+    await renderSelector({ filters: { a: { label: 'Ayy' } }, itemFiltering: true })
+    await page.getByTestId(SELECTOR_ID).click()
+
+    // initial state: visible, focused, empty value
+    await expect.element(page.getByTestId(FILTERING_ID)).toBeVisible()
+    await expect.element(page.getByTestId(FILTERING_ID)).toHaveFocus()
+    await expect.element(page.getByTestId(FILTERING_ID)).toHaveValue('')
+
+    // type into the search bar
+    await page.getByTestId(FILTERING_ID).fill('hello')
+    await expect.element(page.getByTestId(FILTERING_ID)).toHaveValue('hello')
+
+    // close and re-open
+    await userEvent.keyboard('{Escape}')
+    await expect.element(page.getByTestId(FILTERING_ID)).not.toBeVisible()
+    await page.getByTestId(SELECTOR_ID).click()
+
+    // should be reset to initial state
+    await expect.element(page.getByTestId(FILTERING_ID)).toBeVisible()
+    await expect.element(page.getByTestId(FILTERING_ID)).toHaveFocus()
+    await expect.element(page.getByTestId(FILTERING_ID)).toHaveValue('')
+  })
+
+  it('filters items when you type in the itemFiltering input', async () => {
+    await renderSelector({
+      filters: {
+        a: { label: 'Ayy' },
+        b: { label: 'Bee' },
+        c: { label: 'Cee' },
+        f: { label: 'Eff' },
+      },
+      itemFiltering: true,
+    })
+    await page.getByTestId(SELECTOR_ID).click()
+    await expect.element(page.getByTestId(FILTERING_NO_ITEMS_ID)).not.toBeInTheDocument()
+
+    await page.getByTestId(FILTERING_ID).fill('e')
+    const items = page.getByTestId('dropdown-item-trigger')
+    await expect.poll(() => items.all().length).toBe(3) // b, c, f
+    await expect.element(items.nth(0)).toHaveTextContent('Bee')
+    await expect.element(items.nth(1)).toHaveTextContent('Cee')
+    await expect.element(items.nth(2)).toHaveTextContent('Eff')
+
+    await page.getByTestId(FILTERING_ID).fill('ee')
+    await expect.poll(() => items.all().length).toBe(2) // b, c
+    await expect.element(items.nth(0)).toHaveTextContent('Bee')
+    await expect.element(items.nth(1)).toHaveTextContent('Cee')
+
+    await page.getByTestId(FILTERING_ID).fill('eex')
+    await expect.poll(() => items.all().length).toBe(0)
+    await expect.element(page.getByTestId(FILTERING_NO_ITEMS_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(FILTERING_NO_ITEMS_ID)).toBeVisible()
+  })
+
+  it('exposes a slot for each filter item', async () => {
+    await renderSelector({
+      filters: { a: { label: 'Ayy' } },
+      slots: {
+        'filter-item-a': '<div>hello</div>',
+      },
+    })
+    await page.getByTestId(SELECTOR_ID).click()
+    const items = page.getByTestId('dropdown-item-trigger')
+    await expect.poll(() => items.all().length).toBe(1)
+    await expect.element(items.nth(0)).toHaveTextContent('hello')
+  })
+})

--- a/src/components/KFilterGroup/InteractivePill.browser.spec.ts
+++ b/src/components/KFilterGroup/InteractivePill.browser.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { render } from 'vitest-browser-vue'
+import InteractivePill from '@/components/KFilterGroup/InteractivePill.vue'
+
+describe('KFilterGroup - InteractivePill', () => {
+  const PILL_ID = 'interactive-pill'
+  const BASE_LABEL_ID = 'interactive-pill-base-label'
+  const CONTENT_LABEL_ID = 'interactive-pill-content-label'
+  const TRIGGER_ID = 'interactive-pill-trigger'
+  const CLEAR_ICON_ID = 'interactive-pill-clear-icon'
+  const CLEAR_FOCUS_ID = 'interactive-pill-clear-focus'
+  const OPEN_ICON_ID = 'interactive-pill-open-icon'
+
+  const PILL_FOCUS_BOX_SHADOW = 'rgba(0, 68, 244, 0.2) 0px 0px 0px 4px'
+  const CLEAR_FOCUS_BOX_SHADOW = 'color(srgb 0 0.266667 0.956863 / 0.2) 0px 0px 0px 2px'
+
+  const renderPill = async ({
+    label,
+    clearFocus,
+    contentLabel,
+    delimiter,
+    pillFocus,
+    readonly,
+    tooltipText,
+  }: {
+    label: string
+    clearFocus?: boolean
+    contentLabel?: string
+    delimiter?: string
+    pillFocus?: boolean
+    readonly?: boolean
+    tooltipText?: string
+  }) => {
+    const onTrigger = vi.fn()
+    const onClear = vi.fn()
+
+    await render(InteractivePill, {
+      props: {
+        label,
+        ...(clearFocus !== undefined && { clearFocus }),
+        ...(contentLabel !== undefined && { contentLabel }),
+        ...(delimiter !== undefined && { delimiter }),
+        ...(pillFocus !== undefined && { pillFocus }),
+        ...(readonly !== undefined && { readonly }),
+        ...(tooltipText !== undefined && { tooltipText }),
+        onTrigger,
+        onClear,
+      },
+    })
+
+    return { onTrigger, onClear }
+  }
+
+  it('renders content-less by default', async () => {
+    await renderPill({ label: 'test' })
+    await expect.element(page.getByTestId(PILL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(BASE_LABEL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(BASE_LABEL_ID)).toHaveTextContent('test')
+    await expect.element(page.getByTestId(CONTENT_LABEL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(CONTENT_LABEL_ID)).not.toHaveTextContent(/\S/)
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).not.toBeInTheDocument()
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).toBeInTheDocument()
+  })
+
+  it('renders with content when provided', async () => {
+    await renderPill({ label: 'test', contentLabel: 'foo' })
+    await expect.element(page.getByTestId(PILL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(BASE_LABEL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(BASE_LABEL_ID)).toHaveTextContent('test:')
+    await expect.element(page.getByTestId(CONTENT_LABEL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(CONTENT_LABEL_ID)).toHaveTextContent('foo')
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).not.toBeInTheDocument()
+  })
+
+  it('renders the pill focused when `pillFocus` is true', async () => {
+    await renderPill({ label: 'test', pillFocus: true })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveStyle({ boxShadow: PILL_FOCUS_BOX_SHADOW })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('focused')
+  })
+
+  it('renders the pill focused when `pillFocus` is false but has browser focus', async () => {
+    await renderPill({ label: 'test', pillFocus: false })
+    await expect.element(page.getByTestId(PILL_ID)).not.toHaveStyle({ boxShadow: PILL_FOCUS_BOX_SHADOW })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('unfocused')
+    page.getByTestId(TRIGGER_ID).element().focus()
+    await expect.element(page.getByTestId(PILL_ID)).toHaveStyle({ boxShadow: PILL_FOCUS_BOX_SHADOW })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('focused')
+  })
+
+  it('renders the clear icon focused when `clearFocus` is true', async () => {
+    await renderPill({ label: 'test', contentLabel: 'foo', clearFocus: true })
+    await expect.element(page.getByTestId(CLEAR_FOCUS_ID)).toHaveStyle({ boxShadow: CLEAR_FOCUS_BOX_SHADOW })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('clear-focused')
+  })
+
+  it('renders the clear icon focused when `clearFocus` is false but has browser focus', async () => {
+    await renderPill({ label: 'test', contentLabel: 'foo', clearFocus: false })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('clear-unfocused')
+    await expect.element(page.getByTestId(CLEAR_FOCUS_ID)).not.toHaveStyle({ boxShadow: CLEAR_FOCUS_BOX_SHADOW })
+    page.getByTestId(CLEAR_ICON_ID).element().focus()
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('clear-focused')
+    await expect.element(page.getByTestId(CLEAR_FOCUS_ID)).toHaveStyle({ boxShadow: CLEAR_FOCUS_BOX_SHADOW })
+  })
+
+  it('renders clear focus even if the pill is focused', async () => {
+    await renderPill({ label: 'test', contentLabel: 'foo', pillFocus: true, clearFocus: true })
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('clear-focused')
+    await expect.element(page.getByTestId(PILL_ID)).toHaveClass('focused')
+    await expect.element(page.getByTestId(PILL_ID)).toHaveStyle({ boxShadow: PILL_FOCUS_BOX_SHADOW })
+    await expect.element(page.getByTestId(CLEAR_FOCUS_ID)).toHaveStyle({ boxShadow: CLEAR_FOCUS_BOX_SHADOW })
+  })
+
+  it('fires trigger when clicked', async () => {
+    const { onTrigger, onClear } = await renderPill({ label: 'test' })
+    await page.getByTestId(PILL_ID).click()
+    await expect.poll(() => onTrigger.mock.calls.length).toBe(1)
+    expect(onClear).toHaveBeenCalledTimes(0)
+  })
+
+  it('while readonly does not fire trigger when clicked', async () => {
+    const { onTrigger, onClear } = await renderPill({ label: 'test', readonly: true })
+    await expect.element(page.getByTestId(TRIGGER_ID)).toBeDisabled()
+    await page.getByTestId(PILL_ID).click()
+    expect(onTrigger).toHaveBeenCalledTimes(0)
+    expect(onClear).toHaveBeenCalledTimes(0)
+  })
+
+  it('when readonly without content, the control icons do not appear', async () => {
+    await renderPill({ label: 'test', contentLabel: undefined, readonly: true })
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).not.toBeInTheDocument()
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).not.toBeInTheDocument()
+  })
+
+  it('when readonly with content, the control icons do not appear', async () => {
+    await renderPill({ label: 'test', contentLabel: 'foo', readonly: true })
+    await expect.element(page.getByTestId(CLEAR_ICON_ID)).not.toBeInTheDocument()
+    await expect.element(page.getByTestId(OPEN_ICON_ID)).not.toBeInTheDocument()
+  })
+
+  it('fires trigger when enter is pressed on the pill', async () => {
+    const { onTrigger, onClear } = await renderPill({ label: 'test' })
+    await userEvent.type(page.getByTestId(TRIGGER_ID), '{Enter}')
+    await expect.poll(() => onTrigger.mock.calls.length).toBe(1)
+    expect(onClear).toHaveBeenCalledTimes(0)
+  })
+
+  it('fires clear when the clear icon is clicked', async () => {
+    const { onTrigger, onClear } = await renderPill({ label: 'test', contentLabel: 'foo' })
+    await page.getByTestId(CLEAR_ICON_ID).click()
+    await expect.poll(() => onClear.mock.calls.length).toBe(1)
+    expect(onTrigger).toHaveBeenCalledTimes(0)
+  })
+
+  it('fires clear when the enter is pressed on the clear icon', async () => {
+    const { onTrigger, onClear } = await renderPill({ label: 'test', contentLabel: 'foo' })
+    await userEvent.type(page.getByTestId(CLEAR_ICON_ID), '{Enter}')
+    await expect.poll(() => onClear.mock.calls.length).toBe(1)
+    expect(onTrigger).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/components/KFilterGroup/KFilterGroup.browser.spec.ts
+++ b/src/components/KFilterGroup/KFilterGroup.browser.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { h } from 'vue'
+import { render } from 'vitest-browser-vue'
+import KFilterGroup from '@/components/KFilterGroup/KFilterGroup.vue'
+import type { Filter, FilterGroupFilters, FilterGroupSelection, FilterPillSlotProps, FilterSelection } from '@/types'
+
+describe('KFilterGroup', () => {
+  const FILTER_LABEL_ID = 'filter-group-label'
+  const FILTER_SELECTOR_ID = 'filter-selector'
+  const CANCEL_ID = 'filter-pill-cancel'
+  const APPLY_ID = 'filter-pill-apply'
+  const INPUT_ID = 'filter-pill-input'
+  const CLEAR_ID = 'interactive-pill-clear-icon'
+  const getFilterSelector = (key: string) => `[data-testid="filter-group-pill-${key}"] .interactive-pill`
+  const getPopoverSelector = (key: string) => `[data-testid="filter-group-pill-${key}"] .popover`
+
+  const SIMPLE_FILTER_SELECTION: FilterSelection = {
+    operator: 'eq',
+    value: 'simple',
+    text: 'Simple',
+  }
+  const BASIC_FILTER: Filter = { label: 'Basic filter' }
+  const PINNED_FILTER: Filter = { label: 'Pinned filter', pinned: true }
+
+  const renderFilterGroup = async ({
+    filters,
+    groupLabel = undefined,
+    selection = {},
+    slots = {},
+  }: {
+    filters: FilterGroupFilters
+    groupLabel?: string
+    selection?: FilterGroupSelection
+    slots?: any
+  }) => {
+    const onApply = vi.fn()
+    const onClose = vi.fn()
+    const onOpen = vi.fn()
+    const onClear = vi.fn()
+
+    await render(KFilterGroup as any, {
+      props: {
+        filters,
+        groupLabel,
+        modelValue: selection,
+        onApply,
+        onClose,
+        onOpen,
+        onClear,
+      },
+      slots,
+    })
+
+    return { onApply, onClose, onOpen, onClear }
+  }
+
+  const addAndApplyInputFilter = async (key: string) => {
+    await page.getByTestId(FILTER_SELECTOR_ID).click()
+    await page.getByCSS(`[data-testid="dropdown-item-trigger"][value="${key}"]`).click()
+    await page.getByCSS(getPopoverSelector(key)).getByTestId(INPUT_ID).fill('foo')
+    await page.getByCSS(getPopoverSelector(key)).getByTestId(APPLY_ID).click()
+  }
+
+  it('renders', async () => {
+    await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await expect.element(page.getByTestId(FILTER_LABEL_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(FILTER_LABEL_ID)).toBeVisible()
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).toBeInTheDocument()
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).toBeVisible()
+    await expect.element(page.getByCSS(getFilterSelector('pinned'))).toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('pinned'))).toBeVisible()
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).not.toBeInTheDocument()
+  })
+
+  it('renders without the filter selector when all filters have been added/pinned', async () => {
+    await renderFilterGroup({ filters: { pinned: PINNED_FILTER } })
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).not.toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('pinned'))).toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('pinned'))).toBeVisible()
+  })
+
+  it('renders pinned filters in the order they were provided', async () => {
+    await renderFilterGroup({
+      filters: {
+        pinned_a: PINNED_FILTER,
+        pinned_z: PINNED_FILTER,
+        pinned_b: PINNED_FILTER,
+      },
+    })
+    const pillSelect = '[data-testid*="filter-group-pill-"]'
+    await expect.poll(() => page.getByCSS(pillSelect).all().length).toBe(3)
+    await expect.element(page.getByCSS(pillSelect).nth(0)).toHaveAttribute('data-testid', 'filter-group-pill-pinned_a')
+    await expect.element(page.getByCSS(pillSelect).nth(1)).toHaveAttribute('data-testid', 'filter-group-pill-pinned_z')
+    await expect.element(page.getByCSS(pillSelect).nth(2)).toHaveAttribute('data-testid', 'filter-group-pill-pinned_b')
+  })
+
+  it('renders unpinned filters if the selection for it exists', async () => {
+    await renderFilterGroup({
+      filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER },
+      selection: { basic: SIMPLE_FILTER_SELECTION },
+    })
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).not.toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('pinned'))).toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('pinned'))).toBeVisible()
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).toBeVisible()
+  })
+
+  it('adds a filter when clicked', async () => {
+    await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).not.toBeInTheDocument()
+    await page.getByTestId(FILTER_SELECTOR_ID).click()
+    await page.getByCSS('[data-testid="dropdown-item-trigger"][value="basic"]').click()
+    await page.getByCSS(getPopoverSelector('basic')).getByTestId(INPUT_ID).fill('foo')
+    await page.getByCSS(getPopoverSelector('basic')).getByTestId(APPLY_ID).click()
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).toBeInTheDocument()
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).toBeVisible()
+  })
+
+  it('removes non-pinned filters if no value is selected', async () => {
+    await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).not.toBeInTheDocument()
+    await page.getByTestId(FILTER_SELECTOR_ID).click()
+    await page.getByCSS('[data-testid="dropdown-item-trigger"][value="basic"]').click()
+    await page.getByCSS(getPopoverSelector('basic')).getByTestId(CANCEL_ID).click()
+    await expect.element(page.getByCSS(getFilterSelector('basic'))).not.toBeInTheDocument()
+  })
+
+  it('hides the filter selector when all filters are visible', async () => {
+    await renderFilterGroup({ filters: { pinned: PINNED_FILTER } })
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).not.toBeInTheDocument()
+  })
+
+  it('hides the filter selector when all filters are visible because the user added them', async () => {
+    await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).toBeInTheDocument()
+    await addAndApplyInputFilter('basic')
+    await expect.element(page.getByTestId(FILTER_SELECTOR_ID)).not.toBeInTheDocument()
+  })
+
+  it('renders added filters in the order in which they were added', async () => {
+    await renderFilterGroup({
+      filters: {
+        basic_a: BASIC_FILTER,
+        basic_z: BASIC_FILTER,
+        basic_b: BASIC_FILTER,
+      },
+    })
+    await addAndApplyInputFilter('basic_z')
+    await addAndApplyInputFilter('basic_b')
+    await addAndApplyInputFilter('basic_a')
+
+    const pillSelect = '[data-testid*="filter-group-pill-"]'
+    await expect.poll(() => page.getByCSS(pillSelect).all().length).toBe(3)
+    await expect.element(page.getByCSS(pillSelect).nth(0)).toHaveAttribute('data-testid', 'filter-group-pill-basic_z')
+    await expect.element(page.getByCSS(pillSelect).nth(1)).toHaveAttribute('data-testid', 'filter-group-pill-basic_b')
+    await expect.element(page.getByCSS(pillSelect).nth(2)).toHaveAttribute('data-testid', 'filter-group-pill-basic_a')
+  })
+
+  it('exposes slots for filter items', async () => {
+    await renderFilterGroup({
+      filters: { basic_a: BASIC_FILTER },
+      slots: {
+        'filter-item-basic_a': '<div class="slot-test">hello</div>',
+      },
+    })
+    await page.getByTestId(FILTER_SELECTOR_ID).click()
+    await expect.element(page.getByCSS('[data-testid="dropdown-item-trigger"] .slot-test')).toBeInTheDocument()
+  })
+
+  it('forwards custom filter slot props', async () => {
+    const CUSTOM_OPTIONS = [{ label: 'Bar', value: 'bar' }, { label: 'Baz', value: 'baz' }]
+    const { onApply } = await renderFilterGroup({
+      filters: {
+        custom: { label: 'Custom', options: CUSTOM_OPTIONS, pinned: true },
+      },
+      slots: {
+        'filter-custom': (props: FilterPillSlotProps) => h('button', {
+          'data-testid': 'custom-set-value',
+          onClick: () => props.setValue('baz', 'Baz'),
+        }, 'set value'),
+      },
+    })
+    await page.getByCSS(getFilterSelector('custom')).click()
+    await page.getByTestId('custom-set-value').click()
+    await page.getByCSS(getPopoverSelector('custom')).getByTestId(APPLY_ID).click()
+    await expect.poll(() => onApply.mock.calls.length).toBe(1)
+    expect(onApply).toHaveBeenCalledWith('custom', {
+      custom: { operator: 'eq', text: 'Baz', value: 'baz' },
+    })
+    await expect.element(page.getByCSS(getFilterSelector('custom'))).toHaveTextContent('Baz')
+  })
+
+  it('emits @open', async () => {
+    const { onOpen, onClose } = await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await page.getByCSS(getFilterSelector('pinned')).click()
+    await expect.poll(() => onOpen.mock.calls.length).toBe(1)
+    expect(onClose).toHaveBeenCalledTimes(0)
+  })
+
+  it('emits @close', async () => {
+    const { onOpen, onClose } = await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await page.getByCSS(getFilterSelector('pinned')).click()
+    await expect.poll(() => onOpen.mock.calls.length).toBe(1)
+    expect(onClose).toHaveBeenCalledTimes(0)
+
+    await page.getByCSS(getFilterSelector('pinned')).click()
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    await expect.poll(() => onClose.mock.calls.length).toBe(1)
+  })
+
+  it('emits @apply', async () => {
+    const { onApply } = await renderFilterGroup({ filters: { basic: BASIC_FILTER, pinned: PINNED_FILTER } })
+    await addAndApplyInputFilter('basic')
+    await expect.poll(() => onApply.mock.calls.length).toBe(1)
+  })
+
+  it('emits @clear', async () => {
+    const { onApply, onClear } = await renderFilterGroup({ filters: { basic: BASIC_FILTER } })
+    await addAndApplyInputFilter('basic')
+    await expect.poll(() => onApply.mock.calls.length).toBe(1)
+    expect(onClear).toHaveBeenCalledTimes(0)
+
+    await page.getByTestId(CLEAR_ID).click()
+    expect(onApply).toHaveBeenCalledTimes(1)
+    await expect.poll(() => onClear.mock.calls.length).toBe(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
      * of erroring. Listing deps here folds them into the eager pre-bundle, done before any
      * instance connects.
      */
-    include: ['vitest-browser-vue', '@kong/design-tokens/tokens/themeable-tokens', 'swrv', 'virtua/vue', 'lodash-es'],
+    include: ['vitest-browser-vue', '@kong/design-tokens/tokens/themeable-tokens', 'swrv', 'virtua/vue', 'lodash-es', '@floating-ui/vue', 'vue-clamp'],
   },
   resolve: {
     alias: {
@@ -90,7 +90,13 @@ export default defineConfig({
              */
             instances: [
               { browser: 'chromium' },
-              { browser: 'firefox' },
+              /**
+               * Firefox specifically (not Chromium/WebKit) races real keyboard/focus input
+               * across concurrently-running spec files — a known Vitest issue
+               * (https://github.com/vitest-dev/vitest/issues/7916). Serializing just this
+               * instance avoids it without slowing down the other two engines.
+               */
+              { browser: 'firefox', fileParallelism: false },
               { browser: 'webkit' },
             ],
             viewport: { width: 1366, height: 768 },


### PR DESCRIPTION
https://konghq.atlassian.net/browse/KHCP-21676

Converts the KFilterGroup cypress tests (InteractivePill, FilterPill, FilterSelector, KFilterGroup) to vitest.

Also sets `fileParallelism: false` on the Firefox browser instance in `vitest.config.ts`. Firefox specifically (not Chromium/WebKit) intermittently dropped real keyboard/focus input when spec files ran concurrently - a [known Vitest issue](https://github.com/vitest-dev/vitest/issues/7916). Serializing just Firefox's file execution fixes it at the root without slowing down the other two engines and let the InteractivePill keyboard-activation tests stay simple (plain `.focus()` / `userEvent.type`) rather than relying on workarounds.