### PR TITLE
feat(ktabs): optionally cache visited tab panels

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -211,6 +211,23 @@ If you want to keep your `v-model` in sync so that you can programmatically chan
 <KButton @click="currentTab = '#tab2'">Activate Tab 2</KButton>
 ```
 
+### cacheTabs
+
+A `boolean` that keeps visited tab content mounted when switching tabs. Defaults to `false`.
+
+When enabled, each tab mounts on its first activation. Inactive visited panels are hidden with CSS and retain their component instances, DOM, and local state. Unvisited tabs do not mount until selected.
+
+```html
+<KTabs :tabs="tabs" cache-tabs>
+  <template #tab1>Tab 1 content</template>
+  <template #tab2>Tab 2 content</template>
+</KTabs>
+```
+
+This prevents repeated mount-triggered requests. Cached content still uses memory, and its watchers and polling can continue while hidden. Charts may need to resize when their panel becomes visible again.
+
+Removing a tab discards its cached content. Disabling `cacheTabs` unmounts inactive content. Setting `hidePanels` to `true` or unmounting KTabs discards all panel content.
+
 ### hidePanels
 
 A `boolean` that determines whether all tabs should have corresponding "panel" (the tab content) containers. Defaults to `false`.

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -213,9 +213,9 @@ If you want to keep your `v-model` in sync so that you can programmatically chan
 
 ### cacheTabs
 
-A `boolean` that keeps visited tab content mounted when switching tabs. Defaults to `false`.
+A `boolean` that caches visited tab content with Vue’s `KeepAlive` when switching tabs. Defaults to `false`.
 
-When enabled, each tab mounts on its first activation. Inactive visited panels are hidden with CSS and retain their component instances, DOM, and local state. Unvisited tabs do not mount until selected.
+When enabled, each tab mounts on its first activation. Inactive visited panels are deactivated and detached from the document, retaining their component instances, DOM nodes, and local state. Unvisited tabs do not mount until selected.
 
 ```html
 <KTabs :tabs="tabs" cache-tabs>
@@ -224,7 +224,9 @@ When enabled, each tab mounts on its first activation. Inactive visited panels a
 </KTabs>
 ```
 
-This prevents repeated mount-triggered requests. Cached content still uses memory, and its watchers and polling can continue while hidden. Charts may need to resize when their panel becomes visible again.
+This prevents repeated mount-triggered requests. Dashboard components can use `onDeactivated()` to pause polling and `onActivated()` to resume polling or resize charts. These hooks also run in nested components. `onActivated()` runs on the initial mount as well as subsequent activations.
+
+`KeepAlive` does not automatically pause timers, polling, or watchers. Consumers must handle that work in the lifecycle hooks. Cached content still uses memory.
 
 Removing a tab discards its cached content. Disabling `cacheTabs` unmounts inactive content. Setting `hidePanels` to `true` or unmounting KTabs discards all panel content.
 

--- a/src/components/KTabs/KTabs.cy.ts
+++ b/src/components/KTabs/KTabs.cy.ts
@@ -1,4 +1,4 @@
-import { h } from 'vue'
+import { defineComponent, h, onMounted, onUnmounted, ref } from 'vue'
 import type { TabsAppearance } from '@/types'
 import KTabs from '@/components/KTabs/KTabs.vue'
 
@@ -9,6 +9,43 @@ const TABS = [
 ]
 
 const appearances: TabsAppearance[] = ['default', 'minimal']
+
+interface PanelLifecycle {
+  mounts: number
+  unmounts: number
+}
+
+const createStatefulPanel = (name: string, lifecycle: PanelLifecycle) => defineComponent({
+  setup() {
+    const value = ref('')
+
+    onMounted(() => {
+      lifecycle.mounts += 1
+    })
+
+    onUnmounted(() => {
+      lifecycle.unmounts += 1
+    })
+
+    return () => h('div', { 'data-testid': `${name}-panel` }, [
+      h('input', {
+        'data-testid': `${name}-input`,
+        value: value.value,
+        onInput: (event: Event) => {
+          if (event.target instanceof HTMLInputElement) {
+            value.value = event.target.value
+          }
+        },
+      }),
+    ])
+  },
+})
+
+const createPanelSlots = (lifecycles: Record<string, PanelLifecycle>) => ({
+  pictures: h(createStatefulPanel('pictures', lifecycles.pictures)),
+  movies: h(createStatefulPanel('movies', lifecycles.movies)),
+  books: h(createStatefulPanel('books', lifecycles.books)),
+})
 
 describe('KTabs', () => {
   appearances.forEach((appearance) => {
@@ -210,6 +247,122 @@ describe('KTabs', () => {
           cy.get('#movies-tab .tab-link').should('contain.text', moviesSlot)
           cy.get('#books-tab .tab-link').should('contain.text', booksSlot)
         })
+      })
+    })
+  })
+
+  describe('cacheTabs', () => {
+    const slots = {
+      pictures: () => h('input', { 'data-testid': 'pictures-content' }),
+      movies: () => h('input', { 'data-testid': 'movies-content' }),
+      books: () => h('input', { 'data-testid': 'books-content' }),
+    }
+
+    it('unmounts inactive content by default', () => {
+      cy.mount(KTabs, { props: { tabs: TABS }, slots })
+      cy.getTestId('pictures-content').type('discarded')
+      cy.get('#movies-tab').click()
+      cy.getTestId('pictures-content').should('not.exist')
+      cy.get('#pictures-tab').click()
+      cy.getTestId('pictures-content').should('have.value', '')
+    })
+
+    it('caches initial and programmatically activated tabs', () => {
+      cy.mount(KTabs, { props: { tabs: TABS, cacheTabs: true, modelValue: '#books' }, slots })
+      cy.getTestId('books-content').type('retained')
+      cy.getTestId('pictures-content').should('not.exist')
+      cy.then(() => Cypress.vueWrapper.setProps({ modelValue: '#movies' }))
+      cy.getTestId('movies-content').should('be.visible')
+      cy.getTestId('books-content').should('not.be.visible').and('have.value', 'retained')
+      cy.then(() => Cypress.vueWrapper.setProps({ modelValue: '#books' }))
+      cy.getTestId('books-content').should('be.visible').and('have.value', 'retained')
+      cy.getTestId('movies-content').should('not.be.visible')
+      cy.getTestId('pictures-content').should('not.exist')
+    })
+
+    it('does not mount a tab when beforeChange rejects activation', () => {
+      cy.mount(KTabs, { props: { tabs: TABS, cacheTabs: true, beforeChange: async () => false }, slots })
+      cy.get('#movies-tab').click()
+      cy.getTestId('pictures-content').should('be.visible')
+      cy.getTestId('movies-content').should('not.exist')
+    })
+
+    it('discards removed tabs and waits for activation when they are added again', () => {
+      cy.mount(KTabs, { props: { tabs: TABS, cacheTabs: true }, slots })
+      cy.getTestId('pictures-content').type('discarded')
+      cy.get('#movies-tab').click()
+      cy.then(() => Cypress.vueWrapper.setProps({ tabs: TABS.slice(1) }))
+      cy.getTestId('pictures-content').should('not.exist')
+      cy.then(() => Cypress.vueWrapper.setProps({ tabs: TABS }))
+      cy.getTestId('pictures-content').should('not.exist')
+      cy.get('#pictures-tab').click()
+      cy.getTestId('pictures-content').should('be.visible').and('have.value', '')
+    })
+
+    it('discards inactive content when caching is disabled', () => {
+      cy.mount(KTabs, { props: { tabs: TABS, cacheTabs: true }, slots })
+      cy.getTestId('pictures-content').type('discarded')
+      cy.get('#movies-tab').click()
+      cy.getTestId('movies-content').type('active')
+      cy.then(() => Cypress.vueWrapper.setProps({ cacheTabs: false }))
+      cy.getTestId('pictures-content').should('not.exist')
+      cy.getTestId('movies-content').should('have.value', 'active')
+      cy.then(() => Cypress.vueWrapper.setProps({ cacheTabs: true }))
+      cy.getTestId('pictures-content').should('not.exist')
+      cy.get('#pictures-tab').click()
+      cy.getTestId('pictures-content').should('have.value', '')
+      cy.getTestId('movies-content').should('not.be.visible').and('have.value', 'active')
+    })
+
+    it('discards all cached content when hidePanels is enabled', () => {
+      cy.mount(KTabs, { props: { tabs: TABS, cacheTabs: true }, slots })
+      cy.getTestId('pictures-content').type('discarded')
+      cy.get('#movies-tab').click()
+      cy.then(() => Cypress.vueWrapper.setProps({ hidePanels: true }))
+      cy.get('.tab-container').should('not.exist')
+      cy.then(() => Cypress.vueWrapper.setProps({ hidePanels: false }))
+      cy.getTestId('movies-content').should('be.visible')
+      cy.getTestId('pictures-content').should('not.exist')
+    })
+
+    it('lazily mounts visited panels and preserves their state and DOM identity', () => {
+      const lifecycles = {
+        pictures: { mounts: 0, unmounts: 0 },
+        movies: { mounts: 0, unmounts: 0 },
+        books: { mounts: 0, unmounts: 0 },
+      }
+      let picturesPanel: Element | undefined
+
+      cy.mount(KTabs, {
+        props: {
+          tabs: TABS,
+          cacheTabs: true,
+        },
+        slots: createPanelSlots(lifecycles),
+      })
+
+      cy.getTestId('pictures-panel').should('be.visible')
+      cy.getTestId('movies-panel').should('not.exist')
+      cy.getTestId('books-panel').should('not.exist')
+      cy.getTestId('pictures-panel').then(($panel) => {
+        picturesPanel = $panel[0]
+      })
+      cy.getTestId('pictures-input').type('preserved state')
+      cy.get('.tab-item').eq(1).click()
+      cy.getTestId('movies-panel').should('be.visible')
+      cy.get('#panel-0').should('not.be.visible')
+      cy.getTestId('pictures-panel').should('exist')
+      cy.get('.tab-item').eq(0).click()
+      cy.getTestId('pictures-panel').should(($panel) => {
+        expect($panel[0]).to.equal(picturesPanel)
+      })
+      cy.getTestId('pictures-input').should('have.value', 'preserved state')
+      cy.then(() => {
+        expect(lifecycles.pictures.mounts).to.equal(1)
+        expect(lifecycles.pictures.unmounts).to.equal(0)
+        expect(lifecycles.movies.mounts).to.equal(1)
+        expect(lifecycles.movies.unmounts).to.equal(0)
+        expect(lifecycles.books.mounts).to.equal(0)
       })
     })
   })

--- a/src/components/KTabs/KTabs.cy.ts
+++ b/src/components/KTabs/KTabs.cy.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, onMounted, onUnmounted, ref } from 'vue'
+import { defineComponent, h, onActivated, onDeactivated, onMounted, onUnmounted, ref } from 'vue'
 import type { TabsAppearance } from '@/types'
 import KTabs from '@/components/KTabs/KTabs.vue'
 
@@ -11,6 +11,8 @@ const TABS = [
 const appearances: TabsAppearance[] = ['default', 'minimal']
 
 interface PanelLifecycle {
+  activations: number
+  deactivations: number
   mounts: number
   unmounts: number
 }
@@ -18,6 +20,13 @@ interface PanelLifecycle {
 const createStatefulPanel = (name: string, lifecycle: PanelLifecycle) => defineComponent({
   setup() {
     const value = ref('')
+
+    onActivated(() => {
+      lifecycle.activations += 1
+    })
+    onDeactivated(() => {
+      lifecycle.deactivations += 1
+    })
 
     onMounted(() => {
       lifecycle.mounts += 1
@@ -41,11 +50,15 @@ const createStatefulPanel = (name: string, lifecycle: PanelLifecycle) => defineC
   },
 })
 
-const createPanelSlots = (lifecycles: Record<string, PanelLifecycle>) => ({
-  pictures: h(createStatefulPanel('pictures', lifecycles.pictures)),
-  movies: h(createStatefulPanel('movies', lifecycles.movies)),
-  books: h(createStatefulPanel('books', lifecycles.books)),
-})
+const createPanelSlots = (lifecycles: Record<string, PanelLifecycle>) => {
+  const Pictures = createStatefulPanel('pictures', lifecycles.pictures)
+
+  return {
+    pictures: () => [h('span', 'Pictures heading'), h(Pictures)],
+    movies: h(createStatefulPanel('movies', lifecycles.movies)),
+    books: h(createStatefulPanel('books', lifecycles.books)),
+  }
+}
 
 describe('KTabs', () => {
   appearances.forEach((appearance) => {
@@ -273,10 +286,10 @@ describe('KTabs', () => {
       cy.getTestId('pictures-content').should('not.exist')
       cy.then(() => Cypress.vueWrapper.setProps({ modelValue: '#movies' }))
       cy.getTestId('movies-content').should('be.visible')
-      cy.getTestId('books-content').should('not.be.visible').and('have.value', 'retained')
+      cy.getTestId('books-content').should('not.exist')
       cy.then(() => Cypress.vueWrapper.setProps({ modelValue: '#books' }))
       cy.getTestId('books-content').should('be.visible').and('have.value', 'retained')
-      cy.getTestId('movies-content').should('not.be.visible')
+      cy.getTestId('movies-content').should('not.exist')
       cy.getTestId('pictures-content').should('not.exist')
     })
 
@@ -311,7 +324,8 @@ describe('KTabs', () => {
       cy.getTestId('pictures-content').should('not.exist')
       cy.get('#pictures-tab').click()
       cy.getTestId('pictures-content').should('have.value', '')
-      cy.getTestId('movies-content').should('not.be.visible').and('have.value', 'active')
+      cy.get('#movies-tab').click()
+      cy.getTestId('movies-content').should('have.value', 'active')
     })
 
     it('discards all cached content when hidePanels is enabled', () => {
@@ -327,9 +341,9 @@ describe('KTabs', () => {
 
     it('lazily mounts visited panels and preserves their state and DOM identity', () => {
       const lifecycles = {
-        pictures: { mounts: 0, unmounts: 0 },
-        movies: { mounts: 0, unmounts: 0 },
-        books: { mounts: 0, unmounts: 0 },
+        pictures: { mounts: 0, unmounts: 0, activations: 0, deactivations: 0 },
+        movies: { mounts: 0, unmounts: 0, activations: 0, deactivations: 0 },
+        books: { mounts: 0, unmounts: 0, activations: 0, deactivations: 0 },
       }
       let picturesPanel: Element | undefined
 
@@ -342,6 +356,9 @@ describe('KTabs', () => {
       })
 
       cy.getTestId('pictures-panel').should('be.visible')
+      cy.then(() => {
+        expect(lifecycles.pictures.activations).to.equal(1)
+      })
       cy.getTestId('movies-panel').should('not.exist')
       cy.getTestId('books-panel').should('not.exist')
       cy.getTestId('pictures-panel').then(($panel) => {
@@ -350,19 +367,30 @@ describe('KTabs', () => {
       cy.getTestId('pictures-input').type('preserved state')
       cy.get('.tab-item').eq(1).click()
       cy.getTestId('movies-panel').should('be.visible')
-      cy.get('#panel-0').should('not.be.visible')
-      cy.getTestId('pictures-panel').should('exist')
+      cy.getTestId('pictures-panel').should('not.exist')
+      cy.then(() => {
+        expect(lifecycles.pictures.deactivations).to.equal(1)
+        expect(lifecycles.pictures.unmounts).to.equal(0)
+      })
       cy.get('.tab-item').eq(0).click()
       cy.getTestId('pictures-panel').should(($panel) => {
         expect($panel[0]).to.equal(picturesPanel)
       })
       cy.getTestId('pictures-input').should('have.value', 'preserved state')
+      cy.get('#panel-0').should('contain.text', 'Pictures heading')
       cy.then(() => {
+        expect(lifecycles.pictures.activations).to.equal(2)
+        expect(lifecycles.movies.deactivations).to.equal(1)
         expect(lifecycles.pictures.mounts).to.equal(1)
         expect(lifecycles.pictures.unmounts).to.equal(0)
         expect(lifecycles.movies.mounts).to.equal(1)
         expect(lifecycles.movies.unmounts).to.equal(0)
         expect(lifecycles.books.mounts).to.equal(0)
+      })
+      cy.then(() => Cypress.vueWrapper.unmount())
+      cy.then(() => {
+        expect(lifecycles.pictures.unmounts).to.equal(1)
+        expect(lifecycles.movies.unmounts).to.equal(1)
       })
     })
   })

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -40,6 +40,7 @@
     <template v-if="!hidePanels">
       <div
         v-for="(tab, i) in tabs"
+        v-show="!cacheTabs || activeTab === tab.hash"
         :id="`panel-${i}`"
         :key="tab.hash"
         :aria-labelledby="`${getTabSlotName(tab.hash)}-tab`"
@@ -47,7 +48,7 @@
         role="tabpanel"
       >
         <slot
-          v-if="activeTab === tab.hash"
+          v-if="activeTab === tab.hash || (cacheTabs && visitedTabs.has(tab.hash))"
           :name="getTabSlotName(tab.hash)"
         />
       </div>
@@ -56,7 +57,7 @@
 </template>
 
 <script lang="ts" setup generic="const Hash extends string = string">
-import { ref, watch } from 'vue'
+import { ref, shallowRef, watch } from 'vue'
 import KButton from '@/components/KButton/KButton.vue'
 import type { StripHash, Tab, TabsEmits, TabsProps, TabsSlots } from '@/types'
 
@@ -64,6 +65,7 @@ const {
   tabs,
   modelValue = '',
   hidePanels,
+  cacheTabs = false,
   anchorTabindex = 0,
   beforeChange = () => true,
   appearance = 'default',
@@ -97,6 +99,15 @@ const getAnchorTabindex = (tab: Tab): string => {
 watch(() => modelValue, (newTabHash) => {
   activeTab.value = newTabHash
 })
+
+const visitedTabs = shallowRef<Set<Hash>>(new Set())
+
+watch([activeTab, () => cacheTabs, () => hidePanels, () => tabs.map(tab => tab.hash)], () => {
+  // Retain only mounted panels that still belong to this tabs instance.
+  visitedTabs.value = new Set(cacheTabs && !hidePanels
+    ? tabs.filter(tab => tab.hash === activeTab.value || visitedTabs.value.has(tab.hash)).map(tab => tab.hash)
+    : [])
+}, { immediate: true })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KTabs/KTabs.vue
+++ b/src/components/KTabs/KTabs.vue
@@ -40,24 +40,26 @@
     <template v-if="!hidePanels">
       <div
         v-for="(tab, i) in tabs"
-        v-show="!cacheTabs || activeTab === tab.hash"
         :id="`panel-${i}`"
         :key="tab.hash"
         :aria-labelledby="`${getTabSlotName(tab.hash)}-tab`"
         class="tab-container"
         role="tabpanel"
       >
-        <slot
-          v-if="activeTab === tab.hash || (cacheTabs && visitedTabs.has(tab.hash))"
-          :name="getTabSlotName(tab.hash)"
-        />
+        <!-- Exclude all panels when disabled without replacing the active component. -->
+        <KeepAlive :include="cacheTabs ? undefined : []">
+          <KTabsPanel v-if="activeTab === tab.hash">
+            <slot :name="getTabSlotName(tab.hash)" />
+          </KTabsPanel>
+        </KeepAlive>
       </div>
     </template>
   </div>
 </template>
 
 <script lang="ts" setup generic="const Hash extends string = string">
-import { ref, shallowRef, watch } from 'vue'
+import { ref, watch } from 'vue'
+import KTabsPanel from './KTabsPanel.vue'
 import KButton from '@/components/KButton/KButton.vue'
 import type { StripHash, Tab, TabsEmits, TabsProps, TabsSlots } from '@/types'
 
@@ -99,15 +101,6 @@ const getAnchorTabindex = (tab: Tab): string => {
 watch(() => modelValue, (newTabHash) => {
   activeTab.value = newTabHash
 })
-
-const visitedTabs = shallowRef<Set<Hash>>(new Set())
-
-watch([activeTab, () => cacheTabs, () => hidePanels, () => tabs.map(tab => tab.hash)], () => {
-  // Retain only mounted panels that still belong to this tabs instance.
-  visitedTabs.value = new Set(cacheTabs && !hidePanels
-    ? tabs.filter(tab => tab.hash === activeTab.value || visitedTabs.value.has(tab.hash)).map(tab => tab.hash)
-    : [])
-}, { immediate: true })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/KTabs/KTabsPanel.vue
+++ b/src/components/KTabs/KTabsPanel.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- Give KeepAlive a component boundary for arbitrary tab slot content. -->
+  <slot />
+</template>
+
+<script setup lang="ts">
+// KeepAlive needs a name to prune cached panels when caching is disabled.
+defineOptions({ name: 'KTabsPanel' })
+</script>

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -39,7 +39,7 @@ export interface TabsProps<H extends string = string> {
   hidePanels?: boolean
 
   /**
-   * Keep visited tab content mounted and hide inactive panels.
+   * Cache visited tab content with KeepAlive and deactivate inactive panels.
    * Each tab mounts only when first activated.
    * @default false
    */

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -39,6 +39,13 @@ export interface TabsProps<H extends string = string> {
   hidePanels?: boolean
 
   /**
+   * Keep visited tab content mounted and hide inactive panels.
+   * Each tab mounts only when first activated.
+   * @default false
+   */
+  cacheTabs?: boolean
+
+  /**
    * The tabindex of the tab buttons.
    * @deprecated Previously used to support adding links inside tab buttons, this prop is now deprecated as the to prop has built-in support via the `to` prop.
    * @default 0


### PR DESCRIPTION
# Summary

Add opt-in `cache-tabs` to KTabs so dashboards retain their component instances, DOM nodes, and local state across tab switches. Each panel mounts on its first activation, then Vue's native `KeepAlive` caches it while inactive. The default behavior is unchanged.

## Changes

- Add an internal panel component that supports arbitrary slot content, including multiple roots.
- Preserve `onActivated()` and `onDeactivated()` hooks for panel components and their descendants.
- Discard removed tabs and inactive content when caching is disabled, while preserving the active instance. `hidePanels` clears all panels.
- Document the caching behavior and add seven Vitest browser regression tests covering state, DOM identity, lifecycle hooks, programmatic activation, navigation guards, and cleanup.
- Add a `cacheTabs` sandbox example with Draft and Ideas inputs and a caching toggle.

## How to test/verify

1. Run `pnpm sandbox:dev` and open `/tabs`.
2. Find the `cacheTabs` section. Caching is enabled initially.
3. Type in Draft, switch to Ideas, enter different text, then return to Draft. Each tab retains its text.
4. Turn off **Cache visited tabs**, switch away from the active tab, then return. Its text resets.

Local validation passed: all 29 KTabs tests in Chromium, Firefox, and WebKit (87 checks), typecheck, ESLint, and stylelint. The sandbox build also passed.

## Risks or limits

Cached panels retain memory. `KeepAlive` does not automatically pause timers, polling, or watchers; consumers must manage background work in lifecycle hooks.
